### PR TITLE
Add pre-commit config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ parsec/core/gui/_resources_rc.py
 
 # PyQt's forms, automatically generated
 parsec/core/gui/ui/*.py
+
+# Temporary files
+*~

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: 18.9b0
+    hooks:
+    - id: black
+      args:
+          - "--line-length=100"
+          - "--exclude=parsec/core/gui/_resources_rc.py"
+          - "--exclude=parsec/core/gui/ui/"
+      language_version: python3


### PR DESCRIPTION
Pre-commit can be installed using:
```console
$ pip install pre-commit
$ pre-commit install
```
Then black will run before each commit, but only on the staged chunks.