### PR TITLE
Add AESKey to crypto module, RSAPrivateKey supports long text encryption

### DIFF
--- a/parsec/crypto.py
+++ b/parsec/crypto.py
@@ -1,7 +1,15 @@
+from os import urandom
+import struct
+
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.backends.openssl import backend as openssl
+from cryptography.hazmat.primitives.ciphers.algorithms import AES
+from cryptography.hazmat.primitives.ciphers.modes import GCM
+from cryptography.hazmat.primitives.ciphers import Cipher
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.exceptions import InvalidSignature, InvalidTag
 
 
 def load_private_key(raw_key):
@@ -13,9 +21,33 @@ def load_public_key(raw_key):
     return RSAPublicKey(raw_key)
 
 
+def load_sym_key(raw_key: bytes):
+    return AESKey(raw_key)
+
+
+def generate_sym_key():
+    raw_key = urandom(32)  # 256bits long key
+    return AESKey(raw_key)
+
+
+class BaseSymKey:
+
+    def __init__(self, key: bytes):
+        raise NotImplementedError()
+
+    def encrypt(self, cleartext: bytes):
+        raise NotImplementedError()
+
+    def decrypt(self, ciphertext: bytes):
+        raise NotImplementedError()
+
+    @property
+    def key(self):
+        raise NotImplementedError()
+
+
 class BasePrivateAsymKey:
-    @classmethod
-    def load(self, key):
+    def __init__(self, key: bytes):
         raise NotImplementedError()
 
     def sign(self, message):
@@ -27,10 +59,13 @@ class BasePrivateAsymKey:
     def decrypt(self, message):
         raise NotImplementedError()
 
+    @property
+    def pub_key(self):
+        raise NotImplementedError()
+
 
 class BasePublicAsymKey:
-    @classmethod
-    def load(self, key):
+    def __init__(self, key: bytes):
         raise NotImplementedError()
 
     def verify(self, signature, message):
@@ -45,8 +80,11 @@ class BasePublicAsymKey:
 
 class RSAPublicKey(BasePublicAsymKey):
     def __init__(self, key: bytes):
-        public_key = serialization.load_pem_public_key(key, backend=default_backend())
-        self._hazmat_public_key = public_key
+        if isinstance(key, bytes):
+            public_key = serialization.load_pem_public_key(key, backend=default_backend())
+            self._hazmat_public_key = public_key
+        else:
+            self._hazmat_public_key = key
 
     def verify(self, signature: bytes, message: bytes):
         return self._hazmat_public_key.verify(
@@ -70,24 +108,30 @@ class RSAPublicKey(BasePublicAsymKey):
         )
 
     def encrypt(self, message: bytes):
-            return self._hazmat_public_key.encrypt(
-                message,
-                padding.OAEP(
-                    mgf=padding.MGF1(algorithm=hashes.SHA1()),
-                    algorithm=hashes.SHA1(),
-                    label=None
-                )
+        symkey = generate_sym_key()
+        ciphertext = symkey.encrypt(message)
+        ciphersymkey = self._hazmat_public_key.encrypt(
+            symkey.key,
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                algorithm=hashes.SHA256(),
+                label=None
             )
+        )
+        return struct.pack(">I", len(ciphersymkey)) + ciphersymkey + ciphertext
 
 
 class RSAPrivateKey(BasePrivateAsymKey):
     def __init__(self, key: bytes):
-        private_key = serialization.load_pem_private_key(
-            key,
-            password=None,
-            backend=default_backend()
-        )
-        self._hazmat_private_key = private_key
+        if isinstance(key, bytes):
+            private_key = serialization.load_pem_private_key(
+                key,
+                password=None,
+                backend=default_backend()
+            )
+            self._hazmat_private_key = private_key
+        else:
+            self._hazmat_public_key = key
 
     def sign(self, message: bytes):
         return self._hazmat_private_key.sign(
@@ -109,15 +153,61 @@ class RSAPrivateKey(BasePrivateAsymKey):
         )
 
     def decrypt(self, ciphertext: bytes):
