### PR TITLE
Update WinFSP

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -11,7 +11,7 @@ trigger:
 variables:
   python.version: '3.6'
   postgresql.version: '10'
-  winfsp.version: '1.7.20038-pre'
+  winfsp.version: '1.7.20172'
   pytest.base_args: |
     --log-level=DEBUG \
     --durations=10 -v \
@@ -400,7 +400,7 @@ jobs:
     workingDirectory: $(Agent.TempDirectory)/winbuild
   - bash: |
       set -eux
-      curl -L https://github.com/billziss-gh/winfsp/releases/download/v1.7B1/winfsp-1.7.20038.msi -o winfsp-1.7.20038.msi
+      curl -L https://github.com/billziss-gh/winfsp/releases/download/v1.7/winfsp-1.7.20172.msi -o winfsp-1.7.20172.msi
       makensis.exe installer.nsi
       mkdir dist
       cp build/parsec*-setup.exe dist

--- a/newsfragments/1223.misc.rst
+++ b/newsfragments/1223.misc.rst
@@ -1,0 +1,2 @@
+Update WinFSP embedded package
+

--- a/newsfragments/1223.misc.rst
+++ b/newsfragments/1223.misc.rst
@@ -1,2 +1,1 @@
 Update WinFSP embedded package
-

--- a/packaging/win32/installer.nsi
+++ b/packaging/win32/installer.nsi
@@ -33,7 +33,7 @@
 !define LICENSE_FILEPATH "${PARSEC_FREEZE_BUILD_DIR}\LICENSE.txt"
 !define INSTALLER_FILENAME "parsec-${PROGRAM_VERSION}-${PROGRAM_PLATFORM}-setup.exe"
 
-!define WINFSP_INSTALLER "winfsp-1.7.20038.msi"
+!define WINFSP_INSTALLER "winfsp-1.7.20172.msi"
 
 # Set default compressor
 SetCompressor /FINAL /SOLID lzma


### PR DESCRIPTION
The WinFSP package version is outdated and is not a "stable" version. This change now uses the latest (as of today) stable release. This fixes many things, so potentially preventing a lot of future issue using WinFSP.