### PR TITLE
Optimize persistant storage & add garbage collector test

### DIFF
--- a/parsec/core/persistent_storage.py
+++ b/parsec/core/persistent_storage.py
@@ -298,7 +298,14 @@ class PersistentStorage:
             if not limit:
                 cursor.execute("DELETE FROM blocks")
             else:
-                cursor.execute("DELETE FROM blocks ORDER BY accessed_on ASC LIMIT ?", (limit,))
+                cursor.execute(
+                    """
+                    DELETE FROM blocks WHERE block_id IN (
+                        SELECT block_id FROM blocks ORDER BY accessed_on ASC LIMIT ?
+                    )
+                    """,
+                    (limit,),
+                )
 
     def run_block_garbage_collector(self):
         self.clear_clean_blocks()

--- a/tests/core/gui/conftest.py
+++ b/tests/core/gui/conftest.py
@@ -290,7 +290,7 @@ def add_method(cls):
     return _add_method
 
 
-# Since widgets are not longer persistant and are instancied only when needed,
+# Since widgets are not longer persistent and are instantiated only when needed,
 # we can no longer simply access them.
 # These methods help to retrieve a widget according to the current state of the GUI.
 # They're prefixed by "test_" to ensure that they do not erase any "real" methods.

--- a/tests/core/test_persistent_storage.py
+++ b/tests/core/test_persistent_storage.py
@@ -17,6 +17,8 @@ from parsec.core.types import EntryID, BlockID
 from parsec.core.persistent_storage import PersistentStorage, LocalStorageMissingError
 from parsec.core.persistent_storage import DEFAULT_BLOCK_SIZE as block_size
 
+from tests.common import freeze_time
+
 
 ENTRY_ID = EntryID("00000000000000000000000000000001")
 BLOCK_ID = BlockID("0000000000000000000000000000000A")
@@ -106,6 +108,40 @@ def test_local_manual_run_block_garbage_collector(persistent_storage):
     persistent_storage.get_dirty_block(block_id_precious) == b"precious_data"
     with pytest.raises(LocalStorageMissingError):
         persistent_storage.get_clean_block(block_id_deletable)
+
+
+def test_local_manual_run_block_garbage_collector_with_limit(persistent_storage):
+    block_id_precious = BlockID()
+    # No matter how old, shouldn't be deleted
+    with freeze_time("2000-01-01"):
+        persistent_storage.set_dirty_block(block_id_precious, b"precious_data")
+
+    block_id_deletable1 = BlockID()
+    block_id_deletable2 = BlockID()
+    block_id_deletable3 = BlockID()
+    block_id_deletable4 = BlockID()
+    with freeze_time("2000-01-01"):
+        persistent_storage.set_clean_block(block_id_deletable1, b"deletable_data")
+        persistent_storage.set_clean_block(block_id_deletable2, b"deletable_data")
+        persistent_storage.set_clean_block(block_id_deletable3, b"deletable_data")
+
+    with freeze_time("2000-01-02"):
+        persistent_storage.get_clean_block(block_id_deletable2)
+
+    with freeze_time("2000-01-03"):
+        persistent_storage.get_clean_block(block_id_deletable3)
+        persistent_storage.set_clean_block(block_id_deletable4, b"deletable_data")
+
+    # Blocks 1 and 2 are the oldest
+    persistent_storage.clear_clean_blocks(limit=2)
+
+    persistent_storage.get_dirty_block(block_id_precious) == b"precious_data"
+    persistent_storage.get_clean_block(block_id_deletable3) == b"deletable_data"
+    persistent_storage.get_clean_block(block_id_deletable4) == b"deletable_data"
+    with pytest.raises(LocalStorageMissingError):
+        persistent_storage.get_clean_block(block_id_deletable1)
+    with pytest.raises(LocalStorageMissingError):
+        persistent_storage.get_clean_block(block_id_deletable2)
 
 
 def test_local_automatic_run_garbage_collector(persistent_storage):

--- a/tests/core/test_persistent_storage.py
+++ b/tests/core/test_persistent_storage.py
@@ -46,6 +46,9 @@ def test_persistent_storage_cache_size(persistent_storage):
     persistent_storage.set_clean_block(ENTRY_ID, b"data")
     assert persistent_storage.get_cache_size() > 4
 
+    persistent_storage.clear_clean_block(ENTRY_ID)
+    assert persistent_storage.get_cache_size() == 0
+
 
 def test_persistent_storage_set_get_clear_manifest(persistent_storage):
     persistent_storage.set_manifest(ENTRY_ID, b"data")


### PR DESCRIPTION
- configure sqlite with WAL mode, isolation=None and synchronous=OFF
- blocks are stored in sqlite
- Use integer for accessed_on column (faster than text in db + time.time() much faster than pendulum.now())

before:
![before](https://user-images.githubusercontent.com/3187637/62077828-60553900-b24b-11e9-8965-a0c2199a9515.png)

after:
![after](https://user-images.githubusercontent.com/3187637/62077844-6a773780-b24b-11e9-9c27-952ac9b9a07e.png)

Bench is done on a copy of a 10mo file, getting a ~30% improvement

[profs.zip](https://github.com/Scille/parsec-cloud/files/3444084/profs.zip)

