### PR TITLE
Refactor transactions

### DIFF
--- a/parsec/core/fs/local_storage.py
+++ b/parsec/core/fs/local_storage.py
@@ -221,14 +221,14 @@ class LocalStorage:
         self.open_fds[fd] = entry_id
         return fd
 
-    def load_file_descriptor(self, fd: FileDescriptor) -> Tuple[EntryID, LocalFileManifest]:
+    def load_file_descriptor(self, fd: FileDescriptor) -> LocalFileManifest:
         try:
             entry_id = self.open_fds[fd]
         except KeyError:
             raise FSInvalidFileDescriptor(fd)
         manifest = self.get_manifest(entry_id)
         assert isinstance(manifest, LocalFileManifest)
-        return entry_id, manifest
+        return manifest
 
     def remove_file_descriptor(self, fd: FileDescriptor, manifest: LocalFileManifest) -> None:
         assert isinstance(manifest, LocalFileManifest)

--- a/parsec/core/fs/local_storage.py
+++ b/parsec/core/fs/local_storage.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 import trio
 from trio import hazmat
 from typing import Dict, Tuple, Set
+
 from pendulum import Pendulum
 from structlog import get_logger
 from async_generator import asynccontextmanager

--- a/parsec/core/fs/workspacefs/entry_transactions.py
+++ b/parsec/core/fs/workspacefs/entry_transactions.py
@@ -438,3 +438,16 @@ class EntryTransactions(FileTransactions):
 
             # Return the entry id of the open file and the file descriptor
             return manifest.entry_id, self.local_storage.create_file_descriptor(manifest.entry_id)
+
+    async def file_resize(self, path: FsPath) -> EntryID:
+        # Check write rights
+        self._check_write_rights(path)
+
+        # Lock manifest
+        async with self._lock_manifest_from_path(path) as manifest:
+
+            # Perform resize
+            self._file_resize(manifest)
+
+            # Return entry id
+            return manifest.entry_id

