### PR TITLE
Correct misspelling revocated -> revoked

### DIFF
--- a/parsec/api/protocole/user.py
+++ b/parsec/api/protocole/user.py
@@ -25,7 +25,7 @@ class DeviceSchema(UnknownCheckedSchema):
     device_id = fields.DeviceID(required=True)
     created_on = fields.DateTime(required=True)
 
-    revocated_on = fields.DateTime(allow_none=True)
+    revoked_on = fields.DateTime(allow_none=True)
     certified_revocation = fields.Bytes(allow_none=True)
     revocation_certifier = fields.DeviceID(allow_none=True)
 
@@ -60,7 +60,7 @@ user_get_serializer = CmdSerializer(UserGetReqSchema, UserGetRepSchema)
 
 class FindUserReqSchema(BaseReqSchema):
     query = fields.String(missing=None, allow_none=True)
-    omit_revocated = fields.Boolean(missing=False)
+    omit_revoked = fields.Boolean(missing=False)
     page = fields.Int(missing=1, validate=lambda n: n > 0)
     per_page = fields.Integer(missing=100, validate=lambda n: 0 < n <= 100)
 
@@ -217,7 +217,7 @@ class DeviceRevokeReqSchema(BaseReqSchema):
 
 
 class DeviceRevokeRepSchema(BaseRepSchema):
-    user_revocated_on = fields.DateTime(allow_none=True)
+    user_revoked_on = fields.DateTime(allow_none=True)
 
 
 device_revoke_serializer = CmdSerializer(DeviceRevokeReqSchema, DeviceRevokeRepSchema)

--- a/parsec/backend/app.py
+++ b/parsec/backend/app.py
@@ -219,7 +219,7 @@ class BackendApp:
                     if organization.root_verify_key != expected_rvk:
                         result_req = hs.build_rvk_mismatch_result_req()
 
-                    elif device.revocated_on:
+                    elif device.revoked_on:
                         result_req = hs.build_revoked_device_result_req()
 
                     else:

--- a/parsec/backend/drivers/postgresql/user_init.sql
+++ b/parsec/backend/drivers/postgresql/user_init.sql
@@ -29,9 +29,9 @@ CREATE TABLE device (
     -- NULL if certifier is the Root Verify Key
     device_certifier INTEGER REFERENCES device (_id),
     created_on TIMESTAMPTZ NOT NULL,
-    -- NULL if not yet revocated
-    revocated_on TIMESTAMPTZ,
-    -- NULL if not yet revocated
+    -- NULL if not yet revoked
+    revoked_on TIMESTAMPTZ,
+    -- NULL if not yet revoked
     certified_revocation BYTEA,
     -- NULL if certifier is the Root Verify Key
     revocation_certifier INTEGER REFERENCES device (_id),

--- a/parsec/backend/user.py
+++ b/parsec/backend/user.py
@@ -79,7 +79,7 @@ class Device:
     device_certifier: Optional[DeviceID]
 
     created_on: pendulum.Pendulum = attr.ib(factory=pendulum.now)
-    revocated_on: pendulum.Pendulum = None
+    revoked_on: pendulum.Pendulum = None
     certified_revocation: bytes = None
     revocation_certifier: DeviceID = None
 
@@ -109,15 +109,15 @@ class User:
 
     created_on: pendulum.Pendulum = attr.ib(factory=pendulum.now)
 
-    def is_revocated(self) -> bool:
+    def is_revoked(self) -> bool:
         now = pendulum.now()
         for d in self.devices.values():
-            if not d.revocated_on or d.revocated_on > now:
+            if not d.revoked_on or d.revoked_on > now:
                 return False
         return True
 
-    def get_revocated_on(self) -> Optional[pendulum.Pendulum]:
-        revocations = [d.revocated_on for d in self.devices.values()]
+    def get_revoked_on(self) -> Optional[pendulum.Pendulum]:
+        revocations = [d.revoked_on for d in self.devices.values()]
         if not revocations or None in revocations:
             return None
         else:
@@ -659,7 +659,7 @@ class BaseUserComponent:
                 }
 
         try:
