### PR TITLE
Add support for confined (temporary) files

### DIFF
--- a/newsfragments/990.feature.rst
+++ b/newsfragments/990.feature.rst
@@ -1,0 +1,3 @@
+Add support for confined (i.e temporary) files and directories.
+In this context, confined means files that are not meant to be
+synchronized with other clients

--- a/parsec/core/config.py
+++ b/parsec/core/config.py
@@ -80,6 +80,7 @@ class CoreConfig:
     gui_confirmation_before_close: bool = True
     gui_workspace_color: bool = False
     gui_allow_multiple_instances: bool = False
+    gui_show_confined: bool = False
 
     ipc_socket_file: Path = None
     ipc_win32_mutex_name: str = "parsec-cloud"
@@ -109,6 +110,7 @@ def config_factory(
     gui_check_version_allow_pre_release: bool = False,
     gui_workspace_color: bool = False,
     gui_allow_multiple_instances: bool = False,
+    gui_show_confined: bool = False,
     environ: dict = {},
     **_,
 ) -> CoreConfig:
@@ -135,6 +137,7 @@ def config_factory(
         gui_check_version_allow_pre_release=gui_check_version_allow_pre_release,
         gui_workspace_color=gui_workspace_color,
         gui_allow_multiple_instances=gui_allow_multiple_instances,
+        gui_show_confined=gui_show_confined,
         ipc_socket_file=data_base_dir / "parsec-cloud.lock",
         ipc_win32_mutex_name="parsec-cloud",
     )
@@ -219,6 +222,7 @@ def save_config(config: CoreConfig):
                 "gui_check_version_allow_pre_release": config.gui_check_version_allow_pre_release,
                 "gui_workspace_color": config.gui_workspace_color,
                 "gui_allow_multiple_instances": config.gui_allow_multiple_instances,
+                "gui_show_confined": config.gui_show_confined,
             },
             indent=True,
         )

--- a/parsec/core/config.py
+++ b/parsec/core/config.py
@@ -53,6 +53,7 @@ class CoreConfig:
     data_base_dir: Path
     cache_base_dir: Path
     mountpoint_base_dir: Path
+    pattern_filter: Optional[str] = None  # None means: use the default filter
 
     debug: bool = False
 
