### PR TITLE
Fix chunk corruption

### DIFF
--- a/parsec/core/fs/storage/manifest_storage.py
+++ b/parsec/core/fs/storage/manifest_storage.py
@@ -46,9 +46,11 @@ class ManifestStorage:
         # (unless they are purposely kept out of the local database)
         return self.localdb.open_cursor(commit=True)
 
-    def clear_memory_cache(self):
-        self._cache.clear()
+    async def clear_memory_cache(self, flush=True):
+        if flush:
+            await self._flush_cache_ahead_of_persistance()
         self._cache_ahead_of_localdb.clear()
+        self._cache.clear()
 
     # Database initialization
 

--- a/parsec/core/fs/storage/manifest_storage.py
+++ b/parsec/core/fs/storage/manifest_storage.py
@@ -23,7 +23,16 @@ class ManifestStorage:
         self.localdb = localdb
         self.realm_id = realm_id
 
+        # This cache contains all the manifests that have been set or accessed
+        # since the last call to `clear_memory_cache`
         self._cache = {}
+
+        # This dictionnary keeps track of all the entry ids of the manifests
+        # that have been added to the cache but still needs to be written to
+        # the localdb. The corresponding value is a set with the ids of all
+        # the chunks that needs to be removed from the localdb after the
+        # manifest is written. Note: this set might be empty but the manifest
+        # still requires to be flushed.
         self._cache_ahead_of_localdb = {}
 
     @property
@@ -239,10 +248,11 @@ class ManifestStorage:
             entry_id = next(iter(self._cache_ahead_of_localdb))
             await self._ensure_manifest_persistent(entry_id)
 
+    # This method is not used in the code base but it is still tested
+    # as it might come handy in a cleanup routine later
+
     async def clear_manifest(self, entry_id: EntryID) -> None:
         """
-        This method isn't used at the moment.
-
         Raises:
             FSLocalMissError
         """

--- a/parsec/core/fs/storage/workspace_storage.py
+++ b/parsec/core/fs/storage/workspace_storage.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 from collections import defaultdict
-from typing import Dict, Tuple, Set
+from typing import Dict, Tuple, Set, Optional
 
 import trio
 from trio import hazmat
@@ -227,6 +227,20 @@ class WorkspaceStorage:
         except FSLocalMissError:
             if not miss_ok:
                 raise
+
+    async def clear_chunks(
+        self, chunk_ids: Set[ChunkID], postpone: Optional[EntryID] = None
+    ) -> None:
+        # Postponing the clearing as the corresponding manifest is still in cache
+        if postpone and self.manifest_storage.postpone_clear_chunks(chunk_ids, postpone):
+            return
+
+        # Actual clearing of the chunk
+        for chunk_id in chunk_ids:
+            await self.clear_chunk(chunk_id, miss_ok=True)
+
+        # Commit the clean up
+        await self.data_localdb.commit()
 
     # File management interface
 

--- a/parsec/core/fs/storage/workspace_storage.py
+++ b/parsec/core/fs/storage/workspace_storage.py
@@ -178,12 +178,12 @@ class WorkspaceStorage:
         manifest: LocalManifest,
         cache_only: bool = False,
         check_lock_status: bool = True,
-        cleanup: Optional[Set[ChunkID]] = None,
+        removed_ids: Optional[Set[ChunkID]] = None,
     ) -> None:
         if check_lock_status:
             self._check_lock_status(entry_id)
         await self.manifest_storage.set_manifest(
-            entry_id, manifest, cache_only=cache_only, cleanup=cleanup
+            entry_id, manifest, cache_only=cache_only, removed_ids=removed_ids
         )
 
     async def ensure_manifest_persistent(self, entry_id: EntryID) -> None:

--- a/parsec/core/fs/storage/workspace_storage.py
+++ b/parsec/core/fs/storage/workspace_storage.py
@@ -126,8 +126,8 @@ class WorkspaceStorage:
         self.fd_counter += 1
         return FileDescriptor(self.fd_counter)
 
