### PR TITLE
Gui revoked user logging

### DIFF
--- a/newsfragments/1205.bugfix.rst
+++ b/newsfragments/1205.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed revoked user exception handling and notification.

--- a/parsec/core/gui/central_widget.py
+++ b/parsec/core/gui/central_widget.py
@@ -10,7 +10,9 @@ from parsec.core.gui.users_widget import UsersWidget
 from parsec.core.gui.devices_widget import DevicesWidget
 from parsec.core.gui.menu_widget import MenuWidget
 from parsec.core.gui.lang import translate as _
+from parsec.core.gui.custom_dialogs import show_error
 from parsec.core.gui.ui.central_widget import Ui_CentralWidget
+
 
 from parsec.api.protocol import (
     HandshakeAPIVersionError,
@@ -171,6 +173,8 @@ class CentralWidget(QWidget, Ui_CentralWidget):
                 )
             elif isinstance(cause, HandshakeRevokedDevice):
                 tooltip = _("TEXT_BACKEND_STATE_REVOKED_DEVICE")
+                notif = ("REVOKED", tooltip)
+                self.new_notification.emit(*notif)
             elif isinstance(cause, HandshakeOrganizationExpired):
                 tooltip = _("TEXT_BACKEND_STATE_ORGANIZATION_EXPIRED")
             else:
@@ -190,7 +194,8 @@ class CentralWidget(QWidget, Ui_CentralWidget):
             self.new_notification.emit(*notif)
 
     def on_new_notification(self, notif_type, msg):
-        pass
+        if notif_type == "REVOKED":
+            show_error(self, msg)
 
     def show_mount_widget(self):
         self.clear_widgets()

--- a/parsec/core/gui/devices_widget.py
+++ b/parsec/core/gui/devices_widget.py
@@ -1,7 +1,7 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
 from PyQt5.QtCore import pyqtSignal, Qt, QTimer
-from PyQt5.QtWidgets import QWidget, QMenu, QGraphicsDropShadowEffect
+from PyQt5.QtWidgets import QWidget, QMenu, QGraphicsDropShadowEffect, QLabel
 from PyQt5.QtGui import QColor
 
 from parsec.core.gui.trio_thread import JobResultError, ThreadSafeQtSignal, QtToTrioJob
@@ -9,14 +9,9 @@ from parsec.core.gui.lang import translate as _
 from parsec.core.gui.password_change_widget import PasswordChangeWidget
 from parsec.core.gui.flow_layout import FlowLayout
 from parsec.core.gui.ui.devices_widget import Ui_DevicesWidget
-from parsec.core.gui.custom_dialogs import show_error
 from parsec.core.gui.invite_device_widget import InviteDeviceWidget
 from parsec.core.gui.ui.device_button import Ui_DeviceButton
-from parsec.core.backend_connection import BackendNotAvailable
-from parsec.core.remote_devices_manager import (
-    RemoteDevicesManagerBackendOfflineError,
-    RemoteDevicesManagerError,
-)
+from parsec.core.backend_connection import BackendNotAvailable, BackendConnectionError
 
 
 class DeviceButton(QWidget, Ui_DeviceButton):
@@ -59,14 +54,8 @@ async def _do_list_devices(core):
         return await core.get_user_devices_info()
     except BackendNotAvailable as exc:
         raise JobResultError("offline") from exc
-    except RemoteDevicesManagerError as exc:
+    except BackendConnectionError as exc:
         raise JobResultError("error") from exc
-    # TODO : handle all errors from the remote_devices_manager and notify GUI
-    # Raises:
-    #     RemoteDevicesManagerError
-    #     RemoteDevicesManagerBackendOfflineError
-    #     RemoteDevicesManagerNotFoundError
-    #     RemoteDevicesManagerInvalidTrustchainError
 
 
 class DevicesWidget(QWidget, Ui_DevicesWidget):
@@ -91,12 +80,9 @@ class DevicesWidget(QWidget, Ui_DevicesWidget):
         self.list_error.connect(self.on_list_error)
         self.line_edit_search.textChanged.connect(self.filter_timer.start)
         self.filter_timer.timeout.connect(self.on_filter_timer_timeout)
-        self.initialized = False
 
     def show(self):
-        if not self.initialized:
-            self.reset()
-            self.initialized = True
+        self.reset()
         super().show()
 
     def on_filter_timer_timeout(self):
@@ -129,11 +115,14 @@ class DevicesWidget(QWidget, Ui_DevicesWidget):
         button.show()
         self.devices.append(device_name)
 
