### PR TITLE
Mark flaky windows mountpoint tests as flaky using pytest-rerunfailures

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -16,6 +16,7 @@ variables:
     --log-level=DEBUG \
     --durations=10 -v \
     --cov=parsec --cov-config=setup.cfg --cov-append --cov-report= \
+  debug.stress_flaky_tests: 10
 
 jobs:
 
@@ -182,6 +183,15 @@ jobs:
       cp -R tests "$(Agent.TempDirectory)"\\empty
       cp setup.cfg "$(Agent.TempDirectory)"\\empty
     displayName: 'Install'
+  - bash: |
+      set -eux
+      # Install pytest-repeat
+      pip install pytest-repeat
+      # Repeat flaky tests X times
+      py.test tests --runmountpoint --runslow --rungui -m flaky --count $(debug.stress_flaky_tests) -v
+    workingDirectory: $(Agent.TempDirectory)/empty
+    displayName: 'Debug: stress flaky tests'
+    condition: and(succeeded(), gt(variables['debug.stress_flaky_tests'], 0))
   - bash: |
       set -eux
       py.test $(pytest.base_args) \

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -16,7 +16,7 @@ variables:
     --log-level=DEBUG \
     --durations=10 -v \
     --cov=parsec --cov-config=setup.cfg --cov-append --cov-report= \
-  debug.stress_flaky_tests: 10
+  debug.stress_flaky_tests: 0  # Repeat all flaky tests X times
 
 jobs:
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -41,6 +41,11 @@ jobs:
       pip install pre-commit
     displayName: 'Bootstrap'
   - bash: |
+      set -eux
+      # Patch .pre-commit-config.yaml to force mixed-line-ending checks to LF
+      sed -i '/id: mixed-line-ending/a\      args:\n\        - "--fix=lf"' .pre-commit-config.yaml
+      cat .pre-commit-config.yaml
+      # Run all pre-commit hooks on all files
       pre-commit run --all-files --show-diff-on-failure
     displayName: 'Pre-commit hooks check'
   - bash: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -163,9 +163,9 @@ jobs:
       choco install -y --limit-output winfsp --pre --version=$(winfsp.version)
       # Install winfsp-test and put it in PATH
       mkdir winfsp-test
-      curl -L https://github.com/billziss-gh/winfsp/releases/download/v1.5/winfsp-tests-1.5.20002.zip -o winfsp-test/winfsp-tests.zip
+      curl -L https://github.com/billziss-gh/winfsp/releases/download/v1.7/winfsp-tests-1.7.20172.zip -o winfsp-test/winfsp-tests.zip
       unzip winfsp-test/winfsp-tests.zip -d winfsp-test
-      ##vso[task.prependpath]$(Build.SourcesDirectory)/winfsp-test
+      echo "##vso[task.prependpath]$(Build.SourcesDirectory)\\winfsp-test"
     displayName: 'Bootstrap'
   - bash: |
       set -eux
@@ -175,6 +175,8 @@ jobs:
       pip install $(ls dist/parsec_cloud-*.whl)[all]
       # Check dependency compatibility
       pip check parsec[all]
+      # Check winfsp-tests availability
+      python -c "import winfspy.tests.winfsp_tests"
       # Create isolated test directory
       mkdir -p "$(Agent.TempDirectory)"\\empty
       cp -R tests "$(Agent.TempDirectory)"\\empty

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,8 +17,6 @@ repos:
     rev: v2.2.3  # Use the ref you want to point at
     hooks:
     - id: mixed-line-ending
-      args:
-        - "--fix=lf"
     - id: trailing-whitespace
 -   repo: local
     hooks:

