### PR TITLE
[GUI] Display full traceback in error widget

### DIFF
--- a/parsec/core/gui/custom_dialogs.py
+++ b/parsec/core/gui/custom_dialogs.py
@@ -227,7 +227,7 @@ class ErrorWidget(QWidget, Ui_ErrorWidget):
         else:
             import traceback
 
-            stack = traceback.format_tb(exception.__traceback__)
+            stack = traceback.format_exception(None, exception, None)
             if not stack:
                 self.button_details.hide()
             else:


### PR DESCRIPTION
This allows to display the traceback of the exceptions in the `__cause__` chain