### PR TITLE
Store both the base and local manifests in the local storage

### DIFF
--- a/misc/run_test_environment.sh
+++ b/misc/run_test_environment.sh
@@ -17,7 +17,6 @@ alice_workspace and bob_workspace, that their sharing with each other.
 
 PORT=6888
 TMP=`mktemp -d`
-DIR=`dirname ${BASH_SOURCE[0]}`
 export XDG_CACHE_HOME="$TMP/cache"
 export XDG_DATA_HOME="$TMP/share"
 export XDG_CONFIG_HOME="$TMP/config"
@@ -34,4 +33,4 @@ Configure your test environment with the following variables:
 pkill -f "parsec backend run -b MOCKED -P $PORT"
 parsec backend run -b MOCKED -P $PORT &
 sleep 1
-python3 $DIR/initialize_test_organization.py -B "ws://localhost:$PORT" $@
+python3 misc/initialize_test_organization.py -B "ws://localhost:$PORT" $@

--- a/parsec/core/fs/file_syncer.py
+++ b/parsec/core/fs/file_syncer.py
@@ -108,8 +108,7 @@ class FileSyncerMixin(BaseSyncer):
 
         self.local_folder_fs.set_dirty_manifest(moved_access, diverged_manifest)
         self.local_folder_fs.set_dirty_manifest(parent_access, parent_manifest)
-        target_manifest = target_remote_manifest.to_local()
-        self.local_folder_fs.set_clean_manifest(access, target_manifest, force=True)
+        self.local_storage.set_base_manifest(access, target_remote_manifest)
 
         self.event_bus.send(
             "fs.entry.file_update_conflicted",
@@ -141,9 +140,8 @@ class FileSyncerMixin(BaseSyncer):
                 path, access, current_manifest, target_remote_manifest
             )
         else:
-            target_local_manifest = target_remote_manifest.to_local()
             # Otherwise just fast-forward the local data
