### PR TITLE
Add AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,7 @@
+Antoine CARDON
+David DELASSUS
+Maxime GRANDCOLAS
+Emmanuel LEBLOND
+Vincent MICHEL
+Valentin MONTE
+François ROSSIGNEUX


### PR DESCRIPTION
Selon François Pellegrini, un fichier AUTHORS devrait être présent pour être ne accord avec la licence (le copyright appartient à Scille, mais les auteurs sont les développeurs)