--- a/parsec/core/fs/workspacefs/entry_transactions.py
+++ b/parsec/core/fs/workspacefs/entry_transactions.py
@@ -22,6 +22,7 @@ from parsec.core.types import (
 
 
 from parsec.core.fs.local_storage import LocalStorage
+from parsec.core.fs.workspacefs.file_transactions import FileTransactions
 from parsec.core.fs.exceptions import FSEntryNotFound, FSLocalMissError
 from parsec.core.fs.remote_loader import RemoteLoader
 from parsec.core.fs.utils import (
@@ -41,33 +42,13 @@ def from_errno(errno, message=None, filename=None, filename2=None):
     return OSError(errno, message, filename, None, filename2)
 
 
-class EntryTransactions:
-    def __init__(
-        self,
-        workspace_id: EntryID,
-        get_workspace_entry: Callable,
-        device: LocalDevice,
-        local_storage: LocalStorage,
-        remote_loader: RemoteLoader,
-        event_bus: EventBus,
-    ):
-        self.workspace_id = workspace_id
-        self.get_workspace_entry = get_workspace_entry
-        self.local_author = device.device_id
-        self.local_storage = local_storage
-        self.remote_loader = remote_loader
-        self.event_bus = event_bus
+class EntryTransactions(FileTransactions):
 
     # Right management helper
 
     def _check_write_rights(self, path: FsPath):
         if self.get_workspace_entry().role not in WRITE_RIGHT_ROLES:
             raise from_errno(errno.EACCES, str(path))
-
-    # Event helper
-
-    def _send_event(self, event, **kwargs):
-        self.event_bus.send(event, workspace_id=self.workspace_id, **kwargs)
 
     # Look-up helpers
 

--- a/parsec/core/fs/workspacefs/entry_transactions.py
+++ b/parsec/core/fs/workspacefs/entry_transactions.py
@@ -2,18 +2,16 @@
 
 import os
 import errno
-from typing import Tuple, Callable, Dict
+from typing import Tuple, Dict
 from async_generator import asynccontextmanager
 
 from pendulum import Pendulum
 
-from parsec.event_bus import EventBus
 from parsec.types import DeviceID
 from parsec.core.types import (
     EntryID,
     FsPath,
     WorkspaceRole,
-    LocalDevice,
     LocalManifest,
     LocalFileManifest,
     LocalFolderManifest,
@@ -21,10 +19,8 @@ from parsec.core.types import (
 )
 
 
-from parsec.core.fs.local_storage import LocalStorage
 from parsec.core.fs.workspacefs.file_transactions import FileTransactions
 from parsec.core.fs.exceptions import FSEntryNotFound, FSLocalMissError
-from parsec.core.fs.remote_loader import RemoteLoader
 from parsec.core.fs.utils import (
     is_file_manifest,
     is_folder_manifest,

--- a/parsec/core/fs/workspacefs/file_transactions.py
+++ b/parsec/core/fs/workspacefs/file_transactions.py
@@ -120,20 +120,20 @@ class FileTransactions:
         # corresponding to valid file descriptor is always available locally
 
         # Get the corresponding entry_id
-        entry_id, _ = self.local_storage.load_file_descriptor(fd)
+        manifest = self.local_storage.load_file_descriptor(fd)
 
         # Lock the entry_id
-        async with self.local_storage.lock_manifest(entry_id):
+        async with self.local_storage.lock_manifest(manifest.entry_id):
             yield self.local_storage.load_file_descriptor(fd)
 
     # Atomic transactions
 
     async def fd_close(self, fd: FileDescriptor) -> None:
         # Fetch and lock
-        async with self._load_and_lock_file(fd) as (entry_id, manifest):
+        async with self._load_and_lock_file(fd) as manifest:
 
             # Force writing to disk
-            self.local_storage.ensure_manifest_persistent(entry_id)
+            self.local_storage.ensure_manifest_persistent(manifest.entry_id)
 
             # Atomic change
             self.local_storage.remove_file_descriptor(fd, manifest)
@@ -143,7 +143,7 @@ class FileTransactions:
 
     async def fd_write(self, fd: FileDescriptor, content: bytes, offset: int) -> int:
         # Fetch and lock
-        async with self._load_and_lock_file(fd) as (entry_id, manifest):
+        async with self._load_and_lock_file(fd) as manifest:
 
             # No-op
             if not content:
@@ -158,7 +158,7 @@ class FileTransactions:
                 self._write_chunk(chunk, content, offset)
 
             # Atomic change
-            self.local_storage.set_manifest(entry_id, manifest, cache_only=True)
+            self.local_storage.set_manifest(manifest.entry_id, manifest, cache_only=True)
 
             # Clean up
             for removed_id in removed_ids:
@@ -167,11 +167,11 @@ class FileTransactions:
             # Reshaping
             self._write_count[fd] += 1
             if self._write_count[fd] >= 128:
-                self._manifest_reshape(entry_id, manifest, cache_only=True)
+                self._manifest_reshape(manifest, cache_only=True)
                 self._write_count[fd] = 0
 
         # Notify
-        self._send_event("fs.entry.updated", id=entry_id)
+        self._send_event("fs.entry.updated", id=manifest.entry_id)
         return len(content)
 
     async def fd_resize(self, fd: FileDescriptor, length: int) -> None:
@@ -197,7 +197,7 @@ class FileTransactions:
                 self.local_storage.clear_chunk(removed_id, miss_ok=True)
 
         # Notify
-        self._send_event("fs.entry.updated", id=entry_id)
+        self._send_event("fs.entry.updated", id=manifest.entry_id)
 
     async def fd_read(self, fd: FileDescriptor, size: int, offset: int) -> bytes:
         # Loop over attemps
@@ -208,7 +208,7 @@ class FileTransactions:
             await self.remote_loader.load_blocks(missing)
 
             # Fetch and lock
-            async with self._load_and_lock_file(fd) as (entry_id, manifest):
+            async with self._load_and_lock_file(fd) as manifest:
 
                 # Normalize
                 offset = normalize_argument(offset, manifest)
@@ -227,9 +227,9 @@ class FileTransactions:
                     return data
 
     async def fd_flush(self, fd: FileDescriptor) -> None:
-        async with self._load_and_lock_file(fd) as (entry_id, manifest):
-            self._manifest_reshape(entry_id, manifest)
-            self.local_storage.ensure_manifest_persistent(entry_id)
+        async with self._load_and_lock_file(fd) as manifest:
+            self._manifest_reshape(manifest)
+            self.local_storage.ensure_manifest_persistent(manifest.entry_id)
 
     async def file_reshape(self, entry_id: EntryID) -> None:
 
@@ -252,7 +252,7 @@ class FileTransactions:
     # Reshaping helper
 
     def _manifest_reshape(
-        self, entry_id: EntryID, manifest: LocalFileManifest, cache_only: bool = False
+        self, manifest: LocalFileManifest, cache_only: bool = False
     ) -> List[BlockID]:
         """This internal helper does not perform any locking."""
 
@@ -289,7 +289,7 @@ class FileTransactions:
 
         # Craft and set new manifest
         new_manifest = getter(result_dict)
-        self.local_storage.set_manifest(entry_id, new_manifest, cache_only=cache_only)
+        self.local_storage.set_manifest(new_manifest.entry_id, new_manifest, cache_only=cache_only)
 
         # Perform cleanup
         for removed_id in removed_ids:

--- a/parsec/core/fs/workspacefs/file_transactions.py
+++ b/parsec/core/fs/workspacefs/file_transactions.py
@@ -1,12 +1,13 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
-from typing import Tuple, List
+from typing import Tuple, List, Callable
 
 from collections import defaultdict
 from async_generator import asynccontextmanager
 
 from parsec.event_bus import EventBus
-from parsec.core.types import FileDescriptor, EntryID
+from parsec.core.types import FileDescriptor, EntryID, LocalDevice
+
 from parsec.core.fs.remote_loader import RemoteLoader
 from parsec.core.fs.local_storage import LocalStorage
 from parsec.core.fs.exceptions import FSLocalMissError, FSInvalidFileDescriptor
@@ -66,11 +67,15 @@ class FileTransactions:
     def __init__(
         self,
         workspace_id: EntryID,
+        get_workspace_entry: Callable,
+        device: LocalDevice,
         local_storage: LocalStorage,
         remote_loader: RemoteLoader,
         event_bus: EventBus,
     ):
         self.workspace_id = workspace_id
+        self.get_workspace_entry = get_workspace_entry
+        self.local_author = device.device_id
         self.local_storage = local_storage
         self.remote_loader = remote_loader
         self.event_bus = event_bus

--- a/parsec/core/fs/workspacefs/sync_transactions.py
+++ b/parsec/core/fs/workspacefs/sync_transactions.py
@@ -17,6 +17,7 @@ from parsec.core.types import (
     LocalFileManifest,
 )
 
+from parsec.core.fs.workspacefs.entry_transactions import EntryTransactions
 from parsec.core.fs.exceptions import (
     FSFileConflictError,
     FSReshapingRequiredError,
@@ -178,23 +179,7 @@ def merge_manifests(local_manifest: LocalManifest, remote_manifest: Optional[Man
     )
 
 
-class SyncTransactions:
-    def __init__(
-        self,
-        workspace_id: EntryID,
-        local_storage: LocalStorage,
-        remote_loader: RemoteLoader,
-        event_bus: EventBus,
-    ):
-        self.workspace_id = workspace_id
-        self.local_storage = local_storage
-        self.remote_loader = remote_loader
-        self.event_bus = event_bus
-
-    # Event helper
-
-    def _send_event(self, event, **kwargs):
-        self.event_bus.send(event, workspace_id=self.workspace_id, **kwargs)
+class SyncTransactions(EntryTransactions):
 
     # Public read-only helpers
 

--- a/parsec/core/fs/workspacefs/sync_transactions.py
+++ b/parsec/core/fs/workspacefs/sync_transactions.py
@@ -3,10 +3,7 @@
 from itertools import count
 from typing import Optional, List, Dict, Iterator
 
-from parsec.event_bus import EventBus
 from parsec.types import DeviceID
-from parsec.core.fs.remote_loader import RemoteLoader
-from parsec.core.fs.local_storage import LocalStorage
 from parsec.core.types import (
     Chunk,
     EntryID,

--- a/parsec/core/fs/workspacefs/workspacefs.py
+++ b/parsec/core/fs/workspacefs/workspacefs.py
@@ -13,8 +13,6 @@ from parsec.core.types import FsPath, EntryID, LocalDevice, WorkspaceRole, Manif
 
 from parsec.core.fs import workspacefs
 from parsec.core.fs.remote_loader import RemoteLoader
-from parsec.core.fs.workspacefs.file_transactions import FileTransactions
-from parsec.core.fs.workspacefs.entry_transactions import EntryTransactions
 from parsec.core.fs.workspacefs.sync_transactions import SyncTransactions
 
 from parsec.core.fs.utils import is_file_manifest, is_folderish_manifest
@@ -79,19 +77,13 @@ class WorkspaceFS:
             self.remote_device_manager,
             self.local_storage,
         )
-        self.file_transactions = FileTransactions(
-            self.workspace_id, self.local_storage, self.remote_loader, self.event_bus
-        )
-        self.entry_transactions = EntryTransactions(
+        self.transactions = SyncTransactions(
             self.workspace_id,
             self.get_workspace_entry,
             self.device,
             self.local_storage,
             self.remote_loader,
             self.event_bus,
-        )
-        self.sync_transactions = SyncTransactions(
-            self.workspace_id, self.local_storage, self.remote_loader, self.event_bus
         )
 
     def __repr__(self):

--- a/parsec/core/fs/workspacefs/workspacefs.py
+++ b/parsec/core/fs/workspacefs/workspacefs.py
@@ -105,7 +105,7 @@ class WorkspaceFS:
             OSError
             FSError
         """
-        return await self.entry_transactions.entry_info(FsPath(path))
+        return await self.transactions.entry_info(FsPath(path))
 
     async def path_id(self, path: AnyPath) -> UUID:
         """
@@ -113,7 +113,7 @@ class WorkspaceFS:
             OSError
             FSError
         """
-        info = await self.entry_transactions.entry_info(FsPath(path))
+        info = await self.transactions.entry_info(FsPath(path))
         return info["id"]
 
     async def get_entry_path(self, entry_id: EntryID) -> FsPath:
@@ -121,7 +121,7 @@ class WorkspaceFS:
         Raises:
            FSEntryNotFound
         """
-        return await self.entry_transactions.get_entry_path(entry_id)
+        return await self.transactions.get_entry_path(entry_id)
 
     async def get_user_roles(self) -> Dict[UserID, WorkspaceRole]:
         """
@@ -193,7 +193,7 @@ class WorkspaceFS:
             FSError
         """
         path = FsPath(path)
-        return await self.entry_transactions.entry_versions(path)
+        return await self.transactions.entry_versions(path)
 
     async def to_timestamped(self, timestamp: Pendulum):
         workspace = workspacefs.WorkspaceFSTimestamped(self, timestamp)
@@ -214,7 +214,7 @@ class WorkspaceFS:
         """
         path = FsPath(path)
         try:
-            await self.entry_transactions.entry_info(path)
+            await self.transactions.entry_info(path)
         except (FileNotFoundError, NotADirectoryError):
             return False
         return True
@@ -226,7 +226,7 @@ class WorkspaceFS:
             FSError
         """
         path = FsPath(path)
-        info = await self.entry_transactions.entry_info(path)
+        info = await self.transactions.entry_info(path)
         return info["type"] == "folder"
 
     async def is_file(self, path: AnyPath) -> bool:
@@ -236,7 +236,7 @@ class WorkspaceFS:
             FSError
         """
         path = FsPath(path)
-        info = await self.entry_transactions.entry_info(FsPath(path))
+        info = await self.transactions.entry_info(FsPath(path))
         return info["type"] == "file"
 
     async def iterdir(self, path: AnyPath) -> Iterator[FsPath]:
@@ -246,7 +246,7 @@ class WorkspaceFS:
             FSError
         """
         path = FsPath(path)
-        info = await self.entry_transactions.entry_info(path)
+        info = await self.transactions.entry_info(path)
         if "children" not in info:
             raise NotADirectoryError(str(path))
         for child in info["children"]:
@@ -268,7 +268,7 @@ class WorkspaceFS:
         """
         source = FsPath(source)
         destination = FsPath(destination)
-        await self.entry_transactions.entry_rename(source, destination, overwrite=overwrite)
+        await self.transactions.entry_rename(source, destination, overwrite=overwrite)
 
     async def mkdir(self, path: AnyPath, parents: bool = False, exist_ok: bool = False) -> None:
         """
@@ -278,7 +278,7 @@ class WorkspaceFS:
         """
         path = FsPath(path)
         try:
-            await self.entry_transactions.folder_create(path)
+            await self.transactions.folder_create(path)
         except FileNotFoundError:
             if not parents or path.parent == path:
                 raise
@@ -295,7 +295,7 @@ class WorkspaceFS:
             FSError
         """
         path = FsPath(path)
-        await self.entry_transactions.folder_delete(path)
+        await self.transactions.folder_delete(path)
 
     async def touch(self, path: AnyPath, exist_ok: bool = True) -> None:
         """
@@ -305,7 +305,7 @@ class WorkspaceFS:
         """
         path = FsPath(path)
         try:
-            await self.entry_transactions.file_create(path, open=False)
+            await self.transactions.file_create(path, open=False)
         except FileExistsError:
             if not exist_ok:
                 raise
@@ -317,7 +317,7 @@ class WorkspaceFS:
             FSError
         """
         path = FsPath(path)
-        await self.entry_transactions.file_delete(path)
+        await self.transactions.file_delete(path)
 
     async def truncate(self, path: AnyPath, length: int) -> None:
         """
@@ -326,11 +326,11 @@ class WorkspaceFS:
             FSError
         """
         path = FsPath(path)
-        _, fd = await self.entry_transactions.file_open(path, "w")
+        _, fd = await self.transactions.file_open(path, "w")
         try:
-            return await self.file_transactions.fd_resize(fd, length)
+            return await self.transactions.fd_resize(fd, length)
         finally:
-            await self.file_transactions.fd_close(fd)
+            await self.transactions.fd_close(fd)
 
     async def read_bytes(self, path: AnyPath, size: int = -1, offset: int = 0) -> bytes:
         """
@@ -339,11 +339,11 @@ class WorkspaceFS:
             FSError
         """
         path = FsPath(path)
-        _, fd = await self.entry_transactions.file_open(path, "r")
+        _, fd = await self.transactions.file_open(path, "r")
         try:
-            return await self.file_transactions.fd_read(fd, size, offset)
+            return await self.transactions.fd_read(fd, size, offset)
         finally:
-            await self.file_transactions.fd_close(fd)
+            await self.transactions.fd_close(fd)
 
     async def write_bytes(self, path: AnyPath, data: bytes, offset: int = 0) -> int:
         """
@@ -352,11 +352,11 @@ class WorkspaceFS:
             FSError
         """
         path = FsPath(path)
-        _, fd = await self.entry_transactions.file_open(path, "w")
+        _, fd = await self.transactions.file_open(path, "w")
         try:
-            return await self.file_transactions.fd_write(fd, data, offset)
+            return await self.transactions.fd_write(fd, data, offset)
         finally:
-            await self.file_transactions.fd_close(fd)
+            await self.transactions.fd_close(fd)
 
     # Shutil-like interface
 
@@ -444,7 +444,7 @@ class WorkspaceFS:
     # Sync helpers
 
     async def _synchronize_placeholders(self, manifest: Manifest) -> None:
-        for child in self.sync_transactions.get_placeholder_children(manifest):
+        for child in self.transactions.get_placeholder_children(manifest):
             await self.minimal_sync(child)
 
     async def _upload_blocks(self, manifest: Manifest) -> None:
@@ -460,7 +460,7 @@ class WorkspaceFS:
         """
         # Get a minimal manifest to upload
         try:
-            remote_manifest = await self.sync_transactions.get_minimal_remote_manifest(entry_id)
+            remote_manifest = await self.transactions.get_minimal_remote_manifest(entry_id)
         # Not available locally so nothing to synchronize
         except FSLocalMissError:
             return
@@ -481,7 +481,7 @@ class WorkspaceFS:
 
         # Register the manifest to unset the placeholder tag
         try:
-            await self.sync_transactions.synchronization_step(entry_id, remote_manifest, final=True)
+            await self.transactions.synchronization_step(entry_id, remote_manifest, final=True)
         # Not available locally so nothing to synchronize
         except FSLocalMissError:
             pass
@@ -515,13 +515,13 @@ class WorkspaceFS:
 
                 # Perform the sync step transaction
                 try:
-                    new_remote_manifest = await self.sync_transactions.synchronization_step(
+                    new_remote_manifest = await self.transactions.synchronization_step(
                         entry_id, remote_manifest, final
                     )
 
                 # The entry first requires reshaping
                 except FSReshapingRequiredError:
-                    await self.file_transactions.file_reshape(entry_id)
+                    await self.transactions.file_reshape(entry_id)
                     continue
 
             # The manifest doesn't exist locally
@@ -589,7 +589,7 @@ class WorkspaceFS:
             local_manifest, remote_manifest = exc.args
             # Only file manifest have synchronization conflict
             assert is_file_manifest(local_manifest)
-            await self.sync_transactions.file_conflict(entry_id, local_manifest, remote_manifest)
+            await self.transactions.file_conflict(entry_id, local_manifest, remote_manifest)
             return await self.sync_by_id(local_manifest.parent_id)
 
         # Non-recursive
@@ -609,7 +609,7 @@ class WorkspaceFS:
             FSError
         """
         path = FsPath(path)
-        entry_id = (await self.entry_transactions._get_manifest_from_path(path)).entry_id
+        entry_id = (await self.transactions._get_manifest_from_path(path)).entry_id
         # TODO: Maybe the path itself is not synchronized with the remote
         # Should we do something about it?
         await self.sync_by_id(entry_id, remote_changed=remote_changed, recursive=recursive)

--- a/parsec/core/fs/workspacefs/workspacefs_timestamped.py
+++ b/parsec/core/fs/workspacefs/workspacefs_timestamped.py
@@ -2,8 +2,7 @@
 
 import pendulum
 
-from parsec.core.fs.workspacefs.entry_transactions import EntryTransactions
-from parsec.core.fs.workspacefs.file_transactions import FileTransactions
+from parsec.core.fs.workspacefs.sync_transactions import SyncTransactions
 
 from parsec.core.fs.workspacefs.workspacefs import WorkspaceFS
 
@@ -23,10 +22,7 @@ class WorkspaceFSTimestamped(WorkspaceFS):
         self.timestamp = timestamp
 
         self.remote_loader = workspacefs.remote_loader.to_timestamped(timestamp)
-        self.file_transactions = FileTransactions(
-            self.workspace_id, self.local_storage, self.remote_loader, self.event_bus
-        )
-        self.entry_transactions = EntryTransactions(
+        self.transactions = SyncTransactions(
             self.workspace_id,
             self.get_workspace_entry,
             self.device,

--- a/parsec/core/mountpoint/fuse_operations.py
+++ b/parsec/core/mountpoint/fuse_operations.py
@@ -141,14 +141,7 @@ class FuseOperations(LoggingMixIn, Operations):
             if fh:
                 self.fs_access.fd_resize(fh, length)
             else:
-                # TODO: investigate file_truncate
-                # Should it be atomic?
-                # Should it affect the file reference count?
-                fd = self.open(path)
-                try:
-                    self.fs_access.fd_resize(fd, length)
-                finally:
-                    self.fs_access.fd_close(fd)
+                self.fs_access.file_resize(path, length)
 
     def unlink(self, path: FsPath):
         with translate_error():

--- a/parsec/core/mountpoint/thread_fs_access.py
+++ b/parsec/core/mountpoint/thread_fs_access.py
@@ -9,48 +9,51 @@ class ThreadFSAccess:
     # Entry transactions
 
     def entry_info(self, path):
-        return self._portal.run(self.workspace_fs.entry_transactions.entry_info, path)
+        return self._portal.run(self.workspace_fs.transactions.entry_info, path)
 
     def entry_rename(self, source, destination, *, overwrite):
         return self._portal.run(
-            self.workspace_fs.entry_transactions.entry_rename, source, destination, overwrite
+            self.workspace_fs.transactions.entry_rename, source, destination, overwrite
         )
 
     # Folder transactions
 
     def folder_create(self, path):
-        return self._portal.run(self.workspace_fs.entry_transactions.folder_create, path)
+        return self._portal.run(self.workspace_fs.transactions.folder_create, path)
 
     def folder_delete(self, path):
-        return self._portal.run(self.workspace_fs.entry_transactions.folder_delete, path)
+        return self._portal.run(self.workspace_fs.transactions.folder_delete, path)
 
     # File transactions
 
     def file_create(self, path, *, open):
-        return self._portal.run(self.workspace_fs.entry_transactions.file_create, path, open)
+        return self._portal.run(self.workspace_fs.transactions.file_create, path, open)
 
     def file_open(self, path, *, mode):
-        return self._portal.run(self.workspace_fs.entry_transactions.file_open, path, mode)
+        return self._portal.run(self.workspace_fs.transactions.file_open, path, mode)
 
     def file_delete(self, path):
-        return self._portal.run(self.workspace_fs.entry_transactions.file_delete, path)
+        return self._portal.run(self.workspace_fs.transactions.file_delete, path)
+
+    def file_resize(self, path):
+        return self._portal.run(self.workspace_fs.transactions.file_resize, path)
 
     # File descriptor transactions
 
     def fd_close(self, fh):
-        return self._portal.run(self.workspace_fs.file_transactions.fd_close, fh)
+        return self._portal.run(self.workspace_fs.transactions.fd_close, fh)
 
     def fd_seek(self, fh, offset):
-        return self._portal.run(self.workspace_fs.file_transactions.fd_seek, fh, offset)
+        return self._portal.run(self.workspace_fs.transactions.fd_seek, fh, offset)
 
     def fd_read(self, fh, size, offset):
-        return self._portal.run(self.workspace_fs.file_transactions.fd_read, fh, size, offset)
+        return self._portal.run(self.workspace_fs.transactions.fd_read, fh, size, offset)
 
     def fd_write(self, fh, data, offset):
-        return self._portal.run(self.workspace_fs.file_transactions.fd_write, fh, data, offset)
+        return self._portal.run(self.workspace_fs.transactions.fd_write, fh, data, offset)
 
     def fd_resize(self, fh, length):
-        return self._portal.run(self.workspace_fs.file_transactions.fd_resize, fh, length)
+        return self._portal.run(self.workspace_fs.transactions.fd_resize, fh, length)
 
     def fd_flush(self, fh):
-        return self._portal.run(self.workspace_fs.file_transactions.fd_flush, fh)
+        return self._portal.run(self.workspace_fs.transactions.fd_flush, fh)

--- a/tests/core/fs/workspacefs/test_sync_transactions.py
+++ b/tests/core/fs/workspacefs/test_sync_transactions.py
@@ -8,7 +8,7 @@ from parsec.core.types import FolderManifest, FileManifest, LocalFolderManifest
 
 from parsec.core.fs.workspacefs.sync_transactions import merge_manifests
 from parsec.core.fs.workspacefs.sync_transactions import merge_folder_children
-from parsec.core.fs import FSReshapingRequiredError, FSFileConflictError
+from parsec.core.fs import FSFileConflictError
 
 
 def test_merge_folder_children():
@@ -204,9 +204,7 @@ async def test_synchronization_step_transaction(sync_transactions, type):
 
     # Sync child
     if type == "file":
-        with pytest.raises(FSReshapingRequiredError):
-            await synchronization_step(a_entry_id)
-        await sync_transactions.file_reshape(a_entry_id)
+        await synchronization_step(a_entry_id)
     a_manifest = await synchronization_step(a_entry_id)
     assert await synchronization_step(a_entry_id, a_manifest) is None
 

--- a/tests/core/fs/workspacefs/test_sync_transactions.py
+++ b/tests/core/fs/workspacefs/test_sync_transactions.py
@@ -176,11 +176,9 @@ def test_merge_file_manifests():
 
 @pytest.mark.trio
 @pytest.mark.parametrize("type", ["file", "folder"])
-async def test_synchronization_step_transaction(
-    sync_transactions, entry_transactions, file_transactions, type
-):
+async def test_synchronization_step_transaction(sync_transactions, type):
     synchronization_step = sync_transactions.synchronization_step
-    entry_id = entry_transactions.get_workspace_entry().id
+    entry_id = sync_transactions.get_workspace_entry().id
 
     # Sync a placeholder
     manifest = await synchronization_step(entry_id)
@@ -190,11 +188,11 @@ async def test_synchronization_step_transaction(
 
     # Local change
     if type == "file":
-        a_id, fd = await entry_transactions.file_create(FsPath("/a"))
-        await file_transactions.fd_write(fd, b"abc", 0)
-        await file_transactions.fd_close(fd)
+        a_id, fd = await sync_transactions.file_create(FsPath("/a"))
+        await sync_transactions.fd_write(fd, b"abc", 0)
+        await sync_transactions.fd_close(fd)
     else:
-        a_id = await entry_transactions.folder_create(FsPath("/a"))
+        a_id = await sync_transactions.folder_create(FsPath("/a"))
 
     # Sync parent with a placeholder child
     manifest = await synchronization_step(entry_id)
@@ -208,7 +206,7 @@ async def test_synchronization_step_transaction(
     if type == "file":
         with pytest.raises(FSReshapingRequiredError):
             await synchronization_step(a_entry_id)
-        await file_transactions.file_reshape(a_entry_id)
+        await sync_transactions.file_reshape(a_entry_id)
     a_manifest = await synchronization_step(a_entry_id)
     assert await synchronization_step(a_entry_id, a_manifest) is None
 
@@ -217,7 +215,7 @@ async def test_synchronization_step_transaction(
     assert await synchronization_step(entry_id, manifest) is None
 
     # Local change
-    b_id = await entry_transactions.folder_create(FsPath("/b"))
+    b_id = await sync_transactions.folder_create(FsPath("/b"))
 
     # Remote change
     children = {**manifest.children, "c": EntryID()}
@@ -241,16 +239,14 @@ async def test_synchronization_step_transaction(
 
 
 @pytest.mark.trio
-async def test_get_minimal_remote_manifest(
-    sync_transactions, entry_transactions, file_transactions
-):
+async def test_get_minimal_remote_manifest(sync_transactions,):
     # Prepare
     w_id = sync_transactions.workspace_id
-    a_id, fd = await entry_transactions.file_create(FsPath("/a"))
-    await file_transactions.fd_write(fd, b"abc", 0)
-    await file_transactions.fd_close(fd)
-    b_id = await entry_transactions.folder_create(FsPath("/b"))
-    c_id = await entry_transactions.folder_create(FsPath("/b/c"))
+    a_id, fd = await sync_transactions.file_create(FsPath("/a"))
+    await sync_transactions.fd_write(fd, b"abc", 0)
+    await sync_transactions.fd_close(fd)
+    b_id = await sync_transactions.folder_create(FsPath("/b"))
+    c_id = await sync_transactions.folder_create(FsPath("/b/c"))
 
     # Workspace manifest
     minimal = await sync_transactions.get_minimal_remote_manifest(w_id)
@@ -267,7 +263,7 @@ async def test_get_minimal_remote_manifest(
     assert minimal == local.evolve(blocks=(), updated=local.created, size=0).to_remote().evolve(
         version=1
     )
-    await file_transactions.file_reshape(a_id)
+    await sync_transactions.file_reshape(a_id)
     await sync_transactions.synchronization_step(a_id, minimal)
     assert await sync_transactions.get_minimal_remote_manifest(a_id) is None
 
@@ -287,15 +283,15 @@ async def test_get_minimal_remote_manifest(
 
 
 @pytest.mark.trio
-async def test_file_conflict(sync_transactions, entry_transactions, file_transactions):
+async def test_file_conflict(sync_transactions):
     # Prepare
-    a_id, fd = await entry_transactions.file_create(FsPath("/a"))
-    await file_transactions.fd_write(fd, b"abc", offset=0)
-    await file_transactions.file_reshape(a_id)
+    a_id, fd = await sync_transactions.file_create(FsPath("/a"))
+    await sync_transactions.fd_write(fd, b"abc", offset=0)
+    await sync_transactions.file_reshape(a_id)
     remote = await sync_transactions.synchronization_step(a_id)
     assert await sync_transactions.synchronization_step(a_id, remote) is None
-    await file_transactions.fd_write(fd, b"def", offset=3)
-    await file_transactions.file_reshape(a_id)
+    await sync_transactions.fd_write(fd, b"def", offset=3)
+    await sync_transactions.file_reshape(a_id)
     changed_remote = remote.evolve(version=2, blocks=[], size=0, author="b@b")
 
     # Try a synchronization
@@ -304,17 +300,17 @@ async def test_file_conflict(sync_transactions, entry_transactions, file_transac
     local, remote = ctx.value.args
 
     # Write some more
-    await file_transactions.fd_write(fd, b"ghi", offset=6)
+    await sync_transactions.fd_write(fd, b"ghi", offset=6)
 
     # Also create a fake previous conflict file
-    await entry_transactions.file_create(FsPath("/a (conflicting with b@b)"), open=False)
+    await sync_transactions.file_create(FsPath("/a (conflicting with b@b)"), open=False)
 
     # Solve conflict
     with sync_transactions.event_bus.listen() as spy:
         await sync_transactions.file_conflict(a_id, local, remote)
-    assert await file_transactions.fd_read(fd, size=-1, offset=0) == b""
-    a2_id, fd2 = await entry_transactions.file_open(FsPath("/a (conflicting with b@b - 2)"))
-    assert await file_transactions.fd_read(fd2, size=-1, offset=0) == b"abcdefghi"
+    assert await sync_transactions.fd_read(fd, size=-1, offset=0) == b""
+    a2_id, fd2 = await sync_transactions.file_open(FsPath("/a (conflicting with b@b - 2)"))
+    assert await sync_transactions.fd_read(fd2, size=-1, offset=0) == b"abcdefghi"
     spy.assert_events_exactly_occured(
         [
             ("fs.entry.updated", {"workspace_id": sync_transactions.workspace_id, "id": a2_id}),
@@ -329,16 +325,16 @@ async def test_file_conflict(sync_transactions, entry_transactions, file_transac
     )
 
     # Finish synchronization
-    await file_transactions.file_reshape(a2_id)
+    await sync_transactions.file_reshape(a2_id)
     assert await sync_transactions.synchronization_step(a_id, changed_remote) is None
     remote2 = await sync_transactions.synchronization_step(a2_id)
     assert await sync_transactions.synchronization_step(a2_id, remote2) is None
 
     # Create a new conflict then remove a
-    await file_transactions.fd_write(fd, b"abc", 0)
-    await file_transactions.file_reshape(a_id)
+    await sync_transactions.fd_write(fd, b"abc", 0)
+    await sync_transactions.file_reshape(a_id)
     changed_remote = changed_remote.evolve(version=3)
-    await entry_transactions.file_delete(FsPath("/a"))
+    await sync_transactions.file_delete(FsPath("/a"))
 
     # Conflict solving should still succeed
     with pytest.raises(FSFileConflictError) as ctx:
@@ -349,5 +345,5 @@ async def test_file_conflict(sync_transactions, entry_transactions, file_transac
     spy.assert_events_exactly_occured([])
 
     # Close fds
-    await file_transactions.fd_close(fd)
-    await file_transactions.fd_close(fd2)
+    await sync_transactions.fd_close(fd)
+    await sync_transactions.fd_close(fd2)

--- a/tests/core/fs/workspacefs/test_workspace_fs.py
+++ b/tests/core/fs/workspacefs/test_workspace_fs.py
@@ -80,7 +80,7 @@ async def test_get_entry_path(alice_workspace):
 
     # Remove an open file
     path = "/foo/bar"
-    bar_id, bar_fd = await alice_workspace.entry_transactions.file_open(FsPath(path))
+    bar_id, bar_fd = await alice_workspace.transactions.file_open(FsPath(path))
     await alice_workspace.unlink(path)
 
     # Get entry path of a removed entry
@@ -92,7 +92,7 @@ async def test_get_entry_path(alice_workspace):
     with pytest.raises(FSEntryNotFound):
         await alice_workspace.get_entry_path(bar_id)
 
-    await alice_workspace.file_transactions.fd_close(bar_fd)
+    await alice_workspace.transactions.fd_close(bar_fd)
 
 
 @pytest.mark.trio
@@ -422,7 +422,7 @@ async def test_dump(alice_workspace):
 
 @pytest.mark.trio
 async def test_path_info_remote_loader_exceptions(monkeypatch, alice_workspace, alice):
-    manifest = await alice_workspace.entry_transactions._get_manifest_from_path(FsPath("/foo/bar"))
+    manifest = await alice_workspace.transactions._get_manifest_from_path(FsPath("/foo/bar"))
     async with alice_workspace.local_storage.lock_entry_id(manifest.entry_id):
         alice_workspace.local_storage.clear_manifest(manifest.entry_id)
 

--- a/tests/core/fs/workspacefs_timestamped/test_entry_transactions_timestamped.py
+++ b/tests/core/fs/workspacefs_timestamped/test_entry_transactions_timestamped.py
@@ -9,10 +9,10 @@ from parsec.core.fs import FSLocalMissError
 
 @pytest.mark.trio
 async def test_root_entry_info(alice_workspace_t2, alice_workspace_t4):
-    stat2 = await alice_workspace_t2.entry_transactions.entry_info(FsPath("/"))
+    stat2 = await alice_workspace_t2.transactions.entry_info(FsPath("/"))
     assert stat2 == {
         "type": "folder",
-        "id": alice_workspace_t4.entry_transactions.workspace_id,
+        "id": alice_workspace_t4.transactions.workspace_id,
         "base_version": 1,
         "is_placeholder": False,
         "need_sync": False,
@@ -21,10 +21,10 @@ async def test_root_entry_info(alice_workspace_t2, alice_workspace_t4):
         "children": ["foo"],
     }
 
-    stat4 = await alice_workspace_t4.entry_transactions.entry_info(FsPath("/"))
+    stat4 = await alice_workspace_t4.transactions.entry_info(FsPath("/"))
     assert stat4 == {
         "type": "folder",
-        "id": alice_workspace_t4.entry_transactions.workspace_id,
+        "id": alice_workspace_t4.transactions.workspace_id,
         "base_version": 2,
         "is_placeholder": False,
         "need_sync": False,
@@ -37,40 +37,40 @@ async def test_root_entry_info(alice_workspace_t2, alice_workspace_t4):
 @pytest.mark.trio
 async def test_file_create(alice_workspace_t4):
     with pytest.raises(PermissionError):
-        access_id, fd = await alice_workspace_t4.entry_transactions.file_create(FsPath("/foo.txt"))
+        access_id, fd = await alice_workspace_t4.transactions.file_create(FsPath("/foo.txt"))
 
 
 @pytest.mark.trio
 async def test_file_delete(alice_workspace_t4):
     with pytest.raises(PermissionError):
-        await alice_workspace_t4.entry_transactions.file_delete(FsPath("/foo/bar"))
+        await alice_workspace_t4.transactions.file_delete(FsPath("/foo/bar"))
 
 
 @pytest.mark.trio
 async def test_folder_delete(alice_workspace_t4):
     with pytest.raises(PermissionError):
-        await alice_workspace_t4.entry_transactions.folder_delete(FsPath("/foo"))
+        await alice_workspace_t4.transactions.folder_delete(FsPath("/foo"))
 
 
 @pytest.mark.trio
 async def test_rename(alice_workspace_t4):
     with pytest.raises(PermissionError):
-        await alice_workspace_t4.entry_transactions.entry_rename(FsPath("/foo"), FsPath("/foo2"))
+        await alice_workspace_t4.transactions.entry_rename(FsPath("/foo"), FsPath("/foo2"))
 
 
 @pytest.mark.trio
 async def test_access_not_loaded_entry(alice_workspace_t4):
-    entry_id = alice_workspace_t4.entry_transactions.get_workspace_entry().id
-    async with alice_workspace_t4.entry_transactions.local_storage.lock_entry_id(entry_id):
-        alice_workspace_t4.entry_transactions.local_storage.clear_manifest(entry_id)
+    entry_id = alice_workspace_t4.transactions.get_workspace_entry().id
+    async with alice_workspace_t4.transactions.local_storage.lock_entry_id(entry_id):
+        alice_workspace_t4.transactions.local_storage.clear_manifest(entry_id)
     with pytest.raises(FSLocalMissError):
-        await alice_workspace_t4.entry_transactions.local_storage.get_manifest(entry_id)
-    async with alice_workspace_t4.entry_transactions.local_storage.lock_entry_id(entry_id):
-        alice_workspace_t4.entry_transactions.local_storage.clear_manifest(entry_id)
-    await alice_workspace_t4.entry_transactions.entry_info(FsPath("/"))
+        await alice_workspace_t4.transactions.local_storage.get_manifest(entry_id)
+    async with alice_workspace_t4.transactions.local_storage.lock_entry_id(entry_id):
+        alice_workspace_t4.transactions.local_storage.clear_manifest(entry_id)
+    await alice_workspace_t4.transactions.entry_info(FsPath("/"))
 
 
 @pytest.mark.trio
 async def test_access_unknown_entry(alice_workspace_t4):
     with pytest.raises(FileNotFoundError):
-        await alice_workspace_t4.entry_transactions.entry_info(FsPath("/dummy"))
+        await alice_workspace_t4.transactions.entry_info(FsPath("/dummy"))

--- a/tests/core/fs/workspacefs_timestamped/test_file_transactions_timestamped.py
+++ b/tests/core/fs/workspacefs_timestamped/test_file_transactions_timestamped.py
@@ -9,56 +9,56 @@ from parsec.core.fs import FSError, FSInvalidFileDescriptor
 @pytest.mark.trio
 async def test_close_unknown_fd(alice_workspace_t4):
     with pytest.raises(FSInvalidFileDescriptor):
-        await alice_workspace_t4.file_transactions.fd_close(42)
+        await alice_workspace_t4.transactions.fd_close(42)
 
 
 @pytest.mark.trio
 async def test_operations_on_file(alice_workspace_t4, alice_workspace_t5):
-    _, fd4 = await alice_workspace_t4.entry_transactions.file_open(FsPath("/files/content"), "r")
+    _, fd4 = await alice_workspace_t4.transactions.file_open(FsPath("/files/content"), "r")
     assert isinstance(fd4, int)
-    file_transactions_t4 = alice_workspace_t4.file_transactions
-    _, fd5 = await alice_workspace_t5.entry_transactions.file_open(FsPath("/files/content"), "r")
+    transactions_t4 = alice_workspace_t4.transactions
+    _, fd5 = await alice_workspace_t5.transactions.file_open(FsPath("/files/content"), "r")
     assert isinstance(fd5, int)
-    file_transactions_t5 = alice_workspace_t5.file_transactions
+    transactions_t5 = alice_workspace_t5.transactions
 
-    data = await file_transactions_t4.fd_read(fd4, 1, 0)
+    data = await transactions_t4.fd_read(fd4, 1, 0)
     assert data == b"a"
-    data = await file_transactions_t4.fd_read(fd4, 3, 1)
+    data = await transactions_t4.fd_read(fd4, 3, 1)
     assert data == b"bcd"
-    data = await file_transactions_t4.fd_read(fd4, 100, 4)
+    data = await transactions_t4.fd_read(fd4, 100, 4)
     assert data == b"e"
 
-    data = await file_transactions_t4.fd_read(fd4, 4, 0)
+    data = await transactions_t4.fd_read(fd4, 4, 0)
     assert data == b"abcd"
-    data = await file_transactions_t4.fd_read(fd4, -1, 0)
+    data = await transactions_t4.fd_read(fd4, -1, 0)
     assert data == b"abcde"
 
     with pytest.raises(FSError):  # if removed from local_storage, no write right error?..
-        await alice_workspace_t4.file_transactions.fd_write(fd4, b"hello ", 0)
+        await alice_workspace_t4.transactions.fd_write(fd4, b"hello ", 0)
 
-    data = await file_transactions_t5.fd_read(fd5, 100, 0)
+    data = await transactions_t5.fd_read(fd5, 100, 0)
     assert data == b"fghij"
-    data = await file_transactions_t5.fd_read(fd5, 1, 1)
+    data = await transactions_t5.fd_read(fd5, 1, 1)
     assert data == b"g"
 
-    data = await file_transactions_t4.fd_read(fd4, 1, 2)
+    data = await transactions_t4.fd_read(fd4, 1, 2)
     assert data == b"c"
 
-    await file_transactions_t5.fd_close(fd5)
+    await transactions_t5.fd_close(fd5)
     with pytest.raises(FSInvalidFileDescriptor):
-        data = await file_transactions_t5.fd_read(fd5, 1, 0)
-    data = await file_transactions_t4.fd_read(fd4, 1, 3)
+        data = await transactions_t5.fd_read(fd5, 1, 0)
+    data = await transactions_t4.fd_read(fd4, 1, 3)
     assert data == b"d"
 
-    _, fd5 = await alice_workspace_t5.entry_transactions.file_open(FsPath("/files/content"), "r")
-    data = await file_transactions_t5.fd_read(fd5, 3, 0)
+    _, fd5 = await alice_workspace_t5.transactions.file_open(FsPath("/files/content"), "r")
+    data = await transactions_t5.fd_read(fd5, 3, 0)
     assert data == b"fgh"
 
 
 @pytest.mark.trio
 async def test_flush_file(alice_workspace_t4):
-    _, fd4 = await alice_workspace_t4.entry_transactions.file_open(FsPath("/files/content"), "r")
+    _, fd4 = await alice_workspace_t4.transactions.file_open(FsPath("/files/content"), "r")
     assert isinstance(fd4, int)
-    file_transactions_t4 = alice_workspace_t4.file_transactions
+    transactions_t4 = alice_workspace_t4.transactions
 
-    await file_transactions_t4.fd_flush(fd4)
+    await transactions_t4.fd_flush(fd4)


### PR DESCRIPTION
Use inheritance for transaction classes. This allows for a simpler implementation of two fixes:
- Preventing file manifest to get stuck in a sync loop while being written 
- Adding the `file_resize` atomic transaction (see #553)