### PR TITLE
Add `omit_revocated` param to find_user API, add `user_revocated_on` …

### DIFF
--- a/parsec/api/protocole/user.py
+++ b/parsec/api/protocole/user.py
@@ -60,6 +60,7 @@ user_get_serializer = CmdSerializer(UserGetReqSchema, UserGetRepSchema)
 
 class FindUserReqSchema(BaseReqSchema):
     query = fields.String(missing=None, allow_none=True)
+    omit_revocated = fields.Boolean(missing=False)
     page = fields.Int(missing=1, validate=lambda n: n > 0)
     per_page = fields.Integer(missing=100, validate=lambda n: 0 < n <= 100)
 
@@ -216,7 +217,7 @@ class DeviceRevokeReqSchema(BaseReqSchema):
 
 
 class DeviceRevokeRepSchema(BaseRepSchema):
-    pass
+    user_revocated_on = fields.DateTime(allow_none=True)
 
 
 device_revoke_serializer = CmdSerializer(DeviceRevokeReqSchema, DeviceRevokeRepSchema)

--- a/parsec/backend/user.py
+++ b/parsec/backend/user.py
@@ -101,9 +101,6 @@ class User:
     def public_key(self) -> PublicKey:
         return unsecure_certified_user_extract_public_key(self.certified_user)
 
-    def is_revocated(self) -> bool:
-        return any((False for d in self.devices.values if not d.revocated_on), True)
-
     user_id: UserID
     certified_user: bytes
     user_certifier: Optional[DeviceID]
@@ -111,6 +108,20 @@ class User:
     devices: DevicesMapping = attr.ib(factory=DevicesMapping)
 
     created_on: pendulum.Pendulum = attr.ib(factory=pendulum.now)
+
+    def is_revocated(self) -> bool:
+        now = pendulum.now()
+        for d in self.devices.values():
+            if not d.revocated_on or d.revocated_on > now:
+                return False
+        return True
+
+    def get_revocated_on(self) -> Optional[pendulum.Pendulum]:
+        revocations = [d.revocated_on for d in self.devices.values()]
+        if not revocations or None in revocations:
+            return None
+        else:
+            return sorted(revocations)[-1]
 
 
 def new_user_factory(
@@ -619,7 +630,7 @@ class BaseUserComponent:
                 }
 
         try:
-            await self.revoke_device(
+            user_revocated_on = await self.revoke_device(
                 client_ctx.organization_id,
                 data["device_id"],
                 msg["certified_revocation"],
@@ -635,7 +646,9 @@ class BaseUserComponent:
                 "reason": f"Device `{data['device_id']}` already revoked",
             }
 
-        return device_revoke_serializer.rep_dump({"status": "ok"})
+        return device_revoke_serializer.rep_dump(
+            {"status": "ok", "user_revocated_on": user_revocated_on}
+        )
 
     #### Virtual methods ####
 
@@ -697,7 +710,12 @@ class BaseUserComponent:
         raise NotImplementedError()
 
     async def find(
-        self, organization_id: OrganizationID, query: str = None, page: int = 1, per_page: int = 100
+        self,
+        organization_id: OrganizationID,
+        query: str = None,
+        page: int = 1,
+        per_page: int = 100,
+        omit_revocated: bool = False,
     ) -> Tuple[List[UserID], int]:
         raise NotImplementedError()
 
@@ -782,10 +800,11 @@ class BaseUserComponent:
         device_id: DeviceID,
         certified_revocation: bytes,
         revocation_certifier: DeviceID,
-    ) -> None:
+    ) -> Optional[pendulum.Pendulum]:
         """
         Raises:
             UserNotFoundError
             UserAlreadyRevokedError
+        Returns: User revoked date if any
         """
         raise NotImplementedError()

--- a/parsec/core/types/remote_device.py
+++ b/parsec/core/types/remote_device.py
@@ -2,6 +2,7 @@
 
 import attr
 import pendulum
+from typing import Optional
 
 from parsec.types import DeviceID, DeviceName, UserID
 from parsec.trustchain import (
@@ -95,4 +96,15 @@ class RemoteUser:
         return unsecure_certified_user_extract_public_key(self.certified_user)
 
     def is_revocated(self) -> bool:
-        return all(bool(d.revocated_on) for d in self.devices.values())
+        now = pendulum.now()
+        for d in self.devices.values():
+            if not d.revocated_on or d.revocated_on > now:
+                return False
+        return True
+
+    def get_revocated_on(self) -> Optional[pendulum.Pendulum]:
+        revocations = [d.revocated_on for d in self.devices.values()]
+        if not revocations or None in revocations:
+            return None
+        else:
+            return sorted(revocations)[-1]

--- a/tests/backend/user/test_access.py
+++ b/tests/backend/user/test_access.py
@@ -208,14 +208,17 @@ async def test_api_user_find(access_testbed, organization_factory, local_device_
         device = local_device_factory(name, org)
         await binder.bind_device(device, certifier=godfrey1)
 
+    await binder.bind_revocation(binder.get_device("Philip_J_Fry@p1"), certifier=godfrey1)
+    await binder.bind_revocation(binder.get_device("Philippe@p2"), certifier=godfrey1)
+
     # Also create homonyme in different organization, just to be sure...
     other_org = organization_factory("FilmMark")
     other_device = local_device_factory("Philippe@p1", other_org)
     await binder.bind_organization(other_org, other_device)
 
-    # Test exact match
-    rep = await user_find(sock, query="Mike")
-    assert rep == {"status": "ok", "results": ["Mike"], "per_page": 100, "page": 1, "total": 1}
+    # # Test exact match
+    # rep = await user_find(sock, query="Mike")
+    # assert rep == {"status": "ok", "results": ["Mike"], "per_page": 100, "page": 1, "total": 1}
 
     # Test partial search
     rep = await user_find(sock, query="Phil")
@@ -226,6 +229,10 @@ async def test_api_user_find(access_testbed, organization_factory, local_device_
         "page": 1,
         "total": 2,
     }
+
+    # Test partial search while omitting revoked users
+    rep = await user_find(sock, query="Phil", omit_revocated=True)
+    assert rep == {"status": "ok", "results": ["Philippe"], "per_page": 100, "page": 1, "total": 1}
 
     # Test pagination
     rep = await user_find(sock, query="Phil", page=1, per_page=1)
@@ -249,6 +256,16 @@ async def test_api_user_find(access_testbed, organization_factory, local_device_
         "per_page": 100,
         "page": 1,
         "total": 5,
+    }
+
+    # Test omit revoked users
+    rep = await user_find(sock, omit_revocated=True)
+    assert rep == {
+        "status": "ok",
+        "results": ["Blacky", "Godfrey", "Mike", "Philippe"],
+        "per_page": 100,
+        "page": 1,
+        "total": 4,
     }
 
     # Test bad params

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -241,6 +241,13 @@ def backend_data_binder_factory(backend_addr, initial_user_manifest_state):
             self.backend_addr = backend_addr
             self.binded_local_devices = []
 
+        def get_device(self, device_id):
+            for d in self.binded_local_devices:
+                if d.device_id == device_id:
+                    return d
+            else:
+                raise ValueError(device_id)
+
         async def bind_organization(
             self,
             org: OrganizationFullData,


### PR DESCRIPTION
…in response of device_revoke API

close #173 

L'idée du champ `user_revocated_on` dans la réponse à l'API `device_revoke` est de s'assurer qu'un utilisateur n'a pas eu un device créé pendant qu'on était en train de lui révoquer tous ses devices