### PR TITLE
Move load_blocks logic to the remote loader

### DIFF
--- a/parsec/core/fs/remote_loader.py
+++ b/parsec/core/fs/remote_loader.py
@@ -155,6 +155,17 @@ class RemoteLoader:
         _, current_roles = await self._load_realm_role_certificates(realm_id)
         return current_roles
 
+    async def load_blocks(self, accesses: List[BlockAccess]) -> None:
+        """
+        Raises:
+            FSError
+            FSRemoteBlockNotFound
+            FSBackendOfflineError
+            FSWorkspaceInMaintenance
+        """
+        for access in accesses:
+            await self.load_block(access)
+
     async def load_block(self, access: BlockAccess) -> None:
         """
         Raises:

--- a/parsec/core/fs/workspacefs/file_transactions.py
+++ b/parsec/core/fs/workspacefs/file_transactions.py
@@ -209,10 +209,7 @@ class FileTransactions:
         while True:
 
             # Load missing blocks
-            # TODO: add a `load_blocks` method to the remote loader
-            # to download the blocks in a concurrent way.
-            for block_access in missing:
-                await self.remote_loader.load_block(block_access)
+            await self.remote_loader.load_blocks(missing)
 
             # Fetch and lock
             async with self._load_and_lock_file(fd) as (entry_id, manifest):

--- a/parsec/core/fs/workspacefs/sync_transactions.py
+++ b/parsec/core/fs/workspacefs/sync_transactions.py
@@ -278,10 +278,7 @@ class SyncTransactions:
         while True:
 
             # Load missing blocks
-            # TODO: add a `load_blocks` method to the remote loader
-            # to download the blocks in a concurrent way.
-            for access in missing:
-                await self.remote_loader.load_block(access)
+            await self.remote_loader.load_blocks(missing)
 
             # Fetch and lock
             async with self.local_storage.lock_manifest(entry_id) as manifest:


### PR DESCRIPTION
See #553.

No reason to do this concurrently though, as the blocks (except for the last one) are 512KB large