### PR TITLE
[WIP] Add bakend check on user revocation during realm role update

### DIFF
--- a/newsfragments/736.bugfix.rst
+++ b/newsfragments/736.bugfix.rst
@@ -1,0 +1,1 @@
+Add check in backend to prevent non-removal role update on revoked user

--- a/parsec/backend/memory/realm.py
+++ b/parsec/backend/memory/realm.py
@@ -139,8 +139,10 @@ class MemoryRealmComponent(BaseRealmComponent):
         except UserNotFoundError:
             raise RealmNotFoundError(f"User `{new_role.user_id}` doesn't exist")
 
-        if user.revoked_on and user.revoked_on <= pendulum.now():
-            raise RealmNotFoundError(f"User `{new_role.user_id}` has been revoked")
+        if user.revoked_on and user.revoked_on <= pendulum.now() and new_role.role is not None:
+            raise RealmAccessError(
+                f"User `{new_role.user_id}` has been revoked, can only remove it role"
+            )
 
         realm = self._get_realm(organization_id, new_role.realm_id)
 

--- a/parsec/backend/memory/realm.py
+++ b/parsec/backend/memory/realm.py
@@ -135,9 +135,12 @@ class MemoryRealmComponent(BaseRealmComponent):
         assert new_role.granted_by.user_id != new_role.user_id
 
         try:
-            self._user_component._get_user(organization_id, new_role.user_id)
+            user = self._user_component._get_user(organization_id, new_role.user_id)
         except UserNotFoundError:
             raise RealmNotFoundError(f"User `{new_role.user_id}` doesn't exist")
+
+        if user.revoked_on and user.revoked_on <= pendulum.now():
+            raise RealmNotFoundError(f"User `{new_role.user_id}` has been revoked")
 
         realm = self._get_realm(organization_id, new_role.realm_id)
 

--- a/parsec/backend/postgresql/realm_queries/update_roles.py
+++ b/parsec/backend/postgresql/realm_queries/update_roles.py
@@ -116,8 +116,10 @@ async def query_update_roles(
     if not user_id:
         raise RealmNotFoundError(f"User `{new_role.user_id}` doesn't exist")
 
-    if user_revoked_on and user_revoked_on <= pendulum_now():
-        raise RealmNotFoundError(f"User `{new_role.user_id}` has been revoked")
+    if user_revoked_on and user_revoked_on <= pendulum_now() and new_role.role is not None:
+        raise RealmAccessError(
+            f"User `{new_role.user_id}` has been revoked, can only remove it role"
+        )
 
     author_role = STR_TO_REALM_ROLE.get(author_role)
     existing_user_role = STR_TO_REALM_ROLE.get(existing_user_role)

--- a/tests/backend/realm/test_roles.py
+++ b/tests/backend/realm/test_roles.py
@@ -86,6 +86,20 @@ async def test_update_roles_bad_user(backend, alice, mallory, alice_backend_sock
 
 
 @pytest.mark.trio
+async def test_update_roles_revoked_user(backend, alice, bob, alice_backend_sock, realm):
+    await backend.user.revoke_user(
+        organization_id=alice.organization_id,
+        user_id=bob.user_id,
+        revoked_user_certificate=b"dummy",
+        revoked_user_certifier=alice.device_id,
+    )
+    rep = await _realm_generate_certif_and_update_roles_or_fail(
+        alice_backend_sock, alice, realm, bob.user_id, RealmRole.MANAGER
+    )
+    assert rep == {"status": "not_found", "reason": "User `bob` has been revoked"}
+
+
+@pytest.mark.trio
 async def test_update_roles_cannot_modify_self(backend, alice, alice_backend_sock, realm):
     rep = await _realm_generate_certif_and_update_roles_or_fail(
         alice_backend_sock, alice, realm, alice.user_id, RealmRole.MANAGER


### PR DESCRIPTION
DO NOT MERGE YET !

@vxgmichel suggested the real trouble here is the fact to process a role change we have to check for 1) the user role 2) whether the user has been revoked

It would be more logical to have 2) implying 1), hence a role change only needs 1).
This is not possible given user roles are signed by workspace owner and user revocations are signed by organization admin (so overlapping is not always possible)

A solution would be to issue a message informing about the revocation to each owner of workspace the user is part. Then the user would be gradually removed from each workspace each time a message is processed.

Another solution would be to have owner take care of removing revoked user from workspace before doing a re-encryption.
This approach has the benefit of simplicity (only have to add a new step on core side before actually doing the re-encryption) and security (checks are done on client side, we don't send the new key to users which have been revoked).