### PR TITLE
Make the fuse mountpoint manager joinable 

### DIFF
--- a/parsec/core/cli/run.py
+++ b/parsec/core/cli/run.py
@@ -29,7 +29,7 @@ async def _run_mountpoint(config, device, mountpoint):
         display_device = click.style(device.device_id, fg="yellow")
         mountpoint_display = click.style(str(core.mountpoint.absolute()), fg="yellow")
         click.echo(f"{display_device}'s drive mounted at {mountpoint_display}")
-        await trio.sleep_forever()
+        await core.mountpoint_manager.join()
 
 
 @click.command(short_help="run parsec mountpoint")

--- a/parsec/core/mountpoint/not_available.py
+++ b/parsec/core/mountpoint/not_available.py
@@ -6,6 +6,10 @@ class NotAvailableMountpointManager(BaseMountpointManager):
     def __init__(self, fs, event_bus, mode="thread", debug: bool = True, nothreads: bool = False):
         pass
 
+    @property
+    def mountpoint(self):
+        return None
+
     def get_abs_mountpoint(self):
         raise MountpointManagerNotAvailable("Mountpoint manager not available")
 

--- a/tests/core/mountpoint/test_fuse_mount.py
+++ b/tests/core/mountpoint/test_fuse_mount.py
@@ -97,7 +97,10 @@ async def test_mount_fuse(alice_fs, event_bus, tmpdir, fuse_mode):
             await trio.run_sync_in_worker_thread(inspect_mountpoint)
 
         finally:
-            await manager.teardown()
+            with event_bus.listen() as spy:
+                await manager.teardown()
+                await trio.sleep(0.01)  # Synchronization issue - fixed in PR #145
+            spy.assert_events_occured([("mountpoint.stopped", {"mountpoint": mountpoint})])
 
 
 @pytest.mark.trio


### PR DESCRIPTION
Fuse mountpoint on linux can be unmounted using `fusermount -u`. More generally, the mountpoint manager should be able to manage an unmounting operation coming from the OS. This PR refactors the mountpoint manager a bit to be more consistent with this use-case. 

It also integrates this use-case into the `parsec core run` command:
```console
$ source misc/run_test_environment.sh
[...]
$ parsec core run -P test -D corp:alice@laptop
alice@laptop's drive mounted at ~/parsec_mnt/alice@laptop
[...]
```
In another console
```console
$ fusermount -u ~/parsec_mnt/alice@laptop
```
The `parsec core run` command should then stop.

Some extra refactoring has been made on #145.