### PR TITLE
Rework handshake

### DIFF
--- a/misc/initialize_test_organization.py
+++ b/misc/initialize_test_organization.py
@@ -18,7 +18,7 @@ from parsec.core.config import get_default_config_dir, load_config
 from parsec.core.backend_connection import (
     BackendCmdsBadResponse,
     backend_cmds_factory,
-    backend_administrator_cmds_factory,
+    backend_administration_cmds_factory,
     backend_anonymous_cmds_factory,
 )
 from parsec.core.devices_manager import generate_new_device, save_device_with_password
@@ -26,7 +26,7 @@ from parsec.core.devices_manager import load_device_with_password
 from parsec.core.invite_claim import generate_invitation_token, invite_and_create_device
 from parsec.core.invite_claim import invite_and_create_user, claim_device, claim_user
 
-from parsec.backend.config import DEFAULT_ADMINISTRATOR_TOKEN
+from parsec.backend.config import DEFAULT_ADMINISTRATION_TOKEN
 
 
 async def retry(corofn, *args, retries=10, tick=0.1):
@@ -80,7 +80,7 @@ async def amain(
     alice_workspace="alicews",
     bob_workspace="bobws",
     password="test",
-    administrator_token=DEFAULT_ADMINISTRATOR_TOKEN,
+    administration_token=DEFAULT_ADMINISTRATION_TOKEN,
     force=False,
 ):
 
