### PR TITLE
Increase verbosity and add duration reports for CI tests

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -14,6 +14,7 @@ variables:
   winfsp.version: '1.7.20038-pre'
   pytest.base_args: |
     --log-level=DEBUG \
+    --durations=10 -v \
     --cov=parsec --cov-config=../setup.cfg --cov-append --cov-report= \
 
 jobs:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,7 +70,7 @@ def test_share_workspace(tmpdir, alice, bob):
     share_mock.assert_called_once_with("/ws1", alice.user_id)
 
 
-def _run(cmd, env={}, timeout=10.0, capture=True):
+def _run(cmd, env={}, timeout=20.0, capture=True):
     print(f"========= RUN {cmd} ==============")
     env = {**os.environ.copy(), "DEBUG": "true", **env}
     cooked_cmd = ("python -m parsec.cli " + cmd).split()


### PR DESCRIPTION
Also fixes some inconsistent tests. In particular, this first test can take a bit of time to run:

https://dev.azure.com/Scille/parsec/_build/results?buildId=146&view=logs&j=bfccef3f-45d4-504d-9a7f-a8a74922e6bf&t=85724bb3-46c9-5fad-b9a2-5b861fe1fc50&l=48
`6.62s call     tests/test_cli.py::test_gui_with_diagnose_option[Standard environement]`

A 10 seconds timeout was a bit low.