### PR TITLE
Improve unhandled errors display in GUI

### DIFF
--- a/parsec/core/gui/main_window.py
+++ b/parsec/core/gui/main_window.py
@@ -150,6 +150,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             if "Device has been revoked" in str(self.runing_core_job.exc):
                 show_error(self, _("This device has been revoked."))
             else:
+                logger.error("Unhandled error", exc_info=self.runing_core_job.exc)
                 error = "\n".join(traceback.format_tb(self.runing_core_job.exc.__traceback__))
                 show_error(self, _("Unhandled error:\n\n{}").format(error))
         self.runing_core_job = None
@@ -198,9 +199,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             show_error(self, _("Mountpoint already in use."))
 
         except Exception as exc:
+            logger.exception("Unhandled error during login")
             error = "\n".join(traceback.format_tb(exc.__traceback__))
             show_error(self, _("Unhandled error:\n\n{}").format(error))
-            logger.exception("Unhandled error during login")
 
     def login_with_pkcs11(self, key_file, pkcs11_pin, pkcs11_key, pkcs11_token):
         try:
@@ -224,9 +225,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             show_error(self, _("Mountpoint already in use."))
 
         except Exception as exc:
+            logger.exception("Unhandled error during login")
             error = "\n".join(traceback.format_tb(exc.__traceback__))
             show_error(self, _("Unhandled error:\n\n{}").format(error))
-            logger.exception("Unhandled error during login")
 
     def close_app(self, force=False):
         self.need_close = True

--- a/parsec/core/gui/main_window.py
+++ b/parsec/core/gui/main_window.py
@@ -1,6 +1,7 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
 import trio
+import traceback
 from functools import partial
 from structlog import get_logger
 from PyQt5.QtCore import QCoreApplication, pyqtSignal, pyqtSlot
@@ -149,7 +150,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             if "Device has been revoked" in str(self.runing_core_job.exc):
                 show_error(self, _("This device has been revoked."))
             else:
-                show_error(self, _("Unhandled error."))
+                error = "\n".join(traceback.format_tb(self.runing_core_job.exc.__traceback__))
+                show_error(self, _("Unhandled error:\n\n{}").format(error))
         self.runing_core_job = None
         self.core_jobs_ctx = None
         self.core = None
@@ -179,8 +181,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         try:
             device = load_device_with_password(key_file, password)
             self.start_core(device)
-        except LocalDeviceError:
-            show_error(self, _("Authentication failed."))
+
+        except LocalDeviceError as exc:
+            show_error(self, _("Authentication failed ({}).").format(str(exc)))
 
         except BackendHandshakeAPIVersionError:
             show_error(self, _("Incompatible backend API version."))  # TODO
@@ -195,11 +198,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             show_error(self, _("Mountpoint already in use."))
 
         except Exception as exc:
-            import traceback
-
-            traceback.print_exc()
-            show_error(self, _("Can not login"))
-            logger.error("Error while trying to log in: {}".format(str(exc)))
+            error = "\n".join(traceback.format_tb(exc.__traceback__))
+            show_error(self, _("Unhandled error:\n\n{}").format(error))
+            logger.exception("Unhandled error during login")
 
     def login_with_pkcs11(self, key_file, pkcs11_pin, pkcs11_key, pkcs11_token):
         try:
@@ -223,11 +224,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             show_error(self, _("Mountpoint already in use."))
 
         except Exception as exc:
-            import traceback
-
-            traceback.print_exc()
-            show_error(self, _("Can not login."))
-            logger.error("Error while trying to log in: {}".format(str(exc)))
+            error = "\n".join(traceback.format_tb(exc.__traceback__))
+            show_error(self, _("Unhandled error:\n\n{}").format(error))
+            logger.exception("Unhandled error during login")
 
     def close_app(self, force=False):
         self.need_close = True

--- a/parsec/core/gui/tr/parsec_en.po
+++ b/parsec/core/gui/tr/parsec_en.po
@@ -540,10 +540,10 @@ msgid ""
 "us improve your experience ?"
 msgstr ""
 
-msgid "Unhandled error."
+msgid "Unhandled error:\n\n{}"
 msgstr ""
 
-msgid "Authentication failed."
+msgid "Authentication failed ({})."
 msgstr ""
 
 msgid "Incompatible backend API version."

--- a/parsec/core/gui/tr/parsec_fr.po
+++ b/parsec/core/gui/tr/parsec_fr.po
@@ -579,11 +579,11 @@ msgstr ""
 "Autorisez-vous Parsec à envoyer des données en cas d'erreur pour nous permettre "
 "d'améliorer votre expérience ?"
 
-msgid "Unhandled error."
-msgstr "Erreur non gérée."
+msgid "Unhandled error:\n\n{}"
+msgstr "Erreur non gérée:\n\n{}"
 
-msgid "Authentication failed."
-msgstr "L'authentification a échoué."
+msgid "Authentication failed ({})."
+msgstr "L'authentification a échoué ({})."
 
 msgid "Incompatible backend API version."
 msgstr "Votre version de l'application est incompatible avec le serveur."


### PR DESCRIPTION
Le truc pas top c'est que la popup créée par `show_error()` ne possède n'a pas d'ascenseur pour afficher une grosse quantité de texte comme un stacktrace... du coup c'est assez illisible en l'état :'(