### PR TITLE
New api versioning scheme

### DIFF
--- a/parsec/_version.py
+++ b/parsec/_version.py
@@ -3,4 +3,6 @@
 # This file is imported from __init__.py and exec'd from setup.py
 
 __version__ = "0.11.1"
-__api_version__ = "1.0.0"
+__api_major__ = 1
+__api_minor__ = 0
+__api_version__ = __api_major__, __api_minor__

--- a/parsec/api/protocol/__init__.py
+++ b/parsec/api/protocol/__init__.py
@@ -1,7 +1,7 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
 from parsec.api.protocol.base import (
-    ProtocoleError,
+    ProtocolError,
     MessageSerializationError,
     InvalidMessageError,
     packb,
@@ -76,7 +76,7 @@ from parsec.api.protocol.vlob import (
 
 
 __all__ = (
-    "ProtocoleError",
+    "ProtocolError",
     "MessageSerializationError",
     "InvalidMessageError",
     "packb",

--- a/parsec/api/protocol/base.py
+++ b/parsec/api/protocol/base.py
@@ -13,18 +13,18 @@ from parsec.serde import (
 )
 
 
-__all__ = ("ProtocoleError", "BaseReqSchema", "BaseRepSchema", "CmdSerializer")
+__all__ = ("ProtocolError", "BaseReqSchema", "BaseRepSchema", "CmdSerializer")
 
 
-class ProtocoleError(Exception):
+class ProtocolError(Exception):
     pass
 
 
-class InvalidMessageError(SerdeValidationError, ProtocoleError):
+class InvalidMessageError(SerdeValidationError, ProtocolError):
     pass
 
 
-class MessageSerializationError(SerdePackingError, ProtocoleError):
+class MessageSerializationError(SerdePackingError, ProtocolError):
     pass
 
 

--- a/parsec/api/protocol/handshake.py
+++ b/parsec/api/protocol/handshake.py
@@ -6,11 +6,11 @@ from secrets import token_bytes
 from parsec import __api_version__
 from parsec.crypto import CryptoError
 from parsec.serde import UnknownCheckedSchema, OneOfSchema, fields
-from parsec.api.protocol.base import ProtocoleError, InvalidMessageError, serializer_factory
+from parsec.api.protocol.base import ProtocolError, InvalidMessageError, serializer_factory
 from parsec.api.protocol.types import OrganizationIDField, DeviceIDField
 
 
-class HandshakeError(ProtocoleError):
+class HandshakeError(ProtocolError):
     pass
 
 

--- a/parsec/api/protocol/handshake.py
+++ b/parsec/api/protocol/handshake.py
@@ -44,8 +44,8 @@ class HandshakeAPIVersionError(HandshakeError):
 
     @classmethod
     def check_api_version(cls, peer_api_version):
-        local_major, _, _ = map(int, __api_version__.split("."))
-        peer_major, _, _ = map(int, peer_api_version.split("."))
+        local_major, _ = __api_version__
+        peer_major, _ = peer_api_version
         if local_major != peer_major:
             raise cls(peer_api_version)
 
@@ -53,7 +53,7 @@ class HandshakeAPIVersionError(HandshakeError):
 class HandshakeChallengeSchema(UnknownCheckedSchema):
     handshake = fields.CheckedConstant("challenge", required=True)
     challenge = fields.Bytes(required=True)
-    api_version = fields.SemVer(required=True)
+    api_version = fields.ApiVersion(required=True)
 
 
 handshake_challenge_serializer = serializer_factory(HandshakeChallengeSchema)
@@ -62,7 +62,7 @@ handshake_challenge_serializer = serializer_factory(HandshakeChallengeSchema)
 class HandshakeAuthenticatedAnswerSchema(UnknownCheckedSchema):
     handshake = fields.CheckedConstant("answer", required=True)
     type = fields.CheckedConstant("authenticated", required=True)
-    api_version = fields.SemVer(required=True)
+    api_version = fields.ApiVersion(required=True)
     organization_id = OrganizationIDField(required=True)
     device_id = DeviceIDField(required=True)
     rvk = fields.VerifyKey(required=True)
@@ -72,7 +72,7 @@ class HandshakeAuthenticatedAnswerSchema(UnknownCheckedSchema):
 class HandshakeAnonymousAnswerSchema(UnknownCheckedSchema):
     handshake = fields.CheckedConstant("answer", required=True)
     type = fields.CheckedConstant("anonymous", required=True)
-    api_version = fields.SemVer(required=True)
+    api_version = fields.ApiVersion(required=True)
     organization_id = OrganizationIDField(required=True)
     # Cannot provide rvk during organization bootstrap
     rvk = fields.VerifyKey(missing=None)
@@ -81,7 +81,7 @@ class HandshakeAnonymousAnswerSchema(UnknownCheckedSchema):
 class HandshakeAdministrationAnswerSchema(UnknownCheckedSchema):
     handshake = fields.CheckedConstant("answer", required=True)
     type = fields.CheckedConstant("administration", required=True)
-    api_version = fields.SemVer(required=True)
+    api_version = fields.ApiVersion(required=True)
     token = fields.String(required=True)
 
 

--- a/parsec/api/transport.py
+++ b/parsec/api/transport.py
@@ -44,6 +44,22 @@ class Transport:
         self.conn_id = uuid4().hex
         self.logger = logger.bind(conn_id=self.conn_id)
         self._ws_events = ws.events()
+        self._handshake = None
+
+    # Handshake interface
+    # TODO: Investigate a better place for providing an access to the peer API version
+
+    @property
+    def handshake(self):
+        if self._handshake is None:
+            raise TypeError("The handshake has not been set")
+        return self._handshake
+
+    @handshake.setter
+    def handshake(self, handshake):
+        if self._handshake is not None:
+            raise TypeError("The handshake has already been set")
+        self._handshake = handshake
 
     async def _next_ws_event(self):
         while True:

--- a/parsec/backend/app.py
+++ b/parsec/backend/app.py
@@ -224,7 +224,7 @@ class BackendApp:
     async def _do_handshake(self, transport):
         context = None
         try:
-            handshake = ServerHandshake(self.config.handshake_challenge_size)
+            handshake = transport.handshake = ServerHandshake(self.config.handshake_challenge_size)
             challenge_req = handshake.build_challenge_req()
             await transport.send(challenge_req)
             answer_req = await transport.recv()

--- a/parsec/backend/app.py
+++ b/parsec/backend/app.py
@@ -9,7 +9,7 @@ from parsec.api.transport import TransportError, TransportClosedByPeer, Transpor
 from parsec.api.protocol import (
     packb,
     unpackb,
-    ProtocoleError,
+    ProtocolError,
     MessageSerializationError,
     InvalidMessageError,
     ServerHandshake,
@@ -284,7 +284,7 @@ class BackendApp:
                 else:
                     result_req = handshake.build_bad_administration_token_result_req()
 
-        except ProtocoleError as exc:
+        except ProtocolError as exc:
             result_req = handshake.build_bad_format_result_req(str(exc))
 
         await transport.send(result_req)
@@ -390,7 +390,7 @@ class BackendApp:
                         "reason": "Invalid message.",
                     }
 
-                except ProtocoleError as exc:
+                except ProtocolError as exc:
                     rep = {"status": "bad_message", "reason": str(exc)}
 
             client_ctx.logger.debug("rep", rep=_filter_binary_fields(rep))

--- a/parsec/backend/utils.py
+++ b/parsec/backend/utils.py
@@ -2,7 +2,7 @@
 
 from functools import wraps
 
-from parsec.api.protocol import ProtocoleError, InvalidMessageError
+from parsec.api.protocol import ProtocolError, InvalidMessageError
 
 
 def anonymous_api(fn):
@@ -27,7 +27,7 @@ def catch_protocol_errors(fn):
         except InvalidMessageError as exc:
             return {"status": "bad_message", "errors": exc.errors, "reason": "Invalid message."}
 
-        except ProtocoleError as exc:
+        except ProtocolError as exc:
             return {"status": "bad_message", "reason": str(exc)}
 
     return wrapper

--- a/parsec/core/backend_connection/cmds.py
+++ b/parsec/core/backend_connection/cmds.py
@@ -11,7 +11,7 @@ from parsec.api.protocol import (
     UserID,
     DeviceName,
     DeviceID,
-    ProtocoleError,
+    ProtocolError,
     ping_serializer,
     organization_create_serializer,
     organization_bootstrap_serializer,
@@ -81,7 +81,7 @@ async def _send_cmd(transport, serializer, keepalive=False, **req):
     try:
         raw_req = serializer.req_dumps(req)
 
-    except ProtocoleError as exc:
+    except ProtocolError as exc:
         raise BackendCmdsInvalidRequest(exc) from exc
 
     try:
@@ -95,7 +95,7 @@ async def _send_cmd(transport, serializer, keepalive=False, **req):
     try:
         rep = serializer.rep_loads(raw_rep)
 
-    except ProtocoleError as exc:
+    except ProtocolError as exc:
         transport.logger.warning("Request failed (bad protocol)", cmd=req["cmd"], error=exc)
         raise BackendCmdsInvalidResponse(exc) from exc
 

--- a/parsec/core/backend_connection/transport.py
+++ b/parsec/core/backend_connection/transport.py
@@ -57,13 +57,13 @@ async def _connect(
     if administration_token:
         if not isinstance(addr, BackendAddr):
             raise BackendConnectionError(f"Invalid url format `{addr}`")
-        ch = AdministrationClientHandshake(administration_token)
+        handshake = AdministrationClientHandshake(administration_token)
 
     elif not device_id:
         if isinstance(addr, BackendOrganizationBootstrapAddr):
-            ch = AnonymousClientHandshake(addr.organization_id)
+            handshake = AnonymousClientHandshake(addr.organization_id)
         elif isinstance(addr, BackendOrganizationAddr):
-            ch = AnonymousClientHandshake(addr.organization_id, addr.root_verify_key)
+            handshake = AnonymousClientHandshake(addr.organization_id, addr.root_verify_key)
         else:
             raise BackendConnectionError(
                 f"Invalid url format `{addr}` "
@@ -78,7 +78,7 @@ async def _connect(
 
         if not signing_key:
             raise BackendConnectionError(f"Missing signing_key to connect as `{device_id}`")
-        ch = AuthenticatedClientHandshake(
+        handshake = AuthenticatedClientHandshake(
             addr.organization_id, device_id, signing_key, addr.root_verify_key
         )
 
@@ -94,12 +94,13 @@ async def _connect(
 
     try:
         transport = await Transport.init_for_client(stream, addr.hostname)
+
     except TransportError as exc:
         logger.debug("Connection lost during transport creation", reason=exc)
         raise BackendNotAvailable(exc) from exc
 
     try:
-        await _do_handshake(transport, ch)
+        await _do_handshake(transport, handshake)
 
     except BackendHandshakeAPIVersionError as exc:
         logger.debug("Incompatible API version", reason=f"Server API version {str(exc)}")
@@ -127,13 +128,13 @@ def _upgrade_stream_to_ssl(raw_stream, hostname):
     return trio.SSLStream(raw_stream, ssl_context, server_hostname=hostname)
 
 
-async def _do_handshake(transport: Transport, ch):
+async def _do_handshake(transport: Transport, handshake):
     try:
         challenge_req = await transport.recv()
-        answer_req = ch.process_challenge_req(challenge_req)
+        answer_req = handshake.process_challenge_req(challenge_req)
         await transport.send(answer_req)
         result_req = await transport.recv()
-        ch.process_result_req(result_req)
+        handshake.process_result_req(result_req)
         transport.logger.debug("Handshake done")
 
     except TransportError as exc:

--- a/parsec/core/backend_connection/transport.py
+++ b/parsec/core/backend_connection/transport.py
@@ -94,6 +94,7 @@ async def _connect(
 
     try:
         transport = await Transport.init_for_client(stream, addr.hostname)
+        transport.handshake = handshake
 
     except TransportError as exc:
         logger.debug("Connection lost during transport creation", reason=exc)

--- a/parsec/core/backend_connection/transport.py
+++ b/parsec/core/backend_connection/transport.py
@@ -11,7 +11,7 @@ from parsec.crypto import SigningKey
 from parsec.api.transport import Transport, TransportError, TransportClosedByPeer
 from parsec.api.protocol import (
     DeviceID,
-    ProtocoleError,
+    ProtocolError,
     HandshakeRevokedDevice,
     HandshakeAPIVersionError,
     AnonymousClientHandshake,
@@ -149,7 +149,7 @@ async def _do_handshake(transport: Transport, handshake):
         transport.logger.warning("Handshake failed", reason=exc)
         raise BackendDeviceRevokedError(exc) from exc
 
-    except ProtocoleError as exc:
+    except ProtocolError as exc:
         transport.logger.warning("Handshake failed", reason=exc)
         raise BackendHandshakeError(exc) from exc
 

--- a/parsec/serde/fields.py
+++ b/parsec/serde/fields.py
@@ -3,7 +3,7 @@
 from pendulum import Pendulum
 from uuid import UUID as _UUID
 from collections import Mapping
-from marshmallow import ValidationError
+from marshmallow import ValidationError, validate
 from marshmallow.fields import (
     # Republishing
     Int,
@@ -15,7 +15,6 @@ from marshmallow.fields import (
     Boolean,
     Field,
 )
-import re
 
 from parsec.types import FrozenDict as _FrozenDict
 from parsec.crypto import (
@@ -52,7 +51,7 @@ __all__ = (
     "PrivateKey",
     "SecretKey",
     "HashDigest",
-    "SemVer",
+    "ApiVersion",
 )
 
 
@@ -340,17 +339,11 @@ class PublicKey(Field):
             raise ValidationError("Invalid verify key.")
 
 
-class SemVer(Field):
-    default_error_messages = {"no_string": "Not a string.", "regex_failed": "String not a SemVer"}
-
-    def _serialize(self, value, attr, obj):
-        if not isinstance(value, str):
-            self.fail("no_string")
-        if not re.match("(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)", value):
-            self.fail("regex_failed")
-        return value
-
-    _deserialize = _serialize
+class ApiVersion(Tuple):
+    def __init__(self, **kwargs):
+        version = Integer(required=True, validate=validate.Range(min=0))
+        revision = Integer(required=True, validate=validate.Range(min=0))
+        super().__init__(version, revision, **kwargs)
 
 
 SecretKey = bytes_based_field_factory(_SecretKey)

--- a/tests/backend/test_handshake.py
+++ b/tests/backend/test_handshake.py
@@ -13,6 +13,8 @@ from parsec.api.protocol.handshake import (
     HandshakeBadAdministrationToken,
 )
 
+from parsec import __api_version__
+
 
 @pytest.mark.trio
 async def test_anonymous_handshake_invalid_format(backend, server_factory):
@@ -24,6 +26,7 @@ async def test_anonymous_handshake_invalid_format(backend, server_factory):
         req = {
             "handshake": "answer",
             "type": "anonymous",
+            "api_version": __api_version__,
             "organization_id": "zob",
             "dummy": "field",
         }

--- a/tests/backend/test_handshake.py
+++ b/tests/backend/test_handshake.py
@@ -55,6 +55,8 @@ async def test_authenticated_handshake_good(backend, server_factory, alice):
         result_req = await transport.recv()
         ch.process_result_req(result_req)
 
+        assert ch.backend_api_version == __api_version__
+
 
 @pytest.mark.trio
 async def test_administration_handshake_good(backend, server_factory):
@@ -69,6 +71,8 @@ async def test_administration_handshake_good(backend, server_factory):
         await transport.send(answer_req)
         result_req = await transport.recv()
         ch.process_result_req(result_req)
+
+        assert ch.backend_api_version == __api_version__
 
 
 @pytest.mark.trio
@@ -124,6 +128,8 @@ async def test_anonymous_handshake_good(backend, server_factory, coolorg, check_
         await transport.send(answer_req)
         result_req = await transport.recv()
         ch.process_result_req(result_req)
+
+        assert ch.backend_api_version == __api_version__
 
 
 @pytest.mark.trio

--- a/tests/test_handshake.py
+++ b/tests/test_handshake.py
@@ -154,8 +154,6 @@ def test_process_challenge_req_bad_format(alice, req):
         {"handshake": "challenge", "challenge": b"1234567890", "api_version": "0.1.1"},
         {"handshake": "challenge", "challenge": b"1234567890", "api_version": "0.100.0"},
         {"handshake": "challenge", "challenge": b"1234567890", "api_version": "2.0.0"},
-        {"handshake": "challenge", "challenge": b"1234567890", "api_version": "1.0.0"},
-        {"handshake": "challenge", "challenge": b"1234567890", "api_version": "1.0.1"},
     ],
 )
 def test_process_challenge_req_bad_semver(alice, req, monkeypatch):
@@ -170,6 +168,7 @@ def test_process_challenge_req_bad_semver(alice, req, monkeypatch):
 @pytest.mark.parametrize(
     "req",
     [
+        {"handshake": "challenge", "challenge": b"1234567890", "api_version": "1.0.0"},
         {"handshake": "challenge", "challenge": b"1234567890", "api_version": "1.1.0"},
         {"handshake": "challenge", "challenge": b"1234567890", "api_version": "1.1.2"},
         {"handshake": "challenge", "challenge": b"1234567890", "api_version": "1.1.10"},

--- a/tests/test_handshake.py
+++ b/tests/test_handshake.py
@@ -38,6 +38,7 @@ def test_good_handshake(alice):
     assert sh.answer_type == "authenticated"
     assert sh.answer_data == {
         "answer": ANY,
+        "api_version": __api_version__,
         "organization_id": alice.organization_id,
         "device_id": alice.device_id,
         "rvk": alice.root_verify_key,
@@ -46,6 +47,7 @@ def test_good_handshake(alice):
     assert sh.state == "result"
 
     ch.process_result_req(result_req)
+    assert sh.client_api_version == __api_version__
 
 
 @pytest.mark.parametrize("check_rvk", (True, False))
@@ -68,15 +70,21 @@ def test_good_anonymous_handshake(coolorg, check_rvk):
     assert sh.answer_type == "anonymous"
     if check_rvk:
         assert sh.answer_data == {
+            "api_version": __api_version__,
             "organization_id": coolorg.organization_id,
             "rvk": coolorg.root_verify_key,
         }
     else:
-        assert sh.answer_data == {"organization_id": coolorg.organization_id, "rvk": None}
+        assert sh.answer_data == {
+            "api_version": __api_version__,
+            "organization_id": coolorg.organization_id,
+            "rvk": None,
+        }
     result_req = sh.build_result_req()
     assert sh.state == "result"
 
     ch.process_result_req(result_req)
+    assert sh.client_api_version == __api_version__
 
 
 def test_good_administration_handshake():
@@ -94,11 +102,12 @@ def test_good_administration_handshake():
     sh.process_answer_req(answer_req)
     assert sh.state == "answer"
     assert sh.answer_type == "administration"
-    assert sh.answer_data == {"token": admin_token}
+    assert sh.answer_data == {"api_version": __api_version__, "token": admin_token}
     result_req = sh.build_result_req()
     assert sh.state == "result"
 
     ch.process_result_req(result_req)
+    assert sh.client_api_version == __api_version__
 
 
 # 1) Server build challenge (nothing more to test...)
@@ -298,6 +307,7 @@ def test_build_result_req_bad_key(alice, bob):
     answer = {
         "handshake": "answer",
         "type": "authenticated",
+        "api_version": __api_version__,
         "organization_id": alice.organization_id,
         "device_id": alice.device_id,
         "rvk": alice.root_verify_key.encode(),
@@ -314,6 +324,7 @@ def test_build_result_req_bad_challenge(alice):
     answer = {
         "handshake": "answer",
         "type": "authenticated",
+        "api_version": __api_version__,
         "organization_id": alice.organization_id,
         "device_id": alice.device_id,
         "rvk": alice.root_verify_key.encode(),
@@ -340,6 +351,7 @@ def test_build_bad_outcomes(alice, method, expected_result):
     answer = {
         "handshake": "answer",
         "type": "authenticated",
+        "api_version": __api_version__,
         "organization_id": alice.organization_id,
         "device_id": alice.device_id,
         "rvk": alice.root_verify_key.encode(),

--- a/tests/test_handshake.py
+++ b/tests/test_handshake.py
@@ -151,13 +151,13 @@ def test_process_challenge_req_bad_format(alice, req):
 @pytest.mark.parametrize(
     "req",
     [
-        {"handshake": "challenge", "challenge": b"1234567890", "api_version": "0.1.1"},
-        {"handshake": "challenge", "challenge": b"1234567890", "api_version": "0.100.0"},
-        {"handshake": "challenge", "challenge": b"1234567890", "api_version": "2.0.0"},
+        {"handshake": "challenge", "challenge": b"1234567890", "api_version": (0, 1)},
+        {"handshake": "challenge", "challenge": b"1234567890", "api_version": (0, 100)},
+        {"handshake": "challenge", "challenge": b"1234567890", "api_version": (2, 0)},
     ],
 )
 def test_process_challenge_req_bad_semver(alice, req, monkeypatch):
-    monkeypatch.setattr("parsec.api.protocol.handshake.__api_version__", "1.1.1")
+    monkeypatch.setattr("parsec.api.protocol.handshake.__api_version__", (1, 1))
     ch = AuthenticatedClientHandshake(
         alice.organization_id, alice.device_id, alice.signing_key, alice.root_verify_key
     )
@@ -168,15 +168,14 @@ def test_process_challenge_req_bad_semver(alice, req, monkeypatch):
 @pytest.mark.parametrize(
     "req",
     [
-        {"handshake": "challenge", "challenge": b"1234567890", "api_version": "1.0.0"},
-        {"handshake": "challenge", "challenge": b"1234567890", "api_version": "1.1.0"},
-        {"handshake": "challenge", "challenge": b"1234567890", "api_version": "1.1.2"},
-        {"handshake": "challenge", "challenge": b"1234567890", "api_version": "1.1.10"},
-        {"handshake": "challenge", "challenge": b"1234567890", "api_version": "1.2.0"},
+        {"handshake": "challenge", "challenge": b"1234567890", "api_version": (1, 0)},
+        {"handshake": "challenge", "challenge": b"1234567890", "api_version": (1, 1)},
+        {"handshake": "challenge", "challenge": b"1234567890", "api_version": (1, 2)},
+        {"handshake": "challenge", "challenge": b"1234567890", "api_version": (1, 100)},
     ],
 )
 def test_process_challenge_req_good_semver(alice, req, monkeypatch):
-    monkeypatch.setattr("parsec.api.protocol.handshake.__api_version__", "1.1.1")
+    monkeypatch.setattr("parsec.api.protocol.handshake.__api_version__", (1, 1))
     ch = AuthenticatedClientHandshake(
         alice.organization_id, alice.device_id, alice.signing_key, alice.root_verify_key
     )


### PR DESCRIPTION
A few changes:
- The api version checking is done on both side during the handshake
- At this point, only the major versions should match
- The peer version can then be used on both side using the transport object

Example:
```python
# Backend side
transport.handshake.client_api_version
# Client side
transport.handshake.backend_api_version
```