### PR TITLE
Remove trio_typing dep

### DIFF
--- a/parsec/service_nursery.py
+++ b/parsec/service_nursery.py
@@ -12,7 +12,6 @@ from typing import Any, AsyncIterator, Awaitable, Callable, MutableSet, Optional
 
 import attr
 import trio
-from trio_typing import TaskStatus, Nursery
 from async_generator import asynccontextmanager
 
 
@@ -125,7 +124,7 @@ def _get_coroutine_or_flag_problem(
 
 
 @asynccontextmanager
-async def open_service_nursery() -> AsyncIterator[Nursery]:
+async def open_service_nursery() -> AsyncIterator:
     """Provides a nursery augmented with a cancellation ordering constraint.
     If an entire service nursery becomes cancelled, either due to an
     exception raised by some task in the nursery or due to the
@@ -164,7 +163,7 @@ async def open_service_nursery() -> AsyncIterator[Nursery]:
         async def start(
             async_fn: Callable[..., Awaitable[Any]], *args: Any, name: Optional[str] = None
         ) -> Any:
-            async def wrap_child(*, task_status: TaskStatus[Any]) -> None:
+            async def wrap_child(*, task_status) -> None:
                 # For start(), the child doesn't get shielded until it
                 # calls task_status.started().
                 shield_scope = child_task_scopes.open_child(shield=False)

--- a/setup.py
+++ b/setup.py
@@ -251,7 +251,6 @@ requirements = [
     "pendulum==1.3.1",
     "PyNaCl==1.2.1",
     "trio==0.13.0",
-    "trio_typing==0.3.0",
     "python-interface==1.4.0",
     "async_generator>=1.9",
     'contextvars==2.1;python_version<"3.7"',


### PR DESCRIPTION
trio_typing depends on mypy, which add up a lot to the final build:
```shell
$ du -sh /snap/parsec/current/lib/python3.6/site-packages/mypy*
7,2M    /snap/parsec/current/lib/python3.6/site-packages/mypy
3,5K    /snap/parsec/current/lib/python3.6/site-packages/mypy-0.740.dist-info
4,5K    /snap/parsec/current/lib/python3.6/site-packages/mypy_extensions-0.4.3.dist-info
5,0K    /snap/parsec/current/lib/python3.6/site-packages/mypy_extensions.py
1,3M    /snap/parsec/current/lib/python3.6/site-packages/mypyc
75M    /snap/parsec/current/lib/python3.6/site-packages/mypyc_73ace4c88000b89b158a.cpython-36m-x86_64-linux-gnu.so
```