### PR TITLE
Remove duplicates in list_versions

### DIFF
--- a/newsfragments/784.feature.rst
+++ b/newsfragments/784.feature.rst
@@ -1,0 +1,1 @@
+Removed duplicates and supposed minimal sync when listing versions of a path

--- a/parsec/core/fs/workspacefs/versioning_helpers.py
+++ b/parsec/core/fs/workspacefs/versioning_helpers.py
@@ -253,10 +253,7 @@ async def list_versions(
                 and previous[0][3] < previous[0][2].add(seconds=30)  # Check 30 seconds time frame
                 and not previous[1][1]  # Check previous has no source path
             ):
-                previous = (
-                    (item[0][0], item[0][1], previous[0][2], item[0][3]),
-                    (item[1][0], previous[1][1], item[1][2]),
-                )
+                previous = item
                 continue
             new_list += [previous]
         previous = item

--- a/parsec/core/fs/workspacefs/workspacefs.py
+++ b/parsec/core/fs/workspacefs/workspacefs.py
@@ -7,7 +7,7 @@ from typing import Union, Iterator, Dict, Tuple
 from pendulum import Pendulum, now as pendulum_now
 
 from parsec.api.data import Manifest as RemoteManifest
-from parsec.api.protocol import UserID, DeviceID
+from parsec.api.protocol import UserID
 from parsec.core.types import (
     FsPath,
     EntryID,
@@ -19,7 +19,11 @@ from parsec.core.types import (
 from parsec.core.fs import workspacefs
 from parsec.core.fs.remote_loader import RemoteLoader
 from parsec.core.fs.workspacefs.sync_transactions import SyncTransactions
-from parsec.core.fs.workspacefs.versioning_helpers import list_versions
+from parsec.core.fs.workspacefs.versioning_helpers import (
+    list_versions,
+    TimestampBoundedEntry,
+    TimestampBoundedData,
+)
 from parsec.core.fs.utils import is_file_manifest, is_folderish_manifest
 from parsec.core.fs.exceptions import (
     FSRemoteManifestNotFound,
@@ -191,10 +195,7 @@ class WorkspaceFS:
 
     async def versions(
         self, path: AnyPath = "/", remove_supposed_minimal_sync: bool = True
-    ) -> Dict[
-        Tuple[EntryID, int, Pendulum, Pendulum],
-        Tuple[Tuple[DeviceID, Pendulum, bool, int], FsPath, FsPath],
-    ]:
+    ) -> Dict[TimestampBoundedEntry, TimestampBoundedData]:
         """
         Raises:
             FSError

--- a/parsec/core/fs/workspacefs/workspacefs.py
+++ b/parsec/core/fs/workspacefs/workspacefs.py
@@ -190,7 +190,7 @@ class WorkspaceFS:
     # Timestamped version
 
     async def versions(
-        self, path: AnyPath = "/"
+        self, path: AnyPath = "/", remove_supposed_mock=True
     ) -> Dict[
         Tuple[EntryID, int, Pendulum, Pendulum],
         Tuple[Tuple[DeviceID, Pendulum, bool, int], FsPath, FsPath],
@@ -203,7 +203,7 @@ class WorkspaceFS:
             FSRemoteManifestNotFound
         """
         path = FsPath(path)
-        return await list_versions(self, path)
+        return await list_versions(self, path, remove_supposed_mock)
 
     async def to_timestamped(self, timestamp: Pendulum):
         workspace = workspacefs.WorkspaceFSTimestamped(self, timestamp)

--- a/parsec/core/fs/workspacefs/workspacefs.py
+++ b/parsec/core/fs/workspacefs/workspacefs.py
@@ -3,7 +3,7 @@
 import attr
 import trio
 from collections import defaultdict
-from typing import Union, Iterator, Dict, Tuple
+from typing import Union, Iterator, Dict, List, Tuple
 from pendulum import Pendulum, now as pendulum_now
 
 from parsec.api.data import Manifest as RemoteManifest
@@ -19,11 +19,7 @@ from parsec.core.types import (
 from parsec.core.fs import workspacefs
 from parsec.core.fs.remote_loader import RemoteLoader
 from parsec.core.fs.workspacefs.sync_transactions import SyncTransactions
-from parsec.core.fs.workspacefs.versioning_helpers import (
-    list_versions,
-    TimestampBoundedEntry,
-    TimestampBoundedData,
-)
+from parsec.core.fs.workspacefs.versioning_helpers import list_versions, TimestampBoundedData
 from parsec.core.fs.utils import is_file_manifest, is_folderish_manifest
 from parsec.core.fs.exceptions import (
     FSRemoteManifestNotFound,
@@ -194,8 +190,8 @@ class WorkspaceFS:
     # Timestamped version
 
     async def versions(
-        self, path: AnyPath = "/", remove_supposed_minimal_sync: bool = True
-    ) -> Dict[TimestampBoundedEntry, TimestampBoundedData]:
+        self, path: AnyPath = "/", skip_minimal_sync: bool = True
+    ) -> List[TimestampBoundedData]:
         """
         Raises:
             FSError
@@ -204,7 +200,7 @@ class WorkspaceFS:
             FSRemoteManifestNotFound
         """
         path = FsPath(path)
-        return await list_versions(self, path, remove_supposed_minimal_sync)
+        return await list_versions(self, path, skip_minimal_sync)
 
     async def to_timestamped(self, timestamp: Pendulum):
         workspace = workspacefs.WorkspaceFSTimestamped(self, timestamp)

--- a/parsec/core/fs/workspacefs/workspacefs.py
+++ b/parsec/core/fs/workspacefs/workspacefs.py
@@ -190,7 +190,7 @@ class WorkspaceFS:
     # Timestamped version
 
     async def versions(
-        self, path: AnyPath = "/", remove_supposed_mock=True
+        self, path: AnyPath = "/", remove_supposed_minimal_sync: bool = True
     ) -> Dict[
         Tuple[EntryID, int, Pendulum, Pendulum],
         Tuple[Tuple[DeviceID, Pendulum, bool, int], FsPath, FsPath],
@@ -203,7 +203,7 @@ class WorkspaceFS:
             FSRemoteManifestNotFound
         """
         path = FsPath(path)
-        return await list_versions(self, path, remove_supposed_mock)
+        return await list_versions(self, path, remove_supposed_minimal_sync)
 
     async def to_timestamped(self, timestamp: Pendulum):
         workspace = workspacefs.WorkspaceFSTimestamped(self, timestamp)

--- a/parsec/core/gui/file_history_dialog.py
+++ b/parsec/core/gui/file_history_dialog.py
@@ -55,18 +55,19 @@ class FileHistoryDialog(QDialog, Ui_FileHistoryDialog):
         )
 
     def add_history(self):
-        versions_dict = self.versions_job.ret
+        versions_list = self.versions_job.ret
         self.versions_job = None
-        for k, v in versions_dict.items():
+        print(type(versions_list[0].early))
+        for v in versions_list:
             self.versions_table.add_item(
-                entry_id=k.id,
-                version=k.version,
+                entry_id=v.id,
+                version=v.version,
                 actual_path=self.path,
-                is_folder=v.is_dir,
-                creator=v.device_id,
+                is_folder=v.is_folder,
+                creator=v.creator,
                 size=v.size,
-                early_timestamp=k.early,
-                late_timestamp=k.late,
+                early_timestamp=v.early,
+                late_timestamp=v.late,
                 source_path=v.source,
                 destination_path=v.destination,
             )

--- a/parsec/core/gui/file_history_dialog.py
+++ b/parsec/core/gui/file_history_dialog.py
@@ -59,16 +59,16 @@ class FileHistoryDialog(QDialog, Ui_FileHistoryDialog):
         self.versions_job = None
         for k, v in versions_dict.items():
             self.versions_table.add_item(
-                entry_id=k[0],
-                version=k[1],
+                entry_id=k.id,
+                version=k.version,
                 actual_path=self.path,
-                is_folder=v[0][2],
-                creator=v[0][0],
-                size=v[0][3],
-                early_timestamp=k[2],
-                late_timestamp=k[3],
-                source_path=v[1],
-                destination_path=v[2],
+                is_folder=v.is_dir,
+                creator=v.device_id,
+                size=v.size,
+                early_timestamp=k.early,
+                late_timestamp=k.late,
+                source_path=v.source,
+                destination_path=v.destination,
             )
 
     def show_error(self):

--- a/parsec/core/gui/lang.py
+++ b/parsec/core/gui/lang.py
@@ -19,8 +19,10 @@ _current_locale_language = None
 logger = get_logger()
 
 
-def format_datetime(dt, full=False):
+def format_datetime(dt, full=False, seconds=False):
     fmt = "L LT"
+    if seconds:
+        fmt = "L LTS"
     if full:
         fmt = "LLLL"
     return dt.in_tz(pendulum.local_timezone()).format(

--- a/parsec/core/gui/versions_table.py
+++ b/parsec/core/gui/versions_table.py
@@ -118,8 +118,7 @@ class VersionsTable(QTableWidget):
 
         row_id = self.rowCount()
         self.insertRow(row_id)
-
-        _config_data(0, format_datetime(early_timestamp))
+        _config_data(0, format_datetime(early_timestamp, seconds=True))
         _config_data(1, creator)
         _config_data(2, get_filesize(size) if size is not None else "")
         _config_data(3, source_path)

--- a/tests/core/fs/workspacefs_timestamped/conftest.py
+++ b/tests/core/fs/workspacefs_timestamped/conftest.py
@@ -49,36 +49,36 @@ async def alice_workspace(alice_user_fs, running_backend):
         await workspace.sync()
 
     with freeze_time(day6):
-        await workspace.rename("/files/content", "/files/renamed_content")
+        await workspace.rename("/files/content", "/files/renamed")
         await workspace.sync()
     with freeze_time(day7):
-        await workspace.rename("/files/renamed_content", "/files/renamed_again_content")
+        await workspace.rename("/files/renamed", "/files/renamed_again")
         await workspace.sync()
     with freeze_time(day8):
-        await workspace.touch("/files/renamed_content")
-        await workspace.write_bytes("/files/renamed_content", b"aaaaaa")
+        await workspace.touch("/files/renamed")
+        await workspace.write_bytes("/files/renamed", b"aaaaaa")
         await workspace.sync()
 
     with freeze_time(day9):
-        await workspace.rename("/files", "/moved_files")
+        await workspace.rename("/files", "/moved")
         await workspace.sync()
     with freeze_time(day10):
-        await workspace.touch("/moved_files/content2")
-        await workspace.write_bytes("/moved_files/content2", b"bbbbb")
+        await workspace.touch("/moved/content2")
+        await workspace.write_bytes("/moved/content2", b"bbbbb")
         await workspace.sync()
     with freeze_time(day11):
-        await workspace.rename("/moved_files", "/files")
+        await workspace.rename("/moved", "/files")
         await workspace.sync()
 
     with freeze_time(day12):
-        await workspace.unlink("/files/renamed_content")
+        await workspace.unlink("/files/renamed")
         await workspace.sync()
     with freeze_time(day13):
-        await workspace.touch("/files/renamed_content")
+        await workspace.touch("/files/renamed")
         await workspace.sync()
     with freeze_time(day14):
-        await workspace.touch("/files/renamed_content")
-        await workspace.write_bytes("/files/renamed_content", b"ccccc")
+        await workspace.touch("/files/renamed")
+        await workspace.write_bytes("/files/renamed", b"ccccc")
         await workspace.sync()
     return workspace
 

--- a/tests/core/fs/workspacefs_timestamped/test_workspacefs.py
+++ b/tests/core/fs/workspacefs_timestamped/test_workspacefs.py
@@ -18,19 +18,25 @@ async def test_versions_existing_file_no_remove_minimal_synced(alice_workspace, 
     # Moved /files/content to /files/renamed_content on day 5, moved it again later
     assert versions_list[0][0][1:] == (3, Pendulum(2000, 1, 6), Pendulum(2000, 1, 7))
     assert versions_list[0][1] == (
-        (alice.device_id, Pendulum(2000, 1, 5), False, 5),
+        alice.device_id,
+        Pendulum(2000, 1, 5),
+        False,
+        5,
         FsPath("/files/content"),
         FsPath("/files/renamed_again_content"),
     )
 
     # Created a new file with the same name on day 8
     assert versions_list[1][0][1:] == (1, Pendulum(2000, 1, 8), Pendulum(2000, 1, 8))
-    assert versions_list[1][1] == ((alice.device_id, Pendulum(2000, 1, 8), False, 0), None, None)
+    assert versions_list[1][1] == (alice.device_id, Pendulum(2000, 1, 8), False, 0, None, None)
 
     # Wrote on it. Moved it again on day 9 as we renamed /files to /moved_files
     assert versions_list[2][0][1:] == (2, Pendulum(2000, 1, 8), Pendulum(2000, 1, 9))
     assert versions_list[2][1] == (
-        (alice.device_id, Pendulum(2000, 1, 8), False, 6),
+        alice.device_id,
+        Pendulum(2000, 1, 8),
+        False,
+        6,
         None,
         FsPath("/moved_files/renamed_content"),
     )
@@ -38,19 +44,22 @@ async def test_versions_existing_file_no_remove_minimal_synced(alice_workspace, 
     # And moved back /moved_files to /files on day 11, /files/renamed_content is deleted on day 12
     assert versions_list[3][0][1:] == (2, Pendulum(2000, 1, 11), Pendulum(2000, 1, 12))
     assert versions_list[3][1] == (
-        (alice.device_id, Pendulum(2000, 1, 8), False, 6),
+        alice.device_id,
+        Pendulum(2000, 1, 8),
+        False,
+        6,
         FsPath("/moved_files/renamed_content"),
         None,
     )
 
     # Created a file, again, but didn't write
     assert versions_list[4][0][1:] == (1, Pendulum(2000, 1, 13), Pendulum(2000, 1, 14))
-    assert versions_list[4][1] == ((alice.device_id, Pendulum(2000, 1, 13), False, 0), None, None)
+    assert versions_list[4][1] == (alice.device_id, Pendulum(2000, 1, 13), False, 0, None, None)
 
     # Used "touch" method again, but on a created file. Wrote on it. Didn't delete since then
     assert versions_list[5][0][1:3] == (2, Pendulum(2000, 1, 14))
     assert Pendulum.now().add(hours=-1) < versions_list[5][0][3] < Pendulum.now()
-    assert versions_list[5][1] == ((alice.device_id, Pendulum(2000, 1, 14), False, 5), None, None)
+    assert versions_list[5][1] == (alice.device_id, Pendulum(2000, 1, 14), False, 5, None, None)
 
 
 @pytest.mark.trio
@@ -63,7 +72,10 @@ async def test_versions_existing_file_remove_minimal_synced(alice_workspace, ali
     # Moved /files/content to /files/renamed_content on day 5, moved it again later
     assert versions_list[0][0][1:] == (3, Pendulum(2000, 1, 6), Pendulum(2000, 1, 7))
     assert versions_list[0][1] == (
-        (alice.device_id, Pendulum(2000, 1, 5), False, 5),
+        alice.device_id,
+        Pendulum(2000, 1, 5),
+        False,
+        5,
         FsPath("/files/content"),
         FsPath("/files/renamed_again_content"),
     )
@@ -74,7 +86,10 @@ async def test_versions_existing_file_remove_minimal_synced(alice_workspace, ali
     # Moved it again on day 9 as we renamed /files to /moved_files
     assert versions_list[1][0][1:] == (2, Pendulum(2000, 1, 8), Pendulum(2000, 1, 9))
     assert versions_list[1][1] == (
-        (alice.device_id, Pendulum(2000, 1, 8), False, 6),
+        alice.device_id,
+        Pendulum(2000, 1, 8),
+        False,
+        6,
         None,
         FsPath("/moved_files/renamed_content"),
     )
@@ -82,19 +97,22 @@ async def test_versions_existing_file_remove_minimal_synced(alice_workspace, ali
     # And moved back /moved_files to /files on day 11, /files/renamed_content is deleted on day 12
     assert versions_list[2][0][1:] == (2, Pendulum(2000, 1, 11), Pendulum(2000, 1, 12))
     assert versions_list[2][1] == (
-        (alice.device_id, Pendulum(2000, 1, 8), False, 6),
+        alice.device_id,
+        Pendulum(2000, 1, 8),
+        False,
+        6,
         FsPath("/moved_files/renamed_content"),
         None,
     )
 
     # Created a file, again, but didn't write
     assert versions_list[3][0][1:] == (1, Pendulum(2000, 1, 13), Pendulum(2000, 1, 14))
-    assert versions_list[3][1] == ((alice.device_id, Pendulum(2000, 1, 13), False, 0), None, None)
+    assert versions_list[3][1] == (alice.device_id, Pendulum(2000, 1, 13), False, 0, None, None)
 
     # Used "touch" method again, but on a created file. Wrote on it. Didn't delete since then
     assert versions_list[4][0][1:3] == (2, Pendulum(2000, 1, 14))
     assert Pendulum.now().add(hours=-1) < versions_list[4][0][3] < Pendulum.now()
-    assert versions_list[4][1] == ((alice.device_id, Pendulum(2000, 1, 14), False, 5), None, None)
+    assert versions_list[4][1] == (alice.device_id, Pendulum(2000, 1, 14), False, 5, None, None)
 
 
 @pytest.mark.trio
@@ -111,7 +129,10 @@ async def test_versions_non_existing_file_remove_minimal_synced(
 
     assert versions_list[0][0][1:] == (2, Pendulum(2000, 1, 9), Pendulum(2000, 1, 11))
     assert versions_list[0][1] == (
-        (alice.device_id, Pendulum(2000, 1, 8), False, 6),
+        alice.device_id,
+        Pendulum(2000, 1, 8),
+        False,
+        6,
         FsPath("/files/renamed_content"),
         FsPath("/files/renamed_content"),
     )
@@ -128,37 +149,43 @@ async def test_versions_existing_directory(alice_workspace, alice, remove_suppos
     assert len(versions_list) == 8
 
     assert versions_list[0][0][1:] == (1, Pendulum(2000, 1, 4), Pendulum(2000, 1, 4))
-    assert versions_list[0][1] == ((alice.device_id, Pendulum(2000, 1, 4), True, None), None, None)
+    assert versions_list[0][1] == (alice.device_id, Pendulum(2000, 1, 4), True, None, None, None)
 
     assert versions_list[1][0][1:] == (2, Pendulum(2000, 1, 4), Pendulum(2000, 1, 6))
-    assert versions_list[1][1] == ((alice.device_id, Pendulum(2000, 1, 4), True, None), None, None)
+    assert versions_list[1][1] == (alice.device_id, Pendulum(2000, 1, 4), True, None, None, None)
 
     assert versions_list[2][0][1:] == (3, Pendulum(2000, 1, 6), Pendulum(2000, 1, 7))
-    assert versions_list[2][1] == ((alice.device_id, Pendulum(2000, 1, 6), True, None), None, None)
+    assert versions_list[2][1] == (alice.device_id, Pendulum(2000, 1, 6), True, None, None, None)
 
     assert versions_list[3][0][1:] == (4, Pendulum(2000, 1, 7), Pendulum(2000, 1, 8))
-    assert versions_list[3][1] == ((alice.device_id, Pendulum(2000, 1, 7), True, None), None, None)
+    assert versions_list[3][1] == (alice.device_id, Pendulum(2000, 1, 7), True, None, None, None)
 
     assert versions_list[4][0][1:] == (5, Pendulum(2000, 1, 8), Pendulum(2000, 1, 9))
     assert versions_list[4][1] == (
-        (alice.device_id, Pendulum(2000, 1, 8), True, None),
+        alice.device_id,
+        Pendulum(2000, 1, 8),
+        True,
+        None,
         None,
         FsPath("/moved_files"),
     )
 
     assert versions_list[5][0][1:] == (6, Pendulum(2000, 1, 11), Pendulum(2000, 1, 12))
     assert versions_list[5][1] == (
-        (alice.device_id, Pendulum(2000, 1, 10), True, None),
+        alice.device_id,
+        Pendulum(2000, 1, 10),
+        True,
+        None,
         FsPath("/moved_files"),
         None,
     )
 
     assert versions_list[6][0][1:] == (7, Pendulum(2000, 1, 12), Pendulum(2000, 1, 13))
-    assert versions_list[6][1] == ((alice.device_id, Pendulum(2000, 1, 12), True, None), None, None)
+    assert versions_list[6][1] == (alice.device_id, Pendulum(2000, 1, 12), True, None, None, None)
 
     assert versions_list[7][0][1:3] == (8, Pendulum(2000, 1, 13))
     assert Pendulum.now().add(hours=-1) < versions_list[7][0][3] < Pendulum.now()
-    assert versions_list[7][1] == ((alice.device_id, Pendulum(2000, 1, 13), True, None), None, None)
+    assert versions_list[7][1] == (alice.device_id, Pendulum(2000, 1, 13), True, None, None, None)
 
 
 @pytest.mark.trio
@@ -170,14 +197,20 @@ async def test_version_non_existing_directory(alice_workspace, alice):
 
     assert versions_list[0][0][1:] == (5, Pendulum(2000, 1, 9), Pendulum(2000, 1, 10))
     assert versions_list[0][1] == (
-        (alice.device_id, Pendulum(2000, 1, 8), True, None),
+        alice.device_id,
+        Pendulum(2000, 1, 8),
+        True,
+        None,
         FsPath("/files"),
         None,
     )
 
     assert versions_list[1][0][1:] == (6, Pendulum(2000, 1, 10), Pendulum(2000, 1, 11))
     assert versions_list[1][1] == (
-        (alice.device_id, Pendulum(2000, 1, 10), True, None),
+        alice.device_id,
+        Pendulum(2000, 1, 10),
+        True,
+        None,
         None,
         FsPath("/files"),
     )

--- a/tests/core/fs/workspacefs_timestamped/test_workspacefs.py
+++ b/tests/core/fs/workspacefs_timestamped/test_workspacefs.py
@@ -123,11 +123,7 @@ async def test_versions_non_existing_file_remove_mocked(alice_workspace, alice):
     await _test_versions_non_existing_file(alice_workspace, alice, versions)
 
 
-@pytest.mark.trio
-async def test_versions_existing_directory_no_remove_mocked(alice_workspace, alice):
-    versions = await alice_workspace.versions(FsPath("/files"), remove_supposed_mock=False)
-    versions_list = list(versions.items())
-
+async def _test_versions_existing_directory(alice_workspace, alice, versions_list):
     assert len(versions_list) == 8
 
     assert versions_list[0][0][1:] == (1, Pendulum(2000, 1, 4), Pendulum(2000, 1, 4))
@@ -162,47 +158,20 @@ async def test_versions_existing_directory_no_remove_mocked(alice_workspace, ali
     assert versions_list[7][0][1:3] == (8, Pendulum(2000, 1, 13))
     assert Pendulum.now().add(hours=-1) < versions_list[7][0][3] < Pendulum.now()
     assert versions_list[7][1] == ((alice.device_id, Pendulum(2000, 1, 13), True, None), None, None)
+
+
+@pytest.mark.trio
+async def test_versions_existing_directory_no_remove_mocked(alice_workspace, alice):
+    versions = await alice_workspace.versions(FsPath("/files"), remove_supposed_mock=False)
+    versions_list = list(versions.items())
+    await _test_versions_existing_directory(alice_workspace, alice, versions_list)
 
 
 @pytest.mark.trio
 async def test_versions_existing_directory(alice_workspace, alice):
     versions = await alice_workspace.versions(FsPath("/files"))
     versions_list = list(versions.items())
-
-    assert len(versions_list) == 8
-
-    assert versions_list[0][0][1:] == (1, Pendulum(2000, 1, 4), Pendulum(2000, 1, 4))
-    assert versions_list[0][1] == ((alice.device_id, Pendulum(2000, 1, 4), True, None), None, None)
-
-    assert versions_list[1][0][1:] == (2, Pendulum(2000, 1, 4), Pendulum(2000, 1, 6))
-    assert versions_list[1][1] == ((alice.device_id, Pendulum(2000, 1, 4), True, None), None, None)
-
-    assert versions_list[2][0][1:] == (3, Pendulum(2000, 1, 6), Pendulum(2000, 1, 7))
-    assert versions_list[2][1] == ((alice.device_id, Pendulum(2000, 1, 6), True, None), None, None)
-
-    assert versions_list[3][0][1:] == (4, Pendulum(2000, 1, 7), Pendulum(2000, 1, 8))
-    assert versions_list[3][1] == ((alice.device_id, Pendulum(2000, 1, 7), True, None), None, None)
-
-    assert versions_list[4][0][1:] == (5, Pendulum(2000, 1, 8), Pendulum(2000, 1, 9))
-    assert versions_list[4][1] == (
-        (alice.device_id, Pendulum(2000, 1, 8), True, None),
-        None,
-        FsPath("/moved_files"),
-    )
-
-    assert versions_list[5][0][1:] == (6, Pendulum(2000, 1, 11), Pendulum(2000, 1, 12))
-    assert versions_list[5][1] == (
-        (alice.device_id, Pendulum(2000, 1, 10), True, None),
-        FsPath("/moved_files"),
-        None,
-    )
-
-    assert versions_list[6][0][1:] == (7, Pendulum(2000, 1, 12), Pendulum(2000, 1, 13))
-    assert versions_list[6][1] == ((alice.device_id, Pendulum(2000, 1, 12), True, None), None, None)
-
-    assert versions_list[7][0][1:3] == (8, Pendulum(2000, 1, 13))
-    assert Pendulum.now().add(hours=-1) < versions_list[7][0][3] < Pendulum.now()
-    assert versions_list[7][1] == ((alice.device_id, Pendulum(2000, 1, 13), True, None), None, None)
+    await _test_versions_existing_directory(alice_workspace, alice, versions_list)
 
 
 @pytest.mark.trio

--- a/tests/core/fs/workspacefs_timestamped/test_workspacefs.py
+++ b/tests/core/fs/workspacefs_timestamped/test_workspacefs.py
@@ -6,209 +6,270 @@ from pendulum import Pendulum
 from parsec.core.types import FsPath
 
 
+def _day(d):
+    return Pendulum(2000, 1, d)
+
+
 @pytest.mark.trio
 async def test_versions_existing_file_no_remove_minimal_synced(alice_workspace, alice):
-    versions = await alice_workspace.versions(
-        FsPath("/files/renamed_content"), remove_supposed_minimal_sync=False
-    )
-    versions_list = list(versions.items())
+    versions = await alice_workspace.versions(FsPath("/files/renamed"), skip_minimal_sync=False)
 
-    assert len(versions_list) == 6
+    assert len(versions) == 6
 
-    # Moved /files/content to /files/renamed_content on day 5, moved it again later
-    assert versions_list[0][0][1:] == (3, Pendulum(2000, 1, 6), Pendulum(2000, 1, 7))
-    assert versions_list[0][1] == (
+    # Moved /files/content to /files/renamed on day 5, moved it again later
+    assert versions[0][1:] == (
+        3,
+        _day(6),
+        _day(7),
         alice.device_id,
-        Pendulum(2000, 1, 5),
+        _day(5),
         False,
         5,
         FsPath("/files/content"),
-        FsPath("/files/renamed_again_content"),
+        FsPath("/files/renamed_again"),
     )
 
     # Created a new file with the same name on day 8
-    assert versions_list[1][0][1:] == (1, Pendulum(2000, 1, 8), Pendulum(2000, 1, 8))
-    assert versions_list[1][1] == (alice.device_id, Pendulum(2000, 1, 8), False, 0, None, None)
+    assert versions[1][1:] == (1, _day(8), _day(8), alice.device_id, _day(8), False, 0, None, None)
 
-    # Wrote on it. Moved it again on day 9 as we renamed /files to /moved_files
-    assert versions_list[2][0][1:] == (2, Pendulum(2000, 1, 8), Pendulum(2000, 1, 9))
-    assert versions_list[2][1] == (
+    # Wrote on it. Moved it again on day 9 as we renamed /files to /moved
+    assert versions[2][1:] == (
+        2,
+        _day(8),
+        _day(9),
         alice.device_id,
-        Pendulum(2000, 1, 8),
+        _day(8),
         False,
         6,
         None,
-        FsPath("/moved_files/renamed_content"),
+        FsPath("/moved/renamed"),
     )
 
-    # And moved back /moved_files to /files on day 11, /files/renamed_content is deleted on day 12
-    assert versions_list[3][0][1:] == (2, Pendulum(2000, 1, 11), Pendulum(2000, 1, 12))
-    assert versions_list[3][1] == (
+    # And moved back /moved to /files on day 11, /files/renamed is deleted on day 12
+    assert versions[3][1:] == (
+        2,
+        _day(11),
+        _day(12),
         alice.device_id,
-        Pendulum(2000, 1, 8),
+        _day(8),
         False,
         6,
-        FsPath("/moved_files/renamed_content"),
+        FsPath("/moved/renamed"),
         None,
     )
 
     # Created a file, again, but didn't write
-    assert versions_list[4][0][1:] == (1, Pendulum(2000, 1, 13), Pendulum(2000, 1, 14))
-    assert versions_list[4][1] == (alice.device_id, Pendulum(2000, 1, 13), False, 0, None, None)
-
+    assert versions[4][1:] == (
+        1,
+        _day(13),
+        _day(14),
+        alice.device_id,
+        _day(13),
+        False,
+        0,
+        None,
+        None,
+    )
     # Used "touch" method again, but on a created file. Wrote on it. Didn't delete since then
-    assert versions_list[5][0][1:3] == (2, Pendulum(2000, 1, 14))
-    assert Pendulum.now().add(hours=-1) < versions_list[5][0][3] < Pendulum.now()
-    assert versions_list[5][1] == (alice.device_id, Pendulum(2000, 1, 14), False, 5, None, None)
+    assert versions[5][1:3] == (2, _day(14))
+    assert Pendulum.now().add(hours=-1) < versions[5][3] < Pendulum.now()
+    assert versions[5][4:] == (alice.device_id, _day(14), False, 5, None, None)
 
 
 @pytest.mark.trio
 async def test_versions_existing_file_remove_minimal_synced(alice_workspace, alice):
-    versions = await alice_workspace.versions(FsPath("/files/renamed_content"))
-    versions_list = list(versions.items())
+    versions = await alice_workspace.versions(FsPath("/files/renamed"))
 
-    assert len(versions_list) == 5
+    assert len(versions) == 5
 
-    # Moved /files/content to /files/renamed_content on day 5, moved it again later
-    assert versions_list[0][0][1:] == (3, Pendulum(2000, 1, 6), Pendulum(2000, 1, 7))
-    assert versions_list[0][1] == (
+    # Moved /files/content to /files/renamed on day 5, moved it again later
+    assert versions[0][1:] == (
+        3,
+        _day(6),
+        _day(7),
         alice.device_id,
-        Pendulum(2000, 1, 5),
+        _day(5),
         False,
         5,
         FsPath("/files/content"),
-        FsPath("/files/renamed_again_content"),
+        FsPath("/files/renamed_again"),
     )
-
     # Created a new file with the same name on day 8
     # This entry is deleted as we only get the one obtained by writing on it in our list
     # This is the entry where we wrote on it
-    # Moved it again on day 9 as we renamed /files to /moved_files
-    assert versions_list[1][0][1:] == (2, Pendulum(2000, 1, 8), Pendulum(2000, 1, 9))
-    assert versions_list[1][1] == (
+    # Moved it again on day 9 as we renamed /files to /moved
+    assert versions[1][1:] == (
+        2,
+        _day(8),
+        _day(9),
         alice.device_id,
-        Pendulum(2000, 1, 8),
+        _day(8),
         False,
         6,
         None,
-        FsPath("/moved_files/renamed_content"),
+        FsPath("/moved/renamed"),
     )
-
-    # And moved back /moved_files to /files on day 11, /files/renamed_content is deleted on day 12
-    assert versions_list[2][0][1:] == (2, Pendulum(2000, 1, 11), Pendulum(2000, 1, 12))
-    assert versions_list[2][1] == (
+    # And moved back /moved to /files on day 11, /files/renamed is deleted on day 12
+    assert versions[2][1:] == (
+        2,
+        _day(11),
+        _day(12),
         alice.device_id,
-        Pendulum(2000, 1, 8),
+        _day(8),
         False,
         6,
-        FsPath("/moved_files/renamed_content"),
+        FsPath("/moved/renamed"),
         None,
     )
-
     # Created a file, again, but didn't write
-    assert versions_list[3][0][1:] == (1, Pendulum(2000, 1, 13), Pendulum(2000, 1, 14))
-    assert versions_list[3][1] == (alice.device_id, Pendulum(2000, 1, 13), False, 0, None, None)
-
+    assert versions[3][1:] == (
+        1,
+        _day(13),
+        _day(14),
+        alice.device_id,
+        _day(13),
+        False,
+        0,
+        None,
+        None,
+    )
     # Used "touch" method again, but on a created file. Wrote on it. Didn't delete since then
-    assert versions_list[4][0][1:3] == (2, Pendulum(2000, 1, 14))
-    assert Pendulum.now().add(hours=-1) < versions_list[4][0][3] < Pendulum.now()
-    assert versions_list[4][1] == (alice.device_id, Pendulum(2000, 1, 14), False, 5, None, None)
+    assert versions[4][1:3] == (2, _day(14))
+    assert Pendulum.now().add(hours=-1) < versions[4][3] < Pendulum.now()
+    assert versions[4][4:] == (alice.device_id, _day(14), False, 5, None, None)
 
 
 @pytest.mark.trio
-@pytest.mark.parametrize("remove_supposed_minimal_sync", (False, True))
+@pytest.mark.parametrize("skip_minimal_sync", (False, True))
 async def test_versions_non_existing_file_remove_minimal_synced(
-    alice_workspace, alice, remove_supposed_minimal_sync
+    alice_workspace, alice, skip_minimal_sync
 ):
     versions = await alice_workspace.versions(
-        FsPath("/moved_files/renamed_content"),
-        remove_supposed_minimal_sync=remove_supposed_minimal_sync,
+        FsPath("/moved/renamed"), skip_minimal_sync=skip_minimal_sync
     )
-    versions_list = list(versions.items())
-    assert len(versions_list) == 1
+    assert len(versions) == 1
 
-    assert versions_list[0][0][1:] == (2, Pendulum(2000, 1, 9), Pendulum(2000, 1, 11))
-    assert versions_list[0][1] == (
+    assert versions[0][1:] == (
+        2,
+        _day(9),
+        _day(11),
         alice.device_id,
-        Pendulum(2000, 1, 8),
+        _day(8),
         False,
         6,
-        FsPath("/files/renamed_content"),
-        FsPath("/files/renamed_content"),
+        FsPath("/files/renamed"),
+        FsPath("/files/renamed"),
     )
 
 
 @pytest.mark.trio
-@pytest.mark.parametrize("remove_supposed_minimal_sync", (False, True))
-async def test_versions_existing_directory(alice_workspace, alice, remove_supposed_minimal_sync):
-    versions = await alice_workspace.versions(
-        FsPath("/files"), remove_supposed_minimal_sync=remove_supposed_minimal_sync
-    )
-    versions_list = list(versions.items())
-
-    assert len(versions_list) == 8
-
-    assert versions_list[0][0][1:] == (1, Pendulum(2000, 1, 4), Pendulum(2000, 1, 4))
-    assert versions_list[0][1] == (alice.device_id, Pendulum(2000, 1, 4), True, None, None, None)
-
-    assert versions_list[1][0][1:] == (2, Pendulum(2000, 1, 4), Pendulum(2000, 1, 6))
-    assert versions_list[1][1] == (alice.device_id, Pendulum(2000, 1, 4), True, None, None, None)
-
-    assert versions_list[2][0][1:] == (3, Pendulum(2000, 1, 6), Pendulum(2000, 1, 7))
-    assert versions_list[2][1] == (alice.device_id, Pendulum(2000, 1, 6), True, None, None, None)
-
-    assert versions_list[3][0][1:] == (4, Pendulum(2000, 1, 7), Pendulum(2000, 1, 8))
-    assert versions_list[3][1] == (alice.device_id, Pendulum(2000, 1, 7), True, None, None, None)
-
-    assert versions_list[4][0][1:] == (5, Pendulum(2000, 1, 8), Pendulum(2000, 1, 9))
-    assert versions_list[4][1] == (
+@pytest.mark.parametrize("skip_minimal_sync", (False, True))
+async def test_versions_existing_directory(alice_workspace, alice, skip_minimal_sync):
+    versions = await alice_workspace.versions(FsPath("/files"), skip_minimal_sync=skip_minimal_sync)
+    assert len(versions) == 8
+    assert versions[0][1:] == (
+        1,
+        _day(4),
+        _day(4),
         alice.device_id,
-        Pendulum(2000, 1, 8),
+        _day(4),
         True,
         None,
         None,
-        FsPath("/moved_files"),
+        None,
     )
-
-    assert versions_list[5][0][1:] == (6, Pendulum(2000, 1, 11), Pendulum(2000, 1, 12))
-    assert versions_list[5][1] == (
+    assert versions[1][1:] == (
+        2,
+        _day(4),
+        _day(6),
         alice.device_id,
-        Pendulum(2000, 1, 10),
+        _day(4),
         True,
         None,
-        FsPath("/moved_files"),
+        None,
         None,
     )
-
-    assert versions_list[6][0][1:] == (7, Pendulum(2000, 1, 12), Pendulum(2000, 1, 13))
-    assert versions_list[6][1] == (alice.device_id, Pendulum(2000, 1, 12), True, None, None, None)
-
-    assert versions_list[7][0][1:3] == (8, Pendulum(2000, 1, 13))
-    assert Pendulum.now().add(hours=-1) < versions_list[7][0][3] < Pendulum.now()
-    assert versions_list[7][1] == (alice.device_id, Pendulum(2000, 1, 13), True, None, None, None)
+    assert versions[2][1:] == (
+        3,
+        _day(6),
+        _day(7),
+        alice.device_id,
+        _day(6),
+        True,
+        None,
+        None,
+        None,
+    )
+    assert versions[3][1:] == (
+        4,
+        _day(7),
+        _day(8),
+        alice.device_id,
+        _day(7),
+        True,
+        None,
+        None,
+        None,
+    )
+    assert versions[4][1:] == (
+        5,
+        _day(8),
+        _day(9),
+        alice.device_id,
+        _day(8),
+        True,
+        None,
+        None,
+        FsPath("/moved"),
+    )
+    assert versions[5][1:] == (
+        6,
+        _day(11),
+        _day(12),
+        alice.device_id,
+        _day(10),
+        True,
+        None,
+        FsPath("/moved"),
+        None,
+    )
+    assert versions[6][1:] == (
+        7,
+        _day(12),
+        _day(13),
+        alice.device_id,
+        _day(12),
+        True,
+        None,
+        None,
+        None,
+    )
+    assert versions[7][1:3] == (8, _day(13))
+    assert Pendulum.now().add(hours=-1) < versions[7][3] < Pendulum.now()
+    assert versions[7][4:] == (alice.device_id, _day(13), True, None, None, None)
 
 
 @pytest.mark.trio
 async def test_version_non_existing_directory(alice_workspace, alice):
-    versions = await alice_workspace.versions(FsPath("/moved_files"))
-    versions_list = list(versions.items())
-
-    assert len(versions_list) == 2
-
-    assert versions_list[0][0][1:] == (5, Pendulum(2000, 1, 9), Pendulum(2000, 1, 10))
-    assert versions_list[0][1] == (
+    versions = await alice_workspace.versions(FsPath("/moved"))
+    assert len(versions) == 2
+    assert versions[0][1:] == (
+        5,
+        _day(9),
+        _day(10),
         alice.device_id,
-        Pendulum(2000, 1, 8),
+        _day(8),
         True,
         None,
         FsPath("/files"),
         None,
     )
-
-    assert versions_list[1][0][1:] == (6, Pendulum(2000, 1, 10), Pendulum(2000, 1, 11))
-    assert versions_list[1][1] == (
+    assert versions[1][1:] == (
+        6,
+        _day(10),
+        _day(11),
         alice.device_id,
-        Pendulum(2000, 1, 10),
+        _day(10),
         True,
         None,
         None,

--- a/tests/core/fs/workspacefs_timestamped/test_workspacefs.py
+++ b/tests/core/fs/workspacefs_timestamped/test_workspacefs.py
@@ -7,8 +7,10 @@ from parsec.core.types import FsPath
 
 
 @pytest.mark.trio
-async def test_versions_existing_file(alice_workspace, alice):
-    versions = await alice_workspace.versions(FsPath("/files/renamed_content"))
+async def test_versions_existing_file_no_remove_mocked(alice_workspace, alice):
+    versions = await alice_workspace.versions(
+        FsPath("/files/renamed_content"), remove_supposed_mock=False
+    )
     versions_list = list(versions.items())
 
     assert len(versions_list) == 6
@@ -52,25 +54,114 @@ async def test_versions_existing_file(alice_workspace, alice):
 
 
 @pytest.mark.trio
-async def test_versions_non_existing_file(alice_workspace, alice):
-    versions = await alice_workspace.versions(FsPath("/moved_files/renamed_content"))
+async def test_versions_existing_file_remove_mocked(alice_workspace, alice):
+    versions = await alice_workspace.versions(FsPath("/files/renamed_content"))
     versions_list = list(versions.items())
 
-    assert len(versions_list) == 2
+    assert len(versions_list) == 5
 
-    assert versions_list[0][0][1:] == (2, Pendulum(2000, 1, 9), Pendulum(2000, 1, 10))
+    # Moved /files/content to /files/renamed_content on day 5, moved it again later
+    assert versions_list[0][0][1:] == (3, Pendulum(2000, 1, 6), Pendulum(2000, 1, 7))
     assert versions_list[0][1] == (
-        (alice.device_id, Pendulum(2000, 1, 8), False, 6),
-        FsPath("/files/renamed_content"),
-        None,
+        (alice.device_id, Pendulum(2000, 1, 5), False, 5),
+        FsPath("/files/content"),
+        FsPath("/files/renamed_again_content"),
     )
 
-    assert versions_list[1][0][1:] == (2, Pendulum(2000, 1, 10), Pendulum(2000, 1, 11))
+    # Created a new file with the same name on day 8
+    # This entry is deleted as we only get the one obtained by writing on it in our list
+    # This is the entry where we wrote on it
+    # Moved it again on day 9 as we renamed /files to /moved_files
+    assert versions_list[1][0][1:] == (2, Pendulum(2000, 1, 8), Pendulum(2000, 1, 9))
     assert versions_list[1][1] == (
         (alice.device_id, Pendulum(2000, 1, 8), False, 6),
         None,
+        FsPath("/moved_files/renamed_content"),
+    )
+
+    # And moved back /moved_files to /files on day 11, /files/renamed_content is deleted on day 12
+    assert versions_list[2][0][1:] == (2, Pendulum(2000, 1, 11), Pendulum(2000, 1, 12))
+    assert versions_list[2][1] == (
+        (alice.device_id, Pendulum(2000, 1, 8), False, 6),
+        FsPath("/moved_files/renamed_content"),
+        None,
+    )
+
+    # Created a file, again, but didn't write
+    assert versions_list[3][0][1:] == (1, Pendulum(2000, 1, 13), Pendulum(2000, 1, 14))
+    assert versions_list[3][1] == ((alice.device_id, Pendulum(2000, 1, 13), False, 0), None, None)
+
+    # Used "touch" method again, but on a created file. Wrote on it. Didn't delete since then
+    assert versions_list[4][0][1:3] == (2, Pendulum(2000, 1, 14))
+    assert Pendulum.now().add(hours=-1) < versions_list[4][0][3] < Pendulum.now()
+    assert versions_list[4][1] == ((alice.device_id, Pendulum(2000, 1, 14), False, 5), None, None)
+
+
+async def _test_versions_non_existing_file(alice_workspace, alice, versions):
+    versions_list = list(versions.items())
+    assert len(versions_list) == 1
+
+    assert versions_list[0][0][1:] == (2, Pendulum(2000, 1, 9), Pendulum(2000, 1, 11))
+    assert versions_list[0][1] == (
+        (alice.device_id, Pendulum(2000, 1, 8), False, 6),
+        FsPath("/files/renamed_content"),
         FsPath("/files/renamed_content"),
     )
+
+
+@pytest.mark.trio
+async def test_versions_non_existing_file_no_remove_mocked(alice_workspace, alice):
+    versions = await alice_workspace.versions(
+        FsPath("/moved_files/renamed_content"), remove_supposed_mock=False
+    )
+    await _test_versions_non_existing_file(alice_workspace, alice, versions)
+
+
+@pytest.mark.trio
+async def test_versions_non_existing_file_remove_mocked(alice_workspace, alice):
+    versions = await alice_workspace.versions(FsPath("/moved_files/renamed_content"))
+    await _test_versions_non_existing_file(alice_workspace, alice, versions)
+
+
+@pytest.mark.trio
+async def test_versions_existing_directory_no_remove_mocked(alice_workspace, alice):
+    versions = await alice_workspace.versions(FsPath("/files"), remove_supposed_mock=False)
+    versions_list = list(versions.items())
+
+    assert len(versions_list) == 8
+
+    assert versions_list[0][0][1:] == (1, Pendulum(2000, 1, 4), Pendulum(2000, 1, 4))
+    assert versions_list[0][1] == ((alice.device_id, Pendulum(2000, 1, 4), True, None), None, None)
+
+    assert versions_list[1][0][1:] == (2, Pendulum(2000, 1, 4), Pendulum(2000, 1, 6))
+    assert versions_list[1][1] == ((alice.device_id, Pendulum(2000, 1, 4), True, None), None, None)
+
+    assert versions_list[2][0][1:] == (3, Pendulum(2000, 1, 6), Pendulum(2000, 1, 7))
+    assert versions_list[2][1] == ((alice.device_id, Pendulum(2000, 1, 6), True, None), None, None)
+
+    assert versions_list[3][0][1:] == (4, Pendulum(2000, 1, 7), Pendulum(2000, 1, 8))
+    assert versions_list[3][1] == ((alice.device_id, Pendulum(2000, 1, 7), True, None), None, None)
+
+    assert versions_list[4][0][1:] == (5, Pendulum(2000, 1, 8), Pendulum(2000, 1, 9))
+    assert versions_list[4][1] == (
+        (alice.device_id, Pendulum(2000, 1, 8), True, None),
+        None,
+        FsPath("/moved_files"),
+    )
+
+    assert versions_list[5][0][1:] == (6, Pendulum(2000, 1, 11), Pendulum(2000, 1, 12))
+    assert versions_list[5][1] == (
+        (alice.device_id, Pendulum(2000, 1, 10), True, None),
+        FsPath("/moved_files"),
+        None,
+    )
+
+    assert versions_list[6][0][1:] == (7, Pendulum(2000, 1, 12), Pendulum(2000, 1, 13))
+    assert versions_list[6][1] == ((alice.device_id, Pendulum(2000, 1, 12), True, None), None, None)
+
+    assert versions_list[7][0][1:3] == (8, Pendulum(2000, 1, 13))
+    assert Pendulum.now().add(hours=-1) < versions_list[7][0][3] < Pendulum.now()
+    assert versions_list[7][1] == ((alice.device_id, Pendulum(2000, 1, 13), True, None), None, None)
 
 
 @pytest.mark.trio

--- a/tests/core/fs/workspacefs_timestamped/test_workspacefs.py
+++ b/tests/core/fs/workspacefs_timestamped/test_workspacefs.py
@@ -7,9 +7,9 @@ from parsec.core.types import FsPath
 
 
 @pytest.mark.trio
-async def test_versions_existing_file_no_remove_mocked(alice_workspace, alice):
+async def test_versions_existing_file_no_remove_minimal_synced(alice_workspace, alice):
     versions = await alice_workspace.versions(
-        FsPath("/files/renamed_content"), remove_supposed_mock=False
+        FsPath("/files/renamed_content"), remove_supposed_minimal_sync=False
     )
     versions_list = list(versions.items())
 
@@ -54,7 +54,7 @@ async def test_versions_existing_file_no_remove_mocked(alice_workspace, alice):
 
 
 @pytest.mark.trio
-async def test_versions_existing_file_remove_mocked(alice_workspace, alice):
+async def test_versions_existing_file_remove_minimal_synced(alice_workspace, alice):
     versions = await alice_workspace.versions(FsPath("/files/renamed_content"))
     versions_list = list(versions.items())
 
@@ -110,15 +110,15 @@ async def _test_versions_non_existing_file(alice_workspace, alice, versions):
 
 
 @pytest.mark.trio
-async def test_versions_non_existing_file_no_remove_mocked(alice_workspace, alice):
+async def test_versions_non_existing_file_no_remove_minimal_synced(alice_workspace, alice):
     versions = await alice_workspace.versions(
-        FsPath("/moved_files/renamed_content"), remove_supposed_mock=False
+        FsPath("/moved_files/renamed_content"), remove_supposed_minimal_sync=False
     )
     await _test_versions_non_existing_file(alice_workspace, alice, versions)
 
 
 @pytest.mark.trio
-async def test_versions_non_existing_file_remove_mocked(alice_workspace, alice):
+async def test_versions_non_existing_file_remove_minimal_synced(alice_workspace, alice):
     versions = await alice_workspace.versions(FsPath("/moved_files/renamed_content"))
     await _test_versions_non_existing_file(alice_workspace, alice, versions)
 
@@ -161,8 +161,8 @@ async def _test_versions_existing_directory(alice_workspace, alice, versions_lis
 
 
 @pytest.mark.trio
-async def test_versions_existing_directory_no_remove_mocked(alice_workspace, alice):
-    versions = await alice_workspace.versions(FsPath("/files"), remove_supposed_mock=False)
+async def test_versions_existing_directory_no_remove_minimal_synced(alice_workspace, alice):
+    versions = await alice_workspace.versions(FsPath("/files"), remove_supposed_minimal_sync=False)
     versions_list = list(versions.items())
     await _test_versions_existing_directory(alice_workspace, alice, versions_list)
 

--- a/tests/core/fs/workspacefs_timestamped/test_workspacefs.py
+++ b/tests/core/fs/workspacefs_timestamped/test_workspacefs.py
@@ -97,7 +97,15 @@ async def test_versions_existing_file_remove_minimal_synced(alice_workspace, ali
     assert versions_list[4][1] == ((alice.device_id, Pendulum(2000, 1, 14), False, 5), None, None)
 
 
-async def _test_versions_non_existing_file(alice_workspace, alice, versions):
+@pytest.mark.trio
+@pytest.mark.parametrize("remove_supposed_minimal_sync", (False, True))
+async def test_versions_non_existing_file_remove_minimal_synced(
+    alice_workspace, alice, remove_supposed_minimal_sync
+):
+    versions = await alice_workspace.versions(
+        FsPath("/moved_files/renamed_content"),
+        remove_supposed_minimal_sync=remove_supposed_minimal_sync,
+    )
     versions_list = list(versions.items())
     assert len(versions_list) == 1
 
@@ -107,20 +115,6 @@ async def _test_versions_non_existing_file(alice_workspace, alice, versions):
         FsPath("/files/renamed_content"),
         FsPath("/files/renamed_content"),
     )
-
-
-@pytest.mark.trio
-async def test_versions_non_existing_file_no_remove_minimal_synced(alice_workspace, alice):
-    versions = await alice_workspace.versions(
-        FsPath("/moved_files/renamed_content"), remove_supposed_minimal_sync=False
-    )
-    await _test_versions_non_existing_file(alice_workspace, alice, versions)
-
-
-@pytest.mark.trio
-async def test_versions_non_existing_file_remove_minimal_synced(alice_workspace, alice):
-    versions = await alice_workspace.versions(FsPath("/moved_files/renamed_content"))
-    await _test_versions_non_existing_file(alice_workspace, alice, versions)
 
 
 @pytest.mark.trio

--- a/tests/core/fs/workspacefs_timestamped/test_workspacefs.py
+++ b/tests/core/fs/workspacefs_timestamped/test_workspacefs.py
@@ -123,7 +123,14 @@ async def test_versions_non_existing_file_remove_minimal_synced(alice_workspace,
     await _test_versions_non_existing_file(alice_workspace, alice, versions)
 
 
-async def _test_versions_existing_directory(alice_workspace, alice, versions_list):
+@pytest.mark.trio
+@pytest.mark.parametrize("remove_supposed_minimal_sync", (False, True))
+async def test_versions_existing_directory(alice_workspace, alice, remove_supposed_minimal_sync):
+    versions = await alice_workspace.versions(
+        FsPath("/files"), remove_supposed_minimal_sync=remove_supposed_minimal_sync
+    )
+    versions_list = list(versions.items())
+
     assert len(versions_list) == 8
 
     assert versions_list[0][0][1:] == (1, Pendulum(2000, 1, 4), Pendulum(2000, 1, 4))
@@ -158,20 +165,6 @@ async def _test_versions_existing_directory(alice_workspace, alice, versions_lis
     assert versions_list[7][0][1:3] == (8, Pendulum(2000, 1, 13))
     assert Pendulum.now().add(hours=-1) < versions_list[7][0][3] < Pendulum.now()
     assert versions_list[7][1] == ((alice.device_id, Pendulum(2000, 1, 13), True, None), None, None)
-
-
-@pytest.mark.trio
-async def test_versions_existing_directory_no_remove_minimal_synced(alice_workspace, alice):
-    versions = await alice_workspace.versions(FsPath("/files"), remove_supposed_minimal_sync=False)
-    versions_list = list(versions.items())
-    await _test_versions_existing_directory(alice_workspace, alice, versions_list)
-
-
-@pytest.mark.trio
-async def test_versions_existing_directory(alice_workspace, alice):
-    versions = await alice_workspace.versions(FsPath("/files"))
-    versions_list = list(versions.items())
-    await _test_versions_existing_directory(alice_workspace, alice, versions_list)
 
 
 @pytest.mark.trio


### PR DESCRIPTION
Updated list_versions algorithm to ignore both what can be detected as a mocked manifest, and redundant entries gotten from updates of the manifests constituting the parent path.
Resolves #766 