### PR TITLE
Event weakref clash with logging

### DIFF
--- a/parsec/backend/app.py
+++ b/parsec/backend/app.py
@@ -48,9 +48,9 @@ class LoggedClientContext:
     device_id = attr.ib()
     public_key = attr.ib()
     verify_key = attr.ib()
+    event_bus_ctx = attr.ib(default=None)
     conn_id = attr.ib(init=False)
     logger = attr.ib(init=False)
-    subscribed_events = attr.ib(factory=dict)
     channels = attr.ib(factory=lambda: trio.open_memory_channel(100))
 
     def __attrs_post_init__(self):
@@ -300,7 +300,9 @@ class BackendApp:
 
             client_ctx.logger.debug("handshake done")
 
-            await self._handle_client_loop(transport, client_ctx)
+            with self.event_bus.connection_context() as client_ctx.event_bus_ctx:
+
+                await self._handle_client_loop(transport, client_ctx)
 
         except TransportClosedByPeer:
             transport.logger.info("Client has left")

--- a/parsec/core/beacons_monitor.py
+++ b/parsec/core/beacons_monitor.py
@@ -38,12 +38,14 @@ async def monitor_beacons(device, fs, event_bus, *, task_status=trio.TASK_STATUS
         )
         event_bus.send("fs.entry.updated", id=src_id)
 
-    event_bus.connect("fs.workspace.loaded", _on_workspace_loaded, weak=True)
-    event_bus.connect("fs.workspace.unloaded", _on_workspace_unloaded, weak=True)
-    event_bus.connect("backend.beacon.updated", _on_beacon_updated, weak=True)
+    with event_bus.connect_in_context(
+        ("fs.workspace.loaded", _on_workspace_loaded),
+        ("fs.workspace.unloaded", _on_workspace_unloaded),
+        ("backend.beacon.updated", _on_beacon_updated),
+    ):
 
-    task_status.started()
-    await trio.sleep_forever()
+        task_status.started()
+        await trio.sleep_forever()
 
 
 def _retreive_workspace_from_beacon(device, fs, beacon_id):

--- a/parsec/core/sync_monitor.py
+++ b/parsec/core/sync_monitor.py
@@ -29,8 +29,8 @@ class SyncMonitor(BaseAsyncComponent):
         self._backend_online_event = trio.Event()
         self._monitoring_cancel_scope = None
 
-        self.event_bus.connect("backend.online", self._on_backend_online, weak=True)
-        self.event_bus.connect("backend.offline", self._on_backend_offline, weak=True)
+        self.event_bus.connect("backend.online", self._on_backend_online)
+        self.event_bus.connect("backend.offline", self._on_backend_offline)
 
         if backend_online:
             self._on_backend_online(None)
@@ -76,7 +76,7 @@ class SyncMonitor(BaseAsyncComponent):
         updated_entries = {}
         new_event = trio.Event()
 
-        def _on_entry_updated(sender, id):
+        def _on_entry_updated(event, id):
             try:
                 first_updated, _ = updated_entries[id]
                 last_updated = timestamp()
@@ -85,24 +85,24 @@ class SyncMonitor(BaseAsyncComponent):
             updated_entries[id] = (first_updated, last_updated)
             new_event.set()
 
-        self.event_bus.connect("fs.entry.updated", _on_entry_updated, weak=True)
+        with self.event_bus.connect_in_context(("fs.entry.updated", _on_entry_updated)):
 
-        async with trio.open_nursery() as nursery:
-            while True:
-                self.event_bus.send("sync_monitor.ready")
+            async with trio.open_nursery() as nursery:
+                while True:
+                    self.event_bus.send("sync_monitor.ready")
 
-                await new_event.wait()
-                new_event.clear()
+                    await new_event.wait()
+                    new_event.clear()
 
-                await self._monitoring_tick(updated_entries)
+                    await self._monitoring_tick(updated_entries)
 
-                if updated_entries:
+                    if updated_entries:
 
-                    async def _wait():
-                        await trio.sleep(MIN_WAIT)
-                        new_event.set()
+                        async def _wait():
+                            await trio.sleep(MIN_WAIT)
+                            new_event.set()
 