-    def clear_memory_cache(self):
-        self.manifest_storage.clear_memory_cache()
+    async def clear_memory_cache(self, flush=True):
+        await self.manifest_storage.clear_memory_cache(flush=flush)
 
     # Locking helpers
 

--- a/parsec/core/fs/workspacefs/file_transactions.py
+++ b/parsec/core/fs/workspacefs/file_transactions.py
@@ -164,7 +164,7 @@ class FileTransactions:
 
             # Atomic change
             await self.local_storage.set_manifest(
-                manifest.id, manifest, cache_only=True, cleanup=removed_ids
+                manifest.id, manifest, cache_only=True, removed_ids=removed_ids
             )
 
             # Reshaping
@@ -234,7 +234,7 @@ class FileTransactions:
             await self._write_chunk(chunk, b"", offset)
 
         # Atomic change
-        await self.local_storage.set_manifest(manifest.id, manifest, cleanup=removed_ids)
+        await self.local_storage.set_manifest(manifest.id, manifest, removed_ids=removed_ids)
 
     async def _manifest_reshape(
         self, manifest: LocalFileManifest, cache_only: bool = False
@@ -260,10 +260,12 @@ class FileTransactions:
             if source != (destination,):
                 await self._write_chunk(new_chunk, data)
 
-            # Craft and set new manifest
+            # Craft the new manifest
             manifest = update(manifest, new_chunk)
+
+            # Set the new manifest, acting as a checkpoint
             await self.local_storage.set_manifest(
-                manifest.id, manifest, cache_only=True, cleanup=removed_ids
+                manifest.id, manifest, cache_only=True, removed_ids=removed_ids
             )
 
         # Flush if necessary

--- a/parsec/core/fs/workspacefs/file_transactions.py
+++ b/parsec/core/fs/workspacefs/file_transactions.py
@@ -166,8 +166,7 @@ class FileTransactions:
             await self.local_storage.set_manifest(manifest.id, manifest, cache_only=True)
 
             # Clean up
-            for removed_id in removed_ids:
-                await self.local_storage.clear_chunk(removed_id, miss_ok=True)
+            await self.local_storage.clear_chunks(removed_ids, postpone=manifest.id)
 
             # Reshaping
             if self._write_count[fd] >= manifest.blocksize:
@@ -239,8 +238,7 @@ class FileTransactions:
         await self.local_storage.set_manifest(manifest.id, manifest)
 
         # Clean up
-        for removed_id in removed_ids:
-            await self.local_storage.clear_chunk(removed_id, miss_ok=True)
+        await self.local_storage.clear_chunks(removed_ids)
 
     async def _manifest_reshape(
         self, manifest: LocalFileManifest, cache_only: bool = False
@@ -271,8 +269,7 @@ class FileTransactions:
             await self.local_storage.set_manifest(manifest.id, manifest, cache_only=cache_only)
 
             # Perform cleanup
-            for removed_id in cleanup:
-                await self.local_storage.clear_chunk(removed_id, miss_ok=True)
+            await self.local_storage.clear_chunks(cleanup, postpone=manifest.id)
 
         # Return missing block ids
         return missing

--- a/parsec/core/fs/workspacefs/file_transactions.py
+++ b/parsec/core/fs/workspacefs/file_transactions.py
@@ -266,10 +266,14 @@ class FileTransactions:
 
             # Craft and set new manifest
             manifest = update(manifest, new_chunk)
-            await self.local_storage.set_manifest(manifest.id, manifest, cache_only=cache_only)
+            await self.local_storage.set_manifest(manifest.id, manifest, cache_only=True)
 
             # Perform cleanup
             await self.local_storage.clear_chunks(cleanup, postpone=manifest.id)
+
+        # Flush if necessary
+        if not cache_only:
+            await self.local_storage.ensure_manifest_persistent(manifest.id)
 
         # Return missing block ids
         return missing

--- a/tests/core/fs/storage/test_workspace_storage.py
+++ b/tests/core/fs/storage/test_workspace_storage.py
@@ -128,7 +128,7 @@ async def test_cache_set_get(tmpdir, alice, workspace_id):
 @pytest.mark.trio
 @pytest.mark.parametrize("cache_only", (False, True))
 @pytest.mark.parametrize("clear_manifest", (False, True))
-async def test_chunk_cleanup(alice_workspace_storage, cache_only, clear_manifest):
+async def test_chunk_clearing(alice_workspace_storage, cache_only, clear_manifest):
     aws = alice_workspace_storage
     manifest = create_manifest(aws.device, LocalFileManifest)
     data1 = b"abc"
@@ -144,9 +144,11 @@ async def test_chunk_cleanup(alice_workspace_storage, cache_only, clear_manifest
         await aws.set_manifest(manifest.id, manifest)
 
         # Set a new version of the manifest without the chunks
-        cleanup = {chunk1.id, chunk2.id}
+        removed_ids = {chunk1.id, chunk2.id}
         new_manifest = manifest.evolve(blocks=())
-        await aws.set_manifest(manifest.id, new_manifest, cache_only=cache_only, cleanup=cleanup)
+        await aws.set_manifest(
+            manifest.id, new_manifest, cache_only=cache_only, removed_ids=removed_ids
+        )
 
         # The chunks are still accessible
         if cache_only:

--- a/tests/core/fs/test_bootstrap.py
+++ b/tests/core/fs/test_bootstrap.py
@@ -161,7 +161,7 @@ async def test_reloading_v0_user_manifest(
             wid = await user_fs.workspace_create("foo")
             workspace = user_fs.get_workspace(wid)
 
-    local_storage.clear_memory_cache()
+    await local_storage.clear_memory_cache()
 
     # Reload version 0 manifest
     async with user_fs_factory(alice, local_storage) as user_fs:
@@ -180,7 +180,7 @@ async def test_reloading_v0_user_manifest(
             "children": ["foo"],
         }
 
-    local_storage.clear_memory_cache()
+    await local_storage.clear_memory_cache()
 
     # Syncronize version 0 manifest
     async with user_fs_factory(alice, local_storage) as user_fs:

--- a/tests/core/fs/workspacefs/test_file_operations.py
+++ b/tests/core/fs/workspacefs/test_file_operations.py
@@ -86,13 +86,13 @@ class Storage(dict):
 
     def reshape(self, manifest: LocalFileManifest) -> LocalFileManifest:
 
-        for source, destination, update, cleanup in prepare_reshape(manifest):
+        for source, destination, update, removed_ids in prepare_reshape(manifest):
             data = self.build_data(source)
             new_chunk = destination.evolve_as_block(data)
             if source != (destination,):
                 self.write_chunk(new_chunk, data)
             manifest = update(manifest, new_chunk)
-            for removed_id in cleanup:
+            for removed_id in removed_ids:
                 self.clear_chunk_data(removed_id)
 
         return manifest

--- a/tests/core/fs/workspacefs/test_file_transactions.py
+++ b/tests/core/fs/workspacefs/test_file_transactions.py
@@ -32,7 +32,7 @@ class File:
             assert getattr(manifest, k) == v
 
     def is_cache_ahead_of_persistance(self):
-        return self.entry_id in self.local_storage.manifest_storage._cache_ahead_of_persistance_ids
+        return self.entry_id in self.local_storage.manifest_storage._cache_ahead_of_localdb
 
     async def get_manifest(self):
         return await self.local_storage.get_manifest(self.entry_id)


### PR DESCRIPTION
Taken from 4a57172:

> Before this change, there was a risk of data corruption.
For instance, chunks might be cleaned up in the current sqlite
transaction, waiting for the next manifest flush to be committed.
But if a commit occurs before the flushing the current manifest,
the system enters a risky state: the chunk is cleared from the disk
but the current version of the manifest is still in memory. If a
crash happens at this point, the database will stay in its current
state, i.e with a manifest referencing non-existing blocks.

> This is solved by adding the IDs of the chunks to cleanup to the
data structure that keeps track of the unwritten manifests. This
way, the cleanup can occur in between the writing of the manifests
and the committing of the transaction.