### PR TITLE
Run parsec without elevated priviledges at the end of the windows installation

### DIFF
--- a/newsfragments/1303.misc.rst
+++ b/newsfragments/1303.misc.rst
@@ -1,0 +1,1 @@
+Run Parsec with regular user priviledges when the "Run Parsec" checkbox is ticked at the end of the windows installation.

--- a/packaging/win32/installer.nsi
+++ b/packaging/win32/installer.nsi
@@ -65,8 +65,10 @@ SetCompressorDictSize 64
 !define MUI_FINISHPAGE_SHOWREADME_NOTCHECKED
 !define MUI_FINISHPAGE_SHOWREADME_TEXT "Create Desktop Shortcut"
 !define MUI_FINISHPAGE_SHOWREADME_FUNCTION CreateDesktopShortcut
-# Run Parsec after install
-!define MUI_FINISHPAGE_RUN "$INSTDIR\parsec.exe"
+# Run Parsec after install, using explorer.exe to un-elevate priviledges
+# More information: https://stackoverflow.com/a/15041823/2846140
+!define MUI_FINISHPAGE_RUN "$WINDIR\explorer.exe"
+!define MUI_FINISHPAGE_RUN_PARAMETERS "$INSTDIR\parsec.exe"
 !define MUI_FINISHPAGE_RUN_TEXT "Run Parsec"
 !define MUI_FINISHPAGE_RUN_NOTCHECKED
 

--- a/parsec/core/mountpoint/winfsp_operations.py
+++ b/parsec/core/mountpoint/winfsp_operations.py
@@ -358,13 +358,13 @@ class WinFSPOperations(BaseFileSystemOperations):
 
     @handle_error
     def cleanup(self, file_context, file_name, flags) -> None:
-        file_name = _winpath_to_parsec(file_name)
-
         # Cleanup operation is causal but close is not, so it's important
         # to delete file and folder here in order to make sure the file/folder
         # is actually deleted by the time the API call returns.
         FspCleanupDelete = 0x1
         if flags & FspCleanupDelete:
+            # The file name is only provided for a delete operation, it is `None` otherwise
+            file_name = _winpath_to_parsec(file_name)
             if isinstance(file_context, OpenedFile):
                 self.fs_access.file_delete(file_name)
             else:

--- a/tests/core/gui/test_file_history.py
+++ b/tests/core/gui/test_file_history.py
@@ -70,6 +70,7 @@ async def create_directories(logged_gui, aqtbot, monkeypatch, dir_names):
 
 @pytest.mark.gui
 @pytest.mark.trio
+@pytest.mark.flaky(reruns=1)
 @customize_fixtures(logged_gui_as_admin=True)
 async def test_file_history(
     aqtbot,


### PR DESCRIPTION
Fix #1301.

Also fix the following trace:
```
Traceback (most recent call last):
  File "d:\projects\parsec-cloud\parsec\core\mountpoint\winfsp_operations.py", line 41, in translate_error
    yield
  File "d:\projects\parsec-cloud\parsec\core\mountpoint\winfsp_operations.py", line 136, in wrapper
    return func.__get__(self)(arg, *args, **kwargs)
  File "d:\projects\parsec-cloud\parsec\core\mountpoint\winfsp_operations.py", line 361, in cleanup
    file_name = _winpath_to_parsec(file_name)
  File "d:\projects\parsec-cloud\parsec\core\mountpoint\winfsp_operations.py", line 31, in _winpath_to_parsec
    return FsPath(unwinify_entry_name(path.replace("\\", "/")))
AttributeError: 'NoneType' object has no attribute 'replace'
[2m2020-07-24 10:23:03[0m [[31m[1mexception[0m] [1mUnhandled exception in winfsp mountpoint[0m [[34m[1mparsec.core.mountpoint.winfsp_operations[0m] [36moperation[0m=[35mcleanup[0m [36mpath[0m=[35mFsPath('/icon.ico')[0m
Traceback (most recent call last):
  File "d:\projects\parsec-cloud\parsec\core\mountpoint\winfsp_operations.py", line 41, in translate_error
    yield
  File "d:\projects\parsec-cloud\parsec\core\mountpoint\winfsp_operations.py", line 136, in wrapper
    return func.__get__(self)(arg, *args, **kwargs)
  File "d:\projects\parsec-cloud\parsec\core\mountpoint\winfsp_operations.py", line 361, in cleanup
    file_name = _winpath_to_parsec(file_name)
  File "d:\projects\parsec-cloud\parsec\core\mountpoint\winfsp_operations.py", line 31, in _winpath_to_parsec
    return FsPath(unwinify_entry_name(path.replace("\\", "/")))
AttributeError: 'NoneType' object has no attribute 'replace'
```

This is due to the `file_name` argument in winfsp `cleanup` operation to be optional:
> FileName - The name of the file or directory to cleanup. Sent only when a Delete is requested.