### PR TITLE
Fix PKCS11 dependency trying to install on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -285,10 +285,6 @@ test_requirements = [
 PYQT_DEP = "PyQt5==5.13.1"
 BABEL_DEP = ("Babel==2.6.0",)
 extra_requirements = {
-    "pkcs11": [
-        'python-pkcs11==0.5.0;platform_system=="Linux"',
-        'pycrypto==2.6.1;platform_system=="Linux"',
-    ],
     "core": [
         PYQT_DEP,
         BABEL_DEP,

--- a/setup.py
+++ b/setup.py
@@ -286,8 +286,8 @@ PYQT_DEP = "PyQt5==5.13.1"
 BABEL_DEP = ("Babel==2.6.0",)
 extra_requirements = {
     "pkcs11": [
-        'python-pkcs11==0.5.0;platform_system="Linux"',
-        'pycrypto==2.6.1;platform_system="Linux"',
+        'python-pkcs11==0.5.0;platform_system=="Linux"',
+        'pycrypto==2.6.1;platform_system=="Linux"',
     ],
     "core": [
         PYQT_DEP,

--- a/setup.py
+++ b/setup.py
@@ -285,7 +285,10 @@ test_requirements = [
 PYQT_DEP = "PyQt5==5.13.1"
 BABEL_DEP = ("Babel==2.6.0",)
 extra_requirements = {
-    "pkcs11": ["python-pkcs11==0.5.0", "pycrypto==2.6.1"],
+    "pkcs11": [
+        'python-pkcs11==0.5.0;platform_system="Linux"',
+        'pycrypto==2.6.1;platform_system="Linux"',
+    ],
     "core": [
         PYQT_DEP,
         BABEL_DEP,


### PR DESCRIPTION
setup.py : enforce OS check for PKCS11 installation as it tried to install on Windows with 'pip install -e .[all]'