@@ -94,6 +95,7 @@ def config_factory(
     data_base_dir: Path = None,
     cache_base_dir: Path = None,
     mountpoint_base_dir: Path = None,
+    pattern_filter: Optional[str] = None,
     mountpoint_enabled: bool = False,
     disabled_workspaces: FrozenSet[EntryID] = frozenset(),
     backend_max_cooldown: int = 30,
@@ -120,6 +122,7 @@ def config_factory(
         data_base_dir=data_base_dir,
         cache_base_dir=cache_base_dir or get_default_cache_base_dir(environ),
         mountpoint_base_dir=get_default_mountpoint_base_dir(environ),
+        pattern_filter=pattern_filter,
         mountpoint_enabled=mountpoint_enabled,
         disabled_workspaces=disabled_workspaces,
         backend_max_cooldown=backend_max_cooldown,
@@ -209,6 +212,7 @@ def save_config(config: CoreConfig):
             {
                 "data_base_dir": str(config.data_base_dir),
                 "cache_base_dir": str(config.cache_base_dir),
+                "pattern_filter": config.pattern_filter,
                 "telemetry_enabled": config.telemetry_enabled,
                 "disabled_workspaces": list(map(str, config.disabled_workspaces)),
                 "backend_max_cooldown": config.backend_max_cooldown,

--- a/parsec/core/core_events.py
+++ b/parsec/core/core_events.py
@@ -18,6 +18,7 @@ class CoreEvent(Enum):
     FS_ENTRY_SYNCED = "fs.entry.synced"
     FS_ENTRY_DOWNSYNCED = "fs.entry.downsynced"
     FS_ENTRY_MINIMAL_SYNCED = "fs.entry.minimal_synced"
+    FS_ENTRY_CONFINED = "fs.entry.confined"
     FS_ENTRY_UPDATED = "fs.entry.updated"
     FS_ENTRY_FILE_CONFLICT_RESOLVED = "fs.entry.file_conflict_resolved"
     FS_ENTRY_FILE_UPDATE_CONFLICTED = "fs.entry.file_update_conflicted"

--- a/parsec/core/fs/storage/manifest_storage.py
+++ b/parsec/core/fs/storage/manifest_storage.py
@@ -13,7 +13,7 @@ from parsec.core.fs.storage.local_database import LocalDatabase
 
 logger = get_logger()
 
-DEFAULT_FILTER_PATTERN = r"^/b$"  # Do not match anything
+EMPTY_PATTERN = r"^/b$"  # Do not match anything
 
 
 class ManifestStorage:
@@ -108,7 +108,7 @@ class ManifestStorage:
                 """
                 INSERT OR IGNORE INTO pattern_filter(_id, pattern, fully_applied)
                 VALUES (0, ?, 0)""",
-                (DEFAULT_FILTER_PATTERN,),
+                (EMPTY_PATTERN,),
             )
 
     # Pattern filter operations

--- a/parsec/core/fs/storage/manifest_storage.py
+++ b/parsec/core/fs/storage/manifest_storage.py
@@ -4,7 +4,7 @@ import re
 
 import trio
 from structlog import get_logger
-from typing import Dict, Tuple, Set, Optional
+from typing import Dict, Tuple, Set, Optional, Pattern
 from async_generator import asynccontextmanager
 
 from parsec.core.fs.exceptions import FSLocalMissError
@@ -113,14 +113,14 @@ class ManifestStorage:
 
     # Pattern filter operations
 
-    async def get_pattern_filter(self) -> Tuple[re.Pattern, bool]:
+    async def get_pattern_filter(self) -> Tuple[Pattern, bool]:
         async with self._open_cursor() as cursor:
             cursor.execute("SELECT pattern, fully_applied FROM pattern_filter WHERE _id = 0")
             reply = cursor.fetchone()
             pattern, fully_applied = reply
             return (re.compile(pattern), bool(fully_applied))
 
-    async def set_pattern_filter(self, pattern: re.Pattern):
+    async def set_pattern_filter(self, pattern: Pattern):
         async with self._open_cursor() as cursor:
             cursor.execute(
                 """UPDATE pattern_filter SET pattern = ?, fully_applied = 0 WHERE _id = 0 AND pattern != ?""",

--- a/parsec/core/fs/storage/workspace_storage.py
+++ b/parsec/core/fs/storage/workspace_storage.py
@@ -1,9 +1,8 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
-import re
 from pathlib import Path
 from collections import defaultdict
-from typing import Dict, Tuple, Set, Optional, Callable
+from typing import Dict, Tuple, Set, Optional, Callable, Pattern
 
 import trio
 from trio import hazmat
@@ -278,11 +277,11 @@ class WorkspaceStorage:
     def get_pattern_filter_fully_applied(self) -> bool:
         return self._pattern_filter_fully_applied
 
-    async def set_pattern_filter(self, pattern: re.Pattern) -> None:
+    async def set_pattern_filter(self, pattern: Pattern) -> None:
         await self.manifest_storage.set_pattern_filter(pattern)
         await self._load_pattern_filter()
 
-    async def set_pattern_filter_fully_applied(self, pattern: re.Pattern):
+    async def set_pattern_filter_fully_applied(self, pattern: Pattern):
         await self.manifest_storage.set_pattern_filter_fully_applied(pattern)
         await self._load_pattern_filter()
 

--- a/parsec/core/fs/userfs/userfs.py
+++ b/parsec/core/fs/userfs/userfs.py
@@ -1,10 +1,9 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
-import re
 import trio
 from pathlib import Path
 from pendulum import Pendulum, now as pendulum_now
-from typing import List, Tuple, Optional, Union
+from typing import List, Tuple, Optional, Union, Pattern
 from structlog import get_logger
 
 from async_generator import asynccontextmanager
@@ -152,7 +151,7 @@ class UserFS:
         backend_cmds: APIV1_BackendAuthenticatedCmds,
         remote_devices_manager: RemoteDevicesManager,
         event_bus: EventBus,
-        pattern_filter: re.Pattern,
+        pattern_filter: Pattern,
     ):
         self.device = device
         self.path = path

--- a/parsec/core/fs/workspacefs/entry_transactions.py
+++ b/parsec/core/fs/workspacefs/entry_transactions.py
@@ -59,7 +59,7 @@ class EntryTransactions(FileTransactions):
             return await self.local_storage.get_manifest(entry_id)
         except FSLocalMissError as exc:
             remote_manifest = await self.remote_loader.load_manifest(exc.id)
-            return LocalManifest.from_remote(remote_manifest).filter_names(self.pattern_filter)
+            return LocalManifest.from_remote(remote_manifest, self.pattern_filter)
 
     @asynccontextmanager
     async def _load_and_lock_manifest(self, entry_id: EntryID):
@@ -68,9 +68,7 @@ class EntryTransactions(FileTransactions):
                 local_manifest = await self.local_storage.get_manifest(entry_id)
             except FSLocalMissError as exc:
                 remote_manifest = await self.remote_loader.load_manifest(exc.id)
-                local_manifest = LocalManifest.from_remote(remote_manifest).filter_names(
-                    self.pattern_filter
-                )
+                local_manifest = LocalManifest.from_remote(remote_manifest, self.pattern_filter)
                 await self.local_storage.set_manifest(entry_id, local_manifest)
             yield local_manifest
 
@@ -156,11 +154,6 @@ class EntryTransactions(FileTransactions):
             # Release the lock and download the child manifest
             await self._load_manifest(entry_id)
 
-    # Confinement helpers
-
-    def match_confined_pattern(self, path):
-        return self.pattern_filter(path.name)
-
     # Transactions
 
     async def entry_info(self, path: FsPath) -> dict:
@@ -233,18 +226,9 @@ class EntryTransactions(FileTransactions):
 
             # Create new manifest
             new_parent = parent.evolve_children_and_mark_updated(
-                {destination.name: source_entry_id, source.name: None}
+                {destination.name: source_entry_id, source.name: None},
+                pattern_filter=self.pattern_filter,
             )
-
-            # Update confined entries
-            old_confined = source_entry_id in parent.confined_entries
-            new_confined = self.match_confined_pattern(destination)
-            if not old_confined and new_confined:
-                new_confined_entries = parent.confined_entries | {source_entry_id}
-                new_parent = new_parent.evolve(confined_entries=new_confined_entries)
-            if old_confined and not new_confined:
-                new_confined_entries = parent.confined_entries - {source_entry_id}
-                new_parent = new_parent.evolve(confined_entries=new_confined_entries)
 
             # Atomic change
             await self.local_storage.set_manifest(parent.id, new_parent)
@@ -275,12 +259,9 @@ class EntryTransactions(FileTransactions):
                 raise FSDirectoryNotEmptyError(filename=path)
 
             # Create new manifest
-            new_parent = parent.evolve_children_and_mark_updated({path.name: None})
-
-            # Update confined_entries
-            if child.id in parent.confined_entries:
-                new_confined_entries = parent.confined_entries - {child.id}
-                new_parent = new_parent.evolve(confined_entries=new_confined_entries)
+            new_parent = parent.evolve_children_and_mark_updated(
+                {path.name: None}, self.pattern_filter
+            )
 
             # Atomic change
             await self.local_storage.set_manifest(parent.id, new_parent)
@@ -307,12 +288,9 @@ class EntryTransactions(FileTransactions):
                 raise FSIsADirectoryError(filename=path)
 
             # Create new manifest
-            new_parent = parent.evolve_children_and_mark_updated({path.name: None})
-
-            # Update confined_entries
-            if child.id in parent.confined_entries:
-                new_confined_entries = parent.confined_entries - {child.id}
-                new_parent = new_parent.evolve(confined_entries=new_confined_entries)
+            new_parent = parent.evolve_children_and_mark_updated(
+                {path.name: None}, self.pattern_filter
+            )
 
             # Atomic change
             await self.local_storage.set_manifest(parent.id, new_parent)
@@ -338,12 +316,9 @@ class EntryTransactions(FileTransactions):
             child = LocalFolderManifest.new_placeholder(parent=parent.id)
 
             # New parent manifest
-            new_parent = parent.evolve_children_and_mark_updated({path.name: child.id})
-
-            # Filtering
-            if self.match_confined_pattern(path):
-                new_confined_entries = parent.confined_entries | {child.id}
-                new_parent = new_parent.evolve(confined_entries=new_confined_entries)
+            new_parent = parent.evolve_children_and_mark_updated(
+                {path.name: child.id}, pattern_filter=self.pattern_filter
+            )
 
             # ~ Atomic change
             await self.local_storage.set_manifest(child.id, child, check_lock_status=False)
@@ -371,12 +346,9 @@ class EntryTransactions(FileTransactions):
             child = LocalFileManifest.new_placeholder(parent=parent.id)
 
             # New parent manifest
-            new_parent = parent.evolve_children_and_mark_updated({path.name: child.id})
-
-            # Filtering
-            if self.match_confined_pattern(path):
-                new_confined_entries = parent.confined_entries | {child.id}
-                new_parent = new_parent.evolve(confined_entries=new_confined_entries)
+            new_parent = parent.evolve_children_and_mark_updated(
+                {path.name: child.id}, pattern_filter=self.pattern_filter
+            )
 
             # ~ Atomic change
             await self.local_storage.set_manifest(child.id, child, check_lock_status=False)

--- a/parsec/core/fs/workspacefs/entry_transactions.py
+++ b/parsec/core/fs/workspacefs/entry_transactions.py
@@ -1,6 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
-from parsec.core.core_events import CoreEvent
+import re
 from typing import Tuple
 from async_generator import asynccontextmanager
 
@@ -15,6 +15,7 @@ from parsec.core.types import (
 )
 
 
+from parsec.core.core_events import CoreEvent
 from parsec.core.fs.workspacefs.file_transactions import FileTransactions
 from parsec.core.fs.utils import is_file_manifest, is_folder_manifest, is_folderish_manifest
 from parsec.core.fs.exceptions import (
@@ -35,6 +36,10 @@ WRITE_RIGHT_ROLES = (WorkspaceRole.OWNER, WorkspaceRole.MANAGER, WorkspaceRole.C
 
 
 class EntryTransactions(FileTransactions):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        pattern = r"\~\$|\.\~|.*\.tmp$"
+        self.pattern_filter = re.compile(pattern).match
 
     # Right management helper
 
@@ -54,7 +59,7 @@ class EntryTransactions(FileTransactions):
             return await self.local_storage.get_manifest(entry_id)
         except FSLocalMissError as exc:
             remote_manifest = await self.remote_loader.load_manifest(exc.id)
-            return LocalManifest.from_remote(remote_manifest)
+            return LocalManifest.from_remote(remote_manifest).filter_names(self.pattern_filter)
 
     @asynccontextmanager
     async def _load_and_lock_manifest(self, entry_id: EntryID):
@@ -63,7 +68,9 @@ class EntryTransactions(FileTransactions):
                 local_manifest = await self.local_storage.get_manifest(entry_id)
             except FSLocalMissError as exc:
                 remote_manifest = await self.remote_loader.load_manifest(exc.id)
-                local_manifest = LocalManifest.from_remote(remote_manifest)
+                local_manifest = LocalManifest.from_remote(remote_manifest).filter_names(
+                    self.pattern_filter
+                )
                 await self.local_storage.set_manifest(entry_id, local_manifest)
             yield local_manifest
 
@@ -149,6 +156,11 @@ class EntryTransactions(FileTransactions):
             # Release the lock and download the child manifest
             await self._load_manifest(entry_id)
 
+    # Confinement helpers
+
+    def match_confined_pattern(self, path):
+        return self.pattern_filter(path.name)
+
     # Transactions
 
     async def entry_info(self, path: FsPath) -> dict:
@@ -224,6 +236,16 @@ class EntryTransactions(FileTransactions):
                 {destination.name: source_entry_id, source.name: None}
             )
 
+            # Update confined entries
+            old_confined = source_entry_id in parent.confined_entries
+            new_confined = self.match_confined_pattern(destination)
+            if not old_confined and new_confined:
+                new_confined_entries = parent.confined_entries | {source_entry_id}
+                new_parent = new_parent.evolve(confined_entries=new_confined_entries)
+            if old_confined and not new_confined:
+                new_confined_entries = parent.confined_entries - {source_entry_id}
+                new_parent = new_parent.evolve(confined_entries=new_confined_entries)
+
             # Atomic change
             await self.local_storage.set_manifest(parent.id, new_parent)
 
@@ -255,6 +277,11 @@ class EntryTransactions(FileTransactions):
             # Create new manifest
             new_parent = parent.evolve_children_and_mark_updated({path.name: None})
 
+            # Update confined_entries
+            if child.id in parent.confined_entries:
+                new_confined_entries = parent.confined_entries - {child.id}
+                new_parent = new_parent.evolve(confined_entries=new_confined_entries)
+
             # Atomic change
             await self.local_storage.set_manifest(parent.id, new_parent)
 
@@ -282,6 +309,11 @@ class EntryTransactions(FileTransactions):
             # Create new manifest
             new_parent = parent.evolve_children_and_mark_updated({path.name: None})
 
+            # Update confined_entries
+            if child.id in parent.confined_entries:
+                new_confined_entries = parent.confined_entries - {child.id}
+                new_parent = new_parent.evolve(confined_entries=new_confined_entries)
+
             # Atomic change
             await self.local_storage.set_manifest(parent.id, new_parent)
 
@@ -307,6 +339,11 @@ class EntryTransactions(FileTransactions):
 
             # New parent manifest
             new_parent = parent.evolve_children_and_mark_updated({path.name: child.id})
+
+            # Filtering
+            if self.match_confined_pattern(path):
+                new_confined_entries = parent.confined_entries | {child.id}
+                new_parent = new_parent.evolve(confined_entries=new_confined_entries)
 
             # ~ Atomic change
             await self.local_storage.set_manifest(child.id, child, check_lock_status=False)
@@ -335,6 +372,11 @@ class EntryTransactions(FileTransactions):
 
             # New parent manifest
             new_parent = parent.evolve_children_and_mark_updated({path.name: child.id})
+
+            # Filtering
+            if self.match_confined_pattern(path):
+                new_confined_entries = parent.confined_entries | {child.id}
+                new_parent = new_parent.evolve(confined_entries=new_confined_entries)
 
             # ~ Atomic change
             await self.local_storage.set_manifest(child.id, child, check_lock_status=False)

--- a/parsec/core/fs/workspacefs/sync_transactions.py
+++ b/parsec/core/fs/workspacefs/sync_transactions.py
@@ -244,7 +244,9 @@ class SyncTransactions(EntryTransactions):
                     continue
 
                 # Send synced event
-                self._send_event(CoreEvent.FS_ENTRY_CONFINED, id=entry_id, cause=parent_manifest.id)
+                self._send_event(
+                    CoreEvent.FS_ENTRY_CONFINED, entry_id=entry_id, cause_id=parent_manifest.id
+                )
                 return None
 
             # Sync cannot be performed yet

--- a/parsec/core/fs/workspacefs/sync_transactions.py
+++ b/parsec/core/fs/workspacefs/sync_transactions.py
@@ -251,6 +251,8 @@ class SyncTransactions(EntryTransactions):
                 if local_manifest.need_sync:
                     new_local_manifest = local_manifest.evolve(need_sync=False)
                     await self.local_storage.set_manifest(entry_id, new_local_manifest)
+                # Send synced event
+                self._send_event(CoreEvent.FS_ENTRY_CONFINED, id=entry_id)
                 return None
 
             # Sync cannot be performed yet

--- a/parsec/core/fs/workspacefs/sync_transactions.py
+++ b/parsec/core/fs/workspacefs/sync_transactions.py
@@ -1,8 +1,7 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
-import re
 from itertools import count
-from typing import Optional, List, Dict, Iterator
+from typing import Optional, List, Dict, Iterator, Pattern
 
 from pendulum import now as pendulum_now
 from parsec.api.protocol import DeviceID
@@ -138,7 +137,7 @@ def merge_folder_children(
 
 def merge_manifests(
     local_author: DeviceID,
-    pattern_filter: re.Pattern,
+    pattern_filter: Pattern,
     local_manifest: LocalManifest,
     remote_manifest: Optional[RemoteManifest] = None,
     force_filter: Optional[bool] = False,
@@ -215,7 +214,7 @@ class SyncTransactions(EntryTransactions):
 
     # Atomic transactions
 
-    async def apply_filter(self, entry_id: EntryID, pattern_filter: re.Pattern) -> None:
+    async def apply_filter(self, entry_id: EntryID, pattern_filter: Pattern) -> None:
         # Fetch and lock
         async with self.local_storage.lock_manifest(entry_id) as local_manifest:
 

--- a/parsec/core/fs/workspacefs/sync_transactions.py
+++ b/parsec/core/fs/workspacefs/sync_transactions.py
@@ -275,10 +275,9 @@ class SyncTransactions(EntryTransactions):
             # Extract versions
             base_version = local_manifest.base_version
             new_base_version = new_local_manifest.base_version
-            remote_version = base_version if remote_manifest is None else remote_manifest.version
 
             # Set the new base manifest
-            if base_version != remote_version or new_local_manifest.need_sync:
+            if new_local_manifest != local_manifest:
                 await self.local_storage.set_manifest(entry_id, new_local_manifest)
 
             # Send downsynced event

--- a/parsec/core/fs/workspacefs/workspacefs.py
+++ b/parsec/core/fs/workspacefs/workspacefs.py
@@ -1,10 +1,9 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
-import re
 import attr
 import trio
 from collections import defaultdict
-from typing import Union, List, Dict, Tuple, AsyncGenerator
+from typing import Union, List, Dict, Tuple, AsyncGenerator, Pattern
 from pendulum import Pendulum, now as pendulum_now
 
 from parsec.api.data import Manifest as RemoteManifest
@@ -621,7 +620,7 @@ class WorkspaceFS:
 
     # Apply filter
 
-    async def _recursive_apply_filter(self, entry_id: EntryID, pattern_filter: re.Pattern):
+    async def _recursive_apply_filter(self, entry_id: EntryID, pattern_filter: Pattern):
         # Load manifest
         try:
             manifest = await self.local_storage.get_manifest(entry_id)
@@ -640,16 +639,16 @@ class WorkspaceFS:
         for name, child_entry_id in manifest.children.items():
             await self._recursive_apply_filter(child_entry_id, pattern_filter)
 
-    async def apply_pattern_filter(self, pattern: re.Pattern):
+    async def apply_pattern_filter(self, pattern: Pattern):
         # Fully apply pattern filter
         await self._recursive_apply_filter(self.workspace_id, pattern)
         # Acknowledge pattern filter
         await self.local_storage.set_pattern_filter_fully_applied(pattern)
 
-    async def set_pattern_filter(self, pattern: re.Pattern):
+    async def set_pattern_filter(self, pattern: Pattern):
         await self.local_storage.set_pattern_filter(pattern)
 
-    async def set_and_apply_pattern_filter(self, pattern: re.Pattern):
+    async def set_and_apply_pattern_filter(self, pattern: Pattern):
         await self.set_pattern_filter(pattern)
         if not self.local_storage.get_pattern_filter_fully_applied():
             await self.apply_pattern_filter(self.local_storage.get_pattern_filter())

--- a/parsec/core/fs/workspacefs/workspacefs.py
+++ b/parsec/core/fs/workspacefs/workspacefs.py
@@ -1,5 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
+import re
 import attr
 import trio
 from collections import defaultdict
@@ -617,6 +618,41 @@ class WorkspaceFS:
             FSError
         """
         await self.sync_by_id(self.workspace_id, remote_changed=remote_changed, recursive=True)
+
+    # Apply filter
+
+    async def _recursive_apply_filter(self, entry_id: EntryID, pattern_filter: re.Pattern):
+        # Load manifest
+        try:
+            manifest = await self.local_storage.get_manifest(entry_id)
+        # Not stored locally, nothing to do
+        except FSLocalMissError:
+            return
+
+        # A file manifest, nothing to do
+        if is_file_manifest(manifest):
+            return
+
+        # Apply filter (idempotent)
+        await self.transactions.apply_filter(entry_id, pattern_filter)
+
+        # Synchronize children
+        for name, child_entry_id in manifest.children.items():
+            await self._recursive_apply_filter(child_entry_id, pattern_filter)
+
+    async def apply_pattern_filter(self, pattern: re.Pattern):
+        # Fully apply pattern filter
+        await self._recursive_apply_filter(self.workspace_id, pattern)
+        # Acknowledge pattern filter
+        await self.local_storage.set_pattern_filter_fully_applied(pattern)
+
+    async def set_pattern_filter(self, pattern: re.Pattern):
+        await self.local_storage.set_pattern_filter(pattern)
+
+    async def set_and_apply_pattern_filter(self, pattern: re.Pattern):
+        await self.set_pattern_filter(pattern)
+        if not self.local_storage.get_pattern_filter_fully_applied():
+            await self.apply_pattern_filter(self.local_storage.get_pattern_filter())
 
     # Debugging helper
 

--- a/parsec/core/gui/file_table.py
+++ b/parsec/core/gui/file_table.py
@@ -79,6 +79,7 @@ class FileTable(QTableWidget):
         super().__init__(*args, **kwargs)
         self.previous_selection = []
         self.setColumnCount(len(Column))
+        self.config = None
 
         h_header = self.horizontalHeader()
         h_header.setDefaultAlignment(Qt.AlignLeft | Qt.AlignVCenter)
@@ -295,6 +296,8 @@ class FileTable(QTableWidget):
             self.setItem(row_idx, col, item)
 
     def add_folder(self, folder_name, uuid, is_synced, is_confined, selected=False):
+        if is_confined and not self.config.gui_show_confined:
+            return
         row_idx = self.rowCount()
         self.insertRow(row_idx)
         item = FolderTableItem(is_synced, is_confined)
@@ -337,6 +340,8 @@ class FileTable(QTableWidget):
         is_confined,
         selected=False,
     ):
+        if is_confined and not self.config.gui_show_confined:
+            return
         row_idx = self.rowCount()
         self.insertRow(row_idx)
         item = FileTableItem(is_synced, is_confined, file_name)

--- a/parsec/core/gui/file_table.py
+++ b/parsec/core/gui/file_table.py
@@ -294,10 +294,10 @@ class FileTable(QTableWidget):
             item.setFlags(Qt.ItemIsEnabled)
             self.setItem(row_idx, col, item)
 
-    def add_folder(self, folder_name, uuid, is_synced, selected=False):
+    def add_folder(self, folder_name, uuid, is_synced, is_confined, selected=False):
         row_idx = self.rowCount()
         self.insertRow(row_idx)
-        item = FolderTableItem(is_synced)
+        item = FolderTableItem(is_synced, is_confined)
         item.setData(UUID_DATA_INDEX, uuid)
         self.setItem(row_idx, Column.ICON, item)
         item = CustomTableItem(folder_name)
@@ -327,11 +327,19 @@ class FileTable(QTableWidget):
             )
 
     def add_file(
-        self, file_name, uuid, file_size, created_on, updated_on, is_synced, selected=False
+        self,
+        file_name,
+        uuid,
+        file_size,
+        created_on,
+        updated_on,
+        is_synced,
+        is_confined,
+        selected=False,
     ):
         row_idx = self.rowCount()
         self.insertRow(row_idx)
-        item = FileTableItem(is_synced, file_name)
+        item = FileTableItem(is_synced, is_confined, file_name)
         item.setData(NAME_DATA_INDEX, 1)
         item.setData(TYPE_DATA_INDEX, FileType.File)
         item.setData(UUID_DATA_INDEX, uuid)
@@ -366,7 +374,7 @@ class FileTable(QTableWidget):
         inconsistency_color = QColor(255, 144, 155)
         row_idx = self.rowCount()
         self.insertRow(row_idx)
-        item = InconsistencyTableItem(False)
+        item = InconsistencyTableItem(False, False)
         item.setData(NAME_DATA_INDEX, 1)
         item.setData(TYPE_DATA_INDEX, FileType.Inconsistency)
         item.setData(UUID_DATA_INDEX, uuid)

--- a/parsec/core/gui/files_widget.py
+++ b/parsec/core/gui/files_widget.py
@@ -212,6 +212,7 @@ class FilesWidget(QWidget, Ui_FilesWidget):
         self.update_timer.setSingleShot(True)
         self.update_timer.timeout.connect(self.reload)
         self.default_import_path = str(pathlib.Path.home())
+        self.table_files.config = self.core.config
         self.table_files.file_moved.connect(self.on_file_moved)
         self.table_files.item_activated.connect(self.item_activated)
         self.table_files.rename_clicked.connect(self.rename_files)

--- a/parsec/core/gui/files_widget.py
+++ b/parsec/core/gui/files_widget.py
@@ -722,7 +722,7 @@ class FilesWidget(QWidget, Ui_FilesWidget):
                 self.table_files.add_inconsistency(str(path), stats["id"])
             elif stats["type"] == "folder":
                 self.table_files.add_folder(
-                    str(path), stats["id"], not stats["need_sync"], selected
+                    str(path), stats["id"], not stats["need_sync"], stats["confined"], selected
                 )
             else:
                 self.table_files.add_file(
@@ -732,6 +732,7 @@ class FilesWidget(QWidget, Ui_FilesWidget):
                     stats["created"],
                     stats["updated"],
                     not stats["need_sync"],
+                    stats["confined"],
                     selected,
                 )
         self.table_files.sortItems(old_sort, old_order)
@@ -826,6 +827,7 @@ class FilesWidget(QWidget, Ui_FilesWidget):
                     item.data(TYPE_DATA_INDEX) == FileType.File
                     or item.data(TYPE_DATA_INDEX) == FileType.Folder
                 ):
+                    item.confined = False
                     item.is_synced = True
 
     def _on_fs_updated_qt(self, event, uuid):

--- a/parsec/core/gui/forms/settings_widget.ui
+++ b/parsec/core/gui/forms/settings_widget.ui
@@ -69,8 +69,8 @@ border-radius: 8px;
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>563</width>
-        <height>526</height>
+        <width>549</width>
+        <height>563</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -398,6 +398,17 @@ border-radius: 8px;
               </property>
               <property name="text">
                <string>TEXT_SETTINGS_INTERFACE_TITLE</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_12">
+            <item>
+             <widget class="QCheckBox" name="check_box_show_confined">
+              <property name="text">
+               <string>TEXT_SETTINGS_CHECK_SHOW_CONFINED_FILES</string>
               </property>
              </widget>
             </item>

--- a/parsec/core/gui/settings_widget.py
+++ b/parsec/core/gui/settings_widget.py
@@ -36,6 +36,7 @@ class SettingsWidget(QWidget, Ui_SettingsWidget):
         self.check_box_send_data.setChecked(self.core_config.telemetry_enabled)
         self.check_box_workspace_color.setChecked(self.core_config.gui_workspace_color)
         self.button_check_version.clicked.connect(self.check_version)
+        self.check_box_show_confined.setChecked(self.core_config.gui_show_confined)
 
     def check_version(self):
         d = CheckNewVersion(self.jobs_ctx, self.event_bus, self.core_config, parent=self)
@@ -49,5 +50,6 @@ class SettingsWidget(QWidget, Ui_SettingsWidget):
             gui_language=self.combo_languages.currentData(),
             gui_check_version_at_startup=self.check_box_check_at_startup.isChecked(),
             gui_workspace_color=self.check_box_workspace_color.isChecked(),
+            gui_show_confined=self.check_box_show_confined.isChecked(),
         )
         show_info(self, _("TEXT_SETTINGS_NEED_RESTART"))

--- a/parsec/core/gui/tr/parsec_en.po
+++ b/parsec/core/gui/tr/parsec_en.po
@@ -1522,6 +1522,15 @@ msgstr "Parent folder"
 msgid "TEXT_FILE_TREE_PARENT_WORKSPACE"
 msgstr "Workspaces list"
 
+msgid "TEXT_FILE_ITEM_IS_CONFINED_TOOLTIP"
+msgstr "The file will not be synced."
+
+msgid "TEXT_FILE_ITEM_IS_SYNCED_TOOLTIP"
+msgstr "The file is synced."
+
+msgid "TEXT_FILE_ITEM_IS_NOT_SYNCED_TOOLTIP"
+msgstr "The file is not synced yet."
+
 msgid "TEXT_BOOTSTRAP_ORG_INSTRUCTIONS_url-organization"
 msgstr ""
 "You are about to bootstrap the organization <b>{organization}</b>. You "
@@ -2296,6 +2305,9 @@ msgstr "Use colors for workspaces"
 
 msgid "ACTION_SAVE"
 msgstr "Save"
+
+msgid "TEXT_SETTINGS_CHECK_SHOW_CONFINED_FILES"
+msgstr "Display files that will not be synced"
 
 msgid "TEXT_WORKSPACE_SHARING_REMOVE_USER_TOOLTIP"
 msgstr "Remove the user from this workspace."

--- a/parsec/core/gui/tr/parsec_en.ts
+++ b/parsec/core/gui/tr/parsec_en.ts
@@ -1063,13 +1063,18 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/settings_widget.ui" line="414"/>
+        <location filename="../forms/settings_widget.ui" line="425"/>
         <source>TEXT_SETTINGS_CHECK_USE_WORKSPACES_COLORS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/settings_widget.ui" line="504"/>
+        <location filename="../forms/settings_widget.ui" line="515"/>
         <source>ACTION_SAVE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../forms/settings_widget.ui" line="411"/>
+        <source>TEXT_SETTINGS_CHECK_SHOW_CONFINED_FILES</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/parsec/core/gui/tr/parsec_fr.po
+++ b/parsec/core/gui/tr/parsec_fr.po
@@ -1567,6 +1567,15 @@ msgstr "Répertoire parent"
 msgid "TEXT_FILE_TREE_PARENT_WORKSPACE"
 msgstr "Liste des espaces de travail"
 
+msgid "TEXT_FILE_ITEM_IS_CONFINED_TOOLTIP"
+msgstr "Ce fichier ne sera pas synchronisé."
+
+msgid "TEXT_FILE_ITEM_IS_SYNCED_TOOLTIP"
+msgstr "Ce fichier est synchronisé."
+
+msgid "TEXT_FILE_ITEM_IS_NOT_SYNCED_TOOLTIP"
+msgstr "Ce fichier n'est pas encore synchronisé."
+
 msgid "TEXT_BOOTSTRAP_ORG_INSTRUCTIONS_url-organization"
 msgstr ""
 "Vous allez démarrer l'organisation <b>{organization}</b>. Vous serez le "
@@ -2353,6 +2362,9 @@ msgstr "Utiliser des couleurs pour les espaces de travail"
 msgid "ACTION_SAVE"
 msgstr "Sauvegarder"
 
+msgid "TEXT_SETTINGS_CHECK_SHOW_CONFINED_FILES"
+msgstr "Afficher les fichiers exclus de la synchronisation"
+
 msgid "TEXT_WORKSPACE_SHARING_REMOVE_USER_TOOLTIP"
 msgstr "Retirer l'utilisateur de cet espace de travail."
 
@@ -2426,4 +2438,3 @@ msgstr "Créer un nouvel espace de travail"
 
 msgid "ACTION_WORKSPACE_GOTO_FILE_LINK"
 msgstr "Trouver un fichier via son lien"
-

--- a/parsec/core/gui/tr/parsec_fr.ts
+++ b/parsec/core/gui/tr/parsec_fr.ts
@@ -1063,13 +1063,18 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/settings_widget.ui" line="414"/>
+        <location filename="../forms/settings_widget.ui" line="425"/>
         <source>TEXT_SETTINGS_CHECK_USE_WORKSPACES_COLORS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/settings_widget.ui" line="504"/>
+        <location filename="../forms/settings_widget.ui" line="515"/>
         <source>ACTION_SAVE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../forms/settings_widget.ui" line="411"/>
+        <source>TEXT_SETTINGS_CHECK_SHOW_CONFINED_FILES</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/parsec/core/types/manifest.py
+++ b/parsec/core/types/manifest.py
@@ -1,9 +1,8 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
-import re
 import attr
 import functools
-from typing import Optional, Tuple, FrozenSet, TypeVar
+from typing import Optional, Tuple, FrozenSet, TypeVar, Pattern
 from pendulum import Pendulum, now as pendulum_now
 
 from parsec.types import UUID4, FrozenDict
@@ -244,7 +243,7 @@ class LocalManifest(BaseLocalData):
     def from_remote(
         cls,
         remote: RemoteManifest,
-        pattern_filter: Optional[re.Pattern] = None,
+        pattern_filter: Optional[Pattern] = None,
         local_manifest: Optional["LocalManifest"] = None,
     ) -> "LocalManifest":
         if isinstance(remote, RemoteFileManifest):
@@ -435,7 +434,7 @@ class LocalFolderishManifestMixin:
     # Evolve methods
 
     def evolve_children_and_mark_updated(
-        self: LocalFolderishManifestTypeVar, data, pattern_filter: re.Pattern
+        self: LocalFolderishManifestTypeVar, data, pattern_filter: Pattern
     ) -> LocalFolderishManifestTypeVar:
         updated = False
         new_children = dict(self.children)
@@ -490,7 +489,7 @@ class LocalFolderishManifestMixin:
     def _restore_confined_entries(
         self: LocalFolderishManifestTypeVar,
         other: LocalFolderishManifestTypeVar,
-        pattern_filter: re.Pattern,
+        pattern_filter: Pattern,
     ) -> LocalFolderishManifestTypeVar:
         if not other.confined_entries:
             return self
@@ -502,7 +501,7 @@ class LocalFolderishManifestMixin:
         return self.evolve_children_and_mark_updated(previously_confined_entries, pattern_filter)
 
     def _filter_remote_entries(
-        self: LocalFolderishManifestTypeVar, pattern_filter: re.Pattern
+        self: LocalFolderishManifestTypeVar, pattern_filter: Pattern
     ) -> LocalFolderishManifestTypeVar:
         filtered_entries = frozenset(
             {entry_id for name, entry_id in self.children.items() if pattern_filter.match(name)}
@@ -530,7 +529,7 @@ class LocalFolderishManifestMixin:
     # Apply filter
 
     def apply_filter(
-        self: LocalFolderishManifestTypeVar, pattern_filter: re.Pattern
+        self: LocalFolderishManifestTypeVar, pattern_filter: Pattern
     ) -> LocalFolderishManifestTypeVar:
         # Filter confined entries
         result = self._filter_confined_entries()
@@ -606,7 +605,7 @@ class LocalFolderManifest(LocalManifest, LocalFolderishManifestMixin):
     def from_remote(
         cls,
         remote: RemoteFolderManifest,
-        pattern_filter: re.Pattern,
+        pattern_filter: Pattern,
         local_manifest: Optional["LocalFolderManifest"] = None,
     ) -> "LocalFolderManifest":
         # Create local manifest
@@ -703,7 +702,7 @@ class LocalWorkspaceManifest(LocalManifest, LocalFolderishManifestMixin):
     def from_remote(
         cls,
         remote: RemoteFolderManifest,
-        pattern_filter: re.Pattern,
+        pattern_filter: Pattern,
         local_manifest: Optional["LocalWorkspaceManifest"] = None,
     ) -> "LocalWorkspaceManifest":
         # Create local manifest

--- a/parsec/core/types/manifest.py
+++ b/parsec/core/types/manifest.py
@@ -439,14 +439,23 @@ class LocalFolderishManifestMixin:
         updated = False
         new_children = dict(self.children)
         new_confined_entries = set(self.confined_entries)
+
+        # Deal with removal first
         for name, entry_id in data.items():
+            if name not in new_children:
+                continue
             # Remove old entry
-            old_entry_id = new_children.pop(name, None)
-            if old_entry_id in self.confined_entries:
+            old_entry_id = new_children.pop(name)
+            if old_entry_id in new_confined_entries:
                 new_confined_entries.discard(old_entry_id)
             else:
                 updated = True
-            # No entry to add
+
+        # Make sure no entry_id is duplicated
+        assert not set(data.values()).intersection(new_children.values())
+
+        # Deal with additions second
+        for name, entry_id in data.items():
             if entry_id is None:
                 continue
             # Add new entry

--- a/parsec/serde/fields.py
+++ b/parsec/serde/fields.py
@@ -55,6 +55,9 @@ __all__ = (
     "PrivateKey",
     "SecretKey",
     "HashDigest",
+    "FrozenList",
+    "FrozenMap",
+    "FrozenSet",
 )
 
 
@@ -258,6 +261,11 @@ class FrozenMap(Map):
 class FrozenList(List):
     def _deserialize(self, value, attr, obj):
         return tuple(super()._deserialize(value, attr, obj))
+
+
+class FrozenSet(List):
+    def _deserialize(self, value, attr, obj):
+        return frozenset(super()._deserialize(value, attr, obj))
 
 
 class Tuple(Field):

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -11,6 +11,7 @@ from parsec.core.backend_connection import (
 )
 from parsec.core.remote_devices_manager import RemoteDevicesManager
 from parsec.core.fs import UserFS
+from parsec.core.logged_core import DEFAULT_PATTERN_FILTER
 
 
 @pytest.fixture
@@ -115,7 +116,9 @@ def user_fs_factory(local_storage_path, event_bus_factory, initialize_userfs_sto
         ) as cmds:
             path = local_storage_path(device)
             rdm = RemoteDevicesManager(cmds, device.root_verify_key)
-            async with UserFS.run(device, path, cmds, rdm, event_bus) as user_fs:
+            async with UserFS.run(
+                device, path, cmds, rdm, event_bus, DEFAULT_PATTERN_FILTER
+            ) as user_fs:
                 if not initialize_in_v0:
                     await initialize_userfs_storage_v1(user_fs.storage)
                 yield user_fs

--- a/tests/core/fs/test_fs_sync.py
+++ b/tests/core/fs/test_fs_sync.py
@@ -61,6 +61,7 @@ async def test_new_workspace(running_backend, alice, alice_user_fs, alice2_user_
         "children": [],
         "created": Pendulum(2000, 1, 2),
         "updated": Pendulum(2000, 1, 2),
+        "confined": False,
     }
     assert workspace_entry == WorkspaceEntry(
         name="w",
@@ -120,6 +121,7 @@ async def test_new_empty_entry(type, running_backend, alice_user_fs, alice2_user
             "created": Pendulum(2000, 1, 2),
             "updated": Pendulum(2000, 1, 2),
             "size": 0,
+            "confined": False,
         }
     else:
         assert info == {
@@ -131,6 +133,7 @@ async def test_new_empty_entry(type, running_backend, alice_user_fs, alice2_user
             "created": Pendulum(2000, 1, 2),
             "updated": Pendulum(2000, 1, 2),
             "children": [],
+            "confined": False,
         }
     info2 = await workspace2.path_info("/foo")
     assert info == info2
@@ -455,6 +458,7 @@ async def test_create_already_existing_folder_vlob(running_backend, alice_user_f
         "created": Pendulum(2000, 1, 2),
         "updated": Pendulum(2000, 1, 2),
         "children": ["x"],
+        "confined": False,
     }
 
     workspace2 = alice2_user_fs.get_workspace(wid)
@@ -500,6 +504,7 @@ async def test_create_already_existing_file_vlob(running_backend, alice_user_fs,
         "updated": Pendulum(2000, 1, 2),
         "base_version": 1,
         "size": 0,
+        "confined": False,
     }
 
     await workspace2.sync()
@@ -562,6 +567,7 @@ async def test_create_already_existing_block(running_backend, alice_user_fs, ali
         "updated": Pendulum(2000, 1, 3),
         "base_version": 2,
         "size": 4,
+        "confined": False,
     }
 
     await workspace2.sync()
@@ -599,6 +605,7 @@ async def test_sync_data_before_workspace(running_backend, alice_user_fs):
         "is_placeholder": False,
         "need_sync": False,
         "size": 2,
+        "confined": False,
     }
     root_info = await w.path_info("/")
     assert root_info == {
@@ -610,6 +617,7 @@ async def test_sync_data_before_workspace(running_backend, alice_user_fs):
         "is_placeholder": False,
         "need_sync": True,
         "children": ["bar"],
+        "confined": False,
     }
 
 

--- a/tests/core/fs/test_reencrypt_workspace.py
+++ b/tests/core/fs/test_reencrypt_workspace.py
@@ -189,6 +189,7 @@ async def test_no_access_during_reencryption(running_backend, alice2_user_fs, wo
         "is_placeholder": False,
         "need_sync": False,
         "children": ["foo.txt"],
+        "confined": False,
     }
     with pytest.raises(FSWorkspaceInMaintenance):
         await aw.path_info("/foo.txt")
@@ -217,6 +218,7 @@ async def test_no_access_during_reencryption(running_backend, alice2_user_fs, wo
         "is_placeholder": False,
         "need_sync": True,
         "children": ["bar.txt", "foo.txt"],
+        "confined": False,
     }
     with pytest.raises(FSBadEncryptionRevision):
         await aw.path_info("/foo.txt")
@@ -238,6 +240,7 @@ async def test_no_access_during_reencryption(running_backend, alice2_user_fs, wo
         "is_placeholder": False,
         "need_sync": False,
         "size": 2,
+        "confined": False,
     }
 
     # Finally sync is ok

--- a/tests/core/fs/userfs/test_sharing.py
+++ b/tests/core/fs/userfs/test_sharing.py
@@ -488,6 +488,7 @@ async def test_share_workspace_then_conflict_on_rights(
         "base_version": 1,
         "need_sync": False,
         "children": [],
+        "confined": False,
     }
     assert a_w_stat == a2_w_stat
 

--- a/tests/core/fs/workspacefs/test_confinement.py
+++ b/tests/core/fs/workspacefs/test_confinement.py
@@ -1,5 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
+import re
 import pytest
 
 
@@ -11,6 +12,12 @@ async def assert_path_info(workspace, path, **kwargs):
 
 @pytest.mark.trio
 async def test_confined_entries(alice_workspace, running_backend):
+
+    # Apply a *.tmp filter
+    pattern = re.compile(r".*\.tmp$")
+    await alice_workspace.set_and_apply_pattern_filter(pattern)
+    assert alice_workspace.local_storage.get_pattern_filter() == pattern
+    assert alice_workspace.local_storage.get_pattern_filter_fully_applied()
 
     # Use foo as working directory
     await assert_path_info(alice_workspace, "/foo", confined=False, need_sync=False)

--- a/tests/core/fs/workspacefs/test_confinement.py
+++ b/tests/core/fs/workspacefs/test_confinement.py
@@ -1,0 +1,85 @@
+# Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
+
+import pytest
+
+
+async def assert_path_info(workspace, path, **kwargs):
+    info = await workspace.path_info(path)
+    for key, value in kwargs.items():
+        assert info[key] == value
+
+
+@pytest.mark.trio
+async def test_confined_entries(alice_workspace, running_backend):
+
+    # Use foo as working directory
+    await assert_path_info(alice_workspace, "/foo", confined=False, need_sync=False)
+
+    # Create a temporary file and temporary folder
+    await alice_workspace.mkdir("/foo/x.tmp")
+    await alice_workspace.touch("/foo/y.tmp")
+
+    # Check status
+    await assert_path_info(alice_workspace, "/foo", confined=False, need_sync=False)
+    await assert_path_info(alice_workspace, "/foo/x.tmp", confined=True, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/y.tmp", confined=True, need_sync=True)
+
+    # Force a sync
+    await alice_workspace.sync()
+
+    # There should be nothing to synchronize
+    await assert_path_info(alice_workspace, "/foo", confined=False, need_sync=False)
+    await assert_path_info(alice_workspace, "/foo/x.tmp", confined=True, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/y.tmp", confined=True, need_sync=True)
+
+    # Create a non-temporary file
+    await alice_workspace.touch("/foo/z.txt")
+
+    # Check status
+    await assert_path_info(alice_workspace, "/foo", confined=False, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/x.tmp", confined=True, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/y.tmp", confined=True, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/z.txt", confined=False, need_sync=True)
+
+    # Force a sync
+    await alice_workspace.sync()
+
+    # Check status
+    await assert_path_info(alice_workspace, "/foo", confined=False, need_sync=False)
+    await assert_path_info(alice_workspace, "/foo/x.tmp", confined=True, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/y.tmp", confined=True, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/z.txt", confined=False, need_sync=False)
+
+    # Remove a temporary file
+    await alice_workspace.rmdir("/foo/x.tmp")
+    assert not await alice_workspace.exists("/foo/x.tmp")
+
+    # Check status
+    await assert_path_info(alice_workspace, "/foo", confined=False, need_sync=False)
+    await assert_path_info(alice_workspace, "/foo/y.tmp", confined=True, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/z.txt", confined=False, need_sync=False)
+
+    # Force a sync
+    await alice_workspace.sync()
+
+    # Nothing has changed
+    await assert_path_info(alice_workspace, "/foo", confined=False, need_sync=False)
+    await assert_path_info(alice_workspace, "/foo/y.tmp", confined=True, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/z.txt", confined=False, need_sync=False)
+
+    # Rename a temporary file
+    await alice_workspace.rename("/foo/y.tmp", "/foo/y.txt")
+    assert not await alice_workspace.exists("/foo/y.tmp")
+
+    # Check status
+    await assert_path_info(alice_workspace, "/foo", confined=False, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/y.txt", confined=False, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/z.txt", confined=False, need_sync=False)
+
+    # Force a sync
+    await alice_workspace.sync()
+
+    # Check status
+    await assert_path_info(alice_workspace, "/foo", confined=False, need_sync=False)
+    await assert_path_info(alice_workspace, "/foo/y.txt", confined=False, need_sync=False)
+    await assert_path_info(alice_workspace, "/foo/z.txt", confined=False, need_sync=False)

--- a/tests/core/fs/workspacefs/test_entry_transactions.py
+++ b/tests/core/fs/workspacefs/test_entry_transactions.py
@@ -38,6 +38,7 @@ async def test_root_entry_info(alice_entry_transactions):
         "created": Pendulum(2000, 1, 1),
         "updated": Pendulum(2000, 1, 1),
         "children": [],
+        "confined": False,
     }
 
 
@@ -61,6 +62,7 @@ async def test_file_create(alice_entry_transactions, alice_file_transactions, al
         "created": Pendulum(2000, 1, 1),
         "updated": Pendulum(2000, 1, 2),
         "children": ["foo.txt"],
+        "confined": False,
     }
 
     foo_stat = await entry_transactions.entry_info(FsPath("/foo.txt"))
@@ -73,6 +75,7 @@ async def test_file_create(alice_entry_transactions, alice_file_transactions, al
         "created": Pendulum(2000, 1, 2),
         "updated": Pendulum(2000, 1, 2),
         "size": 0,
+        "confined": False,
     }
 
 
@@ -196,6 +199,7 @@ async def test_access_not_loaded_entry(alice, bob, alice_entry_transactions):
         "is_placeholder": True,
         "need_sync": True,
         "children": [],
+        "confined": False,
     }
 
 

--- a/tests/core/fs/workspacefs/test_sync_transactions.py
+++ b/tests/core/fs/workspacefs/test_sync_transactions.py
@@ -1,9 +1,10 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
-from parsec.core.core_events import CoreEvent
+import re
 import pytest
 
 from parsec.api.protocol import DeviceID
+from parsec.core.core_events import CoreEvent
 from parsec.core.types import FsPath, EntryID, Chunk, LocalFolderManifest, LocalFileManifest
 
 from parsec.core.fs.workspacefs.sync_transactions import merge_manifests
@@ -11,8 +12,7 @@ from parsec.core.fs.workspacefs.sync_transactions import merge_folder_children
 from parsec.core.fs.exceptions import FSFileConflictError
 
 
-def empty_filter(name):
-    return False
+empty_filter = re.compile(r"^\b$")
 
 
 def test_merge_folder_children():

--- a/tests/core/fs/workspacefs/test_sync_transactions.py
+++ b/tests/core/fs/workspacefs/test_sync_transactions.py
@@ -11,6 +11,10 @@ from parsec.core.fs.workspacefs.sync_transactions import merge_folder_children
 from parsec.core.fs.exceptions import FSFileConflictError
 
 
+def empty_filter(name):
+    return False
+
+
 def test_merge_folder_children():
     m1 = EntryID()
     m2 = EntryID()
@@ -59,45 +63,45 @@ def test_merge_folder_manifests():
     v1 = LocalFolderManifest.new_placeholder(parent=parent).to_remote(author=other_device)
 
     # Initial base manifest
-    m1 = LocalFolderManifest.from_remote(v1)
-    assert merge_manifests(my_device, m1) == m1
+    m1 = LocalFolderManifest.from_remote(v1, empty_filter)
+    assert merge_manifests(my_device, empty_filter, m1) == m1
 
     # Local change
-    m2 = m1.evolve_children_and_mark_updated({"a": EntryID()})
-    assert merge_manifests(my_device, m2) == m2
+    m2 = m1.evolve_children_and_mark_updated({"a": EntryID()}, empty_filter)
+    assert merge_manifests(my_device, empty_filter, m2) == m2
 
     # Successful upload
     v2 = m2.to_remote(author=my_device)
-    m3 = merge_manifests(my_device, m2, v2)
-    assert m3 == LocalFolderManifest.from_remote(v2)
+    m3 = merge_manifests(my_device, empty_filter, m2, v2)
+    assert m3 == LocalFolderManifest.from_remote(v2, empty_filter)
 
     # Two local changes
-    m4 = m3.evolve_children_and_mark_updated({"b": EntryID()})
-    assert merge_manifests(my_device, m4) == m4
-    m5 = m4.evolve_children_and_mark_updated({"c": EntryID()})
-    assert merge_manifests(my_device, m4) == m4
+    m4 = m3.evolve_children_and_mark_updated({"b": EntryID()}, empty_filter)
+    assert merge_manifests(my_device, empty_filter, m4) == m4
+    m5 = m4.evolve_children_and_mark_updated({"c": EntryID()}, empty_filter)
+    assert merge_manifests(my_device, empty_filter, m4) == m4
 
     # M4 has been successfully uploaded
     v3 = m4.to_remote(author=my_device)
-    m6 = merge_manifests(my_device, m5, v3)
+    m6 = merge_manifests(my_device, empty_filter, m5, v3)
     assert m6 == m5.evolve(base=v3)
 
     # The remote has changed
     v4 = v3.evolve(version=4, children={"d": EntryID(), **v3.children}, author=other_device)
-    m7 = merge_manifests(my_device, m6, v4)
+    m7 = merge_manifests(my_device, empty_filter, m6, v4)
     assert m7.base_version == 4
     assert sorted(m7.children) == ["a", "b", "c", "d"]
     assert m7.need_sync
 
     # Successful upload
     v5 = m7.to_remote(author=my_device)
-    m8 = merge_manifests(my_device, m7, v5)
-    assert m8 == LocalFolderManifest.from_remote(v5)
+    m8 = merge_manifests(my_device, empty_filter, m7, v5)
+    assert m8 == LocalFolderManifest.from_remote(v5, empty_filter)
 
     # The remote has changed
     v6 = v5.evolve(version=6, children={"e": EntryID(), **v5.children}, author=other_device)
-    m9 = merge_manifests(my_device, m8, v6)
-    assert m9 == LocalFolderManifest.from_remote(v6)
+    m9 = merge_manifests(my_device, empty_filter, m8, v6)
+    assert m9 == LocalFolderManifest.from_remote(v6, empty_filter)
 
 
 def test_merge_manifests_with_a_placeholder():
@@ -106,20 +110,20 @@ def test_merge_manifests_with_a_placeholder():
     parent = EntryID()
 
     m1 = LocalFolderManifest.new_placeholder(parent=parent)
-    m2 = merge_manifests(my_device, m1)
+    m2 = merge_manifests(my_device, empty_filter, m1)
     assert m2 == m1
     v1 = m1.to_remote(author=my_device)
 
-    m2a = merge_manifests(my_device, m1, v1)
-    assert m2a == LocalFolderManifest.from_remote(v1)
+    m2a = merge_manifests(my_device, empty_filter, m1, v1)
+    assert m2a == LocalFolderManifest.from_remote(v1, empty_filter)
 
-    m2b = m1.evolve_children_and_mark_updated({"a": EntryID()})
-    m3b = merge_manifests(my_device, m2b, v1)
+    m2b = m1.evolve_children_and_mark_updated({"a": EntryID()}, empty_filter)
+    m3b = merge_manifests(my_device, empty_filter, m2b, v1)
     assert m3b == m2b.evolve(base=v1)
 
     v2 = v1.evolve(version=2, author=other_device, children={"b": EntryID()})
-    m2c = m1.evolve_children_and_mark_updated({"a": EntryID()})
-    m3c = merge_manifests(my_device, m2c, v2)
+    m2c = m1.evolve_children_and_mark_updated({"a": EntryID()}, empty_filter)
+    m3c = merge_manifests(my_device, empty_filter, m2c, v2)
     children = {**v2.children, **m2c.children}
     assert m3c == m2c.evolve(base=v2, children=children, updated=m3c.updated)
 
@@ -137,32 +141,32 @@ def test_merge_file_manifests():
 
     # Initial base manifest
     m1 = LocalFileManifest.from_remote(v1)
-    assert merge_manifests(my_device, m1) == m1
+    assert merge_manifests(my_device, empty_filter, m1) == m1
 
     # Local change
     m2 = evolve(m1, 1)
-    assert merge_manifests(my_device, m2) == m2
+    assert merge_manifests(my_device, empty_filter, m2) == m2
 
     # Successful upload
     v2 = m2.to_remote(author=my_device)
-    m3 = merge_manifests(my_device, m2, v2)
+    m3 = merge_manifests(my_device, empty_filter, m2, v2)
     assert m3 == LocalFileManifest.from_remote(v2)
 
     # Two local changes
     m4 = evolve(m3, 2)
-    assert merge_manifests(my_device, m4) == m4
+    assert merge_manifests(my_device, empty_filter, m4) == m4
     m5 = evolve(m4, 3)
-    assert merge_manifests(my_device, m4) == m4
+    assert merge_manifests(my_device, empty_filter, m4) == m4
 
     # M4 has been successfully uploaded
     v3 = m4.to_remote(author=my_device)
-    m6 = merge_manifests(my_device, m5, v3)
+    m6 = merge_manifests(my_device, empty_filter, m5, v3)
     assert m6 == m5.evolve(base=v3)
 
     # The remote has changed
     v4 = v3.evolve(version=4, size=0, author=other_device)
     with pytest.raises(FSFileConflictError):
-        merge_manifests(my_device, m6, v4)
+        merge_manifests(my_device, empty_filter, m6, v4)
 
 
 @pytest.mark.trio

--- a/tests/core/fs/workspacefs/test_workspace_fs.py
+++ b/tests/core/fs/workspacefs/test_workspace_fs.py
@@ -380,6 +380,8 @@ async def test_dump(alice_workspace):
                 "need_sync": False,
                 "parent": ANY,
                 "updated": ANY,
+                "confined_entries": frozenset(),
+                "filtered_entries": frozenset(),
             }
         },
         "created": ANY,
@@ -387,6 +389,8 @@ async def test_dump(alice_workspace):
         "is_placeholder": False,
         "need_sync": False,
         "updated": ANY,
+        "confined_entries": frozenset(),
+        "filtered_entries": frozenset(),
     }
 
 

--- a/tests/core/fs/workspacefs/test_workspace_fs.py
+++ b/tests/core/fs/workspacefs/test_workspace_fs.py
@@ -29,6 +29,7 @@ async def test_path_info(alice_workspace):
         "need_sync": False,
         "type": "folder",
         "updated": ANY,
+        "confined": False,
     }
 
     info = await alice_workspace.path_info("/foo")
@@ -41,6 +42,7 @@ async def test_path_info(alice_workspace):
         "need_sync": False,
         "type": "folder",
         "updated": ANY,
+        "confined": False,
     }
 
     info = await alice_workspace.path_info("/foo/bar")
@@ -53,6 +55,7 @@ async def test_path_info(alice_workspace):
         "need_sync": False,
         "type": "file",
         "updated": ANY,
+        "confined": False,
     }
 
 
@@ -396,7 +399,7 @@ async def test_dump(alice_workspace):
 
 @pytest.mark.trio
 async def test_path_info_remote_loader_exceptions(monkeypatch, alice_workspace, alice):
-    manifest = await alice_workspace.transactions._get_manifest_from_path(FsPath("/foo/bar"))
+    manifest, _ = await alice_workspace.transactions._get_manifest_from_path(FsPath("/foo/bar"))
     async with alice_workspace.local_storage.lock_entry_id(manifest.id):
         await alice_workspace.local_storage.clear_manifest(manifest.id)
 

--- a/tests/core/fs/workspacefs_timestamped/test_entry_transactions_timestamped.py
+++ b/tests/core/fs/workspacefs_timestamped/test_entry_transactions_timestamped.py
@@ -19,6 +19,7 @@ async def test_root_entry_info(alice_workspace_t2, alice_workspace_t4):
         "created": Pendulum(1999, 12, 31),
         "updated": Pendulum(1999, 12, 31),
         "children": ["foo"],
+        "confined": False,
     }
 
     stat4 = await alice_workspace_t4.transactions.entry_info(FsPath("/"))
@@ -31,6 +32,7 @@ async def test_root_entry_info(alice_workspace_t2, alice_workspace_t4):
         "created": Pendulum(1999, 12, 31),
         "updated": Pendulum(2000, 1, 4),
         "children": ["files", "foo"],
+        "confined": False,
     }
 
 

--- a/tests/core/fs/workspacefs_timestamped/test_workspacefs_timestamped.py
+++ b/tests/core/fs/workspacefs_timestamped/test_workspacefs_timestamped.py
@@ -22,6 +22,7 @@ async def test_path_info(alice_workspace, timestamp_0, alice_workspace_t1, alice
         "need_sync": False,
         "type": "folder",
         "updated": ANY,
+        "confined": False,
     }
 
     info = await alice_workspace_t1.path_info("/foo")
@@ -34,6 +35,7 @@ async def test_path_info(alice_workspace, timestamp_0, alice_workspace_t1, alice
         "need_sync": False,
         "type": "folder",
         "updated": ANY,
+        "confined": False,
     }
 
     with pytest.raises(FileNotFoundError):
@@ -49,6 +51,7 @@ async def test_path_info(alice_workspace, timestamp_0, alice_workspace_t1, alice
         "need_sync": False,
         "type": "folder",
         "updated": ANY,
+        "confined": False,
     }
 
     info = await alice_workspace_t2.path_info("/foo/bar")
@@ -61,6 +64,7 @@ async def test_path_info(alice_workspace, timestamp_0, alice_workspace_t1, alice
         "need_sync": False,
         "type": "file",
         "updated": ANY,
+        "confined": False,
     }
 
     with pytest.raises(FileNotFoundError):

--- a/tests/core/gui/conftest.py
+++ b/tests/core/gui/conftest.py
@@ -281,6 +281,7 @@ def gui_factory(
             gui_last_version=parsec_version,
             mountpoint_enabled=True,
             gui_language="en",
+            gui_show_confined=False,
         )
         event_bus = event_bus or EventBus()
         # Language config rely on global var, must reset it for each test !

--- a/tests/core/gui/test_file_table.py
+++ b/tests/core/gui/test_file_table.py
@@ -59,7 +59,7 @@ def test_file_table_sort(qtbot, core_config):
     w = FileTable(parent=None)
     qtbot.addWidget(w)
     w.add_parent_workspace()
-    w.add_folder("Dir1", uuid.uuid4(), True)
+    w.add_folder("Dir1", uuid.uuid4(), True, False)
     w.add_file(
         "File1.txt",
         uuid.uuid4(),
@@ -67,6 +67,7 @@ def test_file_table_sort(qtbot, core_config):
         pendulum.datetime(2000, 1, 15),
         pendulum.datetime(2000, 1, 20),
         True,
+        False,
     )
     w.add_file(
         "AnotherFile.txt",
@@ -75,6 +76,7 @@ def test_file_table_sort(qtbot, core_config):
         pendulum.datetime(2000, 1, 10),
         pendulum.datetime(2000, 1, 25),
         True,
+        False,
     )
     assert w.rowCount() == 4
     assert w.item(0, 1).text() == "Workspaces list"

--- a/tests/core/test_sync_monitor.py
+++ b/tests/core/test_sync_monitor.py
@@ -1,5 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
+import re
 import trio
 import pytest
 from unittest.mock import ANY
@@ -254,6 +255,10 @@ async def test_sync_confined_children_after_rename(
     # Create a workspace
     wid = await alice_core.user_fs.workspace_create("w")
     alice_w = alice_core.user_fs.get_workspace(wid)
+
+    # Set a filter
+    pattern = re.compile(r".*\.tmp$")
+    await alice_w.set_and_apply_pattern_filter(pattern)
 
     # Create a confined path
     await alice_w.mkdir("/test.tmp/a/b/c", parents=True)

--- a/tests/core/test_sync_monitor.py
+++ b/tests/core/test_sync_monitor.py
@@ -305,3 +305,20 @@ async def test_sync_confined_children_after_rename(
         info = await alice_w.path_info(path)
         assert not info["need_sync"]
         assert not info["confined"]
+
+    # Rename to a confined path
+    await alice_w.rename("/test2", "/test3.tmp")
+
+    # Wait for sync monitor to be idle
+    await alice_core.wait_idle_monitors()
+
+    # Make sure the root is synced
+    info = await alice_w.path_info("/")
+    assert not info["need_sync"]
+    assert not info["confined"]
+
+    # Make sure the rest of the path is confined
+    for path in ["/test3.tmp", "/test3.tmp/a", "/test3.tmp/a/b", "/test3.tmp/a/b/c"]:
+        info = await alice_w.path_info(path)
+        assert not info["need_sync"]
+        assert info["confined"]

--- a/tests/scripts/run_testenv.py
+++ b/tests/scripts/run_testenv.py
@@ -98,6 +98,7 @@ async def generate_gui_config():
         "gui_check_version_at_startup": False,
         "gui_tray_enabled": False,
         "gui_last_version": PARSEC_VERSION,
+        "gui_show_confined": True,
     }
     await config_file.write_text(json.dumps(config, indent=4))
 


### PR DESCRIPTION
Fix #990

Add support for confined (i.e temporary) files and directories.
In this context, confined means files that are not meant to be synchronized with other clients