+    def _flush_devices_list(self):
+        self.devices = []
+        self.layout_devices.clear()
+
     def on_list_success(self, job):
         devices = job.ret
         current_device = self.core.device
-        self.devices = []
-        self.layout_devices.clear()
+        self._flush_devices_list()
         for device in devices:
             self.add_device(
                 device.device_name,
@@ -144,9 +133,10 @@ class DevicesWidget(QWidget, Ui_DevicesWidget):
     def on_list_error(self, job):
         status = job.status
         if status == "error":
-            self.initialized = False
-            errmsg = _("TEXT_USER_LIST_RETRIEVABLE_FAILURE")
-            show_error(self, errmsg, exception=job.exc)
+            self._flush_devices_list()
+            label = QLabel(_("TEXT_DEVICE_LIST_RETRIEVABLE_FAILURE"))
+            label.setAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
+            self.layout_devices.addWidget(label)
 
     def reset(self):
         self.jobs_ctx.submit_job(

--- a/parsec/core/gui/tr/parsec_en.po
+++ b/parsec/core/gui/tr/parsec_en.po
@@ -475,6 +475,10 @@ msgstr "Revoke the user"
 msgid "TEXT_USER_LIST_RETRIEVABLE_FAILURE"
 msgstr "Failed to retrieve the user list from the server."
 
+msgid "TEXT_DEVICE_LIST_RETRIEVABLE_FAILURE"
+msgstr "Failed to retrieve the device list from the server."
+
+
 msgid "TEXT_PARSEC_LICENSE"
 msgstr ""
 "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"\n"

--- a/parsec/core/gui/tr/parsec_fr.po
+++ b/parsec/core/gui/tr/parsec_fr.po
@@ -460,6 +460,9 @@ msgstr "Révoquer l'utilisateur"
 msgid "TEXT_USER_LIST_RETRIEVABLE_FAILURE"
 msgstr "Impossible de récupérer la liste des utilisateurs depuis le serveur."
 
+msgid "TEXT_DEVICE_LIST_RETRIEVABLE_FAILURE"
+msgstr "Impossible de récupérer la liste des appareils depuis le serveur."
+
 msgid "TEXT_PARSEC_LICENSE"
 msgstr ""
 "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"\n"

--- a/parsec/core/gui/users_widget.py
+++ b/parsec/core/gui/users_widget.py
@@ -1,7 +1,7 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
 from PyQt5.QtCore import Qt, pyqtSignal, QTimer
-from PyQt5.QtWidgets import QWidget, QMenu, QGraphicsDropShadowEffect
+from PyQt5.QtWidgets import QWidget, QMenu, QGraphicsDropShadowEffect, QLabel
 from PyQt5.QtGui import QColor
 
 from parsec.api.data import UserProfile
@@ -135,12 +135,9 @@ class UsersWidget(QWidget, Ui_UsersWidget):
         self.revoke_error.connect(self.on_revoke_error)
         self.list_success.connect(self.on_list_success)
         self.list_error.connect(self.on_list_error)
-        self.initialized = False
 
     def show(self):
-        if not self.initialized:
-            self.reset()
-            self.initialized = True
+        self.reset()
         super().show()
 
     def on_filter_timer_timeout(self):
@@ -215,9 +212,8 @@ class UsersWidget(QWidget, Ui_UsersWidget):
             button=user_button,
         )
 
-    def on_list_success(self, job):
+    def _flush_users_list(self):
         self.users = []
-
         while self.layout_users.count() != 0:
             item = self.layout_users.takeAt(0)
             if item:
@@ -226,6 +222,8 @@ class UsersWidget(QWidget, Ui_UsersWidget):
                 w.hide()
                 w.setParent(None)
 
+    def on_list_success(self, job):
+        self._flush_users_list()
         current_user = self.core.device.user_id
         for user in job.ret:
             self.add_user(
@@ -241,9 +239,13 @@ class UsersWidget(QWidget, Ui_UsersWidget):
         status = job.status
         if status == "offline":
             return
+        elif status == "error":
+            self._flush_users_list()
+            label = QLabel(_("TEXT_USER_LIST_RETRIEVABLE_FAILURE"))
+            label.setAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
+            self.layout_users.addWidget(label)
+            return
         else:
-            if status == "error":
-                self.initialized = False
             errmsg = _("TEXT_USER_LIST_RETRIEVABLE_FAILURE")
         show_error(self, errmsg, exception=job.exc)
 

--- a/parsec/core/gui/users_widget.py
+++ b/parsec/core/gui/users_widget.py
@@ -135,7 +135,13 @@ class UsersWidget(QWidget, Ui_UsersWidget):
         self.revoke_error.connect(self.on_revoke_error)
         self.list_success.connect(self.on_list_success)
         self.list_error.connect(self.on_list_error)
-        self.reset()
+        self.initialized = False
+
+    def show(self):
+        if not self.initialized:
+            self.reset()
+            self.initialized = True
+        super().show()
 
     def on_filter_timer_timeout(self):
         self.filter_users(self.line_edit_search.text())
@@ -236,6 +242,8 @@ class UsersWidget(QWidget, Ui_UsersWidget):
         if status == "offline":
             return
         else:
+            if status == "error":
+                self.initialized = False
             errmsg = _("TEXT_USER_LIST_RETRIEVABLE_FAILURE")
         show_error(self, errmsg, exception=job.exc)
 

--- a/tests/core/gui/test_revoked_user.py
+++ b/tests/core/gui/test_revoked_user.py
@@ -1,0 +1,60 @@
+# Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
+
+import pendulum
+import pytest
+from PyQt5 import QtCore
+from PyQt5.QtWidgets import QLabel
+
+from parsec.api.data import RevokedUserCertificateContent
+from parsec.core.local_device import save_device_with_password
+
+
+@pytest.fixture
+async def logged_gui(aqtbot, gui_factory, running_backend, autoclose_dialog, core_config, bob):
+    save_device_with_password(core_config.config_dir, bob, "P@ssw0rd")
+    gui = await gui_factory()
+    lw = gui.test_get_login_widget()
+    tabw = gui.test_get_tab()
+
+    # assert lw.combo_username.currentText() == f"{bob.organization_id}:{bob.device_id}"
+    await aqtbot.key_clicks(lw.line_edit_password, "P@ssw0rd")
+
+    async with aqtbot.wait_signals([lw.login_with_password_clicked, tabw.logged_in]):
+        await aqtbot.mouse_click(lw.button_login, QtCore.Qt.LeftButton)
+
+    # Users and devices are not populated on startup
+    assert gui.test_get_devices_widget().devices == []
+    assert gui.test_get_users_widget().users == []
+
+    return gui
+
+
+@pytest.mark.gui
+@pytest.mark.trio
+async def test_revoked_notification(
+    aqtbot, running_backend, autoclose_dialog, logged_gui, alice_user_fs, bob
+):
+    now = pendulum.now()
+    revoked_device_certificate = RevokedUserCertificateContent(
+        author=alice_user_fs.device.device_id, timestamp=now, user_id=bob.user_id
+    ).dump_and_sign(alice_user_fs.device.signing_key)
+    central_widget = logged_gui.test_get_central_widget()
+    assert central_widget is not None
+    async with aqtbot.wait_signal(central_widget.new_notification):
+        await alice_user_fs.backend_cmds.user_revoke(revoked_device_certificate)
+        await aqtbot.mouse_click(central_widget.menu.button_users, QtCore.Qt.LeftButton)
+        await aqtbot.mouse_click(central_widget.menu.button_devices, QtCore.Qt.LeftButton)
+
+    # Assert dialog
+    assert len(autoclose_dialog.dialogs) == 1
+    dialog = autoclose_dialog.dialogs[0]
+    assert dialog[0] == "Error"
+    assert dialog[1] == "This device is revoked"
+
+    # Assert device and user widgets
+    devices_w = logged_gui.test_get_devices_widget()
+    users_w = logged_gui.test_get_users_widget()
+    assert devices_w.layout_devices.count() == 1
+    assert isinstance(devices_w.layout_devices.itemAt(0).widget(), QLabel)
+    assert users_w.layout_users.count() == 1
+    assert isinstance(users_w.layout_users.itemAt(0).widget(), QLabel)


### PR DESCRIPTION
Widgets that require to fetch information from `get_user_and_devices` can get a `RemoteDevicesManagerError` if the user has been revoked. This error is not handle in `devices_widget`.


This PR try to change how this error is handled. Now, no popup is displayed by the `users_widgets` or the `devices_widget`  if the exception is raised and the devices (or users ) list is filled with an error message. 


There is now a popup saying that the user is revoked when the event bus get the revoked user notification. (This popup is displayed also after logging in).


Also `devices_widget` and `users_widget` are not filled after logging anymore (when the widget is instantiated)  but on display time (only the first time)

linked issue #1191
 