### PR TITLE
Backend checks EntryID timestamp consistency

### DIFF
--- a/parsec/backend/memory/vlob.py
+++ b/parsec/backend/memory/vlob.py
@@ -14,6 +14,7 @@ from parsec.backend.vlob import (
     BaseVlobComponent,
     VlobAccessError,
     VlobVersionError,
+    VlobTimestampError,
     VlobNotFoundError,
     VlobAlreadyExistsError,
     VlobEncryptionRevisionError,
@@ -272,10 +273,11 @@ class MemoryVlobComponent(BaseVlobComponent):
             organization_id, vlob.realm_id, author.user_id, encryption_revision
         )
 
-        if version - 1 == vlob.current_version:
-            vlob.data.append((blob, author, timestamp))
-        else:
+        if version - 1 != vlob.current_version:
             raise VlobVersionError()
+        if timestamp < vlob.data[vlob.current_version - 1][2]:
+            raise VlobTimestampError(timestamp, vlob.data[vlob.current_version - 1][2])
+        vlob.data.append((blob, author, timestamp))
 
         self._update_changes(organization_id, author, vlob.realm_id, vlob_id, version)
 

--- a/parsec/backend/postgresql/vlob.py
+++ b/parsec/backend/postgresql/vlob.py
@@ -368,7 +368,7 @@ WHERE
             query = """
 SELECT
     version,
-    created_on,
+    created_on
 FROM vlob_atom
 WHERE
     organization = ({})

--- a/parsec/backend/postgresql/vlob.py
+++ b/parsec/backend/postgresql/vlob.py
@@ -12,6 +12,7 @@ from parsec.backend.vlob import (
     BaseVlobComponent,
     VlobAccessError,
     VlobVersionError,
+    VlobTimestampError,
     VlobNotFoundError,
     VlobAlreadyExistsError,
     VlobEncryptionRevisionError,
@@ -382,6 +383,9 @@ ORDER BY version DESC LIMIT 1
 
             elif previous["version"] != version - 1:
                 raise VlobVersionError()
+
+            elif previous["timestamp"] > timestamp:
+                raise VlobTimestampError()
 
             query = """
 INSERT INTO vlob_atom (

--- a/parsec/backend/postgresql/vlob.py
+++ b/parsec/backend/postgresql/vlob.py
@@ -367,7 +367,8 @@ WHERE
 
             query = """
 SELECT
-    version
+    version,
+    created_on,
 FROM vlob_atom
 WHERE
     organization = ({})
@@ -384,7 +385,7 @@ ORDER BY version DESC LIMIT 1
             elif previous["version"] != version - 1:
                 raise VlobVersionError()
 
-            elif previous["timestamp"] > timestamp:
+            elif previous["created_on"] > timestamp:
                 raise VlobTimestampError()
 
             query = """

--- a/parsec/backend/vlob.py
+++ b/parsec/backend/vlob.py
@@ -31,6 +31,10 @@ class VlobVersionError(VlobError):
     pass
 
 
+class VlobTimestampError(VlobError):
+    pass
+
+
 class VlobNotFoundError(VlobError):
     pass
 
@@ -99,6 +103,9 @@ class BaseVlobComponent:
         except VlobVersionError:
             return vlob_read_serializer.rep_dump({"status": "bad_version"})
 
+        except VlobTimestampError:
+            return vlob_read_serializer.rep_dump({"status": "bad_timestamp"})
+
         except VlobEncryptionRevisionError:
             return vlob_create_serializer.rep_dump({"status": "bad_encryption_revision"})
 
@@ -134,6 +141,9 @@ class BaseVlobComponent:
 
         except VlobVersionError:
             return vlob_update_serializer.rep_dump({"status": "bad_version"})
+
+        except VlobTimestampError:
+            return vlob_update_serializer.rep_dump({"status": "bad_timestamp"})
 
         except VlobEncryptionRevisionError:
             return vlob_create_serializer.rep_dump({"status": "bad_encryption_revision"})
@@ -326,6 +336,7 @@ class BaseVlobComponent:
         Raises:
             VlobAccessError
             VlobVersionError
+            VlobTimestampError
             VlobNotFoundError
             VlobEncryptionRevisionError: if encryption_revision mismatch
             VlobInMaintenanceError

--- a/parsec/core/backend_connection/exceptions.py
+++ b/parsec/core/backend_connection/exceptions.py
@@ -72,6 +72,10 @@ class BackendCmdsBadVersion(BackendCmdsBadResponse):
     status = "bad_version"
 
 
+class BackendCmdsBadTimestamp(BackendCmdsBadResponse):
+    status = "bad_timestamp"
+
+
 class BackendCmdsNotFound(BackendCmdsBadResponse):
     status = "not_found"
 

--- a/parsec/core/fs/exceptions.py
+++ b/parsec/core/fs/exceptions.py
@@ -130,6 +130,10 @@ class FSRemoteManifestNotFoundBadVersion(FSRemoteManifestNotFound):
     pass
 
 
+class FSRemoteManifestNotFoundBadTimestamp(FSRemoteManifestNotFound):
+    pass
+
+
 class FSRemoteBlockNotFound(FSInternalError):
     pass
 


### PR DESCRIPTION
Backend now checks if timestamp is not inferior of existant on vlob update, if it is, send an error to client which goes offline to avoid the handling of this event in a retry loop