### PR TITLE
Run sqlite3 commit and vacuum statements in a dedicated thread

### DIFF
--- a/parsec/core/fs/storage/local_database.py
+++ b/parsec/core/fs/storage/local_database.py
@@ -1,11 +1,33 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
+import functools
 from pathlib import Path
+from inspect import isasyncgenfunction
 
 import trio
-
 from async_generator import asynccontextmanager
 from sqlite3 import connect as sqlite_connect
+
+
+def protect_with_lock(fn):
+    """Use as a decorator to protect an async method with `self._lock`"""
+
+    if isasyncgenfunction(fn):
+
+        @functools.wraps(fn)
+        async def wrapper(self, *args, **kwargs):
+            async with self._lock:
+                async for item in fn.__get__(self)(*args, **kwargs):
+                    yield item
+
+    else:
+
+        @functools.wraps(fn)
+        async def wrapper(self, *args, **kwargs):
+            async with self._lock:
+                return await fn.__get__(self)(*args, **kwargs)
+
+    return wrapper
 
 
 class LocalDatabase:
@@ -13,6 +35,8 @@ class LocalDatabase:
 
     def __init__(self, path, vacuum_threshold=None):
         self._conn = None
+        self._lock = trio.Lock()
+
         self.path = Path(path)
         self.vacuum_threshold = vacuum_threshold
 
@@ -27,6 +51,9 @@ class LocalDatabase:
             with trio.CancelScope(shield=True):
                 await self._close()
 
+    async def _run_in_thread(self, fn, *args):
+        return await trio.run_sync_in_worker_thread(fn, *args)
+
     # Life cycle
 
     async def _create_connection(self):
@@ -34,7 +61,7 @@ class LocalDatabase:
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
         # Create sqlite connection
-        conn = sqlite_connect(str(self.path))
+        conn = sqlite_connect(str(self.path), check_same_thread=False)
 
         # The default isolation level ("") lets python manage the transaction
         # so we can periodically commit the pending changes.
@@ -50,6 +77,7 @@ class LocalDatabase:
         # Return connection
         return conn
 
+    @protect_with_lock
     async def _connect(self):
         if self._conn is not None:
             raise RuntimeError("Already connected")
@@ -57,19 +85,21 @@ class LocalDatabase:
         # Connect and initialize database
         self._conn = await self._create_connection()
 
+    @protect_with_lock
     async def _close(self):
         # Idempotency
         if self._conn is None:
             return
 
         # Commit and close
-        self._conn.commit()
+        await self._run_in_thread(self._conn.commit)
         self._conn.close()
         self._conn = None
 
     # Cursor management
 
     @asynccontextmanager
+    @protect_with_lock
     async def open_cursor(self, commit=True):
         # Get a cursor
         cursor = self._conn.cursor()
@@ -79,15 +109,16 @@ class LocalDatabase:
             yield cursor
 
             # Commit the transaction when finished
-            if commit:
-                self._conn.commit()
+            if commit and self._conn.in_transaction:
+                await self._run_in_thread(self._conn.commit)
 
         # Close cursor
         finally:
             cursor.close()
 
+    @protect_with_lock
     async def commit(self):
-        self._conn.commit()
+        await self._run_in_thread(self._conn.commit)
 
     # Vacuum
 
@@ -100,23 +131,24 @@ class LocalDatabase:
                 pass
         return disk_usage
 
+    @protect_with_lock
     async def run_vacuum(self):
         # Vacuum disabled
         if self.vacuum_threshold is None:
             return
 
         # Flush to disk
-        self._conn.commit()
+        await self._run_in_thread(self._conn.commit)
 
         # No reason to vacuum yet
         if self.get_disk_usage() < self.vacuum_threshold:
             return
 
         # Run vacuum
-        self._conn.execute("VACUUM")
+        await self._run_in_thread(self._conn.execute, "VACUUM")
 
         # The connection needs to be recreated
         try:
-            await self._close()
+            self._conn.close()
         finally:
             self._conn = await self._create_connection()

--- a/setup.py
+++ b/setup.py
@@ -260,6 +260,7 @@ requirements = [
     "colorama==0.4.0",  # structlog colored output
     "PyPika==0.29.0",
     "async_exit_stack==1.0.1",
+    "outcome==1.0.0",
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -352,7 +352,7 @@ def persistent_mockup(monkeypatch):
 
         def get(self, path):
             if path not in self.connections:
-                self.connections[path] = sqlite3.connect(":memory:")
+                self.connections[path] = sqlite3.connect(":memory:", check_same_thread=False)
             return self.connections[path]
 
         def clear(self):
@@ -376,6 +376,10 @@ def persistent_mockup(monkeypatch):
         storage_set.remove(storage)
         storage._conn = None
 
+    async def _run_in_thread(fn, *args):
+        return fn(*args)
+
+    monkeypatch.setattr(LocalDatabase, "_run_in_thread", _run_in_thread)
     monkeypatch.setattr(LocalDatabase, "_create_connection", _create_connection)
     monkeypatch.setattr(LocalDatabase, "_close", _close)
 


### PR DESCRIPTION
The sqlite3 commit statement after the reshaping of a large file can take more than one second. We cannot allow the trio loop to get frozen for that long, so one solution is to run the costy statements in a dedicated thread.

Note 1: It's not worth running all statements in the dedicated thread since the thread sync overhead is ususally greater that the statement execution.

Note 2: We could simply use `trio.run_sync_in_worker_thread` (see 4b11469) instead of a thread pool (see b0e94fa), but this would mean creating a new thread for every commit. Would that be an issue? More info [here](https://github.com/python-trio/trio/blob/c5497c5ac4f6c457e3390c69cb8b5b62eca41979/trio/_threads.py#L32-L128).