### PR TITLE
Use an async interface for the user and workspace storage

### DIFF
--- a/parsec/core/fs/local_storage.py
+++ b/parsec/core/fs/local_storage.py
@@ -96,10 +96,10 @@ class LocalStorage:
 
     # Manifest interface
 
-    def get_realm_checkpoint(self) -> int:
+    async def get_realm_checkpoint(self) -> int:
         return self.persistent_storage.get_realm_checkpoint()
 
-    def update_realm_checkpoint(
+    async def update_realm_checkpoint(
         self, new_checkpoint: int, changed_vlobs: Dict[EntryID, int]
     ) -> None:
         """
@@ -107,7 +107,7 @@ class LocalStorage:
         """
         self.persistent_storage.update_realm_checkpoint(new_checkpoint, changed_vlobs)
 
-    def get_need_sync_entries(self) -> Tuple[Set[EntryID], Set[EntryID]]:
+    async def get_need_sync_entries(self) -> Tuple[Set[EntryID], Set[EntryID]]:
         return self.persistent_storage.get_need_sync_entries()
 
     def get_manifest(self, entry_id: EntryID) -> LocalManifest:
@@ -234,7 +234,7 @@ class LocalStorage:
 
     # Vacuum
 
-    def run_vacuum(self):
+    async def run_vacuum(self):
         self.persistent_storage.run_vacuum()
 
     # Timestamped workspace

--- a/parsec/core/fs/local_storage.py
+++ b/parsec/core/fs/local_storage.py
@@ -58,11 +58,11 @@ class LocalStorage:
         self.fd_counter += 1
         return FileDescriptor(self.fd_counter)
 
-    def __enter__(self):
+    async def __aenter__(self):
         self.persistent_storage.__enter__()
         return self
 
-    def __exit__(self, *args):
+    async def __aexit__(self, *args):
         if self.locking_tasks:
             raise RuntimeError("Cannot teardown while entries are still locked")
         for entry_id in self.cache_ahead_of_persistance_ids.copy():

--- a/parsec/core/fs/local_storage.py
+++ b/parsec/core/fs/local_storage.py
@@ -66,7 +66,7 @@ class LocalStorage:
         if self.locking_tasks:
             raise RuntimeError("Cannot teardown while entries are still locked")
         for entry_id in self.cache_ahead_of_persistance_ids.copy():
-            self._ensure_manifest_persistent(entry_id)
+            await self._ensure_manifest_persistent(entry_id)
         self.persistent_storage.__exit__(*args)
 
     def clear_memory_cache(self):
@@ -87,7 +87,7 @@ class LocalStorage:
     @asynccontextmanager
     async def lock_manifest(self, entry_id: EntryID):
         async with self.lock_entry_id(entry_id):
-            yield self.get_manifest(entry_id)
+            yield await self.get_manifest(entry_id)
 
     def _check_lock_status(self, entry_id: EntryID) -> None:
         task = self.locking_tasks.get(entry_id)
@@ -110,7 +110,7 @@ class LocalStorage:
     async def get_need_sync_entries(self) -> Tuple[Set[EntryID], Set[EntryID]]:
         return self.persistent_storage.get_need_sync_entries()
 
-    def get_manifest(self, entry_id: EntryID) -> LocalManifest:
+    async def get_manifest(self, entry_id: EntryID) -> LocalManifest:
         """Raises: FSLocalMissError"""
         assert isinstance(entry_id, EntryID)
         try:
@@ -121,7 +121,7 @@ class LocalStorage:
         self.local_manifest_cache[entry_id] = manifest
         return manifest
 
-    def set_manifest(
+    async def set_manifest(
         self,
         entry_id: EntryID,
         manifest: LocalManifest,
@@ -137,19 +137,19 @@ class LocalStorage:
             self.cache_ahead_of_persistance_ids.add(entry_id)
         self.local_manifest_cache[entry_id] = manifest
 
-    def ensure_manifest_persistent(self, entry_id: EntryID) -> None:
+    async def ensure_manifest_persistent(self, entry_id: EntryID) -> None:
         assert isinstance(entry_id, EntryID)
         self._check_lock_status(entry_id)
         if entry_id not in self.cache_ahead_of_persistance_ids:
             return
-        self._ensure_manifest_persistent(entry_id)
+        await self._ensure_manifest_persistent(entry_id)
 
-    def _ensure_manifest_persistent(self, entry_id: EntryID) -> None:
+    async def _ensure_manifest_persistent(self, entry_id: EntryID) -> None:
         manifest = self.local_manifest_cache[entry_id]
         self.persistent_storage.set_manifest(entry_id, manifest)
         self.cache_ahead_of_persistance_ids.remove(entry_id)
 
-    def clear_manifest(self, entry_id: EntryID) -> None:
+    async def clear_manifest(self, entry_id: EntryID) -> None:
         assert isinstance(entry_id, EntryID)
         self._check_lock_status(entry_id)
         try:
@@ -161,38 +161,38 @@ class LocalStorage:
 
     # Clean block interface
 
-    def is_clean_block(self, block_id: BlockID):
+    async def is_clean_block(self, block_id: BlockID):
         assert isinstance(block_id, BlockID)
         return not self.persistent_storage.is_dirty_chunk(block_id)
 
-    def set_clean_block(self, block_id: BlockID, block: bytes) -> None:
+    async def set_clean_block(self, block_id: BlockID, block: bytes) -> None:
         assert isinstance(block_id, BlockID)
         return self.persistent_storage.set_clean_block(block_id, block)
 
-    def clear_clean_block(self, block_id: BlockID) -> None:
+    async def clear_clean_block(self, block_id: BlockID) -> None:
         assert isinstance(block_id, BlockID)
         try:
             self.persistent_storage.clear_clean_block(block_id)
         except FSLocalMissError:
             pass
 
-    def get_dirty_block(self, block_id: BlockID) -> bytes:
+    async def get_dirty_block(self, block_id: BlockID) -> bytes:
         return self.persistent_storage.get_dirty_chunk(ChunkID(block_id))
 
     # Chunk interface
 
-    def get_chunk(self, chunk_id: ChunkID) -> bytes:
+    async def get_chunk(self, chunk_id: ChunkID) -> bytes:
         assert isinstance(chunk_id, ChunkID)
         try:
             return self.persistent_storage.get_dirty_chunk(chunk_id)
         except FSLocalMissError:
             return self.persistent_storage.get_clean_block(chunk_id)
 
-    def set_chunk(self, chunk_id: ChunkID, block: bytes) -> None:
+    async def set_chunk(self, chunk_id: ChunkID, block: bytes) -> None:
         assert isinstance(chunk_id, ChunkID)
         return self.persistent_storage.set_dirty_chunk(chunk_id, block)
 
-    def clear_chunk(self, chunk_id: ChunkID, miss_ok: bool = False) -> None:
+    async def clear_chunk(self, chunk_id: ChunkID, miss_ok: bool = False) -> None:
         assert isinstance(chunk_id, ChunkID)
         try:
             self.persistent_storage.clear_dirty_chunk(chunk_id)
@@ -202,31 +202,22 @@ class LocalStorage:
 
     # File management interface
 
-    def _assert_consistent_file_entry(self, entry_id):
-        try:
-            manifest = self.get_manifest(entry_id)
-        except FSLocalMissError:
-            pass
-        else:
-            assert isinstance(manifest, LocalFileManifest)
-
-    def create_file_descriptor(self, entry_id) -> FileDescriptor:
-        self._assert_consistent_file_entry(entry_id)
+    def create_file_descriptor(self, manifest: LocalFileManifest) -> FileDescriptor:
+        assert isinstance(manifest, LocalFileManifest)
         fd = self._get_next_fd()
-        self.open_fds[fd] = entry_id
+        self.open_fds[fd] = manifest.id
         return fd
 
-    def load_file_descriptor(self, fd: FileDescriptor) -> LocalFileManifest:
+    async def load_file_descriptor(self, fd: FileDescriptor) -> LocalFileManifest:
         try:
             entry_id = self.open_fds[fd]
         except KeyError:
             raise FSInvalidFileDescriptor(fd)
-        manifest = self.get_manifest(entry_id)
+        manifest = await self.get_manifest(entry_id)
         assert isinstance(manifest, LocalFileManifest)
         return manifest
 
-    def remove_file_descriptor(self, fd: FileDescriptor, manifest: LocalFileManifest) -> None:
-        assert isinstance(manifest, LocalFileManifest)
+    def remove_file_descriptor(self, fd: FileDescriptor) -> None:
         try:
             self.open_fds.pop(fd)
         except KeyError:
@@ -265,7 +256,7 @@ class LocalStorageTimestamped(LocalStorage):
 
     # Manifest interface
 
-    def get_manifest(self, entry_id: EntryID) -> LocalManifest:
+    async def get_manifest(self, entry_id: EntryID) -> LocalManifest:
         """Raises: FSLocalMissError"""
         assert isinstance(entry_id, EntryID)
         try:
@@ -273,7 +264,7 @@ class LocalStorageTimestamped(LocalStorage):
         except KeyError:
             raise FSLocalMissError(entry_id)
 
-    def set_manifest(
+    async def set_manifest(
         self, entry_id: EntryID, manifest: LocalManifest, cache_only: bool = False
     ) -> None:  # initially for clean
         assert isinstance(entry_id, EntryID)
@@ -282,10 +273,10 @@ class LocalStorageTimestamped(LocalStorage):
         self._check_lock_status(entry_id)
         self.local_manifest_cache[entry_id] = manifest
 
-    def clear_manifest(self, entry_id: EntryID) -> None:
+    async def clear_manifest(self, entry_id: EntryID) -> None:
         assert isinstance(entry_id, EntryID)
         self._check_lock_status(entry_id)
         self.local_manifest_cache.pop(entry_id, None)
 
-    def ensure_manifest_persistent(self, entry_id: EntryID) -> None:
+    async def ensure_manifest_persistent(self, entry_id: EntryID) -> None:
         pass

--- a/parsec/core/fs/realm_storage.py
+++ b/parsec/core/fs/realm_storage.py
@@ -97,7 +97,7 @@ class RealmStorage:
 
     # Manifest operations
 
-    def get_realm_checkpoint(self) -> int:
+    async def get_realm_checkpoint(self) -> int:
         """
         Raises: Nothing !
         """
@@ -106,7 +106,7 @@ class RealmStorage:
             rep = cursor.fetchone()
             return rep[0] if rep else 0
 
-    def update_realm_checkpoint(
+    async def update_realm_checkpoint(
         self, new_checkpoint: int, changed_vlobs: Dict[EntryID, int]
     ) -> None:
         """
@@ -125,7 +125,7 @@ class RealmStorage:
             )
             cursor.execute("END")
 
-    def get_need_sync_entries(self) -> Tuple[Set[EntryID], Set[EntryID]]:
+    async def get_need_sync_entries(self) -> Tuple[Set[EntryID], Set[EntryID]]:
         """
         Raises: Nothing !
         """
@@ -234,7 +234,7 @@ class RealmStorage:
         if not deleted and not in_cache:
             raise FSLocalMissError(entry_id)
 
-    def run_vacuum(self) -> None:
+    async def run_vacuum(self) -> None:
         pass
 
 

--- a/parsec/core/fs/remote_loader.py
+++ b/parsec/core/fs/remote_loader.py
@@ -206,7 +206,7 @@ class RemoteLoader:
 
         # TODO: let encryption manager do the digest check ?
         assert HashDigest.from_data(block) == access.digest, access
-        self.local_storage.set_clean_block(access.id, block)
+        await self.local_storage.set_clean_block(access.id, block)
 
     async def upload_block(self, access: BlockAccess, data: bytes):
         """
@@ -253,8 +253,8 @@ class RemoteLoader:
             raise FSError(f"Cannot upload block: {exc}") from exc
 
         # Update local storage
-        self.local_storage.set_clean_block(access.id, data)
-        self.local_storage.clear_chunk(ChunkID(access.id), miss_ok=True)
+        await self.local_storage.set_clean_block(access.id, data)
+        await self.local_storage.clear_chunk(ChunkID(access.id), miss_ok=True)
 
     async def load_manifest(
         self, entry_id: EntryID, version: int = None, timestamp: Pendulum = None

--- a/parsec/core/fs/userfs/userfs.py
+++ b/parsec/core/fs/userfs/userfs.py
@@ -234,7 +234,7 @@ class UserFS:
         workspace = await self._instantiate_workspace(workspace_id)
 
         async with workspace.local_storage.lock_entry_id(workspace_id):
-            workspace.local_storage.set_manifest(workspace_id, manifest)
+            await workspace.local_storage.set_manifest(workspace_id, manifest)
 
         self._workspace_storages.setdefault(workspace_id, workspace)
 

--- a/parsec/core/gui/files_widget.py
+++ b/parsec/core/gui/files_widget.py
@@ -300,7 +300,8 @@ class FilesWidget(QWidget, Ui_FilesWidget):
                 self.open_file(f[2])
 
     def open_file(self, file_name):
-        path = self.core.mountpoint_manager.get_path_in_mountpoint(
+        path = self.jobs_ctx.run_sync(
+            self.core.mountpoint_manager.get_path_in_mountpoint,
             self.workspace_fs.workspace_id,
             self.current_directory / file_name,
             self.workspace_fs.timestamp

--- a/parsec/core/gui/workspaces_widget.py
+++ b/parsec/core/gui/workspaces_widget.py
@@ -294,7 +294,8 @@ class WorkspacesWidget(QWidget, Ui_WorkspacesWidget):
 
     def open_workspace_file(self, workspace_fs, file_name):
         file_name = FsPath("/", file_name)
-        path = self.core.mountpoint_manager.get_path_in_mountpoint(
+        path = self.jobs_ctx.run_sync(
+            self.core.mountpoint_manager.get_path_in_mountpoint,
             workspace_fs.workspace_id,
             file_name,
             workspace_fs.timestamp if isinstance(workspace_fs, WorkspaceFSTimestamped) else None,

--- a/parsec/core/logged_core.py
+++ b/parsec/core/logged_core.py
@@ -54,7 +54,7 @@ async def logged_core_factory(
 
             path = config.data_base_dir / device.slug
             remote_devices_manager = RemoteDevicesManager(backend_cmds_pool, device.root_verify_key)
-            with UserFS(
+            async with UserFS(
                 device, path, backend_cmds_pool, remote_devices_manager, event_bus
             ) as user_fs:
 

--- a/parsec/core/sync_monitor.py
+++ b/parsec/core/sync_monitor.py
@@ -94,7 +94,7 @@ class SyncContext:
 
     async def _refresh_checkpoint(self) -> bool:
         # 1) Fetch new checkpoint and changes
-        realm_checkpoint = self._get_local_storage().get_realm_checkpoint()
+        realm_checkpoint = await self._get_local_storage().get_realm_checkpoint()
         try:
             new_checkpoint, changes = await self._get_backend_cmds().vlob_poll_changes(
                 self.id, realm_checkpoint
@@ -117,10 +117,10 @@ class SyncContext:
             return False
 
         # 2) Store new checkpoint and changes
-        self._get_local_storage().update_realm_checkpoint(new_checkpoint, changes)
+        await self._get_local_storage().update_realm_checkpoint(new_checkpoint, changes)
 
         # 3) Compute local and remote changes that need to be synced
-        need_sync_local, need_sync_remote = self._get_local_storage().get_need_sync_entries()
+        need_sync_local, need_sync_remote = await self._get_local_storage().get_need_sync_entries()
         now = timestamp()
         # Ignore local changes in read only mode
         if not self.read_only:
@@ -219,7 +219,7 @@ class SyncContext:
                 # This is where we plug our vacuuming routine
                 # as it corresponds to a fresh synchronized state
                 if not self.local_changes:
-                    self._get_local_storage().run_vacuum()
+                    await self._get_local_storage().run_vacuum()
 
         # Re-compute due time
         if self.remote_changes:

--- a/setup.py
+++ b/setup.py
@@ -297,6 +297,7 @@ requirements = [
     "importlib_resources==1.0.2",
     "colorama==0.4.0",  # structlog colored output
     "PyPika==0.29.0",
+    "async_exit_stack==1.0.1",
 ]
 
 

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -41,14 +41,14 @@ def initialize_local_storage(local_storage_path, initial_user_manifest_state, pe
 
 
 @pytest.fixture
-def initialize_userfs_storage(initial_user_manifest_state, persistent_mockup):
-    def _initialize_userfs_storage(device, storage):
+async def initialize_userfs_storage(initial_user_manifest_state, persistent_mockup):
+    async def _initialize_userfs_storage(device, storage):
         try:
-            storage.get_manifest(device.user_manifest_id)
+            await storage.get_manifest(device.user_manifest_id)
         except FSLocalMissError:
             with freeze_time("2000-01-01"):
                 user_manifest = initial_user_manifest_state.get_user_manifest_v1_for_device(device)
-            storage.set_manifest(device.user_manifest_id, user_manifest)
+            await storage.set_manifest(device.user_manifest_id, user_manifest)
 
     return _initialize_userfs_storage
 
@@ -56,24 +56,24 @@ def initialize_userfs_storage(initial_user_manifest_state, persistent_mockup):
 @pytest.fixture()
 async def alice_local_storage(local_storage_path, initialize_userfs_storage, alice):
     path = local_storage_path(alice)
-    with RealmStorage.factory(alice, path) as storage:
-        initialize_userfs_storage(alice, storage)
+    async with RealmStorage.factory(alice, path) as storage:
+        await initialize_userfs_storage(alice, storage)
         yield storage
 
 
 @pytest.fixture()
 async def alice2_local_storage(local_storage_path, initialize_userfs_storage, alice2):
     path = local_storage_path(alice2)
-    with RealmStorage.factory(alice2, path) as storage:
-        initialize_userfs_storage(alice2, storage)
+    async with RealmStorage.factory(alice2, path) as storage:
+        await initialize_userfs_storage(alice2, storage)
         yield storage
 
 
 @pytest.fixture()
 async def bob_local_storage(local_storage_path, initialize_userfs_storage, bob):
     path = local_storage_path(bob)
-    with RealmStorage.factory(bob, path) as storage:
-        initialize_userfs_storage(bob, storage)
+    async with RealmStorage.factory(bob, path) as storage:
+        await initialize_userfs_storage(bob, storage)
         yield storage
 
 
@@ -165,9 +165,9 @@ def user_fs_factory(
         ) as cmds:
             path = local_storage_path(device)
             rdm = RemoteDevicesManager(cmds, device.root_verify_key)
-            with UserFS(device, path, cmds, rdm, event_bus) as user_fs:
+            async with UserFS(device, path, cmds, rdm, event_bus) as user_fs:
                 if initialize_local_storage:
-                    initialize_userfs_storage(device, user_fs.storage)
+                    await initialize_userfs_storage(device, user_fs.storage)
                 yield user_fs
 
     return _user_fs_factory

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -7,7 +7,6 @@ from async_generator import asynccontextmanager
 from parsec.core.backend_connection import backend_cmds_pool_factory, backend_anonymous_cmds_factory
 from parsec.core.remote_devices_manager import RemoteDevicesManager
 from parsec.core.fs import UserFS, FSLocalMissError
-from parsec.core.fs.local_storage import LocalStorage
 from parsec.core.fs.realm_storage import RealmStorage
 
 from tests.common import freeze_time
@@ -22,26 +21,7 @@ def local_storage_path(tmpdir):
 
 
 @pytest.fixture
-def initialize_local_storage(local_storage_path, initial_user_manifest_state, persistent_mockup):
-    async def _initialize_local_storage(device):
-        device_id = device.device_id
-        path = local_storage_path(device)
-        local_storage = LocalStorage(device_id, device.local_symkey, path)
-        with freeze_time("2000-01-01"):
-            user_manifest = initial_user_manifest_state.get_user_manifest_v1_for_device(device)
-        try:
-            local_storage.get_manifest(device.user_manifest_id)
-        except FSLocalMissError:
-            local_storage.set_manifest(
-                device.user_manifest_id, user_manifest, check_lock_status=False
-            )
-        return local_storage
-
-    return _initialize_local_storage
-
-
-@pytest.fixture
-async def initialize_userfs_storage(initial_user_manifest_state, persistent_mockup):
+def initialize_userfs_storage(initial_user_manifest_state, persistent_mockup):
     async def _initialize_userfs_storage(device, storage):
         try:
             await storage.get_manifest(device.user_manifest_id)
@@ -158,7 +138,7 @@ def user_fs_factory(
     local_storage_path, event_bus_factory, persistent_mockup, initialize_userfs_storage
 ):
     @asynccontextmanager
-    async def _user_fs_factory(device, event_bus=None, initialize_local_storage=True):
+    async def _user_fs_factory(device, event_bus=None, initialize_user_storage=True):
         event_bus = event_bus or event_bus_factory()
         async with backend_cmds_pool_factory(
             device.organization_addr, device.device_id, device.signing_key
@@ -166,7 +146,7 @@ def user_fs_factory(
             path = local_storage_path(device)
             rdm = RemoteDevicesManager(cmds, device.root_verify_key)
             async with UserFS(device, path, cmds, rdm, event_bus) as user_fs:
-                if initialize_local_storage:
+                if initialize_user_storage:
                     await initialize_userfs_storage(device, user_fs.storage)
                 yield user_fs
 

--- a/tests/core/fs/conftest.py
+++ b/tests/core/fs/conftest.py
@@ -27,7 +27,7 @@ def transactions_factory(event_bus, remote_devices_manager_factory):
             id=workspace_entry.id, now=Pendulum(2000, 1, 1)
         )
         async with local_storage.lock_entry_id(workspace_entry.id):
-            local_storage.set_manifest(workspace_entry.id, workspace_manifest)
+            await local_storage.set_manifest(workspace_entry.id, workspace_manifest)
 
         remote_devices_manager = remote_devices_manager_factory(device)
         remote_loader = RemoteLoader(

--- a/tests/core/fs/conftest.py
+++ b/tests/core/fs/conftest.py
@@ -62,8 +62,10 @@ def file_transactions_factory(event_bus, remote_devices_manager_factory, transac
 
 
 @pytest.fixture
-def alice_transaction_local_storage(alice, persistent_mockup):
-    with LocalStorage(alice.device_id, key=alice.local_symkey, path=Path("/dummy")) as storage:
+async def alice_transaction_local_storage(alice, persistent_mockup):
+    async with LocalStorage(
+        alice.device_id, key=alice.local_symkey, path=Path("/dummy")
+    ) as storage:
         yield storage
 
 

--- a/tests/core/fs/test_fs_idempotent_sync.py
+++ b/tests/core/fs/test_fs_idempotent_sync.py
@@ -80,7 +80,7 @@ def test_fs_online_idempotent_sync(
             await self.workspace.sync()
             await self.user_fs.sync()
 
-            self.initial_fs_dump = self.workspace.dump()
+            self.initial_fs_dump = await self.workspace.dump()
             check_fs_dump(self.initial_fs_dump)
 
             return "/dummy"
@@ -148,7 +148,7 @@ def test_fs_online_idempotent_sync(
         @invariant()
         async def check_fs(self):
             try:
-                fs_dump = self.workspace.dump()
+                fs_dump = await self.workspace.dump()
             except AttributeError:
                 # FS not yet initialized
                 pass

--- a/tests/core/fs/test_fs_online_concurrent_tree_and_sync.py
+++ b/tests/core/fs/test_fs_online_concurrent_tree_and_sync.py
@@ -181,8 +181,8 @@ def test_fs_online_concurrent_tree_and_sync(
                 await self.user_fs1.sync()
                 await self.user_fs2.sync()
 
-            user_fs_dump_1 = workspace1.dump()
-            user_fs_dump_2 = workspace2.dump()
+            user_fs_dump_1 = await workspace1.dump()
+            user_fs_dump_2 = await workspace2.dump()
             compare_fs_dumps(user_fs_dump_1, user_fs_dump_2)
 
     run_state_machine_as_test(FSOnlineConcurrentTreeAndSync, settings=hypothesis_settings)

--- a/tests/core/fs/test_fs_online_concurrent_user.py
+++ b/tests/core/fs/test_fs_online_concurrent_user.py
@@ -126,8 +126,8 @@ def test_fs_online_concurrent_user(
             await workspace1.sync()
             await self.user_fs1.sync()
 
-            fs_dump_1 = workspace1.dump()
-            fs_dump_2 = workspace2.dump()
+            fs_dump_1 = await workspace1.dump()
+            fs_dump_2 = await workspace2.dump()
             compare_fs_dumps(fs_dump_1, fs_dump_2)
 
     run_state_machine_as_test(FSOnlineConcurrentUser, settings=hypothesis_settings)

--- a/tests/core/fs/test_persistent_storage.py
+++ b/tests/core/fs/test_persistent_storage.py
@@ -263,7 +263,7 @@ def test_persistent_storage_remote_need_sync(persistent_storage):
 def test_persistent_storage_stateful(tmpdir, hypothesis_settings):
     tentative = 0
 
-    class LocalStorageStateMachine(RuleBasedStateMachine):
+    class PersistentStorageStateMachine(RuleBasedStateMachine):
         PreciousEntry = Bundle("precious_entry")
         DeletableEntry = Bundle("deletable_entry")
 
@@ -351,4 +351,4 @@ def test_persistent_storage_stateful(tmpdir, hypothesis_settings):
                 self.persistent_storage.get_cache_size() <= self.persistent_storage.max_cache_size
             )
 
-    run_state_machine_as_test(LocalStorageStateMachine, settings=hypothesis_settings)
+    run_state_machine_as_test(PersistentStorageStateMachine, settings=hypothesis_settings)

--- a/tests/core/fs/userfs/test_sync.py
+++ b/tests/core/fs/userfs/test_sync.py
@@ -229,7 +229,7 @@ async def test_modify_user_manifest_placeholder(
     device = local_device_factory()
     await backend_data_binder.bind_device(device, initial_user_manifest_in_v0=True)
 
-    async with user_fs_factory(device, initialize_local_storage=False) as user_fs:
+    async with user_fs_factory(device, initialize_user_storage=False) as user_fs:
         with freeze_time("2000-01-02"):
             wid = await user_fs.workspace_create("w1")
         um = user_fs.get_user_manifest()
@@ -252,7 +252,7 @@ async def test_modify_user_manifest_placeholder(
         assert um == expected_um
 
     # Make sure we can fetch back data from the database on user_fs restart
-    async with user_fs_factory(device, initialize_local_storage=False) as user_fs2:
+    async with user_fs_factory(device, initialize_user_storage=False) as user_fs2:
         um2 = user_fs2.get_user_manifest()
         assert um2 == expected_um
 
@@ -265,7 +265,7 @@ async def test_sync_placeholder(
     device = local_device_factory()
     await backend_data_binder.bind_device(device, initial_user_manifest_in_v0=True)
 
-    async with user_fs_factory(device, initialize_local_storage=False) as user_fs:
+    async with user_fs_factory(device, initialize_user_storage=False) as user_fs:
         with freeze_time("2000-01-01"):
             # User manifest should be lazily created on each access
             um = user_fs.get_user_manifest()
@@ -330,9 +330,9 @@ async def test_concurrent_sync_placeholder(
     device2 = local_device_factory("a@2")
     await backend_data_binder.bind_device(device2, initial_user_manifest_in_v0=True)
 
-    async with user_fs_factory(
-        device1, initialize_local_storage=False
-    ) as user_fs1, user_fs_factory(device2, initialize_local_storage=False) as user_fs2:
+    async with user_fs_factory(device1, initialize_user_storage=False) as user_fs1, user_fs_factory(
+        device2, initialize_user_storage=False
+    ) as user_fs2:
         with freeze_time("2000-01-01"):
             w1id = await user_fs1.workspace_create("w1")
         if dev2_has_changes:

--- a/tests/core/fs/userfs/test_sync.py
+++ b/tests/core/fs/userfs/test_sync.py
@@ -50,7 +50,7 @@ async def test_create_workspace(initial_user_manifest_state, alice_user_fs, alic
     )
     assert um == expected_um
 
-    w_manifest = alice_user_fs.get_workspace(wid).local_storage.get_manifest(wid)
+    w_manifest = await alice_user_fs.get_workspace(wid).local_storage.get_manifest(wid)
     expected_w_manifest = LocalWorkspaceManifest.new_placeholder(
         id=w_manifest.id, now=Pendulum(2000, 1, 2)
     )

--- a/tests/core/fs/workspacefs/test_entry_transactions.py
+++ b/tests/core/fs/workspacefs/test_entry_transactions.py
@@ -258,7 +258,7 @@ def test_folder_operations(
 
         async def start_transactions(self):
             async def _transactions_controlled_cb(started_cb):
-                with LocalStorage(
+                async with LocalStorage(
                     alice.device_id, key=alice.local_symkey, path=Path("/dummy")
                 ) as local_storage:
                     entry_transactions = await entry_transactions_factory(

--- a/tests/core/fs/workspacefs/test_entry_transactions.py
+++ b/tests/core/fs/workspacefs/test_entry_transactions.py
@@ -86,7 +86,8 @@ async def test_folder_create_delete(alice_entry_transactions, alice_sync_transac
     assert await entry_transactions.folder_delete(FsPath("/foo")) == foo_id
 
     # The directory is not synced
-    assert entry_transactions.local_storage.get_manifest(foo_id).need_sync
+    manifest = await entry_transactions.local_storage.get_manifest(foo_id)
+    assert manifest.need_sync
 
     # Create and sync a bar directory
     bar_id = await entry_transactions.folder_create(FsPath("/bar"))
@@ -95,7 +96,8 @@ async def test_folder_create_delete(alice_entry_transactions, alice_sync_transac
 
     # Remove the bar directory, the manifest is synced
     assert await entry_transactions.folder_delete(FsPath("/bar")) == bar_id
-    assert not entry_transactions.local_storage.get_manifest(bar_id).need_sync
+    manifest = await entry_transactions.local_storage.get_manifest(bar_id)
+    assert not manifest.need_sync
 
 
 @pytest.mark.trio
@@ -109,7 +111,8 @@ async def test_file_create_delete(alice_entry_transactions, alice_sync_transacti
     assert await entry_transactions.file_delete(FsPath("/foo")) == foo_id
 
     # The file is not synced
-    assert entry_transactions.local_storage.get_manifest(foo_id).need_sync
+    manifest = await entry_transactions.local_storage.get_manifest(foo_id)
+    assert manifest.need_sync
 
     # Create and sync a bar file
     bar_id, fd = await entry_transactions.file_create(FsPath("/bar"), open=False)
@@ -118,7 +121,8 @@ async def test_file_create_delete(alice_entry_transactions, alice_sync_transacti
 
     # Remove the bar file, the manifest is synced
     assert await entry_transactions.file_delete(FsPath("/bar")) == bar_id
-    assert not entry_transactions.local_storage.get_manifest(bar_id).need_sync
+    manifest = await entry_transactions.local_storage.get_manifest(bar_id)
+    assert not manifest.need_sync
 
 
 @pytest.mark.trio
@@ -173,15 +177,15 @@ async def test_access_not_loaded_entry(alice, bob, alice_entry_transactions):
     entry_transactions = alice_entry_transactions
 
     entry_id = entry_transactions.get_workspace_entry().id
-    manifest = entry_transactions.local_storage.get_manifest(entry_id)
+    manifest = await entry_transactions.local_storage.get_manifest(entry_id)
     async with entry_transactions.local_storage.lock_entry_id(entry_id):
-        entry_transactions.local_storage.clear_manifest(entry_id)
+        await entry_transactions.local_storage.clear_manifest(entry_id)
 
     with pytest.raises(FSRemoteManifestNotFound):
         await entry_transactions.entry_info(FsPath("/"))
 
     async with entry_transactions.local_storage.lock_entry_id(entry_id):
-        entry_transactions.local_storage.set_manifest(entry_id, manifest)
+        await entry_transactions.local_storage.set_manifest(entry_id, manifest)
     entry_info = await entry_transactions.entry_info(FsPath("/"))
     assert entry_info == {
         "type": "folder",
@@ -390,14 +394,14 @@ def test_folder_operations(
             root_entry_id = self.entry_transactions.get_workspace_entry().id
             new_id_to_path = set()
 
-            def _recursive_build_id_to_path(entry_id, parent_id):
+            async def _recursive_build_id_to_path(entry_id, parent_id):
                 new_id_to_path.add((entry_id, parent_id))
-                manifest = local_storage.get_manifest(entry_id)
+                manifest = await local_storage.get_manifest(entry_id)
                 if is_folder_manifest(manifest):
                     for child_name, child_entry_id in manifest.children.items():
-                        _recursive_build_id_to_path(child_entry_id, entry_id)
+                        await _recursive_build_id_to_path(child_entry_id, entry_id)
 
-            _recursive_build_id_to_path(root_entry_id, None)
+            await _recursive_build_id_to_path(root_entry_id, None)
 
             added_items = new_id_to_path - self.last_step_id_to_path
             for added_id, added_parent in added_items:

--- a/tests/core/fs/workspacefs/test_entry_transactions.py
+++ b/tests/core/fs/workspacefs/test_entry_transactions.py
@@ -242,7 +242,6 @@ def test_folder_operations(
     tmpdir,
     hypothesis_settings,
     reset_testbed,
-    initialize_local_storage,
     entry_transactions_factory,
     file_transactions_factory,
     alice,

--- a/tests/core/fs/workspacefs/test_file_transactions.py
+++ b/tests/core/fs/workspacefs/test_file_transactions.py
@@ -223,7 +223,7 @@ def test_file_operations(
     class FileOperationsStateMachine(TrioAsyncioRuleBasedStateMachine):
         async def start_transactions(self):
             async def _transactions_controlled_cb(started_cb):
-                with LocalStorage(
+                async with LocalStorage(
                     alice.device_id, key=alice.local_symkey, path=Path("/dummy")
                 ) as local_storage:
                     file_transactions = await file_transactions_factory(

--- a/tests/core/fs/workspacefs/test_file_transactions.py
+++ b/tests/core/fs/workspacefs/test_file_transactions.py
@@ -21,27 +21,28 @@ from tests.common import freeze_time, call_with_control
 
 
 class File:
-    def __init__(self, local_storage, entry_id):
-        self.entry_id = entry_id
+    def __init__(self, local_storage, manifest):
+        self.fresh_manifest = manifest
+        self.entry_id = manifest.id
         self.local_storage = local_storage
 
     def ensure_manifest(self, **kwargs):
-        manifest = self.local_storage.get_manifest(self.entry_id)
+        manifest = self.local_storage.local_manifest_cache[self.entry_id]
         for k, v in kwargs.items():
             assert getattr(manifest, k) == v
 
     def is_cache_ahead_of_persistance(self):
         return self.entry_id in self.local_storage.cache_ahead_of_persistance_ids
 
-    def get_manifest(self):
-        return self.local_storage.get_manifest(self.entry_id)
+    async def get_manifest(self):
+        return await self.local_storage.get_manifest(self.entry_id)
 
     async def set_manifest(self, manifest):
         async with self.local_storage.lock_manifest(self.entry_id):
-            self.local_storage.set_manifest(self.entry_id, manifest)
+            await self.local_storage.set_manifest(self.entry_id, manifest)
 
     def open(self):
-        return self.local_storage.create_file_descriptor(self.entry_id)
+        return self.local_storage.create_file_descriptor(self.fresh_manifest)
 
 
 @pytest.fixture
@@ -52,8 +53,8 @@ async def foo_txt(alice, alice_file_transactions):
     remote_v1 = placeholder.to_remote(author=alice.device_id, timestamp=now)
     manifest = LocalFileManifest.from_remote(remote_v1)
     async with local_storage.lock_entry_id(manifest.id):
-        local_storage.set_manifest(manifest.id, manifest)
-    return File(local_storage, manifest.id)
+        await local_storage.set_manifest(manifest.id, manifest)
+    return File(local_storage, manifest)
 
 
 @pytest.mark.trio
@@ -164,7 +165,7 @@ async def test_flush_file(alice_file_transactions, foo_txt):
 async def test_block_not_loaded_entry(alice_file_transactions, foo_txt):
     file_transactions = alice_file_transactions
 
-    foo_manifest = foo_txt.get_manifest()
+    foo_manifest = await foo_txt.get_manifest()
     chunk1_data = b"a" * 10
     chunk2_data = b"b" * 5
     chunk1 = Chunk.new(0, 10).evolve_as_block(chunk1_data)
@@ -177,8 +178,8 @@ async def test_block_not_loaded_entry(alice_file_transactions, foo_txt):
     with pytest.raises(FSRemoteBlockNotFound):
         await file_transactions.fd_read(fd, 14, 0)
 
-    file_transactions.local_storage.set_chunk(chunk1.id, chunk1_data)
-    file_transactions.local_storage.set_chunk(chunk2.id, chunk2_data)
+    await file_transactions.local_storage.set_chunk(chunk1.id, chunk1_data)
+    await file_transactions.local_storage.set_chunk(chunk2.id, chunk2_data)
 
     data = await file_transactions.fd_read(fd, 14, 0)
     assert data == chunk1_data + chunk2_data[:4]
@@ -192,7 +193,7 @@ async def test_load_block_from_remote(alice_file_transactions, foo_txt):
     workspace_id = file_transactions.remote_loader.workspace_id
     await file_transactions.remote_loader.create_realm(workspace_id)
 
-    foo_manifest = foo_txt.get_manifest()
+    foo_manifest = await foo_txt.get_manifest()
     chunk1_data = b"a" * 10
     chunk2_data = b"b" * 5
     chunk1 = Chunk.new(0, 10).evolve_as_block(chunk1_data)
@@ -203,8 +204,8 @@ async def test_load_block_from_remote(alice_file_transactions, foo_txt):
     fd = foo_txt.open()
     await file_transactions.remote_loader.upload_block(chunk1.access, chunk1_data)
     await file_transactions.remote_loader.upload_block(chunk2.access, chunk2_data)
-    file_transactions.local_storage.clear_clean_block(chunk1.access.id)
-    file_transactions.local_storage.clear_clean_block(chunk2.access.id)
+    await file_transactions.local_storage.clear_clean_block(chunk1.access.id)
+    await file_transactions.local_storage.clear_clean_block(chunk2.access.id)
 
     data = await file_transactions.fd_read(fd, 14, 0)
     assert data == chunk1_data + chunk2_data[:4]
@@ -246,12 +247,12 @@ def test_file_operations(
             self.file_transactions = self.transactions_controller.file_transactions
             self.local_storage = self.file_transactions.local_storage
 
-            manifest = LocalFileManifest.new_placeholder(parent=EntryID())
-            self.entry_id = manifest.id
+            self.fresh_manifest = LocalFileManifest.new_placeholder(parent=EntryID())
+            self.entry_id = self.fresh_manifest.id
             async with self.local_storage.lock_entry_id(self.entry_id):
-                self.local_storage.set_manifest(self.entry_id, manifest)
+                await self.local_storage.set_manifest(self.entry_id, self.fresh_manifest)
 
-            self.fd = self.local_storage.create_file_descriptor(self.entry_id)
+            self.fd = self.local_storage.create_file_descriptor(self.fresh_manifest)
             self.file_oracle_path = tmpdir / f"oracle-test-{tentative}.txt"
             self.file_oracle_fd = os.open(self.file_oracle_path, os.O_RDWR | os.O_CREAT)
 
@@ -282,7 +283,7 @@ def test_file_operations(
         @rule()
         async def reopen(self):
             await self.file_transactions.fd_close(self.fd)
-            self.fd = self.local_storage.create_file_descriptor(self.entry_id)
+            self.fd = self.local_storage.create_file_descriptor(self.fresh_manifest)
             os.close(self.file_oracle_fd)
             self.file_oracle_fd = os.open(self.file_oracle_path, os.O_RDWR)
 

--- a/tests/core/fs/workspacefs/test_file_transactions.py
+++ b/tests/core/fs/workspacefs/test_file_transactions.py
@@ -216,13 +216,7 @@ size = st.integers(min_value=0, max_value=4 * 1024 ** 2)  # Between 0 and 4MB
 @pytest.mark.slow
 @pytest.mark.skipif(os.name == "nt", reason="Windows file style not compatible with oracle")
 def test_file_operations(
-    tmpdir,
-    hypothesis_settings,
-    reset_testbed,
-    initialize_local_storage,
-    file_transactions_factory,
-    alice,
-    alice_backend_cmds,
+    tmpdir, hypothesis_settings, reset_testbed, file_transactions_factory, alice, alice_backend_cmds
 ):
     tentative = 0
 

--- a/tests/core/fs/workspacefs/test_sync_transactions.py
+++ b/tests/core/fs/workspacefs/test_sync_transactions.py
@@ -188,7 +188,7 @@ async def test_synchronization_step_transaction(alice_sync_transactions, type):
     # Sync parent with a placeholder child
     manifest = await synchronization_step(entry_id)
     children = []
-    for child in sync_transactions.get_placeholder_children(manifest):
+    async for child in sync_transactions.get_placeholder_children(manifest):
         children.append(child)
     a_entry_id, = children
     assert a_entry_id == a_id
@@ -213,7 +213,7 @@ async def test_synchronization_step_transaction(alice_sync_transactions, type):
     # Sync parent with a placeholder child
     manifest = await synchronization_step(entry_id, manifest)
     children = []
-    for child in sync_transactions.get_placeholder_children(manifest):
+    async for child in sync_transactions.get_placeholder_children(manifest):
         children.append(child)
     b_entry_id, = children
     assert b_entry_id == b_id
@@ -241,7 +241,7 @@ async def test_get_minimal_remote_manifest(alice, alice_sync_transactions):
 
     # Workspace manifest
     minimal = await sync_transactions.get_minimal_remote_manifest(w_id)
-    local = sync_transactions.local_storage.get_manifest(w_id)
+    local = await sync_transactions.local_storage.get_manifest(w_id)
     expected = local.to_remote(author=alice.device_id, timestamp=minimal.timestamp).evolve(
         children={}, updated=local.created
     )
@@ -252,7 +252,7 @@ async def test_get_minimal_remote_manifest(alice, alice_sync_transactions):
 
     # File manifest
     minimal = await sync_transactions.get_minimal_remote_manifest(a_id)
-    local = sync_transactions.local_storage.get_manifest(a_id)
+    local = await sync_transactions.local_storage.get_manifest(a_id)
     expected = local.evolve(blocks=(), updated=local.created, size=0).to_remote(
         author=alice.device_id, timestamp=minimal.timestamp
     )
@@ -263,7 +263,7 @@ async def test_get_minimal_remote_manifest(alice, alice_sync_transactions):
 
     # Folder manifest
     minimal = await sync_transactions.get_minimal_remote_manifest(b_id)
-    local = sync_transactions.local_storage.get_manifest(b_id)
+    local = await sync_transactions.local_storage.get_manifest(b_id)
     expected = local.to_remote(author=alice.device_id, timestamp=minimal.timestamp).evolve(
         children={}, updated=local.created
     )
@@ -273,7 +273,7 @@ async def test_get_minimal_remote_manifest(alice, alice_sync_transactions):
 
     # Empty folder manifest
     minimal = await sync_transactions.get_minimal_remote_manifest(c_id)
-    local = sync_transactions.local_storage.get_manifest(c_id)
+    local = await sync_transactions.local_storage.get_manifest(c_id)
     expected = local.to_remote(author=alice.device_id, timestamp=minimal.timestamp)
     assert minimal == expected
     await sync_transactions.synchronization_step(c_id, minimal)

--- a/tests/core/fs/workspacefs/test_workspace_fs.py
+++ b/tests/core/fs/workspacefs/test_workspace_fs.py
@@ -379,8 +379,8 @@ async def test_rmtree(alice_workspace):
 async def test_dump(alice_workspace):
     baz_id = await alice_workspace.path_id("/foo/baz")
     async with alice_workspace.local_storage.lock_entry_id(baz_id):
-        alice_workspace.local_storage.clear_manifest(baz_id)
-    assert alice_workspace.dump() == {
+        await alice_workspace.local_storage.clear_manifest(baz_id)
+    assert await alice_workspace.dump() == {
         "base_version": 1,
         "children": {
             "foo": {
@@ -420,7 +420,7 @@ async def test_dump(alice_workspace):
 async def test_path_info_remote_loader_exceptions(monkeypatch, alice_workspace, alice):
     manifest = await alice_workspace.transactions._get_manifest_from_path(FsPath("/foo/bar"))
     async with alice_workspace.local_storage.lock_entry_id(manifest.id):
-        alice_workspace.local_storage.clear_manifest(manifest.id)
+        await alice_workspace.local_storage.clear_manifest(manifest.id)
 
     vanilla_file_manifest_deserialize = RemoteManifest._deserialize
 

--- a/tests/core/fs/workspacefs_timestamped/test_entry_transactions_timestamped.py
+++ b/tests/core/fs/workspacefs_timestamped/test_entry_transactions_timestamped.py
@@ -62,11 +62,11 @@ async def test_rename(alice_workspace_t4):
 async def test_access_not_loaded_entry(alice_workspace_t4):
     entry_id = alice_workspace_t4.transactions.get_workspace_entry().id
     async with alice_workspace_t4.transactions.local_storage.lock_entry_id(entry_id):
-        alice_workspace_t4.transactions.local_storage.clear_manifest(entry_id)
+        await alice_workspace_t4.transactions.local_storage.clear_manifest(entry_id)
     with pytest.raises(FSLocalMissError):
         await alice_workspace_t4.transactions.local_storage.get_manifest(entry_id)
     async with alice_workspace_t4.transactions.local_storage.lock_entry_id(entry_id):
-        alice_workspace_t4.transactions.local_storage.clear_manifest(entry_id)
+        await alice_workspace_t4.transactions.local_storage.clear_manifest(entry_id)
     await alice_workspace_t4.transactions.entry_info(FsPath("/"))
 
 

--- a/tests/core/mountpoint/test_base.py
+++ b/tests/core/mountpoint/test_base.py
@@ -241,7 +241,7 @@ def test_manifest_not_available(mountpoint_service):
         await workspace.touch("/foo.txt")
         foo_id = await workspace.path_id("/foo.txt")
         async with workspace.local_storage.lock_entry_id(foo_id):
-            workspace.local_storage.clear_manifest(foo_id)
+            await workspace.local_storage.clear_manifest(foo_id)
         await mountpoint_manager.mount_all()
 
     mountpoint_service.start()

--- a/tests/core/test_sync_monitor_stateful.py
+++ b/tests/core/test_sync_monitor_stateful.py
@@ -230,8 +230,8 @@ def test_sync_monitor_stateful(
                     # No access, workspace can only diverge from bob's
                     continue
 
-                bob_dump = bob_w.dump()
-                alice_dump = alice_w.dump()
+                bob_dump = await bob_w.dump()
+                alice_dump = await alice_w.dump()
                 if self.alice_workspaces_role[alice_workspace_entry.id] == WorkspaceRole.READER:
                     # Synced with bob, but we can have local changes that cannot be synced
                     recursive_compare_fs_dumps(alice_dump, bob_dump, ignore_need_sync=True)


### PR DESCRIPTION
The storage interface is not connected to anything asynchronous for the moment (the synchronous `sqlite3` library is still in use) but it will be easier to implement it in a later PR.