### PR TITLE
[GUI] Updated workspace sharing to use roles

### DIFF
--- a/parsec/core/gui/file_table.py
+++ b/parsec/core/gui/file_table.py
@@ -13,6 +13,8 @@ from PyQt5.QtWidgets import (
     QMenu,
 )
 
+from parsec.core.types import WorkspaceRole
+
 from parsec.core.gui.lang import translate as _
 from parsec.core.gui.file_items import (
     FileTableItem,
@@ -70,6 +72,7 @@ class FileTable(QTableWidget):
         self.itemSelectionChanged.connect(self.change_selection)
         self.customContextMenuRequested.connect(self.show_context_menu)
         self.cellDoubleClicked.connect(self.item_double_clicked)
+        self.current_user_role = WorkspaceRole.OWNER
 
     def selected_files(self):
         files = []
@@ -94,10 +97,11 @@ class FileTable(QTableWidget):
         menu = QMenu(self)
         action = menu.addAction(_("Open"))
         action.triggered.connect(self.open_clicked.emit)
-        action = menu.addAction(_("Rename"))
-        action.triggered.connect(self.rename_clicked.emit)
-        action = menu.addAction(_("Delete"))
-        action.triggered.connect(self.delete_clicked.emit)
+        if self.current_user_role != WorkspaceRole.READER:
+            action = menu.addAction(_("Rename"))
+            action.triggered.connect(self.rename_clicked.emit)
+            action = menu.addAction(_("Delete"))
+            action.triggered.connect(self.delete_clicked.emit)
         menu.exec_(global_pos)
 
     def item_double_clicked(self, row, column):

--- a/parsec/core/gui/forms/sharing_widget.ui
+++ b/parsec/core/gui/forms/sharing_widget.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>572</width>
-    <height>35</height>
+    <height>45</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>20</width>
-    <height>20</height>
+    <height>45</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -53,16 +53,16 @@ color: rgb(125, 125, 125);
     <number>10</number>
    </property>
    <property name="leftMargin">
-    <number>10</number>
+    <number>0</number>
    </property>
    <property name="topMargin">
-    <number>5</number>
+    <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>75</number>
+    <number>0</number>
    </property>
    <property name="bottomMargin">
-    <number>5</number>
+    <number>0</number>
    </property>
    <item>
     <widget class="QLabel" name="label_name">
@@ -85,73 +85,47 @@ color: rgb(125, 125, 125);
     </spacer>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkbox_admin">
+    <widget class="QComboBox" name="combo_role">
      <property name="minimumSize">
       <size>
-       <width>110</width>
-       <height>20</height>
+       <width>0</width>
+       <height>32</height>
       </size>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>110</width>
-       <height>20</height>
-      </size>
-     </property>
-     <property name="layoutDirection">
-      <enum>Qt::RightToLeft</enum>
-     </property>
-     <property name="text">
-      <string/>
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+      </font>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkbox_read">
-     <property name="minimumSize">
-      <size>
-       <width>110</width>
-       <height>20</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>110</width>
-       <height>20</height>
-      </size>
-     </property>
-     <property name="layoutDirection">
-      <enum>Qt::RightToLeft</enum>
+    <widget class="QToolButton" name="button_delete">
+     <property name="toolTip">
+      <string>Remove user permissions.</string>
      </property>
      <property name="text">
       <string/>
      </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="checkbox_write">
-     <property name="minimumSize">
+     <property name="icon">
+      <iconset resource="../rc/resources.qrc">
+       <normaloff>:/icons/images/icons/menu_cancel.png</normaloff>:/icons/images/icons/menu_cancel.png</iconset>
+     </property>
+     <property name="iconSize">
       <size>
-       <width>110</width>
-       <height>20</height>
+       <width>24</width>
+       <height>24</height>
       </size>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>110</width>
-       <height>20</height>
-      </size>
-     </property>
-     <property name="layoutDirection">
-      <enum>Qt::RightToLeft</enum>
-     </property>
-     <property name="text">
-      <string/>
+     <property name="autoRaise">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../rc/resources.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/parsec/core/gui/forms/workspace_sharing_dialog.ui
+++ b/parsec/core/gui/forms/workspace_sharing_dialog.ui
@@ -6,12 +6,18 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>721</width>
-    <height>524</height>
+    <width>578</width>
+    <height>529</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Manage workspace sharing</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">QDialog#WorkspaceSharingDialog
+{
+background-color: rgb(255, 255, 255);
+}</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="leftMargin">
@@ -28,6 +34,9 @@
    </property>
    <item>
     <widget class="QWidget" name="widget" native="true">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
      <property name="styleSheet">
       <string notr="true">QWidget#widget
 {
@@ -47,23 +56,41 @@ QLineEdit:disabled
 background-color: rgb(200, 200, 200);
 }
 
-QCheckBox::indicator
+QComboBox
 {
-width: 15px;
-height: 15px;
-background-color: rgb(255, 255, 255);
-border: 2px solid rgb(46, 46, 46);
+border: 1px solid rgb(46, 46, 46);
+background-color: white;
 color: black;
+padding-left: 5px;
 }
 
-QCheckBox::indicator:checked
+QComboBox:disabled
 {
-image: url(:/icons/images/icons/checked.png)
+background-color: rgb(220, 220, 220);
+}
+
+QComboBox::drop-down
+{
+border: 0px;
+background-color: rgb(255, 255, 255);
+}
+
+QComboBox::down-arrow
+{
+image: url(:/icons/images/icons/down-arrow.png);
+width: 16px;
+height: 16px;
+padding-right: 5px;
+}
+
+QComboBox::drop-down:disabled
+{
+background-color: rgb(220, 220, 220);
 }</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <property name="spacing">
-       <number>0</number>
+       <number>10</number>
       </property>
       <property name="leftMargin">
        <number>15</number>
@@ -87,100 +114,57 @@ image: url(:/icons/images/icons/checked.png)
           <number>0</number>
          </property>
          <property name="topMargin">
-          <number>10</number>
+          <number>0</number>
          </property>
          <property name="rightMargin">
           <number>0</number>
          </property>
          <property name="bottomMargin">
-          <number>10</number>
+          <number>0</number>
          </property>
          <item>
-          <widget class="QLineEdit" name="line_edit_share">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>32</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>12</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="placeholderText">
-            <string>Share with</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_4">
-           <property name="leftMargin">
-            <number>20</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>20</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
            <item>
-            <widget class="QCheckBox" name="checkbox_admin">
+            <widget class="QLineEdit" name="line_edit_share">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>32</height>
+              </size>
+             </property>
              <property name="font">
               <font>
                <pointsize>12</pointsize>
               </font>
              </property>
              <property name="text">
-              <string>User can administer</string>
+              <string/>
              </property>
-             <property name="checked">
-              <bool>true</bool>
+             <property name="placeholderText">
+              <string>Share with</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QCheckBox" name="checkbox_read">
+            <widget class="QComboBox" name="combo_role">
              <property name="enabled">
               <bool>true</bool>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>150</width>
+               <height>32</height>
+              </size>
              </property>
              <property name="font">
               <font>
                <pointsize>12</pointsize>
               </font>
              </property>
-             <property name="text">
-              <string>User can read</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="checkbox_write">
-             <property name="enabled">
-              <bool>true</bool>
-             </property>
-             <property name="font">
-              <font>
-               <pointsize>12</pointsize>
-              </font>
-             </property>
-             <property name="layoutDirection">
-              <enum>Qt::LeftToRight</enum>
-             </property>
-             <property name="text">
-              <string>User can write</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
+             <property name="toolTip">
+              <string>A reader can see uploaded files.
+A collaborator can upload files (and see them).
+A manager can add people and manage their permissions (and see and upload files).</string>
              </property>
             </widget>
            </item>
@@ -261,24 +245,8 @@ color: rgb(255, 255, 255);
        </widget>
       </item>
       <item>
-       <widget class="QWidget" name="widget_title" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>32</height>
-         </size>
-        </property>
-        <property name="styleSheet">
-         <string notr="true">QWidget#widget_title
-{
-border: 0;
-background-color: rgb(46, 46, 46);
-color: white;
-font-weight: bold;
-}
-</string>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <widget class="QWidget" name="widget_2" native="true">
+        <layout class="QVBoxLayout" name="verticalLayout_5">
          <property name="spacing">
           <number>0</number>
          </property>
@@ -289,172 +257,124 @@ font-weight: bold;
           <number>0</number>
          </property>
          <property name="rightMargin">
-          <number>40</number>
+          <number>0</number>
          </property>
          <property name="bottomMargin">
           <number>0</number>
          </property>
          <item>
-          <widget class="QLabel" name="label_3">
-           <property name="text">
-            <string/>
+          <widget class="QWidget" name="widget_title" native="true">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>32</height>
+            </size>
            </property>
+           <property name="styleSheet">
+            <string notr="true">QWidget#widget_title
+{
+border: 0;
+background-color: rgb(46, 46, 46);
+color: white;
+font-weight: bold;
+}
+</string>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>40</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+           </layout>
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="label_4">
-           <property name="minimumSize">
-            <size>
-             <width>120</width>
-             <height>0</height>
-            </size>
+          <widget class="QScrollArea" name="scrollArea">
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
            </property>
-           <property name="maximumSize">
-            <size>
-             <width>120</width>
-             <height>16777215</height>
-            </size>
+           <property name="frameShadow">
+            <enum>QFrame::Plain</enum>
            </property>
-           <property name="font">
-            <font>
-             <pointsize>12</pointsize>
-            </font>
+           <property name="lineWidth">
+            <number>0</number>
            </property>
-           <property name="styleSheet">
-            <string notr="true">color: rgb(255, 255, 255);</string>
+           <property name="horizontalScrollBarPolicy">
+            <enum>Qt::ScrollBarAlwaysOff</enum>
            </property>
-           <property name="text">
-            <string>Admin</string>
+           <property name="widgetResizable">
+            <bool>true</bool>
            </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="label">
-           <property name="minimumSize">
-            <size>
-             <width>120</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>120</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>12</pointsize>
-            </font>
-           </property>
-           <property name="styleSheet">
-            <string notr="true">color: rgb(255, 255, 255);</string>
-           </property>
-           <property name="text">
-            <string>Read</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_2">
-           <property name="minimumSize">
-            <size>
-             <width>120</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>120</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>12</pointsize>
-            </font>
-           </property>
-           <property name="styleSheet">
-            <string notr="true">color: rgb(255, 255, 255);</string>
-           </property>
-           <property name="text">
-            <string>Write</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
+           <widget class="QWidget" name="scroll_content">
+            <property name="geometry">
+             <rect>
+              <x>0</x>
+              <y>0</y>
+              <width>548</width>
+              <height>291</height>
+             </rect>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">QWidget#scroll_content
+{
+background-color: rgb(255, 255, 255);
+border: 1px solid rgb(46, 46, 46);
+}</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_3">
+             <property name="spacing">
+              <number>5</number>
+             </property>
+             <property name="leftMargin">
+              <number>20</number>
+             </property>
+             <property name="topMargin">
+              <number>9</number>
+             </property>
+             <property name="rightMargin">
+              <number>20</number>
+             </property>
+             <item>
+              <spacer name="verticalSpacer">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </widget>
           </widget>
          </item>
         </layout>
        </widget>
       </item>
       <item>
-       <widget class="QScrollArea" name="scrollArea">
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Plain</enum>
-        </property>
-        <property name="lineWidth">
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <property name="spacing">
          <number>0</number>
         </property>
-        <property name="horizontalScrollBarPolicy">
-         <enum>Qt::ScrollBarAlwaysOff</enum>
-        </property>
-        <property name="widgetResizable">
-         <bool>true</bool>
-        </property>
-        <widget class="QWidget" name="scroll_content">
-         <property name="geometry">
-          <rect>
-           <x>0</x>
-           <y>0</y>
-           <width>691</width>
-           <height>239</height>
-          </rect>
-         </property>
-         <property name="styleSheet">
-          <string notr="true">QWidget#scroll_content
-{
-background-color: rgb(255, 255, 255);
-border: 1px solid rgb(46, 46, 46);
-}</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_3">
-          <property name="topMargin">
-           <number>9</number>
-          </property>
-          <item>
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
-       </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
         <property name="topMargin">
-         <number>10</number>
+         <number>0</number>
         </property>
         <property name="bottomMargin">
-         <number>10</number>
+         <number>0</number>
         </property>
         <item>
          <spacer name="horizontalSpacer_4">
@@ -503,7 +423,7 @@ color: rgb(255, 255, 255);
 }</string>
           </property>
           <property name="text">