-            user_revocated_on = await self.revoke_device(
+            user_revoked_on = await self.revoke_device(
                 client_ctx.organization_id,
                 data["device_id"],
                 msg["certified_revocation"],
@@ -677,7 +677,7 @@ class BaseUserComponent:
             }
 
         return device_revoke_serializer.rep_dump(
-            {"status": "ok", "user_revocated_on": user_revocated_on}
+            {"status": "ok", "user_revoked_on": user_revoked_on}
         )
 
     #### Virtual methods ####
@@ -745,7 +745,7 @@ class BaseUserComponent:
         query: str = None,
         page: int = 1,
         per_page: int = 100,
-        omit_revocated: bool = False,
+        omit_revoked: bool = False,
     ) -> Tuple[List[UserID], int]:
         raise NotImplementedError()
 
@@ -830,7 +830,7 @@ class BaseUserComponent:
         device_id: DeviceID,
         certified_revocation: bytes,
         revocation_certifier: DeviceID,
-        revocated_on: pendulum.Pendulum = None,
+        revoked_on: pendulum.Pendulum = None,
     ) -> Optional[pendulum.Pendulum]:
         """
         Raises:

--- a/parsec/core/backend_connection/cmds.py
+++ b/parsec/core/backend_connection/cmds.py
@@ -235,7 +235,7 @@ async def user_get(
                 certified_device=rep_device["certified_device"],
                 device_certifier=rep_device["device_certifier"],
                 created_on=rep_device["created_on"],
-                revocated_on=rep_device["revocated_on"],
+                revoked_on=rep_device["revoked_on"],
                 certified_revocation=rep_device["certified_revocation"],
                 revocation_certifier=rep_device["revocation_certifier"],
             )
@@ -253,7 +253,7 @@ async def user_get(
             certified_device=v["certified_device"],
             device_certifier=v["device_certifier"],
             created_on=v["created_on"],
-            revocated_on=v["revocated_on"],
+            revoked_on=v["revoked_on"],
             certified_revocation=v["certified_revocation"],
             revocation_certifier=v["revocation_certifier"],
         )
@@ -267,7 +267,7 @@ async def user_find(
     query: str = None,
     page: int = 1,
     per_page: int = 100,
-    omit_revocated: bool = False,
+    omit_revoked: bool = False,
 ) -> List[UserID]:
     rep = await _send_cmd(
         transport,
@@ -276,7 +276,7 @@ async def user_find(
         query=query,
         page=page,
         per_page=per_page,
-        omit_revocated=omit_revocated,
+        omit_revoked=omit_revoked,
     )
     return rep["results"]
 
@@ -345,7 +345,7 @@ async def device_revoke(
         cmd="device_revoke",
         certified_revocation=certified_revocation,
     )
-    return rep["user_revocated_on"]
+    return rep["user_revoked_on"]
 
 
 ###  Backend anonymous cmds  ###

--- a/parsec/core/gui/devices_widget.py
+++ b/parsec/core/gui/devices_widget.py
@@ -182,8 +182,8 @@ class DevicesWidget(CoreWidget, Ui_DevicesWidget):
                     self.add_device(
                         device_name,
                         is_current_device=device_name == current_device.device_name,
-                        is_revoked=bool(device.revocated_on),
-                        revoked_on=device.revocated_on,
+                        is_revoked=bool(device.revoked_on),
+                        revoked_on=device.revoked_on,
                     )
             except BackendNotAvailable:
                 pass

--- a/parsec/core/gui/users_widget.py
+++ b/parsec/core/gui/users_widget.py
@@ -182,7 +182,7 @@ class UsersWidget(CoreWidget, Ui_UsersWidget):
                         str(user_info.user_id),
                         is_current_user=user_id == user,
                         created_on=user_info.created_on,
-                        is_revoked=user_info.is_revocated(),
+                        is_revoked=user_info.is_revoked(),
                     )
             except BackendNotAvailable:
                 pass

--- a/parsec/core/gui/workspaces_widget.py
+++ b/parsec/core/gui/workspaces_widget.py
@@ -10,12 +10,7 @@ from parsec.core.types import FsPath
 from parsec.core.fs import FSEntryNotFound
 from parsec.core.mountpoint.exceptions import MountpointAlreadyMounted
 from parsec.core.gui import desktop
-from parsec.core.gui.custom_widgets import (
-    show_error,
-    show_warning,
-    get_text,
-    TaskbarButton,
-)
+from parsec.core.gui.custom_widgets import show_error, show_warning, get_text, TaskbarButton
 from parsec.core.gui.core_widget import CoreWidget
 from parsec.core.gui.workspace_button import WorkspaceButton
 from parsec.core.gui.ui.workspaces_widget import Ui_WorkspacesWidget

--- a/parsec/core/types/remote_device.py
+++ b/parsec/core/types/remote_device.py
@@ -22,7 +22,7 @@ class RemoteDevice:
     device_certifier: DeviceID
 
     created_on: pendulum.Pendulum = attr.ib(factory=pendulum.now)
-    revocated_on: pendulum.Pendulum = None
+    revoked_on: pendulum.Pendulum = None
     certified_revocation: bytes = None
     revocation_certifier: DeviceID = None
 
@@ -49,7 +49,7 @@ class RemoteDeviceSchema(UnknownCheckedSchema):
     device_id = fields.DeviceID(required=True)
     created_on = fields.DateTime(required=True)
 
-    revocated_on = fields.DateTime(allow_none=True)
+    revoked_on = fields.DateTime(allow_none=True)
     certified_revocation = fields.Bytes(allow_none=True)
     revocation_certifier = fields.DeviceID(allow_none=True)
 
@@ -117,15 +117,15 @@ class RemoteUser:
     def public_key(self) -> PublicKey:
         return unsecure_certified_user_extract_public_key(self.certified_user)
 
-    def is_revocated(self) -> bool:
+    def is_revoked(self) -> bool:
         now = pendulum.now()
         for d in self.devices.values():
-            if not d.revocated_on or d.revocated_on > now:
+            if not d.revoked_on or d.revoked_on > now:
                 return False
         return True
 
-    def get_revocated_on(self) -> Optional[pendulum.Pendulum]:
-        revocations = [d.revocated_on for d in self.devices.values()]
+    def get_revoked_on(self) -> Optional[pendulum.Pendulum]:
+        revocations = [d.revoked_on for d in self.devices.values()]
         if not revocations or None in revocations:
             return None
         else:

--- a/parsec/trustchain.py
+++ b/parsec/trustchain.py
@@ -231,7 +231,7 @@ def certify_device_revocation(
 
 
 def validate_payload_certified_device_revocation(
-    certifier_key: VerifyKey, payload: bytes, revocated_on: Pendulum
+    certifier_key: VerifyKey, payload: bytes, revoked_on: Pendulum
 ) -> dict:
     """
     Raises:
@@ -239,7 +239,7 @@ def validate_payload_certified_device_revocation(
         TrustChainTooOldError
     """
     return _validate_certified_payload(
-        certified_device_revocation_schema, certifier_key, payload, revocated_on
+        certified_device_revocation_schema, certifier_key, payload, revoked_on
     )
 
 
@@ -287,10 +287,10 @@ def validate_user_with_trustchain(user, trustchain, root_verify_key: VerifyKey):
                 )
 
             _recursive_validate_device(certifier_device)
-            if certifier_device.revocated_on and timestamp > certifier_device.revocated_on:
+            if certifier_device.revoked_on and timestamp > certifier_device.revoked_on:
                 raise TrustChainSignedByRevokedDeviceError(
                     f"Device `{certifier_id}` signed `{needed_by}` after it revocation "
-                    f"(revoked at {certifier_device.revocated_on}, signed at {timestamp})"
+                    f"(revoked at {certifier_device.revoked_on}, signed at {timestamp})"
                 )
             certifier_verify_key = certifier_device.verify_key
 
@@ -314,11 +314,11 @@ def validate_user_with_trustchain(user, trustchain, root_verify_key: VerifyKey):
             certifier_verify_key, certified_payload = _extract_certif_key_and_payload(
                 device.certified_revocation,
                 device.revocation_certifier,
-                device.revocated_on,
+                device.revoked_on,
                 device.device_id,
             )
             validate_payload_certified_device_revocation(
-                certifier_verify_key, certified_payload, device.revocated_on
+                certifier_verify_key, certified_payload, device.revoked_on
             )
         # All set ! This device is valid ;-)
         validated_devices[device.device_id] = device

--- a/tests/backend/user/test_access.py
+++ b/tests/backend/user/test_access.py
@@ -56,7 +56,7 @@ async def test_api_user_get_ok(access_testbed):
             device.device_name: {
                 "device_id": device.device_id,
                 "created_on": Pendulum(2000, 1, 1),
-                "revocated_on": None,
+                "revoked_on": None,
                 "certified_revocation": None,
                 "revocation_certifier": None,
                 "certified_device": ANY,
@@ -106,7 +106,7 @@ async def test_api_user_get_ok_deep_trustchain(
             mike1.device_id.device_name: {
                 "device_id": mike1.device_id,
                 "created_on": d1,
-                "revocated_on": None,
+                "revoked_on": None,
                 "certified_revocation": None,
                 "revocation_certifier": None,
                 "certified_device": ANY,
@@ -115,7 +115,7 @@ async def test_api_user_get_ok_deep_trustchain(
             mike2.device_id.device_name: {
                 "device_id": mike2.device_id,
                 "created_on": d1,
-                "revocated_on": d2,
+                "revoked_on": d2,
                 "certified_revocation": ANY,
                 "revocation_certifier": ph2.device_id,
                 "certified_device": ANY,
@@ -126,7 +126,7 @@ async def test_api_user_get_ok_deep_trustchain(
             godfrey1.device_id: {
                 "device_id": godfrey1.device_id,
                 "created_on": d1,
-                "revocated_on": None,
+                "revoked_on": None,
                 "certified_revocation": None,
                 "revocation_certifier": None,
                 "certified_device": ANY,
@@ -135,7 +135,7 @@ async def test_api_user_get_ok_deep_trustchain(
             mike1.device_id: {
                 "device_id": mike1.device_id,
                 "created_on": d1,
-                "revocated_on": None,
+                "revoked_on": None,
                 "certified_revocation": None,
                 "revocation_certifier": None,
                 "certified_device": ANY,
@@ -144,7 +144,7 @@ async def test_api_user_get_ok_deep_trustchain(
             roger1.device_id: {
                 "device_id": roger1.device_id,
                 "created_on": d1,
-                "revocated_on": d2,
+                "revoked_on": d2,
                 "certified_revocation": ANY,
                 "revocation_certifier": ph1.device_id,
                 "certified_device": ANY,
@@ -153,7 +153,7 @@ async def test_api_user_get_ok_deep_trustchain(
             ph1.device_id: {
                 "device_id": ph1.device_id,
                 "created_on": d1,
-                "revocated_on": None,
+                "revoked_on": None,
                 "certified_revocation": None,
                 "revocation_certifier": None,
                 "certified_device": ANY,
@@ -162,7 +162,7 @@ async def test_api_user_get_ok_deep_trustchain(
             ph2.device_id: {
                 "device_id": ph2.device_id,
                 "created_on": d1,
-                "revocated_on": None,
+                "revoked_on": None,
                 "certified_revocation": None,
                 "revocation_certifier": None,
                 "certified_device": ANY,
@@ -231,7 +231,7 @@ async def test_api_user_find(access_testbed, organization_factory, local_device_
     }
 
     # Test partial search while omitting revoked users
-    rep = await user_find(sock, query="Phil", omit_revocated=True)
+    rep = await user_find(sock, query="Phil", omit_revoked=True)
     assert rep == {"status": "ok", "results": ["Philippe"], "per_page": 100, "page": 1, "total": 1}
 
     # Test pagination
@@ -259,7 +259,7 @@ async def test_api_user_find(access_testbed, organization_factory, local_device_
     }
 
     # Test omit revoked users
-    rep = await user_find(sock, omit_revocated=True)
+    rep = await user_find(sock, omit_revoked=True)
     assert rep == {
         "status": "ok",
         "results": ["Blacky", "Godfrey", "Mike", "Philippe"],

--- a/tests/backend/user/test_device_revoke.py
+++ b/tests/backend/user/test_device_revoke.py
@@ -40,7 +40,7 @@ async def test_device_revoke_ok(
     # Revoke Alice's first device
     with freeze_time(now):
         rep = await device_revoke(bob_backend_sock, certified_revocation=alice_revocation)
-    assert rep == {"status": "ok", "user_revocated_on": None}
+    assert rep == {"status": "ok", "user_revoked_on": None}
 
     # Alice cannot connect from now on...
     with pytest.raises(HandshakeRevokedDevice):
@@ -54,7 +54,7 @@ async def test_device_revoke_ok(
     # Revoke Alice's second device (should automatically revoke the user)
     with freeze_time(now):
         rep = await device_revoke(bob_backend_sock, certified_revocation=alice2_revocation)
-    assert rep == {"status": "ok", "user_revocated_on": now}
+    assert rep == {"status": "ok", "user_revoked_on": now}
 
     # Alice2 cannot connect from now on...
     with pytest.raises(HandshakeRevokedDevice):
@@ -80,7 +80,7 @@ async def test_device_revoke_own_device_not_admin(
     )
 
     rep = await device_revoke(alice_backend_sock, certified_revocation=alice2_revocation)
-    assert rep == {"status": "ok", "user_revocated_on": None}
+    assert rep == {"status": "ok", "user_revoked_on": None}
 
     # Make sure alice2 cannot connect from now on
     with pytest.raises(HandshakeRevokedDevice):

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -30,23 +30,23 @@ def test_user_revocation_access():
     yesterday = datetime(2000, 1, 1)
     tomorrow = datetime(2000, 1, 3)
 
-    dev_not_revocated = RemoteDevice(
-        device_id=DeviceID("user@dev_not_revocated"),
+    dev_not_revoked = RemoteDevice(
+        device_id=DeviceID("user@dev_not_revoked"),
         certified_device=b"<certif>",
         device_certifier=None,
     )
-    dev_revocated_yesterday = RemoteDevice(
-        device_id=DeviceID("user@dev_revocated_yesterday"),
+    dev_revoked_yesterday = RemoteDevice(
+        device_id=DeviceID("user@dev_revoked_yesterday"),
         certified_device=b"<certif>",
         device_certifier=None,
-        revocated_on=yesterday,
+        revoked_on=yesterday,
         certified_revocation=b"<certif>",
     )
-    dev_revocated_tomorrow = RemoteDevice(
-        device_id=DeviceID("user@dev_revocated_tomorrow"),
+    dev_revoked_tomorrow = RemoteDevice(
+        device_id=DeviceID("user@dev_revoked_tomorrow"),
         certified_device=b"<certif>",
         device_certifier=None,
-        revocated_on=tomorrow,
+        revoked_on=tomorrow,
         certified_revocation=b"<certif>",
     )
 
@@ -60,24 +60,24 @@ def test_user_revocation_access():
 
     with freeze_time("2000-01-02"):
         user = _user_factory()
-        assert user.is_revocated()
-        assert user.get_revocated_on() is None
+        assert user.is_revoked()
+        assert user.get_revoked_on() is None
 
-        user = _user_factory(dev_revocated_yesterday)
-        assert user.is_revocated()
-        assert user.get_revocated_on() == yesterday
+        user = _user_factory(dev_revoked_yesterday)
+        assert user.is_revoked()
+        assert user.get_revoked_on() == yesterday
 
-        user = _user_factory(dev_not_revocated)
-        assert not user.is_revocated()
-        assert user.get_revocated_on() is None
+        user = _user_factory(dev_not_revoked)
+        assert not user.is_revoked()
+        assert user.get_revoked_on() is None
 
-        user = _user_factory(dev_not_revocated, dev_revocated_tomorrow)
-        assert not user.is_revocated()
-        assert user.get_revocated_on() is None
+        user = _user_factory(dev_not_revoked, dev_revoked_tomorrow)
+        assert not user.is_revoked()
+        assert user.get_revoked_on() is None
 
-        user = _user_factory(dev_revocated_yesterday, dev_revocated_tomorrow)
-        assert not user.is_revocated()
-        assert user.get_revocated_on() == tomorrow
+        user = _user_factory(dev_revoked_yesterday, dev_revoked_tomorrow)
+        assert not user.is_revoked()
+        assert user.get_revoked_on() == tomorrow
 
 
 class TestBlockAccessSchema:

--- a/tests/test_trustchain.py
+++ b/tests/test_trustchain.py
@@ -160,7 +160,7 @@ def trustchain_ctx_factory(local_device_factory, coolorg):
             created_on = todo_device.get("created_on", now)
             revoker = todo_device.get("revoker", None)
             if revoker:
-                revocated_on = todo_device.get("revocated_on", now)
+                revoked_on = todo_device.get("revoked_on", now)
 
             data = {"device_id": local_device.device_id}
 
@@ -181,9 +181,9 @@ def trustchain_ctx_factory(local_device_factory, coolorg):
                 revoker_id = revoker_ld.device_id
                 revoker_key = revoker_ld.signing_key
                 data["certified_revocation"] = certify_device_revocation(
-                    revoker_id, revoker_key, local_device.device_id, now=revocated_on
+                    revoker_id, revoker_key, local_device.device_id, now=revoked_on
                 )
-                data["revocated_on"] = revocated_on
+                data["revoked_on"] = revoked_on
                 data["revocation_certifier"] = revoker_id
 
             remote_devices[local_device.device_id] = RemoteDevice(**data)
@@ -258,8 +258,8 @@ def test_validate_user_with_trustchain_with_user_created_by_revoked_certifier(
         todo_devices=(
             {"id": "alice@dev1"},
             {"id": "alice@dev2", "certifier": "alice@dev1"},
-            {"id": "mallory@dev1", "revoker": "alice@dev2", "revocated_on": Pendulum(2000, 1, 3)},
-            {"id": "bob@dev1", "revoker": "mallory@dev1", "revocated_on": Pendulum(2000, 1, 2)},
+            {"id": "mallory@dev1", "revoker": "alice@dev2", "revoked_on": Pendulum(2000, 1, 3)},
+            {"id": "bob@dev1", "revoker": "mallory@dev1", "revoked_on": Pendulum(2000, 1, 2)},
             {"id": "alice@dev3", "certifier": "alice@dev2"},
         ),
         todo_user={"id": "alice", "certifier": "bob@dev1"},
@@ -273,8 +273,8 @@ def test_validate_user_with_trustchain_with_revoked_user(trustchain_ctx_factory)
         todo_devices=(
             {"id": "alice@dev1"},
             {"id": "alice@dev2", "certifier": "alice@dev1"},
-            {"id": "mallory@dev1", "revoker": "alice@dev2", "revocated_on": Pendulum(2000, 1, 3)},
-            {"id": "bob@dev1", "revoker": "mallory@dev1", "revocated_on": Pendulum(2000, 1, 2)},
+            {"id": "mallory@dev1", "revoker": "alice@dev2", "revoked_on": Pendulum(2000, 1, 3)},
+            {"id": "bob@dev1", "revoker": "mallory@dev1", "revoked_on": Pendulum(2000, 1, 2)},
             {"id": "alice@dev3", "certifier": "bob@dev1"},
         ),
         todo_user={"id": "alice"},
@@ -288,8 +288,8 @@ def test_validate_user_with_trustchain_broken_chain(trustchain_ctx_factory):
         todo_devices=(
             {"id": "alice@dev1"},
             {"id": "alice@dev2", "certifier": "alice@dev1"},
-            {"id": "mallory@dev1", "revoker": "alice@dev2", "revocated_on": Pendulum(2000, 1, 3)},
-            {"id": "bob@dev1", "revoker": "mallory@dev1", "revocated_on": Pendulum(2000, 1, 2)},
+            {"id": "mallory@dev1", "revoker": "alice@dev2", "revoked_on": Pendulum(2000, 1, 3)},
+            {"id": "bob@dev1", "revoker": "mallory@dev1", "revoked_on": Pendulum(2000, 1, 2)},
             {"id": "alice@dev3", "certifier": "bob@dev1"},
         ),
         todo_user={"id": "alice"},
@@ -349,14 +349,14 @@ def test_validate_user_with_trustchain_with_invalid_revocation(trustchain_ctx_fa
     ctx = trustchain_ctx_factory(
         todo_devices=(
             {"id": "alice@dev1"},
-            {"id": "bob@dev1", "revoker": "alice@dev1", "revocated_on": Pendulum(2000, 1, 2)},
+            {"id": "bob@dev1", "revoker": "alice@dev1", "revoked_on": Pendulum(2000, 1, 2)},
             {"id": "alice@dev2", "certifier": "alice@dev1"},
-            # Bob already revocated when it is supposed to do revoke alice
+            # Bob already revoked when it is supposed to do revoke alice
             {
                 "id": "alice@dev3",
                 "certifier": "alice@dev2",
                 "revoker": "bob@dev1",
-                "revocated_on": Pendulum(2000, 1, 3),
+                "revoked_on": Pendulum(2000, 1, 3),
             },
         ),
         todo_user={"id": "alice"},


### PR DESCRIPTION
cf. https://en.wiktionary.org/wiki/revoke#English vs https://en.wiktionary.org/wiki/revocate#English