-                    nursery.start_soon(_wait)
+                        nursery.start_soon(_wait)
 
     async def _monitoring_tick(self, updated_entries):
         now = timestamp()
@@ -131,5 +131,6 @@ class SyncMonitor(BaseAsyncComponent):
 
 
 async def monitor_sync(backend_online, fs, event_bus, *, task_status=trio.TASK_STATUS_IGNORED):
-    sync_monitor = SyncMonitor(backend_online, fs, event_bus)
-    await sync_monitor.run(task_status=task_status)
+    with event_bus.connection_context() as event_bus_ctx:
+        sync_monitor = SyncMonitor(backend_online, fs, event_bus_ctx)
+        await sync_monitor.run(task_status=task_status)

--- a/parsec/event_bus.py
+++ b/parsec/event_bus.py
@@ -82,5 +82,5 @@ class EventBus:
 
     def disconnect(self, event, cb):
         # logger.debug("disconnect event", event_name=event, cb=cb)
-        self._event_handlers[event].discard(cb)
+        self._event_handlers[event].remove(cb)
         self.send("event.disconnected", event_name=event)

--- a/tests/backend/test_events.py
+++ b/tests/backend/test_events.py
@@ -25,8 +25,7 @@ async def events_subscribe(sock, **kwargs):
 
 async def events_listen_nowait(sock):
     await sock.send(events_listen_serializer.req_dumps({"cmd": "events_listen", "wait": False}))
-    with trio.fail_after(1):
-        raw_rep = await sock.recv()
+    raw_rep = await sock.recv()
     return events_listen_serializer.rep_loads(raw_rep)
 
 
