### PR TITLE
 Add version option to parsec cli 

### DIFF
--- a/parsec/cli.py
+++ b/parsec/cli.py
@@ -1,5 +1,6 @@
 import click
 
+import parsec
 from parsec.cli_utils import generate_not_available_cmd
 
 
@@ -16,6 +17,7 @@ except ImportError as exc:
 
 
 @click.group()
+@click.version_option(version=parsec.__version__, prog_name="parsec")
 def cli():
     pass
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,9 +5,19 @@ from pathlib import Path
 from contextlib import contextmanager
 from time import sleep
 import subprocess
+from click.testing import CliRunner
 
+import parsec
+from parsec.cli import cli
 
 CWD = Path(__file__).parent.parent
+
+
+def test_version():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert f"parsec, version {parsec.__version__}\n" in result.output
 
 
 def _run(cmd):


### PR DESCRIPTION
Usage:
```
$ parsec --version
parsec, version 0.8.3
```