-            self.local_folder_fs.set_clean_manifest(access, target_local_manifest)
+            self.local_storage.set_base_manifest(access, target_remote_manifest)
         return True
 
     async def _sync_file_actual_sync(
@@ -326,4 +324,4 @@ class FileSyncerMixin(BaseSyncer):
             self.local_folder_fs.set_dirty_manifest(access, final_manifest)
         else:
             # New manifest is up to date with the remote: safely clean up the local manifest
-            self.local_folder_fs.set_clean_manifest(access, final_manifest, force=True)
+            self.local_storage.set_base_manifest(access, final_manifest.to_remote())

--- a/parsec/core/fs/folder_syncer.py
+++ b/parsec/core/fs/folder_syncer.py
@@ -90,6 +90,10 @@ class FolderSyncerMixin(BaseSyncer):
                 to_sync_manifest, sync_needed, conflicts = merge_remote_manifests(
                     base, to_sync_manifest, target
                 )
+
+                # Hot fix: make sure to_sync_manifest has the right author
+                to_sync_manifest = to_sync_manifest.evolve(author=self.device.device_id)
+
                 for original_name, original_id, diverged_name, diverged_id in conflicts:
                     self.event_bus.send(
                         "fs.entry.name_conflicted",
@@ -207,7 +211,7 @@ class FolderSyncerMixin(BaseSyncer):
         current_manifest = self.local_folder_fs.get_manifest(access)
         assert is_folderish_manifest(current_manifest)
 
-        target_manifest = target_remote_manifest.to_local()
+        target_manifest = target_remote_manifest.to_local(self.device.device_id)
         final_manifest, _, conflicts = merge_local_manifests(
             base_manifest, current_manifest, target_manifest
         )

--- a/parsec/core/fs/remote_loader.py
+++ b/parsec/core/fs/remote_loader.py
@@ -40,9 +40,8 @@ class RemoteLoader:
         remote_manifest = remote_manifest_serializer.loads(raw)
         # TODO: better exception !
         assert remote_manifest.version == expected_version
+        assert remote_manifest.author == expected_author_id
         # TODO: also store access id in remote_manifest and check it here
+        self.local_storage.set_base_manifest(access, remote_manifest)
 
-        local_manifest = remote_manifest.to_local()
-        self.local_storage.set_clean_manifest(access, local_manifest)
-
-        return local_manifest
+        return remote_manifest.to_local(self.local_storage.device_id)

--- a/parsec/core/fs/sync_base.py
+++ b/parsec/core/fs/sync_base.py
@@ -237,10 +237,12 @@ class BaseSyncer:
         manifest = remote_manifest_serializer.loads(raw)
         # TODO: better exception !
         assert manifest.version == expected_version
+        assert manifest.author == expected_author_id
         return manifest
 
     async def _backend_vlob_create(self, vlob_group, access, manifest):
         assert manifest.version == 1
+        assert manifest.author == self.device.device_id
         now = pendulum.now()
         ciphered = encrypt_signed_msg_with_secret_key(
             self.device.device_id,
@@ -258,6 +260,7 @@ class BaseSyncer:
 
     async def _backend_vlob_update(self, access, manifest):
         assert manifest.version > 1
+        assert manifest.author == self.device.device_id
         now = pendulum.now()
         ciphered = encrypt_signed_msg_with_secret_key(
             self.device.device_id,

--- a/parsec/core/fs/userfs/userfs.py
+++ b/parsec/core/fs/userfs/userfs.py
@@ -243,14 +243,14 @@ class UserFS:
             return
 
         # New things in remote, merge is needed
-        target_um = target_um.to_local()
+        target_um = target_um.to_local(self.device.device_id)
 
         base_um = None
         while True:
             if diverged_um.base_version != 0:
                 # TODO: keep base manifest somewhere to avoid this query
                 base_um = await self._fetch_remote_user_manifest(version=diverged_um.base_version)
-                base_um = base_um.to_local()
+                base_um = base_um.to_local(self.device.device_id)
 
             # Merge and store result
             async with self._update_user_manifest_lock:

--- a/parsec/core/fs/workspacefs/entry_transactions.py
+++ b/parsec/core/fs/workspacefs/entry_transactions.py
@@ -270,7 +270,7 @@ class EntryTransactions:
             )
 
             # Atomic change
-            self.local_storage.set_dirty_manifest(parent.access, new_parent_manifest)
+            self.local_storage.set_manifest(parent.access, new_parent_manifest)
 
         # Send event
         self._send_event("fs.entry.updated", id=parent.access.id)
@@ -303,9 +303,10 @@ class EntryTransactions:
             )
 
             # Atomic change
-            self.local_storage.set_dirty_manifest(parent.access, new_parent_manifest)
+            self.local_storage.set_manifest(parent.access, new_parent_manifest)
 
             # Clean up
+            # TODO: actually we can't do that: this child my require synchronization
             self.local_storage.clear_manifest(child.access)
 
         # Send event
@@ -335,7 +336,7 @@ class EntryTransactions:
             )
 
             # Atomic change
-            self.local_storage.set_dirty_manifest(parent.access, new_parent_manifest)
+            self.local_storage.set_manifest(parent.access, new_parent_manifest)
 
             # Clean up
             self.local_storage.remove_file_reference(child.access, child.manifest)
@@ -367,8 +368,8 @@ class EntryTransactions:
             )
 
             # ~ Atomic change
-            self.local_storage.set_dirty_manifest(child_access, child_manifest)
-            self.local_storage.set_dirty_manifest(parent.access, new_parent_manifest)
+            self.local_storage.set_manifest(child_access, child_manifest)
+            self.local_storage.set_manifest(parent.access, new_parent_manifest)
 
         # Send events
         self._send_event("fs.entry.updated", id=parent.access.id)
@@ -398,8 +399,8 @@ class EntryTransactions:
             )
 
             # ~ Atomic change
-            self.local_storage.set_dirty_manifest(child_access, child_manifest)
-            self.local_storage.set_dirty_manifest(parent.access, new_parent_manifest)
+            self.local_storage.set_manifest(child_access, child_manifest)
+            self.local_storage.set_manifest(parent.access, new_parent_manifest)
             fd = self.local_storage.create_cursor(child_access) if open else None
 
         # Send events

--- a/parsec/core/local_storage.py
+++ b/parsec/core/local_storage.py
@@ -87,6 +87,7 @@ class LocalStorage:
     # Manifest interface
 
     def get_base_manifest(self, access: Access) -> RemoteManifest:
+        """Raises: LocalStorageMissingEntry"""
         try:
             return self.base_manifest_cache[access.id]
         except KeyError:
@@ -97,6 +98,7 @@ class LocalStorage:
         return manifest
 
     def get_manifest(self, access: Access) -> LocalManifest:
