### PR TITLE
Multi error refactoring

### DIFF
--- a/parsec/__init__.py
+++ b/parsec/__init__.py
@@ -2,5 +2,7 @@
 
 from parsec._version import __version__
 
+# The parsec.utils includes a bit of patching, let's make sure it is imported
+import parsec.utils  # noqa
 
 __all__ = ("__version__",)

--- a/parsec/__init__.py
+++ b/parsec/__init__.py
@@ -2,7 +2,7 @@
 
 from parsec._version import __version__
 
-# The parsec.utils includes a bit of patching, let's make sure it is imported
+# The parsec.utils module includes a bit of patching, let's make sure it is imported
 import parsec.utils  # noqa
 
 __all__ = ("__version__",)

--- a/parsec/core/gui/trio_thread.py
+++ b/parsec/core/gui/trio_thread.py
@@ -5,24 +5,12 @@ import trio
 import threading
 from inspect import iscoroutinefunction
 from structlog import get_logger
-from parsec.utils import trio_run
 from parsec.core.fs import FSError
+from parsec.utils import trio_run, split_multi_error
 from PyQt5.QtCore import pyqtBoundSignal, Q_ARG, QMetaObject, Qt
 
 
 logger = get_logger()
-
-
-def split_multi_error(exc):
-    def is_cancelled(exc):
-        return exc if isinstance(exc, trio.Cancelled) else None
-
-    def not_cancelled(exc):
-        return None if isinstance(exc, trio.Cancelled) else exc
-
-    cancelled_errors = trio.MultiError.filter(is_cancelled, exc)
-    other_exceptions = trio.MultiError.filter(not_cancelled, exc)
-    return cancelled_errors, other_exceptions
 
 
 class JobResultError(Exception):

--- a/parsec/service_nursery.py
+++ b/parsec/service_nursery.py
@@ -12,10 +12,7 @@ from typing import Any, AsyncIterator, Awaitable, Callable, MutableSet, Optional
 
 import attr
 import trio
-from structlog import get_logger
 from async_generator import asynccontextmanager
-
-logger = get_logger()
 
 
 @attr.s(cmp=False)
