### PR TITLE
Fix check newsfragment

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -54,7 +54,6 @@ jobs:
         then exit 0; fi
       done
       echo "NO NEW NEWSFRAGMENT FOUND" >&2
-      exit 1
     displayName: 'Newsfragment'
   - bash: |
       git fetch --tags  # Needed by releaser.py to have a consistent `git describe`

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -53,7 +53,7 @@ jobs:
         if ! git log origin/master --exit-code -- newsfragments/"$FILENAME" > /dev/null
         then exit 0; fi
       done
-      echo "NO NEW NEWSFRAGMENT FOUND" 1>&2
+      echo "NO NEW NEWSFRAGMENT FOUND" >&2
       exit 1
     displayName: 'Newsfragment'
   - bash: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -50,7 +50,7 @@ jobs:
         # If file never existed in master, consider as a new newsfragment
         # Cannot git diff against master branch here given newsfragments removed in master will be considered as
         # new items in our branch
-        if ! git log master --exit-code -- newsfragments/"$FILENAME" > /dev/null
+        if ! git log origin/master --exit-code -- newsfragments/"$FILENAME" > /dev/null
         then exit 0; fi
       done
       echo "NO NEW NEWSFRAGMENT FOUND"

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -50,7 +50,7 @@ jobs:
         # If file never existed in master, consider as a new newsfragment
         # Cannot git diff against master branch here given newsfragments removed in master will be considered as
         # new items in our branch
-        if ! git log origin/master --exit-code -- newsfragments/"$FILENAME" > /dev/null
+        if ! git log origin/master --exit-code -- "$FILENAME" > /dev/null
         then exit 0; fi
       done
       echo "NO NEW NEWSFRAGMENT FOUND" >&2

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -55,6 +55,7 @@ jobs:
       done
       echo "NO NEW NEWSFRAGMENT FOUND" >&2
     displayName: 'Newsfragment'
+    failOnStderr: true
   - bash: |
       git fetch --tags  # Needed by releaser.py to have a consistent `git describe`
       python ./misc/releaser.py check --verbose

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -53,7 +53,7 @@ jobs:
         if ! git log origin/master --exit-code -- newsfragments/"$FILENAME" > /dev/null
         then exit 0; fi
       done
-      echo "NO NEW NEWSFRAGMENT FOUND"
+      echo "NO NEW NEWSFRAGMENT FOUND" 1>&2
       exit 1
     displayName: 'Newsfragment'
   - bash: |

--- a/newsfragments/1069.empty.rst
+++ b/newsfragments/1069.empty.rst
@@ -1,0 +1,2 @@
+Fixed checking on newsfragment from origin/master as it seems master wasn't automatically fetched on CI.
+Also now uses stderr instead of exit 1 as it now prints the error message in CI logs more obviously.


### PR DESCRIPTION
Fixed checking on newsfragment from origin/master as it seems master wasn't automatically fetched on CI.
Also now uses stderr instead of exit 1 as it now prints the error message in CI logs more obviously.