-           <string>Apply</string>
+           <string>Update</string>
           </property>
           <property name="icon">
            <iconset resource="../rc/resources.qrc">
@@ -521,8 +441,11 @@ color: rgb(255, 255, 255);
       </item>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
+        <property name="spacing">
+         <number>0</number>
+        </property>
         <property name="topMargin">
-         <number>10</number>
+         <number>0</number>
         </property>
         <item>
          <spacer name="horizontalSpacer">

--- a/parsec/core/gui/mount_widget.py
+++ b/parsec/core/gui/mount_widget.py
@@ -42,6 +42,10 @@ class MountWidget(QWidget, Ui_MountWidget):
         )
         self.layout_content.insertWidget(0, files_widget)
         files_widget.back_clicked.connect(self.show_workspaces_widget)
+        files_widget.taskbar_updated.connect(self.on_taskbar_updated)
+        self.widget_switched.emit(self.get_taskbar_buttons())
+
+    def on_taskbar_updated(self):
         self.widget_switched.emit(self.get_taskbar_buttons())
 
     def show_workspaces_widget(self):

--- a/parsec/core/gui/workspace_button.py
+++ b/parsec/core/gui/workspace_button.py
@@ -22,7 +22,7 @@ class WorkspaceButton(QWidget, Ui_WorkspaceButton):
     def __init__(
         self,
         workspace_fs,
-        participants,
+        is_shared,
         is_creator,
         files=None,
         enable_workspace_color=False,
@@ -34,7 +34,7 @@ class WorkspaceButton(QWidget, Ui_WorkspaceButton):
         self.workspace_fs = workspace_fs
         self.label_empty.show()
         self.widget_files.hide()
-        self.participants = participants
+        self.is_shared = is_shared
         self.is_creator = is_creator
         files = files or []
 
@@ -68,7 +68,7 @@ class WorkspaceButton(QWidget, Ui_WorkspaceButton):
         self.button_open_workspace.clicked.connect(self.button_open_workspace_clicked)
         if not self.is_creator:
             self.label_owner.hide()
-        if len(participants) == 1:
+        if not self.is_shared:
             self.label_shared.hide()
         self.reload_workspace_name()
 
@@ -79,10 +79,10 @@ class WorkspaceButton(QWidget, Ui_WorkspaceButton):
         self.file_clicked.emit(self.workspace_fs, file_name)
 
     def button_share_clicked(self):
-        self.share_clicked.emit(self)
+        self.share_clicked.emit(self.workspace_fs)
 
     def button_delete_clicked(self):
-        self.delete_clicked.emit(self)
+        self.delete_clicked.emit(self.workspace_fs)
 
     def button_rename_clicked(self):
         self.rename_clicked.emit(self)
@@ -97,11 +97,12 @@ class WorkspaceButton(QWidget, Ui_WorkspaceButton):
         if len(display) > 20:
             display = display[:20] + "..."
 
-        if len(self.participants) > 1:
+        if self.is_shared:
             if self.is_creator:
-                display += _(" (shared)")
-            else:
-                display += _(" (shared by {})").format(self.workspace_fs.device.user_id)
+                display += _(" (shared with others)")
+            # TODO: uncomment once the workspace name does not contain "shared by XX" anymore
+            # else:
+            #     display += _(" (shared with you)")
         self.label_workspace.setText(display)
         self.label_workspace.setToolTip(workspace_name)
 


### PR DESCRIPTION
- Updated the GUI to user roles instead of permissions
- Fixed a few bugs (like the destruction of the underlying Qt object in some cases)
- Restricted the permissions for a user to add/delete/rename items in a workspace if they're only readers
- Handle permissions update signals correctly, so the GUI should react correctly when the role of a user changes