### PR TITLE
Improve performance when writing blocks

### DIFF
--- a/parsec/core/fs/workspacefs/file_operations.py
+++ b/parsec/core/fs/workspacefs/file_operations.py
@@ -228,6 +228,11 @@ def prepare_reshape(
         if len(chunks) == 1 and chunks[0].is_block:
             continue
 
+        # Already a pseudo-block
+        if len(chunks) == 1 and chunks[0].is_pseudo_block:
+            operations[block] = (chunks, chunks[0], set())
+            continue
+
         # Write new block
         start, stop = chunks[0].start, chunks[-1].stop
         new_chunk = Chunk.new_chunk(start, stop)

--- a/parsec/core/fs/workspacefs/file_transactions.py
+++ b/parsec/core/fs/workspacefs/file_transactions.py
@@ -271,9 +271,10 @@ class FileTransactions:
                 missing += extra_missing
                 continue
 
-            # Write data
+            # Write data if necessary
             new_chunk = destination.evolve_as_block(data)
-            self._write_chunk(new_chunk, data)
+            if source != (destination,):
+                self._write_chunk(new_chunk, data)
 
             # Update structures
             removed_ids |= cleanup

--- a/parsec/core/fs/workspacefs/file_transactions.py
+++ b/parsec/core/fs/workspacefs/file_transactions.py
@@ -90,7 +90,7 @@ class FileTransactions:
 
     def _read_chunk(self, chunk: Chunk) -> bytes:
         data = self.local_storage.get_chunk(chunk.id)
-        return data[chunk.start - chunk.reference : chunk.stop - chunk.reference]
+        return data[chunk.start - chunk.raw_offset : chunk.stop - chunk.raw_offset]
 
     def _write_chunk(self, chunk: Chunk, content: bytes, offset: int = 0) -> None:
         data = padded_data(content, offset, offset + chunk.stop - chunk.start)

--- a/parsec/core/types/local_manifests.py
+++ b/parsec/core/types/local_manifests.py
@@ -121,7 +121,8 @@ class LocalFileManifest:
             for chunk in chunks:
                 assert chunk.start == current
                 assert chunk.start < chunk.stop
-                assert chunk.reference <= chunk.start
+                assert chunk.raw_offset <= chunk.start
+                assert chunk.stop <= chunk.raw_offset + chunk.raw_size
                 current = chunk.stop
         assert current == self.size
 


### PR DESCRIPTION
Writing files by chunks of `DEFAULT_BLOCK_SIZE` minimizes the amount of reshape operations required. The qt application can take advantage of this, making this writing pattern a nominal use case.
This PR implements two optimizations that should make a significant difference for this use case. 