@@ -130,7 +129,7 @@ async def test_event_resubscribe(backend, alice_backend_sock, alice2_backend_soc
     await subscribe_pinged(alice_backend_sock, ["bar", "spam"])
 
     with backend.event_bus.listen() as spy:
-        await ping(alice2_backend_sock, "foo")
+        await ping(alice2_backend_sock, "foo")  # Should be ignored
         await ping(alice2_backend_sock, "bar")
         await ping(alice2_backend_sock, "spam")
 

--- a/tests/core/test_cross_cores_sync.py
+++ b/tests/core/test_cross_cores_sync.py
@@ -29,9 +29,13 @@ async def wait_for_entries_synced(core, entries_pathes):
         if synced == to_sync:
             event.set()
 
-    core.signal_ns.connect("fs.entry.synced", _on_entry_synced, weak=True)
-    yield event
-    await event.wait()
+    core.signal_ns.connect("fs.entry.synced", _on_entry_synced)
+    try:
+        yield event
+        await event.wait()
+
+    finally:
+        core.signal_ns.disconnect("fs.entry.synced", _on_entry_synced)
 
 
 # @pytest.mark.trio

--- a/tests/event_bus_spy.py
+++ b/tests/event_bus_spy.py
@@ -152,5 +152,8 @@ class SpiedEventBus(EventBus):
     @contextmanager
     def listen(self):
         spy = self.create_spy()
-        yield spy
-        self.destroy_spy(spy)
+        try:
+            yield spy
+
+        finally:
+            self.destroy_spy(spy)

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1,0 +1,128 @@
+# Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
+
+import pytest
+import trio
+
+
+@pytest.mark.trio
+async def test_waiter_on(event_bus):
+    async def _trigger(id):
+        await trio.sleep(0)
+        event_bus.send("foo", id=id)
+
+    async with trio.open_nursery() as nursery:
+
+        with event_bus.waiter_on("foo") as waiter:
+            nursery.start_soon(_trigger, 1)
+            event = await waiter.wait()
+            assert event == ("foo", {"id": 1})
+
+            # Event is ignored
+            event_bus.send("foo", id=2)
+            same_event = await waiter.wait()
+            assert same_event == event
+
+            waiter.clear()
+            nursery.start_soon(_trigger, 3)
+            event = await waiter.wait()
+            assert event == ("foo", {"id": 3})
+
+        assert event_bus.stats() == {}
+
+
+@pytest.mark.trio
+async def test_waiter_on_filter(event_bus):
+    async def _triggers():
+        await trio.sleep(0)
+        event_bus.send("foo", id=1)
+        event_bus.send("foo", id=42)
+
+    async with trio.open_nursery() as nursery:
+
+        with event_bus.waiter_on("foo", filter=lambda event, id: id == 42) as waiter:
+            nursery.start_soon(_triggers)
+            event = await waiter.wait()
+            assert event == ("foo", {"id": 42})
+
+
+@pytest.mark.trio
+async def test_waiter_on_first(event_bus):
+    async def _trigger(event, id):
+        await trio.sleep(0)
+        event_bus.send(event, id=id)
+
+    async with trio.open_nursery() as nursery:
+
+        with event_bus.waiter_on_first("foo", "bar") as waiter:
+            nursery.start_soon(_trigger, "foo", 1)
+            event = await waiter.wait()
+            assert event == ("foo", {"id": 1})
+
+            # Event is ignored
+            event_bus.send("bar", id=2)
+            same_event = await waiter.wait()
+            assert same_event == event
+
+            waiter.clear()
+            nursery.start_soon(_trigger, "bar", 3)
+            event = await waiter.wait()
+            assert event == ("bar", {"id": 3})
+
+        assert event_bus.stats() == {}
+
+
+@pytest.mark.trio
+async def test_waiter_on_first_filter(event_bus):
+    async def _triggers():
+        await trio.sleep(0)
+        event_bus.send("foo", id=1)
+        event_bus.send("bar", id=42)
+
+    async with trio.open_nursery() as nursery:
+
+        with event_bus.waiter_on_first("foo", "bar", filter=lambda event, id: id == 42) as waiter:
+            nursery.start_soon(_triggers)
+            event = await waiter.wait()
+            assert event == ("bar", {"id": 42})
+
+
+def test_connection_context(event_bus):
+    events_received = []
+
+    def _listen_from_global(event):
+        events_received.append(("global", event))
+
+    def _listen_from_context(event):
+        events_received.append(("ctx", event))
+
+    event_bus.connect("foo", _listen_from_global)
+
+    with event_bus.connection_context() as event_bus_ctx:
+        event_bus_ctx.connect("foo", _listen_from_context)
+        event_bus_ctx.connect("bar", _listen_from_context)
+
+        assert event_bus.stats() == {"foo": 2, "bar": 1}
+
+        event_bus.send("foo")
+        assert events_received == [("global", "foo"), ("ctx", "foo")]
+
+        events_received.clear()
+        event_bus_ctx.send("foo")
+        assert events_received == [("global", "foo"), ("ctx", "foo")]
+
+        events_received.clear()
+        event_bus_ctx.send("bar")
+        assert events_received == [("ctx", "bar")]
+
+        event_bus_ctx.disconnect("foo", _listen_from_context)
+        events_received.clear()
+        event_bus_ctx.send("foo")
+        assert events_received == [("global", "foo")]
+
+        assert event_bus.stats() == {"foo": 1, "bar": 1}
+
+    assert event_bus.stats() == {"foo": 1}
+
+    events_received.clear()
+    event_bus_ctx.send("foo")
+    assert events_received == [("global", "foo")]


### PR DESCRIPTION
J'ai eu un bug très bizarre sous windows: la configuration de structlog semble sauvegarder des frames (j'imagine que c'est en rapport avec pytest qui garde en cache les logs, ceux-ci n'étant pas formattés en string à ce moment...)
De fait si la frame de `EventsComponent.api_events_subscribe` se fait enregistrée, elle garde une référence sur les callbacks des events. Du coup si on essait de remplacer ces callbacks, ceux-ci restent vivant...

config:
```
# python --version
Python 3.6.5
# pip freeze | grep -i pytest
pytest==4.2.0
pytest-cov==2.6.0
pytest-forked==0.2
pytest-logbook==1.2.0
pytest-trio==0.5.1
pytest-xdist==1.24.1
pip freeze | grep structlog
structlog==18.2.0
```

Au final pas sûr que cette PR doit être mergée (je n'ai corrigé que les events sur backend car c'est ceux qui provoquent le bug, mais il y a aussi des weak refs dans le core donc à corriger potentiellement...)