### PR TITLE
Improve local storage tests

### DIFF
--- a/tests/core/fs/test_local_storage.py
+++ b/tests/core/fs/test_local_storage.py
@@ -2,8 +2,6 @@
 
 import pytest
 
-from parsec.types import DeviceID
-from parsec.crypto import SecretKey
 from parsec.core.fs.local_storage import LocalStorage
 from parsec.core.fs import FSLocalMissError
 from parsec.core.types import (
@@ -15,67 +13,146 @@ from parsec.core.types import (
 )
 
 
-DEVICE = DeviceID("a@b")
-
-
-def create_entry(type=LocalUserManifest):
+def create_entry(device, type=LocalUserManifest):
     entry_id = EntryID()
     if type is LocalUserManifest:
         manifest = LocalUserManifest(
-            author=DEVICE, base_version=0, is_placeholder=True, need_sync=True
+            author=device.device_id, base_version=0, is_placeholder=True, need_sync=True
         )
     elif type is LocalWorkspaceManifest:
-        manifest = type.make_placeholder(entry_id=entry_id, author=DEVICE)
+        manifest = type.make_placeholder(entry_id=entry_id, author=device.device_id)
     else:
-        manifest = type.make_placeholder(entry_id=entry_id, author=DEVICE, parent_id=EntryID())
+        manifest = type.make_placeholder(
+            entry_id=entry_id, author=device.device_id, parent_id=EntryID()
+        )
     return entry_id, manifest
 
 
-@pytest.fixture
-def local_storage(tmpdir):
-    key = SecretKey.generate()
-    with LocalStorage(DEVICE, key, tmpdir) as db:
-        yield db
+@pytest.mark.trio
+async def test_lock_required(tmpdir, alice):
+    entry_id, manifest = create_entry(alice)
 
+    with LocalStorage(alice.device_id, alice.local_symkey, tmpdir) as als:
 
-def test_get_manifest(local_storage):
-    entry_id, manifest = create_entry()
-    with pytest.raises(FSLocalMissError):
-        local_storage.get_manifest(entry_id)
-    local_storage.local_manifest_cache[entry_id] = manifest
-    assert local_storage.get_manifest(entry_id) == manifest
+        msg = f"Entry `{entry_id}` modified without beeing locked"
+
+        with pytest.raises(RuntimeError) as exc:
+            als.set_manifest(entry_id, manifest)
+        assert str(exc.value) == msg
+
+        with pytest.raises(RuntimeError) as exc:
+            als.ensure_manifest_persistant(entry_id)
+        assert str(exc.value) == msg
+
+        with pytest.raises(RuntimeError) as exc:
+            als.clear_manifest(entry_id)
+        assert str(exc.value) == msg
+
+        # Note: `get_manifest` doesn't need a lock before use
 
 
 @pytest.mark.trio
-async def test_set_manifest(local_storage):
-    entry_id, manifest = create_entry()
-    async with local_storage.lock_entry_id(entry_id):
-        local_storage.set_manifest(entry_id, manifest)
-    assert local_storage.local_manifest_cache[entry_id] == manifest
+async def test_basic_set_get_clear(tmpdir, alice):
+    entry_id, manifest = create_entry(alice)
+
+    with LocalStorage(alice.device_id, alice.local_symkey, tmpdir) as als:
+
+        async with als.lock_entry_id(entry_id):
+
+            # 1) No data
+            with pytest.raises(FSLocalMissError):
+                als.get_manifest(entry_id)
+
+            # 2) Set data
+            als.set_manifest(entry_id, manifest)
+            assert als.get_manifest(entry_id) == manifest
+            # Make sure data are not only stored in cache
+            with LocalStorage(alice.device_id, alice.local_symkey, tmpdir) as als2:
+                assert als2.get_manifest(entry_id) == manifest
+
+            # 3) Clear data
+            als.clear_manifest(entry_id)
+            with pytest.raises(FSLocalMissError):
+                als.get_manifest(entry_id)
+            with LocalStorage(alice.device_id, alice.local_symkey, tmpdir) as als3:
+                with pytest.raises(FSLocalMissError):
+                    assert als3.get_manifest(entry_id) == manifest
 
 
 @pytest.mark.trio
-async def test_clear_manifest(local_storage):
-    entry_id, manifest = create_entry()
-    async with local_storage.lock_entry_id(entry_id):
-        local_storage.set_manifest(entry_id, manifest)
-    assert local_storage.get_manifest(entry_id) == manifest
+async def test_cache_set_get(tmpdir, alice):
+    entry_id, manifest = create_entry(alice)
 
-    async with local_storage.lock_entry_id(entry_id):
-        local_storage.clear_manifest(entry_id)
-    assert entry_id not in local_storage.local_manifest_cache
-    with pytest.raises(FSLocalMissError):
-        local_storage.get_manifest(entry_id)
+    with LocalStorage(alice.device_id, alice.local_symkey, tmpdir) as als:
+
+        async with als.lock_entry_id(entry_id):
+
+            # 1) Set data
+            als.set_manifest(entry_id, manifest, cache_only=True)
+            assert als.get_manifest(entry_id) == manifest
+            with LocalStorage(alice.device_id, alice.local_symkey, tmpdir) as als2:
+                with pytest.raises(FSLocalMissError):
+                    als2.get_manifest(entry_id)
+
+            # 2) Clear should work as expected
+            als.clear_manifest(entry_id)
+            with pytest.raises(FSLocalMissError):
+                als.get_manifest(entry_id)
+
+            # 3) Re-set data
+            als.set_manifest(entry_id, manifest, cache_only=True)
+            assert als.get_manifest(entry_id) == manifest
+            with LocalStorage(alice.device_id, alice.local_symkey, tmpdir) as als3:
+                with pytest.raises(FSLocalMissError):
+                    als3.get_manifest(entry_id)
+
+            # 4) Flush data
+            als.ensure_manifest_persistant(entry_id)
+            assert als.get_manifest(entry_id) == manifest
+            with LocalStorage(alice.device_id, alice.local_symkey, tmpdir) as als4:
+                assert als4.get_manifest(entry_id) == manifest
+
+
+@pytest.mark.trio
+async def test_cache_flushed_on_exit(tmpdir, alice):
+    entry_id, manifest = create_entry(alice)
+
+    with LocalStorage(alice.device_id, alice.local_symkey, tmpdir) as als:
+        async with als.lock_entry_id(entry_id):
+            als.set_manifest(entry_id, manifest, cache_only=True)
+
+    with LocalStorage(alice.device_id, alice.local_symkey, tmpdir) as als2:
+        assert als2.get_manifest(entry_id) == manifest
+
+
+@pytest.mark.trio
+async def test_clear_cache(tmpdir, alice):
+    entry_id1, manifest1 = create_entry(alice)
+    entry_id2, manifest2 = create_entry(alice)
+
+    with LocalStorage(alice.device_id, alice.local_symkey, tmpdir) as als:
+        async with als.lock_entry_id(entry_id1):
+            als.set_manifest(entry_id1, manifest1)
+        async with als.lock_entry_id(entry_id2):
+            als.set_manifest(entry_id2, manifest2, cache_only=True)
+
+        als.clear_memory_cache()
+
+        assert als.get_manifest(entry_id1) == manifest1
+        with pytest.raises(FSLocalMissError):
+            als.get_manifest(entry_id2)
 
 
 @pytest.mark.parametrize(
     "type", [LocalUserManifest, LocalWorkspaceManifest, LocalFolderManifest, LocalFileManifest]
 )
 @pytest.mark.trio
-async def test_get_manifest_with_cache_miss(local_storage, type):
-    entry_id, manifest = create_entry(type)
-    async with local_storage.lock_entry_id(entry_id):
-        local_storage.set_manifest(entry_id, manifest)
-    assert local_storage.get_manifest(entry_id) == manifest
-    local_storage.clear_memory_cache()
-    assert local_storage.get_manifest(entry_id) == manifest
+async def test_serialize_types(tmpdir, alice, type):
+    entry_id, manifest = create_entry(alice, type)
+
+    with LocalStorage(alice.device_id, alice.local_symkey, tmpdir) as als:
+        async with als.lock_entry_id(entry_id):
+            als.set_manifest(entry_id, manifest)
+
+    with LocalStorage(alice.device_id, alice.local_symkey, tmpdir) as als2:
+        assert als2.get_manifest(entry_id) == manifest


### PR DESCRIPTION
`_check_lock_status` now raises `RuntimeError` instead of doing an assert to make it more readable in the tests (`pytest.raises(AssertionError)` feels weird...)