### PR TITLE
Remount mountpoint at workspace renaming

### DIFF
--- a/parsec/core/gui/main_window.py
+++ b/parsec/core/gui/main_window.py
@@ -67,8 +67,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.login_widget.login_with_password_clicked.connect(self.login_with_password)
         self.login_widget.login_with_pkcs11_clicked.connect(self.login_with_pkcs11)
 
-        self.mountpoint_stopped.connect(self._qt_on_mountpoint_stopped)
-
         self.show_login_widget()
 
         if not settings.get_value("global/no_check_version", "false"):
@@ -162,15 +160,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
     def _on_mountpoint_stopped(self, event, mountpoint):
         self.mountpoint_stopped.emit()
-
-    def _qt_on_mountpoint_stopped(self):
-        show_error(
-            self,
-            QCoreApplication.translate(
-                "MainWindow", "The mounpoint has been unmounted, you will now be logged off."
-            ),
-        )
-        self.logout()
 
     def stop_core(self):
         if self.core:

--- a/parsec/core/gui/tr/parsec_en.ts
+++ b/parsec/core/gui/tr/parsec_en.ts
@@ -798,11 +798,6 @@ This device has been revoked.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main_window.py" line="167"/>
-        <source>The mounpoint has been unmounted, you will now be logged off.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../main_window.py" line="237"/>
         <source>User not registered in the backend.</source>
         <translation type="unfinished"></translation>

--- a/parsec/core/gui/tr/parsec_fr.ts
+++ b/parsec/core/gui/tr/parsec_fr.ts
@@ -1353,11 +1353,6 @@ L&apos;appareil a été révoqué.</translation>
         <translation type="obsolete">Connecté</translation>
     </message>
     <message>
-        <location filename="../main_window.py" line="167"/>
-        <source>The mounpoint has been unmounted, you will now be logged off.</source>
-        <translation>Le point de montage a été démonté, vous allez être déconnecté.</translation>
-    </message>
-    <message>
         <location filename="../main_window.py" line="237"/>
         <source>User not registered in the backend.</source>
         <translation>L&apos;utilisateur n&apos;est pas enregistré sur le backend.</translation>

--- a/parsec/core/gui/workspaces_widget.py
+++ b/parsec/core/gui/workspaces_widget.py
@@ -109,6 +109,9 @@ class WorkspacesWidget(CoreWidget, Ui_WorkspacesWidget):
                 self,
                 QCoreApplication.translate("WorkspacesWidget", "Can not rename the workspace."),
             )
+        else:
+            self.portal.run(self.core.mountpoint_manager.unmount_workspace, current_file_path[1:])
+            self.portal.run(self.core.mountpoint_manager.mount_workspace, new_name)
 
     def share_workspace(self, workspace_button):
         d = WorkspaceSharingDialog(workspace_button.name, self.core, self.portal)


### PR DESCRIPTION
Premier draft (faudrait régénérer les fichiers de traduction dont les lignes sont décalées).