@@ -127,7 +124,7 @@ def _get_coroutine_or_flag_problem(
 
 
 @asynccontextmanager
-async def _open_service_nursery() -> AsyncIterator:
+async def open_service_nursery() -> AsyncIterator:
     """Provides a nursery augmented with a cancellation ordering constraint.
     If an entire service nursery becomes cancelled, either due to an
     exception raised by some task in the nursery or due to the
@@ -192,44 +189,3 @@ async def _open_service_nursery() -> AsyncIterator:
             yield nursery
         finally:
             child_task_scopes.shield = False
-
-
-def collapse_multierror(multierror):
-    exceptions = multierror.exceptions
-    pick = exceptions[0]
-    try:
-        name = f"{type(pick).__name__}AndFriends"
-        cls = type(name, (type(pick), trio.MultiError), {})
-        result = super(cls, cls).__new__(cls)
-        result.__dict__.update(pick.__dict__)
-        result.args = pick.args
-        result.exceptions = exceptions
-        result.__cause__ = multierror.__cause__
-        result.__context__ = multierror.__context__
-        result.__traceback__ = multierror.__traceback__
-        result.__suppress_context__ = True
-        return result
-    except Exception:
-        logger.exception("Cound not create a collapsed exception")
-        return pick
-
-
-@asynccontextmanager
-async def open_service_nursery() -> AsyncIterator:
-    """Open a service nursery.
-
-    This nursery does not raise MultiError exceptions.
-    Instead, it collapses the MultiError into a single exception.
-    More precisely, the first exception of the MultiError is raised,
-    patched with extra MultiError capabilities.
-    """
-    try:
-        async with _open_service_nursery() as nursery:
-            yield nursery
-    except trio.MultiError as exc:
-        logger.exception("A MultiError has been detected")
-        raise collapse_multierror(exc)
-
-
-# Add it to trio
-trio.open_service_nursery = open_service_nursery

--- a/parsec/utils.py
+++ b/parsec/utils.py
@@ -1,14 +1,24 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
+
 import attr
 import trio
 from pendulum import Pendulum
+from structlog import get_logger
+from async_generator import asynccontextmanager
 
+from parsec import service_nursery
 from parsec.monitoring import TaskMonitoringInstrument
-from parsec.service_nursery import open_service_nursery
 
-__all__ = ["timestamps_in_the_ballpark", "start_task", "trio_run", "open_service_nursery"]
+__all__ = [
+    "timestamps_in_the_ballpark",
+    "start_task",
+    "trio_run",
+    "open_service_nursery",
+    "split_multi_error",
+]
 
+logger = get_logger()
 TIMESTAMP_MAX_DT = 30 * 60
 
 
@@ -100,3 +110,84 @@ def trio_run(async_fn, *args, use_asyncio=False):
         return trio_asyncio.run(async_fn, *args)
     instruments = (TaskMonitoringInstrument(),)
     return trio.run(async_fn, *args, instruments=instruments)
+
+
+# MultiError handling
+
+
+def split_multi_error(exc):
+    def is_cancelled(exc):
+        return exc if isinstance(exc, trio.Cancelled) else None
+
+    def not_cancelled(exc):
+        return None if isinstance(exc, trio.Cancelled) else exc
+
+    cancelled_errors = trio.MultiError.filter(is_cancelled, exc)
+    other_exceptions = trio.MultiError.filter(not_cancelled, exc)
+    return cancelled_errors, other_exceptions
+
+
+def collapse_multi_error(multierror):
+    # Pick the first exception as the reference exception
+    pick = multierror.exceptions[0]
+    try:
+        # Craft a new a name to indicate the exception is collapsed
+        name = f"{type(pick).__name__}AndFriends"
+        # Init method should be ignored as it might get called by `MultiError([result])`
+        attrs = {"__init__": lambda *args, **kwargs: None}
+        # Craft the specific class, inheriting from MultiError
+        cls = type(name, (type(pick), trio.MultiError), attrs)
+        # Instantiate the instance
+        result = cls()
+        # Replicate the picked exception inner state
+        result.__dict__.update(pick.__dict__)
+        result.args = pick.args
+        # Replicate the multierror inner state
+        result.exceptions = multierror.exceptions
+        result.__cause__ = multierror.__cause__
+        result.__context__ = multierror.__context__
+        result.__traceback__ = multierror.__traceback__
+        # Supress context, we do not want the collasping to appear in the stacktrace
+        result.__suppress_context__ = True
+        return result
+    except Exception:
+        # Something went wrong while collapsing
+        logger.exception("Cound not create a collapsed exception")
+        return pick
+
+
+def transform_multi_error(exc):
+    # Cancelled errors must be treated separetely
+    cancelled_errors, other_exceptions = split_multi_error(exc)
+    # No transformation needed
+    if not other_exceptions or not isinstance(other_exceptions, trio.MultiError):
+        return exc
+    # Collapse non-cancelled exceptions
+    collapsed_errors = collapse_multi_error(other_exceptions)
+    if not cancelled_errors:
+        return collapsed_errors
+    return trio.MultiError([cancelled_errors, collapsed_errors])
+
+
+@asynccontextmanager
+async def open_service_nursery():
+    """Open a service nursery.
+
+    This nursery does not raise MultiError exceptions.
+    Instead, it collapses the MultiError into a single exception.
+    More precisely, the first exception of the MultiError is raised,
+    patched with extra MultiError capabilities.
+    """
+    try:
+        async with service_nursery.open_service_nursery() as nursery:
+            yield nursery
+    except trio.MultiError as exc:
+        new_exc = transform_multi_error(exc)
+        if new_exc is exc:
+            raise
+        logger.exception("A MultiError has been detected")
+        raise new_exc
+
+
+# Add it to trio
+trio.open_service_nursery = open_service_nursery

--- a/parsec/utils.py
+++ b/parsec/utils.py
@@ -147,7 +147,7 @@ def collapse_multi_error(multierror):
         result.__cause__ = multierror.__cause__
         result.__context__ = multierror.__context__
         result.__traceback__ = multierror.__traceback__
-        # Supress context, we do not want the collasping to appear in the stacktrace
+        # Supress context, we do not want the collapsing to appear in the stacktrace
         result.__suppress_context__ = True
         return result
     except Exception:

--- a/tests/test_nursery.py
+++ b/tests/test_nursery.py
@@ -46,3 +46,42 @@ async def test_open_service_nursery_multierror_collapse():
     assert not isinstance(a, trio.MultiError)
     assert isinstance(b, RuntimeError)
     assert not isinstance(b, trio.MultiError)
+
+
+@pytest.mark.trio
+async def test_open_service_nursery_multierror_with_cancelled():
+    async def _raise(exc):
+        raise exc
+
+    with pytest.raises(ZeroDivisionError) as ctx:
+        with trio.CancelScope() as cancel_scope:
+            async with trio.open_service_nursery() as nursery:
+                nursery.start_soon(_raise, ZeroDivisionError(1, 2, 3))
+                cancel_scope.cancel()
+                await trio.sleep(1)
+
+    exception = ctx.value
+    assert isinstance(exception, ZeroDivisionError)
+    assert exception.args == (1, 2, 3)
+
+    assert not isinstance(exception, trio.MultiError)
+
+    with pytest.raises(ZeroDivisionError) as ctx:
+        with trio.CancelScope() as cancel_scope:
+            async with trio.open_service_nursery() as nursery:
+                nursery.start_soon(_raise, RuntimeError())
+                cancel_scope.cancel()
+                raise ZeroDivisionError(1, 2, 3)
+
+    exception = ctx.value
+    assert isinstance(exception, ZeroDivisionError)
+    assert exception.args == (1, 2, 3)
+
+    assert isinstance(exception, trio.MultiError)
+    assert len(exception.exceptions) == 2
+
+    a, b = exception.exceptions
+    assert isinstance(a, ZeroDivisionError)
+    assert not isinstance(a, trio.MultiError)
+    assert isinstance(b, RuntimeError)
+    assert not isinstance(b, trio.MultiError)


### PR DESCRIPTION
Following up on #1027 

As it turns out, `trio.Cancelled()` exceptions require a bit of attention. 