### PR TITLE
Restore event logging

### DIFF
--- a/parsec/event_bus.py
+++ b/parsec/event_bus.py
@@ -80,6 +80,9 @@ class EventBus:
         return EventBusConnectionContext(self)
 
     def send(self, event, **kwargs):
+        # Do not log meta events (event.connected and event.disconnected)
+        if "event_name" not in kwargs:
+            logger.debug("Send event", event_name=event, **kwargs)
         for cb in self._event_handlers[event]:
             cb(event, **kwargs)
 


### PR DESCRIPTION
The event logging disappeared after the following changes:
- https://github.com/Scille/parsec-cloud/commit/2a4f90dec04791f6c4d161e0d1ee7f21fb942909#diff-106a4d5f45c3f7d1b5ecc9f3adcab10fR83
- https://github.com/Scille/parsec-cloud/commit/8f66f733f567f7be1200ab01dbdb1e578f0acc7a#diff-106a4d5f45c3f7d1b5ecc9f3adcab10f

Now every the events are logged as "debug", and the meta events (`event.connected` and `event.disconnected`) are not logged at all.