@@ -96,7 +96,7 @@ async def amain(
 
     # Create organization
 
-    async with backend_administrator_cmds_factory(backend_address, administrator_token) as cmds:
+    async with backend_administration_cmds_factory(backend_address, administration_token) as cmds:
 
         bootstrap_token = await cmds.organization_create(organization_id)
 

--- a/parsec/api/protocole/__init__.py
+++ b/parsec/api/protocole/__init__.py
@@ -13,8 +13,9 @@ from parsec.api.protocole.handshake import (
     HandshakeBadIdentity,
     HandshakeRevokedDevice,
     ServerHandshake,
-    ClientHandshake,
+    AuthenticatedClientHandshake,
     AnonymousClientHandshake,
+    AdministrationClientHandshake,
 )
 from parsec.api.protocole.organization import (
     organization_create_serializer,
@@ -61,8 +62,9 @@ __all__ = (
     "HandshakeBadIdentity",
     "HandshakeRevokedDevice",
     "ServerHandshake",
-    "ClientHandshake",
+    "AuthenticatedClientHandshake",
     "AnonymousClientHandshake",
+    "AdministrationClientHandshake",
     # Organization
     "organization_create_serializer",
     "organization_bootstrap_serializer",

--- a/parsec/api/protocole/handshake.py
+++ b/parsec/api/protocole/handshake.py
@@ -4,7 +4,7 @@ import attr
 from secrets import token_bytes
 
 from parsec.crypto import CryptoError
-from parsec.serde import UnknownCheckedSchema, fields
+from parsec.serde import UnknownCheckedSchema, OneOfSchema, fields
 from parsec.api.protocole.base import ProtocoleError, InvalidMessageError, serializer_factory
 
 
@@ -13,6 +13,10 @@ class HandshakeError(ProtocoleError):
 
 
 class HandshakeFailedChallenge(HandshakeError):
+    pass
+
+
+class HandshakeBadAdministrationToken(HandshakeError):
     pass
 
 
@@ -36,12 +40,40 @@ class HandshakeChallengeSchema(UnknownCheckedSchema):
 handshake_challenge_serializer = serializer_factory(HandshakeChallengeSchema)
 
 
-class HandshakeAnswerSchema(UnknownCheckedSchema):
+class HandshakeAuthenticatedAnswerSchema(UnknownCheckedSchema):
     handshake = fields.CheckedConstant("answer", required=True)
+    type = fields.CheckedConstant("authenticated", required=True)
     organization_id = fields.OrganizationID(required=True)
-    device_id = fields.DeviceID(allow_none=True, missing=None)
-    rvk = fields.VerifyKey(allow_none=True, missing=None)
-    answer = fields.Bytes(allow_none=True, missing=None)
+    device_id = fields.DeviceID(required=True)
+    rvk = fields.VerifyKey(required=True)
+    answer = fields.Bytes(required=True)
+
+
+class HandshakeAnonymousAnswerSchema(UnknownCheckedSchema):
+    handshake = fields.CheckedConstant("answer", required=True)
+    type = fields.CheckedConstant("anonymous", required=True)
+    organization_id = fields.OrganizationID(required=True)
+    # Cannot provide rvk during organization bootstrap
+    rvk = fields.VerifyKey(missing=None)
+
+
+class HandshakeAdministrationAnswerSchema(UnknownCheckedSchema):
+    handshake = fields.CheckedConstant("answer", required=True)
+    type = fields.CheckedConstant("administration", required=True)
+    token = fields.String(required=True)
+
+
+class HandshakeAnswerSchema(OneOfSchema):
+    type_field = "type"
+    type_field_remove = False
+    type_schemas = {
+        "authenticated": HandshakeAuthenticatedAnswerSchema(),
+        "anonymous": HandshakeAnonymousAnswerSchema(),
+        "administration": HandshakeAdministrationAnswerSchema(),
+    }
+
+    def get_obj_type(self, obj):
+        return obj["type"]
 
 
 handshake_answer_serializer = serializer_factory(HandshakeAnswerSchema)
@@ -60,9 +92,8 @@ handshake_result_serializer = serializer_factory(HandshakeResultSchema)
 class ServerHandshake:
     challenge_size = attr.ib(default=48)
     challenge = attr.ib(default=None)
-    answer = attr.ib(default=None)
-    device_id = attr.ib(default=None)
-    root_verify_key = attr.ib(default=None)
+    answer_type = attr.ib(default=None)
+    answer_data = attr.ib(default=None)
     state = attr.ib(default="stalled")
 
     def is_anonymous(self):
@@ -85,14 +116,9 @@ class ServerHandshake:
 
         data = handshake_answer_serializer.loads(req)
 
-        defined_fields = [x for x in [data["device_id"], data["answer"]] if x]
-        if len(defined_fields) not in (0, 2):
-            raise InvalidMessageError("Field device_id and answer must be set together")
-
-        self.answer = data["answer"] or b""
-        self.organization_id = data["organization_id"]
-        self.root_verify_key = data["rvk"]
-        self.device_id = data["device_id"]
+        data.pop("handshake")
+        self.answer_type = data.pop("type")
+        self.answer_data = data
         self.state = "answer"
 
     def build_bad_format_result_req(self, help="Invalid params") -> bytes:
@@ -102,6 +128,17 @@ class ServerHandshake:
         self.state = "result"
         return handshake_result_serializer.dumps(
             {"handshake": "result", "result": "bad_format", "help": help}
+        )
+
+    def build_bad_administration_token_result_req(
+        self, help="Invalid administration token"
+    ) -> bytes:
+        if not self.state == "answer":
+            raise HandshakeError("Invalid state.")
+
+        self.state = "result"
+        return handshake_result_serializer.dumps(
+            {"handshake": "result", "result": "bad_admin_token", "help": help}
         )
 
     def build_bad_identity_result_req(self, help="Unknown Organization or Device") -> bytes:
@@ -140,9 +177,14 @@ class ServerHandshake:
         if not self.state == "answer":
             raise HandshakeError("Invalid state.")
 
-        if verify_key:
+        if self.answer_type == "authenticated":
+            if not verify_key:
+                raise HandshakeError(
+                    "`verify_key` param must be provided for authenticated handshake"
+                )
+
             try:
-                returned_challenge = verify_key.verify(self.answer)
+                returned_challenge = verify_key.verify(self.answer_data["answer"])
                 if returned_challenge != self.challenge:
                     raise HandshakeFailedChallenge("Invalid returned challenge")
 
@@ -153,26 +195,7 @@ class ServerHandshake:
         return handshake_result_serializer.dumps({"handshake": "result", "result": "ok"})
 
 
-@attr.s
-class ClientHandshake:
-    organization_id = attr.ib()
-    device_id = attr.ib()
-    user_signkey = attr.ib()
-    root_verify_key = attr.ib()
-
-    def process_challenge_req(self, req: bytes) -> bytes:
-        data = handshake_challenge_serializer.loads(req)
-        answer = self.user_signkey.sign(data["challenge"])
-        return handshake_answer_serializer.dumps(
-            {
-                "handshake": "answer",
-                "organization_id": self.organization_id,
-                "device_id": self.device_id,
-                "rvk": self.root_verify_key,
-                "answer": answer,
-            }
-        )
-
+class BaseClientHandshake:
     def process_result_req(self, req: bytes) -> bytes:
         data = handshake_result_serializer.loads(req)
         if data["result"] != "ok":
@@ -185,6 +208,9 @@ class ClientHandshake:
             elif data["result"] == "revoked_device":
                 raise HandshakeRevokedDevice(data["help"])
 
+            if data["result"] == "bad_admin_token":
+                raise HandshakeBadAdministrationToken(data["help"])
+
             else:
                 raise InvalidMessageError(
                     f"Bad `result` handshake: {data['result']} ({data['help']})"
@@ -192,7 +218,29 @@ class ClientHandshake:
 
 
 @attr.s
-class AnonymousClientHandshake:
+class AuthenticatedClientHandshake(BaseClientHandshake):
+    organization_id = attr.ib()
+    device_id = attr.ib()
+    user_signkey = attr.ib()
+    root_verify_key = attr.ib()
+
+    def process_challenge_req(self, req: bytes) -> bytes:
+        data = handshake_challenge_serializer.loads(req)
+        answer = self.user_signkey.sign(data["challenge"])
+        return handshake_answer_serializer.dumps(
+            {
+                "handshake": "answer",
+                "type": "authenticated",
+                "organization_id": self.organization_id,
+                "device_id": self.device_id,
+                "rvk": self.root_verify_key,
+                "answer": answer,
+            }
+        )
+
+
+@attr.s
+class AnonymousClientHandshake(BaseClientHandshake):
     organization_id = attr.ib()
     root_verify_key = attr.ib(default=None)
 
@@ -201,21 +249,19 @@ class AnonymousClientHandshake:
         return handshake_answer_serializer.dumps(
             {
                 "handshake": "answer",
+                "type": "anonymous",
                 "organization_id": self.organization_id,
                 "rvk": self.root_verify_key,
             }
         )
 
-    def process_result_req(self, req: bytes) -> bytes:
-        data = handshake_result_serializer.loads(req)
-        if data["result"] != "ok":
-            if data["result"] == "bad_identity":
-                raise HandshakeBadIdentity(data["help"])
 
-            elif data["result"] == "rvk_mismatch":
-                raise HandshakeRVKMismatch(data["help"])
+@attr.s
+class AdministrationClientHandshake(BaseClientHandshake):
+    token = attr.ib()
 
-            else:
-                raise InvalidMessageError(
-                    f"Bad `result` handshake: {data['result']} ({data['help']})"
-                )
+    def process_challenge_req(self, req: bytes) -> bytes:
+        handshake_challenge_serializer.loads(req)  # Sanity check
+        return handshake_answer_serializer.dumps(
+            {"handshake": "answer", "type": "administration", "token": self.token}
+        )

--- a/parsec/backend/config.py
+++ b/parsec/backend/config.py
@@ -6,12 +6,11 @@ import itertools
 from typing import List
 from collections import defaultdict
 
-
 __all__ = ("config_factory", "BackendConfig", "BaseBlockstoreConfig")
 
 
 # Must be changed in production obviously !!!
-DEFAULT_ADMINISTRATOR_TOKEN = "CCDCC27B6108438D99EF8AF5E847C3BB"
+DEFAULT_ADMINISTRATION_TOKEN = "CCDCC27B6108438D99EF8AF5E847C3BB"
 
 
 blockstore_environ_vars = {
@@ -159,7 +158,7 @@ class MockedBlockstoreConfig(BaseBlockstoreConfig):
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)
 class BackendConfig:
-    administrator_token: str = None
+    administration_token: str = None
 
     db_url: str = None
     db_type: str = None
@@ -188,7 +187,9 @@ def config_factory(
     config["blockstore_config"] = _extract_blockstore_config(blockstore_type, environ)
 
     # TODO: turn this mandatory to avoid misconfiguration ?
-    config["administrator_token"] = environ.get("ADMINISTRATOR_TOKEN", DEFAULT_ADMINISTRATOR_TOKEN)
+    config["administration_token"] = environ.get(
+        "ADMINISTRATION_TOKEN", DEFAULT_ADMINISTRATION_TOKEN
+    )
 
     config["sentry_url"] = environ.get("SENTRY_URL") or None
 

--- a/parsec/core/backend_connection/__init__.py
+++ b/parsec/core/backend_connection/__init__.py
@@ -12,7 +12,7 @@ from parsec.core.backend_connection.exceptions import (
 from parsec.core.backend_connection.transport import (
     authenticated_transport_factory,
     anonymous_transport_factory,
-    administrator_transport_factory,
+    administration_transport_factory,
     transport_pool_factory,
     TransportPool,
 )
@@ -23,8 +23,8 @@ from parsec.core.backend_connection.porcelain import (
     backend_cmds_factory,
     BackendAnonymousCmds,
     backend_anonymous_cmds_factory,
-    BackendAdministratorCmds,
-    backend_administrator_cmds_factory,
+    BackendAdministrationCmds,
+    backend_administration_cmds_factory,
 )
 
 
@@ -38,7 +38,7 @@ __all__ = (
     "BackendCmdsBadResponse",
     "authenticated_transport_factory",
     "anonymous_transport_factory",
-    "administrator_transport_factory",
+    "administration_transport_factory",
     "transport_pool_factory",
     "TransportPool",
     "backend_listen_events",
@@ -50,6 +50,6 @@ __all__ = (
     "backend_cmds_factory",
     "BackendAnonymousCmds",
     "backend_anonymous_cmds_factory",
-    "BackendAdministratorCmds",
-    "backend_administrator_cmds_factory",
+    "BackendAdministrationCmds",
+    "backend_administration_cmds_factory",
 )

--- a/parsec/core/backend_connection/porcelain.py
+++ b/parsec/core/backend_connection/porcelain.py
@@ -9,7 +9,7 @@ from parsec.core.backend_connection.exceptions import BackendNotAvailable
 from parsec.core.backend_connection.transport import (
     transport_pool_factory,
     anonymous_transport_factory,
-    administrator_transport_factory,
+    administration_transport_factory,
     TransportError,
 )
 from parsec.core.backend_connection import cmds
@@ -104,7 +104,7 @@ class BackendAnonymousCmds:
     device_claim = _expose_cmds("device_claim")
 
 
-class BackendAdministratorCmds:
+class BackendAdministrationCmds:
     def __init__(self, addr, transport):
         self.addr = addr
         self.transport = transport
@@ -141,11 +141,11 @@ async def backend_anonymous_cmds_factory(addr: BackendOrganizationAddr) -> Backe
 
 
 @asynccontextmanager
-async def backend_administrator_cmds_factory(
+async def backend_administration_cmds_factory(
     addr: BackendAddr, token: str
-) -> BackendAdministratorCmds:
+) -> BackendAdministrationCmds:
     try:
-        async with administrator_transport_factory(addr, token) as transport:
-            yield BackendAdministratorCmds(addr, transport)
+        async with administration_transport_factory(addr, token) as transport:
+            yield BackendAdministrationCmds(addr, transport)
     except TransportError as exc:
         raise BackendNotAvailable(exc) from exc

--- a/parsec/core/cli/create_organization.py
+++ b/parsec/core/cli/create_organization.py
@@ -7,12 +7,12 @@ import click
 from parsec.types import OrganizationID, BackendAddr, BackendOrganizationBootstrapAddr
 from parsec.logging import configure_logging
 from parsec.cli_utils import spinner, cli_exception_handler
-from parsec.core.backend_connection import backend_administrator_cmds_factory
+from parsec.core.backend_connection import backend_administration_cmds_factory
 
 
-async def _create_organization(debug, name, backend_addr, administrator_token):
+async def _create_organization(debug, name, backend_addr, administration_token):
     async with spinner("Creating organization in backend"):
-        async with backend_administrator_cmds_factory(backend_addr, administrator_token) as cmds:
+        async with backend_administration_cmds_factory(backend_addr, administration_token) as cmds:
             bootstrap_token = await cmds.organization_create(name)
 
     organization_addr = BackendOrganizationBootstrapAddr.build(backend_addr, name, bootstrap_token)
@@ -23,10 +23,10 @@ async def _create_organization(debug, name, backend_addr, administrator_token):
 @click.command(short_help="create new organization")
 @click.argument("name", required=True, type=OrganizationID)
 @click.option("--addr", "-B", required=True, type=BackendAddr)
-@click.option("--administrator-token", "-T", required=True)
-def create_organization(name, addr, administrator_token):
+@click.option("--administration-token", "-T", required=True)
+def create_organization(name, addr, administration_token):
     debug = "DEBUG" in os.environ
     configure_logging(log_level="DEBUG" if debug else "WARNING")
 
     with cli_exception_handler(debug):
-        trio.run(_create_organization, debug, name, addr, administrator_token)
+        trio.run(_create_organization, debug, name, addr, administration_token)

--- a/tests/backend/test_handshake.py
+++ b/tests/backend/test_handshake.py
@@ -5,42 +5,28 @@ import pytest
 from parsec.api.protocole import packb, unpackb
 from parsec.api.transport import Transport
 from parsec.api.protocole.handshake import (
-    ClientHandshake,
+    AuthenticatedClientHandshake,
     AnonymousClientHandshake,
+    AdministrationClientHandshake,
     HandshakeRVKMismatch,
+    HandshakeBadIdentity,
+    HandshakeBadAdministrationToken,
 )
 
 
-# @pytest.mark.trio
-# @pytest.mark.parametrize("bad_part", ["user_id", "device_name"])
-# async def test_handshake_unknown_device(bad_part, backend, server_factory, alice):
-#     async with server_factory(backend.handle_client) as server:
-#         stream = server.connection_factory()
-#         transport = await Transport.init_for_client(stream, server.addr)
-#         if bad_part == "user_id":
-#             identity = "zack@dummy"
-#         else:
-#             identity = f"{alice.user_id}@dummy"
-
-#         await transport.recv()  # Get challenge
-#         await transport.send(
-#             packb({"handshake": "answer",
-#                 "identity": identity,
-#                 "organization":
-#                 "answer": b"fooo"})
-#         )
-#         result_req = await transport.recv()
-#         assert unpackb(result_req) == {"handshake": "result", "result": "bad_identity"}
-
-
 @pytest.mark.trio
-async def test_handshake_invalid_format(backend, server_factory):
+async def test_anonymous_handshake_invalid_format(backend, server_factory):
     async with server_factory(backend.handle_client) as server:
         stream = server.connection_factory()
         transport = await Transport.init_for_client(stream, server.addr)
 
         await transport.recv()  # Get challenge
-        req = {"handshake": "answer", "organization_id": "zob", "dummy": "field"}
+        req = {
+            "handshake": "answer",
+            "type": "anonymous",
+            "organization_id": "zob",
+            "dummy": "field",
+        }
         await transport.send(packb(req))
         result_req = await transport.recv()
         assert unpackb(result_req) == {
@@ -51,8 +37,8 @@ async def test_handshake_invalid_format(backend, server_factory):
 
 
 @pytest.mark.trio
-async def test_handshake_good(backend, server_factory, alice):
-    ch = ClientHandshake(
+async def test_authenticated_handshake_good(backend, server_factory, alice):
+    ch = AuthenticatedClientHandshake(
         alice.organization_id, alice.device_id, alice.signing_key, alice.root_verify_key
     )
     async with server_factory(backend.handle_client) as server:
@@ -68,16 +54,44 @@ async def test_handshake_good(backend, server_factory, alice):
 
 
 @pytest.mark.trio
+async def test_administration_handshake_good(backend, server_factory):
+    ch = AdministrationClientHandshake(backend.config.administration_token)
+    async with server_factory(backend.handle_client) as server:
+        stream = server.connection_factory()
+        transport = await Transport.init_for_client(stream, server.addr)
+
+        challenge_req = await transport.recv()
+        answer_req = ch.process_challenge_req(challenge_req)
+
+        await transport.send(answer_req)
+        result_req = await transport.recv()
+        ch.process_result_req(result_req)
+
+
+@pytest.mark.trio
+async def test_admin_handshake_bad_token(backend, server_factory):
+    ch = AdministrationClientHandshake("dummy token")
+    async with server_factory(backend.handle_client) as server:
+        stream = server.connection_factory()
+        transport = await Transport.init_for_client(stream, server.addr)
+
+        challenge_req = await transport.recv()
+        answer_req = ch.process_challenge_req(challenge_req)
+
+        await transport.send(answer_req)
+        result_req = await transport.recv()
+        with pytest.raises(HandshakeBadAdministrationToken):
+            ch.process_result_req(result_req)
+
+
+@pytest.mark.trio
 @pytest.mark.parametrize("is_anonymous", [True, False])
-async def test_handshake_mismatch_rvc(
-    backend, server_factory, coolorg, alice, organization_factory, is_anonymous
-):
-    badorg = organization_factory()
+async def test_handshake_bad_rvk(backend, server_factory, coolorg, alice, otherorg, is_anonymous):
     if is_anonymous:
-        ch = AnonymousClientHandshake(coolorg.organization_id, badorg.root_verify_key)
+        ch = AnonymousClientHandshake(coolorg.organization_id, otherorg.root_verify_key)
     else:
-        ch = ClientHandshake(
-            alice.organization_id, alice.device_id, alice.signing_key, badorg.root_verify_key
+        ch = AuthenticatedClientHandshake(
+            alice.organization_id, alice.device_id, alice.signing_key, otherorg.root_verify_key
         )
     async with server_factory(backend.handle_client) as server:
         stream = server.connection_factory()
@@ -89,4 +103,81 @@ async def test_handshake_mismatch_rvc(
         await transport.send(answer_req)
         result_req = await transport.recv()
         with pytest.raises(HandshakeRVKMismatch):
+            ch.process_result_req(result_req)
+
+
+@pytest.mark.trio
+@pytest.mark.parametrize("check_rvk", [True, False])
+async def test_anonymous_handshake_good(backend, server_factory, coolorg, check_rvk):
+    to_check_rvk = coolorg.root_verify_key if check_rvk else None
+    ch = AnonymousClientHandshake(coolorg.organization_id, to_check_rvk)
+    async with server_factory(backend.handle_client) as server:
+        stream = server.connection_factory()
+        transport = await Transport.init_for_client(stream, server.addr)
+
+        challenge_req = await transport.recv()
+        answer_req = ch.process_challenge_req(challenge_req)
+
+        await transport.send(answer_req)
+        result_req = await transport.recv()
+        ch.process_result_req(result_req)
+
+
+@pytest.mark.trio
+async def test_anonymous_handshake_bad_rvk(backend, server_factory, coolorg, otherorg):
+    ch = AnonymousClientHandshake(coolorg.organization_id, otherorg.root_verify_key)
+    async with server_factory(backend.handle_client) as server:
+        stream = server.connection_factory()
+        transport = await Transport.init_for_client(stream, server.addr)
+
+        challenge_req = await transport.recv()
+        answer_req = ch.process_challenge_req(challenge_req)
+
+        await transport.send(answer_req)
+        result_req = await transport.recv()
+        with pytest.raises(HandshakeRVKMismatch):
+            ch.process_result_req(result_req)
+
+
+@pytest.mark.trio
+@pytest.mark.parametrize("type", ["anonymous", "authenticated"])
+async def test_anonymous_handshake_unknown_organization(
+    backend, server_factory, organization_factory, alice, type
+):
+    bad_org = organization_factory()
+    if type == "anonymous":
+        ch = AnonymousClientHandshake(bad_org.organization_id, bad_org.root_verify_key)
+    else:  # authenticated
+        ch = AuthenticatedClientHandshake(
+            bad_org.organization_id, alice.device_id, alice.signing_key, bad_org.root_verify_key
+        )
+
+    async with server_factory(backend.handle_client) as server:
+        stream = server.connection_factory()
+        transport = await Transport.init_for_client(stream, server.addr)
+
+        challenge_req = await transport.recv()
+        answer_req = ch.process_challenge_req(challenge_req)
+
+        await transport.send(answer_req)
+        result_req = await transport.recv()
+        with pytest.raises(HandshakeBadIdentity):
+            ch.process_result_req(result_req)
+
+
+@pytest.mark.trio
+async def test_authenticated_handshake_unknown_device(backend, server_factory, mallory):
+    ch = AuthenticatedClientHandshake(
+        mallory.organization_id, mallory.device_id, mallory.signing_key, mallory.root_verify_key
+    )
+    async with server_factory(backend.handle_client) as server:
+        stream = server.connection_factory()
+        transport = await Transport.init_for_client(stream, server.addr)
+
+        challenge_req = await transport.recv()
+        answer_req = ch.process_challenge_req(challenge_req)
+
+        await transport.send(answer_req)
+        result_req = await transport.recv()
+        with pytest.raises(HandshakeBadIdentity):
             ch.process_result_req(result_req)

--- a/tests/backend/test_organization.py
+++ b/tests/backend/test_organization.py
@@ -42,14 +42,14 @@ async def organization_bootstrap(
 
 
 @pytest.mark.trio
-async def test_organization_create_already_exists(administrator_backend_sock, coolorg):
-    rep = await organization_create(administrator_backend_sock, coolorg.organization_id)
+async def test_organization_create_already_exists(administration_backend_sock, coolorg):
+    rep = await organization_create(administration_backend_sock, coolorg.organization_id)
     assert rep["status"] == "already_exists"
 
 
 @pytest.mark.trio
-async def test_organization_create_bad_name(administrator_backend_sock):
-    rep = await organization_create(administrator_backend_sock, "a" * 33)
+async def test_organization_create_bad_name(administration_backend_sock):
+    rep = await organization_create(administration_backend_sock, "a" * 33)
     assert rep["status"] == "bad_message"
 
 
@@ -59,7 +59,7 @@ async def test_organization_create_and_bootstrap(
     organization_factory,
     local_device_factory,
     alice,
-    administrator_backend_sock,
+    administration_backend_sock,
     backend_sock_factory,
 ):
     neworg = organization_factory("NewOrg")
@@ -67,7 +67,7 @@ async def test_organization_create_and_bootstrap(
     # 1) Create organization, note this means `neworg.bootstrap_token`
     # will contain an invalid token
 
-    rep = await organization_create(administrator_backend_sock, neworg.organization_id)
+    rep = await organization_create(administration_backend_sock, neworg.organization_id)
     assert rep == {"status": "ok", "bootstrap_token": ANY}
     bootstrap_token = rep["bootstrap_token"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,11 @@ from parsec.core import CoreConfig
 from parsec.core.logged_core import logged_core_factory
 from parsec.core.mountpoint import get_mountpoint_runner
 from parsec.backend import BackendApp, config_factory as backend_config_factory
-from parsec.api.protocole import ClientHandshake, AnonymousClientHandshake
+from parsec.api.protocole import (
+    AdministrationClientHandshake,
+    AuthenticatedClientHandshake,
+    AnonymousClientHandshake,
+)
 from parsec.api.transport import Transport
 
 # TODO: needed ?
@@ -391,10 +395,10 @@ def backend_sock_factory(server_factory, coolorg):
                 elif auth_as == "anonymous":
                     # TODO: for legacy test, refactorise this ?
                     ch = AnonymousClientHandshake(coolorg.organization_id)
-                elif auth_as == "administrator":
-                    ch = AnonymousClientHandshake(backend.config.administrator_token)
+                elif auth_as == "administration":
+                    ch = AdministrationClientHandshake(backend.config.administration_token)
                 else:
-                    ch = ClientHandshake(
+                    ch = AuthenticatedClientHandshake(
                         auth_as.organization_id,
                         auth_as.device_id,
                         auth_as.signing_key,
@@ -418,8 +422,8 @@ async def anonymous_backend_sock(backend_sock_factory, backend):
 
 
 @pytest.fixture
-async def administrator_backend_sock(backend_sock_factory, backend):
-    async with backend_sock_factory(backend, "administrator") as sock:
+async def administration_backend_sock(backend_sock_factory, backend):
+    async with backend_sock_factory(backend, "administration") as sock:
         yield sock
 
 

--- a/tests/core/backend_connection/test_base.py
+++ b/tests/core/backend_connection/test_base.py
@@ -5,7 +5,7 @@ import pytest
 from parsec.core.backend_connection import (
     backend_cmds_factory,
     backend_anonymous_cmds_factory,
-    backend_administrator_cmds_factory,
+    backend_administration_cmds_factory,
 )
 
 
@@ -17,9 +17,9 @@ async def test_anonymous_ping(running_backend, coolorg):
 
 
 @pytest.mark.trio
-async def test_administrator_ping(running_backend, backend_addr, backend):
-    async with backend_administrator_cmds_factory(
-        backend_addr, backend.config.administrator_token
+async def test_administration_ping(running_backend, backend_addr, backend):
+    async with backend_administration_cmds_factory(
+        backend_addr, backend.config.administration_token
     ) as cmds:
         pong = await cmds.ping("Hello World !")
         assert pong == "Hello World !"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ from click.testing import CliRunner
 
 import parsec
 from parsec.cli import cli
-from parsec.backend.config import DEFAULT_ADMINISTRATOR_TOKEN
+from parsec.backend.config import DEFAULT_ADMINISTRATION_TOKEN
 
 
 CWD = Path(__file__).parent.parent
@@ -161,7 +161,7 @@ def test_full_run(alice, alice2, bob, unused_tcp_port, tmpdir):
         p = _run(
             "core create_organization "
             f"{org} --addr=ws://localhost:{unused_tcp_port} "
-            f"--administrator-token={DEFAULT_ADMINISTRATOR_TOKEN}"
+            f"--administration-token={DEFAULT_ADMINISTRATION_TOKEN}"
         )
         url = re.search(
             r"^Bootstrap organization url: (.*)$", p.stdout.decode(), re.MULTILINE


### PR DESCRIPTION
divide between anonymous/authenticated/administration on authentications

Le système d'authentification manquait de clarté dans certains cas: le token d'administration été passé comme si c'était un organization_id, du coup si le token configuré n'a pas le format d'un OrganizationID (si il est trop long typiquement), on se retrouve avec des erreurs vraiment pas clair:
```
(venv) ~/projects/parsec-cloud rework-blockstore ⇈6±29*90 ♦ parsec core create_organization Org42 --addr ws://localhost:6777 -T <bad-token>
Creating organization in backend ⠦2019-02-28 10:33:45 [warning  ] Handshake failed               [parsec.api.transport] conn_id=035e7a6055224b21ba311a8da3738ca5 reason=InvalidMessageError("Bad `result` handshake: bad_format ({'organization_id': ['Invalid organization ID']})",)
Creating organization in backend ✘
Error: Bad `result` handshake: bad_format ({'organization_id': ['Invalid organization ID']})
```

Alors que maintenant:
```
(venv) ~/projects/parsec-cloud master *90 ♦ parsec core create_organization Org42 --addr ws://localhost:6777 -T <bad-token>
Creating organization in backend ⠋2019-02-28 12:43:33 [warning  ] Handshake failed               [parsec.api.transport] conn_id=bfdf369f54224ebc8372541e79fdbf02 reason=HandshakeBadAdministrationToken('Invalid administration token',)
Creating organization in backend ✘
Error: Invalid administration token
```