### PR TITLE
 Rename --store option to --db in parsec backend run command

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: parsec backend run --host=0.0.0.0 --port=$PORT --store=$DATABASE_URL --blockstore=S3 --debug --log-level=INFO
+web: parsec backend run --host=0.0.0.0 --port=$PORT --db=$DATABASE_URL --blockstore=S3 --debug --log-level=INFO

--- a/parsec/backend/cli.py
+++ b/parsec/backend/cli.py
@@ -41,9 +41,7 @@ def init_cmd(db, force):
 @click.command(short_help="run the server")
 @click.option("--host", "-H", default="127.0.0.1", help="Host to listen on (default: 127.0.0.1)")
 @click.option("--port", "-P", default=6777, type=int, help=("Port to listen on (default: 6777)"))
-@click.option(
-    "--store", "-s", default="MOCKED", help="Store configuration (default: mocked in memory)"
-)
+@click.option("--db", default="MOCKED", help="Database configuration (default: mocked in memory)")
 @click.option(
     "--blockstore",
     "-b",
@@ -69,7 +67,7 @@ def init_cmd(db, force):
 def run_cmd(
     host,
     port,
-    store,
+    db,
     blockstore,
     ssl_keyfile,
     ssl_certfile,
@@ -85,7 +83,7 @@ def run_cmd(
 
         try:
             config = config_factory(
-                blockstore_type=blockstore, db_url=store, debug=debug, environ=os.environ
+                blockstore_type=blockstore, db_url=db, debug=debug, environ=os.environ
             )
 
         except ValueError as exc:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,10 +83,7 @@ def test_init_backend(postgresql_url, unused_tcp_port):
 
     # Test backend can run
     with _running(
-        (
-            "backend run --blockstore=POSTGRESQL "
-            f"--store={postgresql_url} --port={unused_tcp_port}"
-        ),
+        ("backend run --blockstore=POSTGRESQL " f"--db={postgresql_url} --port={unused_tcp_port}"),
         wait_for="Starting Parsec Backend",
     ):
         pass


### PR DESCRIPTION
For more consistency with the `parsec backend init` command.