### PR TITLE
Remove useless --db-drop-deleted-data option from backend run command

### DIFF
--- a/newsfragments/1246.misc.rst
+++ b/newsfragments/1246.misc.rst
@@ -1,0 +1,1 @@
+Remove noop --db-drop-deleted-data option from backend run command

--- a/parsec/backend/cli/run.py
+++ b/parsec/backend/cli/run.py
@@ -208,12 +208,6 @@ Allowed values:
 """,
 )
 @click.option(
-    "--db-drop-deleted-data",
-    is_flag=True,
-    envvar="PARSEC_DB_DROP_DELETED_DATA",
-    help="Actually delete data database instead of just marking it has deleted",
-)
-@click.option(
     "--db-min-connections",
     default=5,
     show_default=True,
@@ -354,7 +348,6 @@ def run_cmd(
     host,
     port,
     db,
-    db_drop_deleted_data,
     db_min_connections,
     db_max_connections,
     blockstore,
@@ -410,7 +403,6 @@ def run_cmd(
         config = BackendConfig(
             administration_token=administration_token,
             db_url=db,
-            db_drop_deleted_data=db_drop_deleted_data,
             db_min_connections=db_min_connections,
             db_max_connections=db_max_connections,
             blockstore_config=blockstore,

--- a/parsec/backend/config.py
+++ b/parsec/backend/config.py
@@ -79,8 +79,6 @@ class BackendConfig:
     administration_token: str
 
     db_url: str
-    # If False, deleted data are only marked for deletion
-    db_drop_deleted_data: bool
     db_min_connections: int
     db_max_connections: int
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -502,7 +502,6 @@ def backend_factory(
         config = BackendConfig(
             **{
                 "administration_token": "s3cr3t",
-                "db_drop_deleted_data": False,
                 "db_min_connections": 1,
                 "db_max_connections": 5,
                 "debug": False,


### PR DESCRIPTION
This option has never done anything and it wasn't part of the documentation so I guess it's safe to remove it entirely for the moment ;-)