### PR TITLE
Improve test monitor display

### DIFF
--- a/tests/monitor.py
+++ b/tests/monitor.py
@@ -49,34 +49,41 @@ def _render_subtree(name, rendered_children):
     return lines
 
 
-def _rendered_nursery_children(nursery):
-    return [task_tree_lines(t) for t in nursery.child_tasks]
+def _rendered_nursery_children(nursery, format_task):
+    return [task_tree_lines(t, format_task) for t in nursery.child_tasks]
 
 
-def task_tree_lines(task):
+def task_tree_lines(task, format_task):
     rendered_children = []
     nurseries = list(task.child_nurseries)
     while nurseries:
         nursery = nurseries.pop()
-        nursery_children = _rendered_nursery_children(nursery)
+        nursery_children = _rendered_nursery_children(nursery, format_task)
         if rendered_children:
             nested = _render_subtree("(nested nursery)", rendered_children)
             nursery_children.append(nested)
         rendered_children = nursery_children
-    return _render_subtree(task.name, rendered_children)
+    return _render_subtree(format_task(task), rendered_children)
 
 
-def render_task_tree(task=None):
-    return "\n".join(line for line in task_tree_lines(task)) + "\n"
+def render_task_tree(task, format_task):
+    return "\n".join(line for line in task_tree_lines(task, format_task)) + "\n"
 
 
 class Monitor(Instrument):
     def __init__(self, host=MONITOR_HOST, port=MONITOR_PORT):
         self.address = (host, port)
         self._trio_token = None
+        self._next_task_short_id = 0
         self._tasks = {}
         self._closing = None
         self._ui_thread = None
+
+    def get_task_from_short_id(self, shortid):
+        for task in self._tasks.values():
+            if task._monitor_short_id == shortid:
+                return task
+        return None
 
     def before_run(self):
         LOGGER.info("Starting Trio monitor at %s:%d", *self.address)
@@ -87,6 +94,8 @@ class Monitor(Instrument):
 
     def task_spawned(self, task):
         self._tasks[id(task)] = task
+        task._monitor_short_id = self._next_task_short_id
+        self._next_task_short_id += 1
         task._monitor_state = "spawned"
 
     def task_scheduled(self, task):
@@ -255,22 +264,36 @@ io_statistics:
         sout.write("\n")
         sout.write(" ".join(w * "-" for w in widths))
         sout.write("\n")
-        for taskid in sorted(self._tasks):
-            task = self._tasks[taskid]
+        for task in sorted(self._tasks.values(), key=lambda t: t._monitor_short_id):
             sout.write(
                 "%-*d %-*s %-*s\n"
-                % (widths[0], taskid, widths[1], task._monitor_state, widths[2], task.name)
+                % (
+                    widths[0],
+                    task._monitor_short_id,
+                    widths[1],
+                    task._monitor_state,
+                    widths[2],
+                    task.name,
+                )
             )
 
     def command_task_tree(self, sout):
         root_task = next(iter(self._tasks.values()))
         while root_task.parent_nursery is not None:
             root_task = root_task.parent_nursery.parent_task
-        task_tree = render_task_tree(root_task)
+
+        def _format_task(task):
+            return "%s (id=%s, status=%s)" % (
+                task.name,
+                task._monitor_short_id,
+                task._monitor_state,
+            )
+
+        task_tree = render_task_tree(root_task, _format_task)
         sout.write(task_tree)
 
     def command_where(self, sout, taskid):
-        task = self._tasks.get(taskid)
+        task = self.get_task_from_short_id(taskid)
         if task:
 
             def walk_coro_stack(coro):
@@ -311,9 +334,9 @@ io_statistics:
         sout.write("Not supported yet...")
 
     def command_parents(self, sout, taskid):
-        task = self._tasks.get(taskid)
+        task = self.get_task_from_short_id(taskid)
         while task:
-            sout.write("%-6d %12s %s\n" % (id(task), "running", task.name))
+            sout.write("%-6d %12s %s\n" % (task._monitor_short_id, "running", task.name))
             task = task.parent_nursery._parent_task if task.parent_nursery else None
 
     def command_exit(self, sout):

--- a/tests/monitor.py
+++ b/tests/monitor.py
@@ -257,8 +257,8 @@ io_statistics:
         )
 
     def command_ps(self, sout):
-        headers = ("Task", "State", "Task")
-        widths = (15, 12, 50)
+        headers = ("Id", "State", "Shielded", "Task")
+        widths = (5, 10, 10, 50)
         for h, w in zip(headers, widths):
             sout.write("%-*s " % (w, h))
         sout.write("\n")
@@ -266,13 +266,15 @@ io_statistics:
         sout.write("\n")
         for task in sorted(self._tasks.values(), key=lambda t: t._monitor_short_id):
             sout.write(
-                "%-*d %-*s %-*s\n"
+                "%-*d %-*s %-*s %-*s\n"
                 % (
                     widths[0],
                     task._monitor_short_id,
                     widths[1],
                     task._monitor_state,
                     widths[2],
+                    "yes" if task._cancel_status._scope.shield else "",
+                    widths[3],
                     task.name,
                 )
             )
@@ -283,10 +285,11 @@ io_statistics:
             root_task = root_task.parent_nursery.parent_task
 
         def _format_task(task):
-            return "%s (id=%s, status=%s)" % (
+            return "%s (id=%s, %s%s)" % (
                 task.name,
                 task._monitor_short_id,
                 task._monitor_state,
+                ", shielded" if task._cancel_status._scope.shield else "",
             )
 
         task_tree = render_task_tree(root_task, _format_task)


### PR DESCRIPTION
example:
```
Trio Monitor: 12 tasks running
Type help for commands
trio > tree
<init> (id=0, status=waiting)
|- pytest_trio.plugin._trio_test_runner_factory.<locals>._bootstrap_fixtures_and_run_test (id=1, status=waiting)
|  |- <fixture 'backend'> (id=4, status=waiting)
|  |  |_ (nested nursery)
|  |     |_ parsec.backend.memory.factory.components_factory.<locals>._dispatch_event (id=9, status=waiting)
|  |- <fixture 'backend_factory'> (id=5, status=waiting)
|  |- <test 'test_user_invite_claim_cancel_invitation'> (id=3, status=waiting)
|  |  |_ (nested nursery)
|  |     |_ tests.core.test_invite_claim.test_user_invite_claim_cancel_invitation.<locals>._from_alice (id=10, status=waiting)
|  |- <fixture 'asyncio_loop'> (id=6, status=waiting)
|  |  |_ (nested nursery)
|  |     |_ trio_asyncio.base.BaseTrioEventLoop._main_loop (id=8, status=waiting)
|  |_ <fixture 'running_backend'> (id=7, status=waiting)
|     |_ (nested nursery)
|        |_ parsec.backend.app.BackendApp.handle_client (id=11, status=waiting)
|_ <TrioToken.run_sync_soon task> (id=2, status=waiting)
trio > ps
Task            State        Task                                               
--------------- ------------ --------------------------------------------------
0               waiting      <init>                                            
1               waiting      pytest_trio.plugin._trio_test_runner_factory.<locals>._bootstrap_fixtures_and_run_test
2               waiting      <TrioToken.run_sync_soon task>                    
3               waiting      <test 'test_user_invite_claim_cancel_invitation'> 
4               waiting      <fixture 'backend'>                               
5               waiting      <fixture 'backend_factory'>                       
6               waiting      <fixture 'asyncio_loop'>                          
7               waiting      <fixture 'running_backend'>                       
8               waiting      trio_asyncio.base.BaseTrioEventLoop._main_loop    
9               waiting      parsec.backend.memory.factory.components_factory.<locals>._dispatch_event
10              waiting      tests.core.test_invite_claim.test_user_invite_claim_cancel_invitation.<locals>._from_alice
11              waiting      parsec.backend.app.BackendApp.handle_client  
```