-        return self._hazmat_private_key.decrypt(
-            ciphertext,
+        lenciphersymkey, = struct.unpack(">I", ciphertext[:4])
+        ciphersymkey = ciphertext[4:4 + lenciphersymkey]
+        ciphertext = ciphertext[4 + lenciphersymkey:]
+
+        symkey = load_sym_key(self._hazmat_private_key.decrypt(
+            ciphersymkey,
             padding.OAEP(
-                mgf=padding.MGF1(algorithm=hashes.SHA1()),
-                algorithm=hashes.SHA1(),
+                mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                algorithm=hashes.SHA256(),
                 label=None
             )
-        )
+        ))
+        return symkey.decrypt(ciphertext)
 
     @property
     def pub_key(self):
-        raise NotImplementedError('TODO !')
+        return RSAPublicKey(self._hazmat_private_key.public_key())
+
+
+class AESKey(BaseSymKey):
+
+    def __init__(self, key: bytes):
+        self._hazmat_key = AES(key)
+
+    def encrypt(self, cleartext: bytes):
+        # No need for padding as we are using GCM
+        # Get a new iv for GCM
+        iv = urandom(int(AES.block_size // 8))
+        cipher = Cipher(self._hazmat_key, GCM(iv), backend=openssl)
+        encryptor = cipher.encryptor()
+        enc = encryptor.update(cleartext) + encryptor.finalize()
+        return iv + enc + encryptor.tag
+
+    def decrypt(self, ciphertext: bytes):
+        iv = ciphertext[:AES.block_size // 8]
+        tag = ciphertext[-16:]
+        cipher = Cipher(self._hazmat_key, GCM(iv, tag), backend=openssl).decryptor()
+        return cipher.update(ciphertext[16:-16]) + cipher.finalize()
+
+    @property
+    def key(self):
+        return self._hazmat_key.key
+
+
+__all__ = (
+    'InvalidSignature',
+    'InvalidTag',
+    'load_private_key',
+    'load_public_key',
+    'load_sym_key',
+    'generate_sym_key',
+    'BaseSymKey',
+    'BasePrivateAsymKey',
+    'BasePublicAsymKey',
+    'RSAPublicKey',
+    'RSAPrivateKey',
+    'AESKey',
+)

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,0 +1,172 @@
+import pytest
+
+from parsec.crypto import (
+    load_private_key, load_public_key, load_sym_key,
+    BasePrivateAsymKey, BasePublicAsymKey, InvalidSignature,
+    InvalidTag
+)
+
+
+ALICE_PRIVATE_RSA = b"""
+-----BEGIN RSA PRIVATE KEY-----
+MIICWgIBAAKBgGITzwWRxv+mTAwqQd9pmQ8qqUO04KJSq1cH87KtmkqI3qewvXtW
+qFsHP6ZNOT6wba7lrohJh1rDLU98GjorL4D/eX/mG/U9gURDi4aTTXT02RbHESBp
+yMpeBUCzPTq1OgAk9OaawpV48vNkQifuT743hK49SLhqGNmNAnH2E3lxAgMBAAEC
+gYBY2S0QFJG8AwCdfKKUK+t2q+UO6wscwdtqSk/grBg8MWXTb+8XjteRLy3gD9Eu
+E1IpwPStjj7KYEnp2blAvOKY0E537d2a4NLrDbSi84q8kXqvv0UeGMC0ZB2r4C89
+/6BTZii4mjIlg3iPtkbRdLfexjqmtELliPkHKJIIMH3fYQJBAKd/k1hhnoxEx4sq
+GRKueAX7orR9iZHraoR9nlV69/0B23Na0Q9/mP2bLphhDS4bOyR8EXF3y6CjSVO4
+LBDPOmUCQQCV5hr3RxGPuYi2n2VplocLK/6UuXWdrz+7GIqZdQhvhvYSKbqZ5tvK
+Ue8TYK3Dn4K/B+a7wGTSx3soSY3RBqwdAkAv94jqtooBAXFjmRq1DuGwVO+zYIAV
+GaXXa2H8eMqr2exOjKNyHMhjWB1v5dswaPv25tDX/caCqkBFiWiVJ8NBAkBnEnqo
+Xe3tbh5btO7+08q4G+BKU9xUORURiaaELr1GMv8xLhBpkxy+2egS4v+Y7C3zPXOi
+1oB9jz1YTnt9p6DhAkBy0qgscOzo4hAn062MAYWA6hZOTkvzRbRpnyTRctKwZPSC
++tnlGk8FAkuOm/oKabDOY1WZMkj5zWAXrW4oR3Q2
+-----END RSA PRIVATE KEY-----
+"""
+ALICE_PUBLIC_RSA = b"""
+-----BEGIN PUBLIC KEY-----
+MIGeMA0GCSqGSIb3DQEBAQUAA4GMADCBiAKBgGITzwWRxv+mTAwqQd9pmQ8qqUO0
+4KJSq1cH87KtmkqI3qewvXtWqFsHP6ZNOT6wba7lrohJh1rDLU98GjorL4D/eX/m
+G/U9gURDi4aTTXT02RbHESBpyMpeBUCzPTq1OgAk9OaawpV48vNkQifuT743hK49
+SLhqGNmNAnH2E3lxAgMBAAE=
+-----END PUBLIC KEY-----
+"""
+BOB_PRIVATE_RSA = b"""
+-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQDCqVQVdVhJqW9rrbObvDZ4ET6FoIyVn6ldWhOJaycMeFYBN3t+
+cGr9/xHPGrYXK63nc8x4IVxhfXZ7JwrQ+AJv935S3rAV6JhDKDfDFrkzUVZmcc/g
+HhjiP7rTAt4RtACvhZwrDuj3Pc4miCpGN/T3tbOKG889JN85nABKR9WkdwIDAQAB
+AoGBAJFU3Dr9FgJA5rfMwpiV51CzByu61trqjgbtNkLVZhzwRr23z5Jxmd+yLHik
+J6ia6sYvdUuHFLKQegGt/2xOjXn8UBpa725gLojHn2umtJDL7amTlBwiJfNXuZrF
+BSKK9+xZnNDWMq1IuCqPeintbve+MNSc62JYuGGtXSz9L5f5AkEA/xBkUksBfEUl
+65oEPgxvMKHNjLq48otRmCaG+i3MuQqTYQ+c8Z/l26yQL4OV2b36a8/tTaLhwhAZ
+Ibtv05NKfQJBAMNgMbOsUWpY8A1Cec79Oj6RVe79E5ciZ4mW3lx5tjJRyNxwlQag
+u+T6SwBIa6xMfLBQeizzxqXqxAyW/riQ6QMCQQCadUu7Re6tWZaAGTGufYsr8R/v
+s/dh8ZpEwDgG8otCFzRul6zb6Y+huttJ2q55QIGQnka/N/7srSD6+23Zux1lAkBx
+P30PzL6UimD7DqFUnev5AH1zPjbwz/x8AHt71wEJQebQAGIhqWHAZGS9ET14bg2I
+ld172QI4glCJi6yyhyzJAkBzfmHZEE8FyLCz4z6b+Z2ghMds2Xz7RwgVqCIXt9Ku
+P7Bq0eXXgyaBo+jpr3h4K7QnPh+PaHSlGqSfczZ6GIpx
+-----END RSA PRIVATE KEY-----
+"""
+BOB_PUBLIC_RSA = b"""
+-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDCqVQVdVhJqW9rrbObvDZ4ET6F
+oIyVn6ldWhOJaycMeFYBN3t+cGr9/xHPGrYXK63nc8x4IVxhfXZ7JwrQ+AJv935S
+3rAV6JhDKDfDFrkzUVZmcc/gHhjiP7rTAt4RtACvhZwrDuj3Pc4miCpGN/T3tbOK
+G889JN85nABKR9WkdwIDAQAB
+-----END PUBLIC KEY-----
+"""
+
+
+@pytest.fixture
+def alice():
+    return load_private_key(ALICE_PRIVATE_RSA)
+
+
+@pytest.fixture
+def bob():
+    return load_private_key(BOB_PRIVATE_RSA)
+
+
+@pytest.fixture
+def symkey():
+    raw_key = b'0' * 32
+    return load_sym_key(raw_key)
+
+
+def _shrink_ids(x):
+    return x if len(x) < 20 else x[:10] + b'...' + x[-10:]
+
+
+class TestRSAAsymCrypto:
+    def test_load_private_key(self):
+        key = load_private_key(ALICE_PRIVATE_RSA)
+        assert isinstance(key, BasePrivateAsymKey)
+
+    @pytest.mark.parametrize('badkey', [
+        ALICE_PUBLIC_RSA,
+        b'fooo'
+    ], ids=_shrink_ids)
+    def test_bad_load_private_key(self, badkey):
+        with pytest.raises(ValueError):
+            load_private_key(badkey)
+
+    def test_load_public_key(self):
+        key = load_public_key(ALICE_PUBLIC_RSA)
+        assert isinstance(key, BasePublicAsymKey)
+
+    def test_pub_key_in_private_key(self, alice):
+        assert isinstance(alice.pub_key, BasePublicAsymKey)
+
+    @pytest.mark.parametrize('badkey', [
+        ALICE_PRIVATE_RSA,
+        b'fooo'
+    ], ids=_shrink_ids)
+    def test_bad_load_public_key(self, badkey):
+        with pytest.raises(ValueError):
+            load_public_key(badkey)
+
+    @pytest.mark.parametrize('msg', [
+        b'fooo',
+        b'l' + b'o' * 1000000 + b'ng'
+    ], ids=_shrink_ids)
+    def test_sign_and_verify(self, msg, alice, bob):
+        signature = alice.sign(msg)
+        assert isinstance(signature, bytes)
+        alice.pub_key.verify(signature, msg)
+        with pytest.raises(InvalidSignature):
+            bad_signature = signature + b'.'
+            alice.pub_key.verify(bad_signature, msg)
+        with pytest.raises(InvalidSignature):
+            bad_msg = msg + b'.'
+            alice.pub_key.verify(signature, bad_msg)
+        with pytest.raises(InvalidSignature):
+            bob.pub_key.verify(signature, msg)
+
+    @pytest.mark.parametrize('msg', [
+        b'fooo',
+        b'l' + b'o' * 1000000 + b'ng'
+    ], ids=_shrink_ids)
+    def test_crypt_and_decrypt(self, msg, alice, bob):
+        crypted = alice.pub_key.encrypt(msg)
+        assert isinstance(crypted, bytes)
+        decrypted = alice.decrypt(crypted)
+        assert isinstance(decrypted, bytes)
+        assert decrypted == msg
+        with pytest.raises(ValueError):
+            bob.decrypt(crypted)
+
+
+class TestAESSymCrypto:
+
+    def test_export_key(self, symkey):
+        assert isinstance(symkey.key, bytes)
+
+    @pytest.mark.parametrize('msg', [
+        b'fooo',
+        b'l' + b'o' * 1000000 + b'ng'
+    ], ids=_shrink_ids)
+    def test_aes_encrypt_good(self, msg, symkey):
+        crypted = symkey.encrypt(msg)
+        assert isinstance(crypted, bytes)
+        msg2 = symkey.decrypt(crypted)
+        assert msg == msg2
+
+    def test_aes_decrypt_bad_iv(self, symkey):
+        crypted = symkey.encrypt(b'foo')
+        bad_crypted = crypted[:15] + b'x' + crypted[16:]
+        with pytest.raises(InvalidTag):
+            symkey.decrypt(bad_crypted)
+
+    def test_aes_decrypt_bad_tag(self, symkey):
+        crypted = symkey.encrypt(b'foo')
+        bad_crypted = crypted[:-16] + b'x' * 16
+        with pytest.raises(InvalidTag):
+            symkey.decrypt(bad_crypted)
+
+    def test_aes_decrypt_bad_key(self, symkey):
+        crypted = symkey.encrypt(b'foo')
+        badsymkey = load_sym_key(symkey.key[:31] + b'x')
+        with pytest.raises(InvalidTag):
+            badsymkey.decrypt(crypted)


### PR DESCRIPTION
Je n'ai pas conservé l'API d'Antoine car elle retournait les éléments de chiffrements [les uns séparés des atures](https://github.com/Scille/parsec-cloud/blob/pubkeyservice-in-backend/parsec/crypto/crypto.py#L38), c'est beaucoup plus intéressant de cacher ça dans l'implémentation  et de retourner un `bytes` standard.