### PR TITLE
 Add misc/run_test_environment.sh script 

### DIFF
--- a/misc/initialize_test_organization.py
+++ b/misc/initialize_test_organization.py
@@ -1,0 +1,190 @@
+import os
+import trio
+
+import click
+import pendulum
+
+from parsec.crypto import SigningKey
+from parsec.trustchain import certify_user, certify_device
+
+from parsec.types import BackendAddr
+from parsec.types import DeviceID, BackendOrganizationBootstrapAddr
+
+from parsec.core import logged_core_factory
+from parsec.logging import configure_logging
+from parsec.core.config import get_default_config_dir, load_config
+from parsec.core.backend_connection import backend_cmds_factory
+from parsec.core.backend_connection import backend_anonymous_cmds_factory
+from parsec.core.devices_manager import generate_new_device, save_device_with_password
+from parsec.core.devices_manager import load_device_with_password
+from parsec.core.invite_claim import generate_invitation_token, invite_and_create_device
+from parsec.core.invite_claim import invite_and_create_user, claim_device, claim_user
+
+
+@click.command()
+@click.option("-B", "--backend-address", default="ws://localhost:6777")
+@click.option("-O", "--organization", default="corp")
+@click.option("-a", "--alice-device-id", default="alice@laptop")
+@click.option("-b", "--bob-device-id", default="bob@laptop")
+@click.option("-o", "--other-device-name", default="pc")
+@click.option("-x", "--alice-workspace", default="alice_workspace")
+@click.option("-y", "--bob-workspace", default="bob_workspace")
+@click.option("-P", "--password", default="test")
+@click.option("--force/--no-force", default=False)
+def main(*args, **kwargs):
+    """Initialize a test origanization for parsec from a clean environment.
+
+    You might want to create a test environment beforehand with the
+    following commands:
+
+        TMP=`mktemp -d`
+        export XDG_CACHE_HOME="$TMP/cache"
+        export XDG_DATA_HOME="$TMP/share"
+        export XDG_CONFIG_HOME="$TMP/config"
+        mkdir $XDG_CACHE_HOME $XDG_DATA_HOME $XDG_CONFIG_HOME
+        parsec backend run -b MOCKED -P 6888 &
+
+    And use `-B ws://localhost:6888` as a backend adress.
+
+    This scripts create two users, alice and bob who both own two devices,
+    laptop and pc. They each have their workspace, respectively
+    alice_workspace and bob_workspace, that their sharing with each other.
+    """
+    trio.run(lambda: amain(*args, **kwargs))
+
+
+async def amain(
+    backend_address="ws://localhost:6777",
+    organization="vcorp",
+    alice_device_id="alice@laptop",
+    bob_device_id="bob@laptop",
+    other_device_name="pc",
+    alice_workspace="alicews",
+    bob_workspace="bobws",
+    password="test",
+    force=False,
+):
+
+    configure_logging("WARNING")
+
+    config_dir = get_default_config_dir(os.environ)
+    backend_address = BackendAddr(backend_address)
+    alice_device_id = DeviceID(alice_device_id)
+    bob_device_id = DeviceID(bob_device_id)
+
+    # Create organization
+
+    async with backend_anonymous_cmds_factory(backend_address) as cmds:
+
+        bootstrap_token = await cmds.organization_create(organization)
+
+        organization_bootstrap_addr = BackendOrganizationBootstrapAddr.build(
+            backend_address, organization, bootstrap_token
+        )
+
+    # Bootstrap organization and Alice user
+
+    async with backend_anonymous_cmds_factory(backend_address) as cmds:
+        root_signing_key = SigningKey.generate()
+        root_verify_key = root_signing_key.verify_key
+        organization_addr = organization_bootstrap_addr.generate_organization_addr(root_verify_key)
+
+        alice_device = generate_new_device(alice_device_id, organization_addr)
+
+        save_device_with_password(config_dir, alice_device, password, force=force)
+
+        now = pendulum.now()
+        certified_user = certify_user(
+            None, root_signing_key, alice_device.user_id, alice_device.public_key, now
+        )
+        certified_device = certify_device(
+            None, root_signing_key, alice_device_id, alice_device.verify_key, now
+        )
+
+        await cmds.organization_bootstrap(
+            organization_bootstrap_addr.organization,
+            organization_bootstrap_addr.bootstrap_token,
+            root_verify_key,
+            certified_user,
+            certified_device,
+        )
+
+    # Create a workspace for Alice
+
+    config = load_config(config_dir, debug="DEBUG" in os.environ)
+    async with logged_core_factory(config, alice_device) as core:
+        await core.fs.workspace_create(f"/{alice_workspace}")
+
+    # Register a new device for Alice
+
+    token = generate_invitation_token()
+    other_alice_device_id = DeviceID("@".join((alice_device.user_id, other_device_name)))
+
+    async def invite_task():
+
+        async with backend_cmds_factory(
+            alice_device.backend_addr, alice_device.device_id, alice_device.signing_key
+        ) as cmds:
+            await invite_and_create_device(alice_device, cmds, other_device_name, token)
+
+    async def claim_task():
+        async with backend_anonymous_cmds_factory(alice_device.backend_addr) as cmds:
+
+            other_alice_device = await claim_device(cmds, other_alice_device_id, token)
+            save_device_with_password(config_dir, other_alice_device, password, force=force)
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(invite_task)
+        await trio.sleep(0.2)
+        nursery.start_soon(claim_task)
+
+    # Invite Bob in
+
+    token = generate_invitation_token()
+
+    async def invite_task():
+
+        async with backend_cmds_factory(
+            alice_device.backend_addr, alice_device.device_id, alice_device.signing_key
+        ) as cmds:
+            await invite_and_create_user(alice_device, cmds, bob_device_id.user_id, token)
+
+    async def claim_task():
+        async with backend_anonymous_cmds_factory(alice_device.backend_addr) as cmds:
+
+            bob_device = await claim_user(cmds, bob_device_id, token)
+            save_device_with_password(config_dir, bob_device, password, force=force)
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(invite_task)
+        await trio.sleep(0.2)
+        nursery.start_soon(claim_task)
+
+    # Create bob workspace and share with Alice
+
+    bob_device = load_device_with_password(config.config_dir, bob_device_id, password)
+
+    async with logged_core_factory(config, bob_device) as core:
+        await core.fs.workspace_create(f"/{bob_workspace}")
+        await core.fs.share(f"/{bob_workspace}", alice_device_id.user_id)
+
+    # Share Alice workspace with bob
+
+    async with logged_core_factory(config, alice_device) as core:
+        await core.fs.share(f"/{alice_workspace}", bob_device_id.user_id)
+
+    # Print out
+
+    click.echo(
+        f"""
+Mount alice and bob drives using:
+
+    $ parsec core run -P {password} -D {alice_device_id}
+    $ parsec core run -P {password} -D {other_alice_device_id}
+    $ parsec core run -P {password} -D {bob_device_id}
+"""
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/misc/run_test_environment.sh
+++ b/misc/run_test_environment.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+: '
+Create a temporary environment and initialize a test setup for parsec.
+
+WARNING: it also leaves an in-memory backend running in the background
+on port 6888.
+
+This scripts create two users, alice and bob who both own two devices,
+laptop and pc. They each have their workspace, respectively
+alice_workspace and bob_workspace, that their sharing with each other.
+'
+
+PORT=6888
+TMP=`mktemp -d`
+DIR=`dirname $0`
+export XDG_CACHE_HOME="$TMP/cache"
+export XDG_DATA_HOME="$TMP/share"
+export XDG_CONFIG_HOME="$TMP/config"
+mkdir $XDG_CACHE_HOME $XDG_DATA_HOME $XDG_CONFIG_HOME
+
+echo """\
+Configure your test environment with the following variables:
+
+    export XDG_CACHE_HOME=$XDG_CACHE_HOME
+    export XDG_DATA_HOME=$XDG_DATA_HOME
+    export XDG_CONFIG_HOME=$XDG_CONFIG_HOME
+"""
+
+pkill -f "parsec backend run -b MOCKED -P $PORT"
+parsec backend run -b MOCKED -P $PORT &
+sleep 1
+python $DIR/initialize_test_organization.py -B "ws://localhost:$PORT" $@

--- a/parsec/core/backend_connection/event_listener.py
+++ b/parsec/core/backend_connection/event_listener.py
@@ -118,7 +118,7 @@ class BackendEventsManager:
             except (BackendHandshakeError, BackendDeviceRevokedError):
                 # No need to retry given backend don't want to talk to us...
                 self._event_pump_lost()
-                logger.exceptions("Cannot connect to the backend")
+                logger.exception("Cannot connect to the backend")
                 return
 
     async def _event_pump(self, *, task_status=trio.TASK_STATUS_IGNORED):


### PR DESCRIPTION
This script create a temporary environment and initialize a test setup for parsec.

Example:

```console
$ misc/run_test_environment.sh
Configure your test environment with the following variables:

    export XDG_CACHE_HOME=/tmp/tmp.JOO4qgQJtY/cache
    export XDG_DATA_HOME=/tmp/tmp.JOO4qgQJtY/share
    export XDG_CONFIG_HOME=/tmp/tmp.JOO4qgQJtY/config

Starting Parsec Backend on 127.0.0.1:6888 (db=MOCKED, blockstore=MOCKED)

Mount alice and bob drives using:

    $ parsec core run -P test -D alice@laptop
    $ parsec core run -P test -D alice@pc
    $ parsec core run -P test -D bob@laptop

$ export XDG_CACHE_HOME=/tmp/tmp.JOO4qgQJtY/cache 
$ export XDG_DATA_HOME=/tmp/tmp.JOO4qgQJtY/share
$ export XDG_CONFIG_HOME=/tmp/tmp.JOO4qgQJtY/config
$ parsec core run -P test -D alice@laptop
alice@laptop's drive mounted at /home/vinmic/parsec_mnt/alice@laptop
```