### PR TITLE
 Provide fusepy with the file system encoding

### DIFF
--- a/newsfragments/827.misc.rst
+++ b/newsfragments/827.misc.rst
@@ -1,0 +1,1 @@
+Provide fusepy with the file system encoding. Also use EINVAL as fallback error code.

--- a/parsec/core/mountpoint/fuse_operations.py
+++ b/parsec/core/mountpoint/fuse_operations.py
@@ -49,7 +49,8 @@ def translate_error(event_bus, operation, path):
     except Exception as exc:
         logger.exception("Unhandled exception in fuse mountpoint")
         event_bus.send("mountpoint.unhandled_error", exc=exc, operation=operation, path=path)
-        raise FuseOSError(errno.EIO) from exc
+        # Use EINVAL as fallback error code, since this is what fusepy does.
+        raise FuseOSError(errno.EINVAL) from exc
 
 
 class FuseOperations(LoggingMixIn, Operations):

--- a/tests/core/mountpoint/test_base.py
+++ b/tests/core/mountpoint/test_base.py
@@ -310,14 +310,13 @@ def test_unhandled_crash_in_fs_operation(caplog, mountpoint_service, monkeypatch
     with pytest.raises(OSError) as exc:
         (mountpoint / "crash_me").stat()
 
+    assert exc.value.errno == errno.EINVAL
     if os.name == "nt":
-        assert exc.value.args == (22, "An internal error occurred")
         caplog.assert_occured(
             "[exception] Unhandled exception in winfsp mountpoint [parsec.core.mountpoint.winfsp_operations]"
         )
 
     else:
-        assert exc.value.args == (5, "Input/output error")
         caplog.assert_occured(
             "[exception] Unhandled exception in fuse mountpoint [parsec.core.mountpoint.fuse_operations]"
         )


### PR DESCRIPTION
Also use EINVAL as fallback error code in fuse operations.