+        """Raises: LocalStorageMissingEntry"""
         try:
             return self.local_manifest_cache[access.id]
         except KeyError:

--- a/parsec/core/logged_core.py
+++ b/parsec/core/logged_core.py
@@ -60,7 +60,9 @@ async def logged_core_factory(
             keepalive_time=config.backend_connection_keepalive,
         ) as backend_cmds_pool:
 
-            with LocalStorage(config.data_base_dir / device.slug) as local_storage:
+            with LocalStorage(
+                device.device_id, config.data_base_dir / device.slug
+            ) as local_storage:
 
                 remote_devices_manager = RemoteDevicesManager(
                     backend_cmds_pool, device.root_verify_key

--- a/parsec/core/persistent_storage.py
+++ b/parsec/core/persistent_storage.py
@@ -175,14 +175,6 @@ class PersistentStorage:
 
     # Generic manifest operations
 
-    def _check_presence(self, conn: Connection, access: Access):
-        with self._open_cursor(conn) as cursor:
-            cursor.execute(
-                "SELECT manifest_id FROM manifests WHERE manifest_id = ?", (str(access.id),)
-            )
-            row = cursor.fetchone()
-        return bool(row)
-
     def _get_manifest(self, conn: Connection, access: Access):
         with self._open_cursor(conn) as cursor:
             cursor.execute(
@@ -219,8 +211,6 @@ class PersistentStorage:
         return self._get_manifest(self.clean_conn, access)
 
     def set_clean_manifest(self, access: Access, raw: bytes):
-        if self._check_presence(self.dirty_conn, access):
-            raise ValueError("Cannot set clean manifest: a dirty manifest is already present")
         self._set_manifest(self.clean_conn, access, raw)
 
     def clear_clean_manifest(self, access: Access):
@@ -232,8 +222,6 @@ class PersistentStorage:
         return self._get_manifest(self.dirty_conn, access)
 
     def set_dirty_manifest(self, access: Access, raw: bytes):
-        if self._check_presence(self.clean_conn, access):
-            raise ValueError("Cannot set dirty manifest: a clean manifest is already present")
         self._set_manifest(self.dirty_conn, access, raw)
 
     def clear_dirty_manifest(self, access: Access):

--- a/parsec/core/types/remote_manifests.py
+++ b/parsec/core/types/remote_manifests.py
@@ -44,9 +44,9 @@ class FileManifest:
     def evolve(self, **data) -> "FileManifest":
         return attr.evolve(self, **data)
 
-    def to_local(self) -> "local_manifests.LocalFileManifest":
+    def to_local(self, author: DeviceID) -> "local_manifests.LocalFileManifest":
         return local_manifests.LocalFileManifest(
-            author=self.author,
+            author=author,
             base_version=self.version,
             created=self.created,
             updated=self.updated,
@@ -91,9 +91,9 @@ class FolderManifest:
     def evolve(self, **data) -> "FolderManifest":
         return attr.evolve(self, **data)
 
-    def to_local(self) -> "local_manifests.LocalFolderManifest":
+    def to_local(self, author: DeviceID) -> "local_manifests.LocalFolderManifest":
         return local_manifests.LocalFolderManifest(
-            author=self.author,
+            author=author,
             base_version=self.version,
             created=self.created,
             updated=self.updated,
@@ -131,9 +131,9 @@ folder_manifest_serializer = serializer_factory(FolderManifestSchema)
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)
 class WorkspaceManifest(FolderManifest):
-    def to_local(self) -> "local_manifests.LocalWorkspaceManifest":
+    def to_local(self, author: DeviceID) -> "local_manifests.LocalWorkspaceManifest":
         return local_manifests.LocalWorkspaceManifest(
-            author=self.author,
+            author=author,
             base_version=self.version,
             created=self.created,
             updated=self.updated,
@@ -171,9 +171,9 @@ class UserManifest:
     def evolve(self, **data) -> "UserManifest":
         return attr.evolve(self, **data)
 
-    def to_local(self) -> "local_manifests.LocalUserManifest":
+    def to_local(self, author: DeviceID) -> "local_manifests.LocalUserManifest":
         return local_manifests.LocalUserManifest(
-            author=self.author,
+            author=author,
             base_version=self.version,
             created=self.created,
             updated=self.updated,

--- a/parsec/core/types/remote_manifests.py
+++ b/parsec/core/types/remote_manifests.py
@@ -166,7 +166,7 @@ class UserManifest:
     created: pendulum.Pendulum
     updated: pendulum.Pendulum
     last_processed_message: int
-    workspaces: List[WorkspaceEntry]
+    workspaces: Tuple[WorkspaceEntry] = attr.ib(converter=tuple)
 
     def evolve(self, **data) -> "UserManifest":
         return attr.evolve(self, **data)

--- a/parsec/core/types/remote_manifests.py
+++ b/parsec/core/types/remote_manifests.py
@@ -2,7 +2,7 @@
 
 import attr
 import pendulum
-from typing import Tuple, Dict, List, Union
+from typing import Tuple, Dict, Union
 
 from parsec.types import DeviceID, FrozenDict
 from parsec.serde import UnknownCheckedSchema, OneOfSchema, fields, validate, post_load

--- a/tests/common.py
+++ b/tests/common.py
@@ -61,8 +61,8 @@ class InMemoryPersistentStorage(PersistentStorage):
 
 
 class InMemoryLocalStorage(LocalStorage):
-    def __init__(self):
-        super().__init__("unused")
+    def __init__(self, device_id):
+        super().__init__(device_id, "unused")
         self.persistent_storage = InMemoryPersistentStorage()
 
 

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -18,10 +18,11 @@ def local_storage_factory(initial_user_manifest_state):
         device_id = device.device_id
         assert force or (device_id not in local_storages)
 
-        local_storage = InMemoryLocalStorage()
+        local_storage = InMemoryLocalStorage(device_id)
         local_storages[device_id] = local_storage
         if not user_manifest_in_v0:
             user_manifest = initial_user_manifest_state.get_user_manifest_v1_for_device(device)
+            user_manifest = user_manifest.evolve(author=device_id)
             local_storage.set_dirty_manifest(device.user_manifest_access, user_manifest)
         return local_storage
 

--- a/tests/core/fs/test_bootstrap.py
+++ b/tests/core/fs/test_bootstrap.py
@@ -148,8 +148,7 @@ async def test_reloading_v0_user_manifest(
         with freeze_time("2000-01-02"):
             stat = await fs.workspace_create("/foo")
 
-    # TODO: clean manifest cache once it's been moved to local storage
-    # local_storage.clear_memory_cache()
+    local_storage.clear_memory_cache()
 
     # Reload version 0 manifest
     async with fs_factory(alice, local_storage) as fs:
@@ -168,7 +167,7 @@ async def test_reloading_v0_user_manifest(
             "children": ["foo"],
         }
 
-    local_storage.manifest_cache.clear()
+    local_storage.clear_memory_cache()
 
     # Syncronize version 0 manifest
     async with fs_factory(alice, local_storage) as fs:

--- a/tests/core/fs/test_fs_online_concurrent_tree_and_sync.py
+++ b/tests/core/fs/test_fs_online_concurrent_tree_and_sync.py
@@ -20,6 +20,9 @@ st_fs = st.sampled_from(["fs_1", "fs_2"])
 
 
 def compare_fs_dumps(entry_1, entry_2):
+    entry_1.pop("author", None)
+    entry_2.pop("author", None)
+
     def cook_entry(entry):
         if "children" in entry:
             return {**entry, "children": {k: v["access"] for k, v in entry["children"].items()}}

--- a/tests/core/fs/test_fs_online_concurrent_user.py
+++ b/tests/core/fs/test_fs_online_concurrent_user.py
@@ -19,6 +19,9 @@ st_fs = st.sampled_from(["fs_1", "fs_2"])
 
 
 def compare_fs_dumps(entry_1, entry_2):
+    entry_1.pop("author", None)
+    entry_2.pop("author", None)
+
     def cook_entry(entry):
         if "children" in entry:
             return {**entry, "children": {k: v["access"] for k, v in entry["children"].items()}}

--- a/tests/core/fs/test_fs_sync.py
+++ b/tests/core/fs/test_fs_sync.py
@@ -343,16 +343,12 @@ async def test_concurrent_update(running_backend, alice_fs, alice2_fs):
     # 2) Make both fs diverged
 
     with freeze_time("2000-01-03"):
-        # z_by_alice_id = await alice_fs.workspace_create("/z")
-        # z_by_alice = alice_fs._local_folder_fs.get_access(FsPath("/z"))
         await alice_fs.file_write("/w/foo.txt", b"alice's v2")
         await alice_fs.folder_create("/w/bar/from_alice")
         await alice_fs.folder_create("/w/bar/spam")
         await alice_fs.touch("/w/bar/buzz.txt")
 
     with freeze_time("2000-01-04"):
-        # z_by_alice2_id = await alice2_fs.workspace_create("/z")
-        # z_by_alice2 = alice2_fs._local_folder_fs.get_access(FsPath("/z"))
         await alice2_fs.file_write("/w/foo.txt", b"alice2's v2")
         await alice2_fs.folder_create("/w/bar/from_alice2")
         await alice2_fs.folder_create("/w/bar/spam")

--- a/tests/core/fs/test_local_folder_fs.py
+++ b/tests/core/fs/test_local_folder_fs.py
@@ -199,7 +199,8 @@ def test_access_not_loaded_entry(alice, bob, local_folder_fs):
     with pytest.raises(FSManifestLocalMiss):
         local_folder_fs.stat(FsPath("/w/"))
 
-    local_folder_fs.set_dirty_manifest(w_entry.access, w_manifest)
+    alice_w_manifest = w_manifest.evolve(author=alice.device_id)
+    local_folder_fs.set_dirty_manifest(w_entry.access, alice_w_manifest)
     stat = local_folder_fs.stat(FsPath("/w/"))
     assert stat == {
         "type": "workspace",

--- a/tests/core/fs/userfs/test_sharing.py
+++ b/tests/core/fs/userfs/test_sharing.py
@@ -363,7 +363,7 @@ async def test_share_workspace_then_conflict_on_rights(
     am = alice_user_fs.get_user_manifest()
     a2m = alice2_user_fs.get_user_manifest()
     expected = LocalUserManifest(
-        author=alice2.device_id,
+        author=alice.device_id,
         created=Pendulum(2000, 1, 1),
         updated=Pendulum(2000, 1, 3),
         base_version=synced_version,
@@ -380,7 +380,7 @@ async def test_share_workspace_then_conflict_on_rights(
         ),
     )
     assert am == expected
-    assert a2m == am
+    assert a2m == expected.evolve(author=alice2.device_id)
 
     a_w = alice_user_fs.get_workspace(wid)
     a2_w = alice2_user_fs.get_workspace(wid)

--- a/tests/core/fs/userfs/test_sync.py
+++ b/tests/core/fs/userfs/test_sync.py
@@ -180,7 +180,7 @@ async def test_sync_under_concurrency(
     um2 = alice2_user_fs.get_user_manifest()
 
     expected_um = LocalUserManifest(
-        author=alice2.device_id,
+        author=alice.device_id,
         base_version=3,
         need_sync=False,
         is_placeholder=False,
@@ -203,7 +203,7 @@ async def test_sync_under_concurrency(
         ),
     )
     assert um == expected_um
-    assert um == um2
+    assert um2 == expected_um.evolve(author=alice2.device_id)
 
 
 @pytest.mark.trio
@@ -299,7 +299,7 @@ async def test_concurrent_sync_placeholder(
         um2 = user_fs2.get_user_manifest()
         if dev2_has_changes:
             expected_um = LocalUserManifest(
-                author=device2.device_id,
+                author=device1.device_id,
                 base_version=2,
                 need_sync=False,
                 is_placeholder=False,
@@ -339,8 +339,9 @@ async def test_concurrent_sync_placeholder(
                     ),
                 ),
             )
+
         assert um1 == expected_um
-        assert um1 == um2
+        assert um2 == expected_um.evolve(author=device2.device_id)
 
 
 @pytest.mark.trio
@@ -367,7 +368,7 @@ async def test_sync_remote_changes(running_backend, alice_user_fs, alice2_user_f
     um2 = alice2_user_fs.get_user_manifest()
 
     expected_um = LocalUserManifest(
-        author=alice2.device_id,
+        author=alice.device_id,
         base_version=2,
         need_sync=False,
         is_placeholder=False,
@@ -383,5 +384,6 @@ async def test_sync_remote_changes(running_backend, alice_user_fs, alice2_user_f
             ),
         ),
     )
+
     assert um == expected_um
-    assert um == um2
+    assert um2 == expected_um.evolve(author=alice2.device_id)

--- a/tests/core/mountpoint/test_fuse.py
+++ b/tests/core/mountpoint/test_fuse.py
@@ -100,7 +100,8 @@ async def test_mountpoint_path_already_in_use_concurrent_with_non_empty_dir(
     async def _mocked_bootstrap_mountpoint(*args):
         trio_mountpoint_path = trio.Path(f"{mountpoint_path}")
         await trio_mountpoint_path.mkdir(parents=True)
-        await (trio_mountpoint_path / "bar.txt").touch()
+        file_path = trio_mountpoint_path / "bar.txt"
+        await file_path.touch()
         st_dev = (await trio_mountpoint_path.stat()).st_dev
         return mountpoint_path, st_dev
 

--- a/tests/core/test_local_storage.py
+++ b/tests/core/test_local_storage.py
@@ -19,50 +19,47 @@ def test_get_manifest(local_storage):
     access = ManifestAccess()
     with pytest.raises(LocalStorageMissingEntry):
         local_storage.get_manifest(access)
-    local_storage.manifest_cache[access.id] = "manifest"
+    local_storage.local_manifest_cache[access.id] = "manifest"
     assert local_storage.get_manifest(access) == "manifest"
 
 
-@mock.patch("parsec.core.persistent_storage.PersistentStorage.clear_dirty_manifest")
-def test_set_clean_manifest(clear_dirty_manifest_mock, local_storage):
+def test_base_manifest(local_storage):
+    access = ManifestAccess()
+    manifest = LocalUserManifest(
+        author="a@b", base_version=1, is_placeholder=False, need_sync=False
+    )
+    remote_manifest = manifest.to_remote()
+    local_storage.set_base_manifest(access, remote_manifest)
+    assert local_storage.get_base_manifest(access) == remote_manifest
+    assert local_storage.get_manifest(access) == manifest
+
+    assert local_storage.base_manifest_cache[access.id] == remote_manifest
+    local_storage.base_manifest_cache.clear()
+
+    assert local_storage.get_base_manifest(access) == remote_manifest
+    assert local_storage.get_manifest(access) == manifest
+
+
+def test_set_manifest(local_storage):
     access = ManifestAccess()
     manifest = LocalUserManifest(author=123, base_version=1, is_placeholder=False, need_sync=False)
-    local_storage.set_clean_manifest(access, manifest, False)
-    clear_dirty_manifest_mock.assert_not_called()
-    assert local_storage.manifest_cache[access.id] == manifest
-    local_storage.manifest_cache = OrderedDict()
-    # Force clear
-    local_storage.set_clean_manifest(access, manifest, True)
-    clear_dirty_manifest_mock.assert_called_once_with(access)
-    assert local_storage.manifest_cache[access.id] == manifest
+    local_storage.set_manifest(access, manifest)
+    assert local_storage.local_manifest_cache[access.id] == manifest
 
 
-def test_set_dirty_manifest(local_storage):
+def test_clear_manifest(local_storage):
     access = ManifestAccess()
     manifest = LocalUserManifest(author=123, base_version=1, is_placeholder=False, need_sync=False)
-    local_storage.set_dirty_manifest(access, manifest)
-    assert local_storage.manifest_cache[access.id] == manifest
+    local_storage.set_base_manifest(access, manifest.to_remote())
+    local_storage.set_manifest(access, manifest)
 
+    assert local_storage.get_base_manifest(access)
+    assert local_storage.get_manifest(access)
 
-@mock.patch("parsec.core.persistent_storage.PersistentStorage.clear_clean_manifest")
-@mock.patch("parsec.core.persistent_storage.PersistentStorage.clear_dirty_manifest")
-def test_clear_manifest(clear_dirty_manifest_mock, clear_clean_manifest_mock, local_storage):
-    access = ManifestAccess()
-    manifest = LocalUserManifest(author=123, base_version=1, is_placeholder=False, need_sync=False)
-    local_storage.manifest_cache == OrderedDict({access.id: manifest})
     local_storage.clear_manifest(access)
-    clear_clean_manifest_mock.assert_called_once_with(access)
-    clear_dirty_manifest_mock.assert_not_called()
-    clear_clean_manifest_mock.reset_mock()
-    assert local_storage.manifest_cache == OrderedDict()
-
-    local_storage.manifest_cache == OrderedDict({access.id: manifest})
-    clear_clean_manifest_mock.side_effect = LocalStorageMissingEntry(access)
-    local_storage.clear_manifest(access)
-    clear_clean_manifest_mock.assert_called_once_with(access)
-    clear_dirty_manifest_mock.assert_called_once_with(access)
-    assert local_storage.manifest_cache == OrderedDict()
-
-    clear_clean_manifest_mock.side_effect = LocalStorageMissingEntry(access)
-    clear_dirty_manifest_mock.side_effect = LocalStorageMissingEntry(access)
-    local_storage.clear_manifest(access)
+    assert access not in local_storage.base_manifest_cache
+    assert access not in local_storage.local_manifest_cache
+    with pytest.raises(LocalStorageMissingEntry):
+        local_storage.get_base_manifest(access)
+    with pytest.raises(LocalStorageMissingEntry):
+        local_storage.get_manifest(access)

--- a/tests/core/test_local_storage.py
+++ b/tests/core/test_local_storage.py
@@ -9,7 +9,7 @@ from parsec.core.types import LocalUserManifest, ManifestAccess
 
 @pytest.fixture
 def local_storage(tmpdir):
-    with LocalStorage(tmpdir) as db:
+    with LocalStorage("a@b", tmpdir) as db:
         yield db
 
 
@@ -40,14 +40,18 @@ def test_base_manifest(local_storage):
 
 def test_set_manifest(local_storage):
     access = ManifestAccess()
-    manifest = LocalUserManifest(author=123, base_version=1, is_placeholder=False, need_sync=False)
+    manifest = LocalUserManifest(
+        author="a@b", base_version=1, is_placeholder=False, need_sync=False
+    )
     local_storage.set_manifest(access, manifest)
     assert local_storage.local_manifest_cache[access.id] == manifest
 
 
 def test_clear_manifest(local_storage):
     access = ManifestAccess()
-    manifest = LocalUserManifest(author=123, base_version=1, is_placeholder=False, need_sync=False)
+    manifest = LocalUserManifest(
+        author="a@b", base_version=1, is_placeholder=False, need_sync=False
+    )
     local_storage.set_base_manifest(access, manifest.to_remote())
     local_storage.set_manifest(access, manifest)
 

--- a/tests/core/test_local_storage.py
+++ b/tests/core/test_local_storage.py
@@ -1,8 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
-from collections import OrderedDict
 import pytest
-from unittest import mock
 
 from parsec.core.local_storage import LocalStorage
 from parsec.core.persistent_storage import LocalStorageMissingEntry

--- a/tests/core/test_local_storage.py
+++ b/tests/core/test_local_storage.py
@@ -2,14 +2,17 @@
 
 import pytest
 
+from parsec.types import DeviceID
 from parsec.core.local_storage import LocalStorage
 from parsec.core.persistent_storage import LocalStorageMissingEntry
 from parsec.core.types import LocalUserManifest, ManifestAccess
 
+DEVICE = DeviceID("a@b")
+
 
 @pytest.fixture
 def local_storage(tmpdir):
-    with LocalStorage("a@b", tmpdir) as db:
+    with LocalStorage(DEVICE, tmpdir) as db:
         yield db
 
 
@@ -24,7 +27,7 @@ def test_get_manifest(local_storage):
 def test_base_manifest(local_storage):
     access = ManifestAccess()
     manifest = LocalUserManifest(
-        author="a@b", base_version=1, is_placeholder=False, need_sync=False
+        author=DEVICE, base_version=1, is_placeholder=False, need_sync=False
     )
     remote_manifest = manifest.to_remote()
     local_storage.set_base_manifest(access, remote_manifest)
@@ -41,7 +44,7 @@ def test_base_manifest(local_storage):
 def test_set_manifest(local_storage):
     access = ManifestAccess()
     manifest = LocalUserManifest(
-        author="a@b", base_version=1, is_placeholder=False, need_sync=False
+        author=DEVICE, base_version=1, is_placeholder=False, need_sync=False
     )
     local_storage.set_manifest(access, manifest)
     assert local_storage.local_manifest_cache[access.id] == manifest
@@ -50,7 +53,7 @@ def test_set_manifest(local_storage):
 def test_clear_manifest(local_storage):
     access = ManifestAccess()
     manifest = LocalUserManifest(
-        author="a@b", base_version=1, is_placeholder=False, need_sync=False
+        author=DEVICE, base_version=1, is_placeholder=False, need_sync=False
     )
     local_storage.set_base_manifest(access, manifest.to_remote())
     local_storage.set_manifest(access, manifest)


### PR DESCRIPTION
Also fix the authorship for manifests:
- `remote_manifest.author` is the id of the device uploading the manifest
- `local_manifest.author` is the id of of the device working on the manifest