### PR TITLE
Add Enter key on top of Return in GUI

### DIFF
--- a/parsec/core/gui/custom_dialogs.py
+++ b/parsec/core/gui/custom_dialogs.py
@@ -139,7 +139,7 @@ class TextInputWidget(QWidget, Ui_InputWidget):
         return self.line_edit_text.text()
 
     def keyPressEvent(self, event):
-        if event.key() == Qt.Key_Return:
+        if event.key() in (Qt.Key_Return, Qt.Key_Enter):
             self._on_button_clicked()
         event.accept()
 

--- a/parsec/core/gui/login_widget.py
+++ b/parsec/core/gui/login_widget.py
@@ -36,7 +36,7 @@ class LoginWidget(QWidget, Ui_LoginWidget):
         self.button_login.setText(_("ACTION_LOG_IN"))
 
     def keyPressEvent(self, event):
-        if event.key() == Qt.Key_Return and self.button_login.isEnabled():
+        if event.key() in (Qt.Key_Return, Qt.Key_Enter) and self.button_login.isEnabled():
             self.try_login()
         event.accept()
 


### PR DESCRIPTION
The numpad `Enter` key did nothing in the gui, this PR fixes it.