--- a/parsec/core/mountpoint/winfsp_runner.py
+++ b/parsec/core/mountpoint/winfsp_runner.py
@@ -180,6 +180,11 @@ async def winfsp_mountpoint_runner(
 
             # Run fs start in a thread
             await trio.to_thread.run_sync(fs.start)
+
+            # The system is too sensitive right after starting
+            await trio.sleep(0.010)  # 10 ms
+
+            # Make sure the mountpoint is ready
             await _wait_for_winfsp_ready(mountpoint_path)
 
             # Notify the manager that the mountpoint is ready

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,3 +52,14 @@ filterwarnings =
      default::DeprecationWarning:tests\.(.*)|parsec\.(.*)
      # Ignore our todo warnings
      ignore:TODO:UserWarning:parsec|tests
+markers =
+    linux: marks tests as linux only
+    win32: marks tests as Windows only
+    gui: marks tests as GUI (select with '--rungui')
+    slow: marks tests as slow (select with '--runslow')
+    mountpoint: marks tests as mountpoint (select with '--runmountpoint')
+    postgresql
+    raid0_blockstore
+    raid1_blockstore
+    raid5_blockstore
+    backend_not_populated

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,10 +55,10 @@ filterwarnings =
 markers =
     linux: marks tests as linux only
     win32: marks tests as Windows only
-    gui: marks tests as GUI (select with '--rungui')
-    slow: marks tests as slow (select with '--runslow')
-    mountpoint: marks tests as mountpoint (select with '--runmountpoint')
-    postgresql
+    gui: marks tests as GUI (enable with '--rungui')
+    slow: marks tests as slow (enable with '--runslow')
+    mountpoint: marks tests as mountpoint (enable with '--runmountpoint')
+    postgresql: marks tests as postgresql only (enable with '--postgresql')
     raid0_blockstore
     raid1_blockstore
     raid5_blockstore

--- a/setup.py
+++ b/setup.py
@@ -295,6 +295,7 @@ test_requirements = [
     "pytest-xdist==1.28.0",
     "pytest-trio==0.5.2",
     "pytest-qt==3.2.2",
+    "pytest-rerunfailures==9.0",
     "pluggy==0.9.0",  # see https://github.com/pytest-dev/pytest/issues/3753
     "hypothesis==5.3.0",
     "hypothesis-trio==0.5.0",

--- a/setup.py
+++ b/setup.py
@@ -290,16 +290,15 @@ requirements = [
 
 
 test_requirements = [
-    "pytest==4.4.0",
-    "pytest-cov==2.6.1",
-    "pytest-xdist==1.28.0",
+    "pytest==5.4.3",
+    "pytest-cov==2.10.0",
+    "pytest-xdist==1.32.0",
     "pytest-trio==0.5.2",
-    "pytest-qt==3.2.2",
+    "pytest-qt==3.3.0",
     "pytest-rerunfailures==9.0",
-    "pluggy==0.9.0",  # see https://github.com/pytest-dev/pytest/issues/3753
     "hypothesis==5.3.0",
     "hypothesis-trio==0.5.0",
-    "trustme==0.5.2",
+    "trustme==0.6.0",
     # Winfsptest requirements
     # We can't use `winfspy[test]` because of some pip limitations
     # - see pip issues #7096/#6239/#4391/#988

--- a/tests/core/mountpoint/test_base.py
+++ b/tests/core/mountpoint/test_base.py
@@ -318,6 +318,7 @@ def test_unhandled_crash_in_fs_operation(caplog, mountpoint_service, monkeypatch
 
 @pytest.mark.trio
 @pytest.mark.mountpoint
+@pytest.mark.flaky(reruns=1)
 @pytest.mark.parametrize("revoking", ["read", "write"])
 async def test_mountpoint_revoke_access(
     base_mountpoint,

--- a/tests/core/mountpoint/test_folder_operations.py
+++ b/tests/core/mountpoint/test_folder_operations.py
@@ -86,6 +86,7 @@ class PathElement:
 
 @pytest.mark.slow
 @pytest.mark.mountpoint
+@pytest.mark.flaky(reruns=1)
 def test_folder_operations(tmpdir, caplog, hypothesis_settings, mountpoint_service_factory):
 
     tentative = 0

--- a/tests/core/mountpoint/test_winfsp_tests.py
+++ b/tests/core/mountpoint/test_winfsp_tests.py
@@ -67,6 +67,7 @@ def file_system_path(mountpoint_service):
 
 @pytest.mark.slow
 @pytest.mark.mountpoint
+@pytest.mark.flaky(reruns=1)
 @pytest.mark.parametrize("test_case", winfsp_tests.TEST_CASES)
 def test_winfsp_tests(test_case, file_system_tempdir):
 

--- a/tests/core/mountpoint/test_winfstest.py
+++ b/tests/core/mountpoint/test_winfstest.py
@@ -28,6 +28,7 @@ def file_system_path(mountpoint_service):
 
 @pytest.mark.slow
 @pytest.mark.mountpoint
+@pytest.mark.flaky(reruns=1)
 @pytest.mark.parametrize("test_module_path", TEST_MODULES, ids=[path.name for path in TEST_MODULES])
 def test_winfstest(test_module_path, file_system_path, process_runner):
 
@@ -54,9 +55,6 @@ def test_winfstest(test_module_path, file_system_path, process_runner):
     # Setting security attributes is not supported at the moment
     if "GetSetSecurity" in test_module_path.name:
         pytest.xfail()
-
-    # TODO: those tests are too unstable
-    pytest.xfail()
 
     # Run winfstest with the parsec mountpoint
     winfstest.test_winfs(test_module_path, file_system_path, process_runner)


### PR DESCRIPTION
Use the flaky mark from pytest-rerunfailures to deal with flaky tests in a more flexible way.