### PR TITLE
Reset fuse signal handlers after a fuse instance has started

### DIFF
--- a/parsec/core/mountpoint/fuse_runner.py
+++ b/parsec/core/mountpoint/fuse_runner.py
@@ -3,6 +3,7 @@
 import trio
 import time
 import errno
+import ctypes
 import signal
 import threading
 from pathlib import Path
@@ -29,15 +30,12 @@ def _reset_signals(signals=None):
     """
     if signals is None:
         signals = (signal.SIGINT, signal.SIGTERM, signal.SIGHUP, signal.SIGPIPE)
-    saved = {sig: signal.getsignal(sig) for sig in signals}
+    saved = {sig: ctypes.pythonapi.PyOS_getsig(sig) for sig in signals}
     try:
         yield
     finally:
         for sig, handler in saved.items():
-            try:
-                signal.signal(sig, handler)
-            except ValueError:
-                pass
+            ctypes.pythonapi.PyOS_setsig(sig, handler)
 
 
 def _bootstrap_mountpoint(mountpoint):

--- a/parsec/core/mountpoint/fuse_runner.py
+++ b/parsec/core/mountpoint/fuse_runner.py
@@ -137,7 +137,7 @@ async def _wait_for_fuse_ready(mountpoint, fuse_thread_started, initial_st_dev):
     def _wait_for_fuse_ready_thread():
         fuse_thread_started.wait()
         while not need_stop:
-            time.sleep(0.1)
+            time.sleep(0.01)
             try:
                 if mountpoint.stat().st_dev != initial_st_dev:
                     break


### PR DESCRIPTION
Fix issue #292.

Sadly doesn't fix the `fuse: fuse_remove_signal_handlers: unknown session` error message in `stderr`.