### PR TITLE
Switched from trio.open_cancel_scope() (deprecated) to trio.CancelScope()

### DIFF
--- a/parsec/core/backend_connection/event_listener.py
+++ b/parsec/core/backend_connection/event_listener.py
@@ -122,7 +122,7 @@ class BackendEventsManager:
                 return
 
     async def _event_pump(self, *, task_status=trio.TASK_STATUS_IGNORED):
-        with trio.open_cancel_scope() as cancel_scope:
+        with trio.CancelScope() as cancel_scope:
             async with backend_cmds_factory(
                 self.device.organization_addr,
                 self.device.device_id,

--- a/parsec/core/base.py
+++ b/parsec/core/base.py
@@ -50,7 +50,7 @@ def taskify(func, *args, **kwargs):
 
         stopped = trio.Event()
         try:
-            with trio.open_cancel_scope() as cancel_scope:
+            with trio.CancelScope() as cancel_scope:
 
                 async def stop():
                     cancel_scope.cancel()

--- a/parsec/core/gui/bootstrap_organization_widget.py
+++ b/parsec/core/gui/bootstrap_organization_widget.py
@@ -36,7 +36,7 @@ async def _trio_bootstrap_organization(
 ):
     portal = trio.BlockingTrioPortal()
     queue.put(portal)
-    with trio.open_cancel_scope() as cancel_scope:
+    with trio.CancelScope() as cancel_scope:
         queue.put(cancel_scope)
         try:
             root_signing_key = SigningKey.generate()

--- a/parsec/core/gui/claim_device_widget.py
+++ b/parsec/core/gui/claim_device_widget.py
@@ -36,7 +36,7 @@ async def _trio_claim_device(
 ):
     portal = trio.BlockingTrioPortal()
     queue.put(portal)
-    with trio.open_cancel_scope() as cancel_scope:
+    with trio.CancelScope() as cancel_scope:
         queue.put(cancel_scope)
         try:
             async with backend_anonymous_cmds_factory(addr) as cmds:

--- a/parsec/core/gui/claim_user_widget.py
+++ b/parsec/core/gui/claim_user_widget.py
@@ -36,7 +36,7 @@ async def _trio_claim_user(
 ):
     portal = trio.BlockingTrioPortal()
     queue.put(portal)
-    with trio.open_cancel_scope() as cancel_scope:
+    with trio.CancelScope() as cancel_scope:
         queue.put(cancel_scope)
         try:
             async with backend_anonymous_cmds_factory(addr) as cmds:

--- a/parsec/core/gui/register_device_dialog.py
+++ b/parsec/core/gui/register_device_dialog.py
@@ -19,7 +19,7 @@ async def _handle_invite_and_create_device(
     queue, qt_on_done, qt_on_error, core, device_name, token
 ):
     try:
-        with trio.open_cancel_scope() as cancel_scope:
+        with trio.CancelScope() as cancel_scope:
             queue.put(cancel_scope)
             await invite_and_create_device(core.device, core.backend_cmds, device_name, token)
             qt_on_done.emit()

--- a/parsec/core/gui/register_user_dialog.py
+++ b/parsec/core/gui/register_user_dialog.py
@@ -19,7 +19,7 @@ async def _handle_invite_and_create_user(
     queue, qt_on_done, qt_on_error, core, username, token, is_admin
 ):
     try:
-        with trio.open_cancel_scope() as cancel_scope:
+        with trio.CancelScope() as cancel_scope:
             queue.put(cancel_scope)
             await invite_and_create_user(core.device, core.backend_cmds, username, token, is_admin)
             qt_on_done.emit()

--- a/parsec/core/messages_monitor.py
+++ b/parsec/core/messages_monitor.py
@@ -37,7 +37,7 @@ async def monitor_messages(backend_online, fs, event_bus, *, task_status=trio.TA
     while True:
         try:
 
-            with trio.open_cancel_scope() as process_message_cancel_scope:
+            with trio.CancelScope() as process_message_cancel_scope:
                 event_bus.send("message_monitor.reconnection_message_processing.started")
                 try:
                     await fs.process_last_messages()

--- a/parsec/core/mountpoint/thread.py
+++ b/parsec/core/mountpoint/thread.py
@@ -132,7 +132,7 @@ async def _join_fuse_thread(mountpoint, fuse_operations, fuse_thread_stopped, st
         except OSError:
             pass
 
-    with trio.open_cancel_scope(shield=True):
+    with trio.CancelScope(shield=True):
         if stop:
             logger.info("Stopping fuse thread...")
             fuse_operations.schedule_exit()

--- a/parsec/core/sync_monitor.py
+++ b/parsec/core/sync_monitor.py
@@ -61,7 +61,7 @@ class SyncMonitor(BaseAsyncComponent):
             self.event_bus.send("sync_monitor.disconnected")
 
     async def _monitoring(self):
-        with trio.open_cancel_scope() as self._monitoring_cancel_scope:
+        with trio.CancelScope() as self._monitoring_cancel_scope:
             self.event_bus.send("sync_monitor.reconnection_sync.started")
             try:
                 await self.fs.full_sync()


### PR DESCRIPTION
https://github.com/python-trio/trio/issues/607
https://github.com/python-trio/trio-asyncio/commit/4990c61421486c24095099a961c5b6a7f4110cdc

Doesn't change anything, I just don't like warnings :p
