### PR TITLE
Expired organization 

### DIFF
--- a/newsfragments/1206.feature.rst
+++ b/newsfragments/1206.feature.rst
@@ -1,0 +1,1 @@
+Notify user when the current in used organization has expired

--- a/parsec/backend/app.py
+++ b/parsec/backend/app.py
@@ -130,10 +130,6 @@ class BackendApp:
                     self.event_bus.send(
                         BackendEvent.ORGANIZATION_EXPIRED, organization_id=organization_id
                     )
-                    selected_logger.debug(
-                        f"Oranization {organization_id} has expired, diconnect clients",
-                        **error_infos,
-                    )
                 selected_logger.info("Connection dropped: bad handshake", **error_infos)
                 return
 

--- a/parsec/backend/app.py
+++ b/parsec/backend/app.py
@@ -125,9 +125,10 @@ class BackendApp:
             client_ctx, error_infos = await do_handshake(self, transport)
             if not client_ctx:
                 # Invalid handshake
-                if error_infos.get("reason", "") == "Expired organization":
+                # TODO Fragile test based on reason, make it more robust
+                if error_infos and error_infos.get("reason", "") == "Expired organization":
                     organization_id = error_infos["organization_id"]
-                    self.event_bus.send(
+                    await self.events.send(
                         BackendEvent.ORGANIZATION_EXPIRED, organization_id=organization_id
                     )
                 selected_logger.info("Connection dropped: bad handshake", **error_infos)

--- a/parsec/backend/backend_events.py
+++ b/parsec/backend/backend_events.py
@@ -16,6 +16,7 @@ class BackendEvent(Enum):
     USER_CREATED = "user.created"
     USER_REVOKED = "user.revoked"
     USER_INVITATION_CANCELLED = "user.invitation.cancelled"
+    ORGANIZATION_EXPIRED = "organization.expired"
     # api Event mirror
     PINGED = "pinged"
     MESSAGE_RECEIVED = "message.received"

--- a/parsec/backend/events.py
+++ b/parsec/backend/events.py
@@ -7,11 +7,13 @@ from parsec.backend.utils import catch_protocol_errors, run_with_breathing_trans
 from parsec.backend.realm import BaseRealmComponent
 from parsec.backend.backend_events import BackendEvent
 from functools import partial
+from typing import Callable
 
 
 class EventsComponent:
-    def __init__(self, realm_component: BaseRealmComponent):
+    def __init__(self, realm_component: BaseRealmComponent, send_event: Callable):
         self._realm_component = realm_component
+        self.send = send_event
 
     @api("events_subscribe")
     @catch_protocol_errors

--- a/parsec/backend/handshake.py
+++ b/parsec/backend/handshake.py
@@ -111,7 +111,7 @@ async def _do_process_authenticated_answer(
         result_req = handshake.build_rvk_mismatch_result_req()
         return None, result_req, _make_error_infos("Bad root verify key")
 
-    if organization.expiration_date is not None and organization.expiration_date <= pendulum_now():
+    if organization.is_expired:
         result_req = handshake.build_organization_expired_result_req()
         return None, result_req, _make_error_infos("Expired organization")
 
@@ -156,7 +156,7 @@ async def _process_invited_answer(
         result_req = handshake.build_bad_identity_result_req()
         return None, result_req, _make_error_infos("Bad organization")
 
-    if organization.expiration_date is not None and organization.expiration_date <= pendulum_now():
+    if organization.is_expired:
         result_req = handshake.build_organization_expired_result_req()
         return None, result_req, _make_error_infos("Expired organization")
 
@@ -234,7 +234,7 @@ async def _apiv1_process_anonymous_answer(
             result_req = handshake.build_bad_identity_result_req()
             return None, result_req, _make_error_infos("Bad organization")
 
-    if organization.expiration_date is not None and organization.expiration_date <= pendulum_now():
+    if organization.is_expired:
         result_req = handshake.build_organization_expired_result_req()
         return None, result_req, _make_error_infos("Expired organization")
 

--- a/parsec/backend/memory/factory.py
+++ b/parsec/backend/memory/factory.py
@@ -34,7 +34,7 @@ async def components_factory(config: BackendConfig, event_bus: EventBus):
 
     webhooks = WebhooksComponent(config)
     http = HTTPComponent(config)
-    organization = MemoryOrganizationComponent(webhooks)
+    organization = MemoryOrganizationComponent(event_bus, webhooks)
     user = MemoryUserComponent(_send_event, event_bus)
     invite = MemoryInviteComponent(_send_event, event_bus, config)
     message = MemoryMessageComponent(_send_event)

--- a/parsec/backend/memory/factory.py
+++ b/parsec/backend/memory/factory.py
@@ -34,7 +34,7 @@ async def components_factory(config: BackendConfig, event_bus: EventBus):
 
     webhooks = WebhooksComponent(config)
     http = HTTPComponent(config)
-    organization = MemoryOrganizationComponent(event_bus, webhooks)
+    organization = MemoryOrganizationComponent(_send_event, webhooks)
     user = MemoryUserComponent(_send_event, event_bus)
     invite = MemoryInviteComponent(_send_event, event_bus, config)
     message = MemoryMessageComponent(_send_event)
@@ -43,7 +43,7 @@ async def components_factory(config: BackendConfig, event_bus: EventBus):
     ping = MemoryPingComponent(_send_event)
     block = MemoryBlockComponent()
     blockstore = blockstore_factory(config.blockstore_config)
-    events = EventsComponent(realm)
+    events = EventsComponent(realm, send_event=_send_event)
 
     components = {
         "events": events,

--- a/parsec/backend/memory/organization.py
+++ b/parsec/backend/memory/organization.py
@@ -23,13 +23,13 @@ from parsec.backend.events import BackendEvent
 
 
 class MemoryOrganizationComponent(BaseOrganizationComponent):
-    def __init__(self, event_bus, *args, **kwargs):
+    def __init__(self, send_event, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._user_component = None
         self._vlob_component = None
         self._block_component = None
         self._organizations = {}
-        self.event_bus = event_bus
+        self._send_event = send_event
 
     def register_components(
         self,
@@ -110,6 +110,6 @@ class MemoryOrganizationComponent(BaseOrganizationComponent):
                 expiration_date=expiration_date
             )
             if self._organizations[id].is_expired:
-                self.event_bus.send(BackendEvent.ORGANIZATION_EXPIRED, organization_id=id)
+                await self._send_event(BackendEvent.ORGANIZATION_EXPIRED, organization_id=id)
         except KeyError:
             raise OrganizationNotFoundError()

--- a/parsec/backend/memory/organization.py
+++ b/parsec/backend/memory/organization.py
@@ -19,15 +19,17 @@ from parsec.backend.organization import (
 )
 from parsec.backend.memory.vlob import MemoryVlobComponent
 from parsec.backend.memory.block import MemoryBlockComponent
+from parsec.backend.events import BackendEvent
 
 
 class MemoryOrganizationComponent(BaseOrganizationComponent):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, event_bus, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._user_component = None
         self._vlob_component = None
         self._block_component = None
         self._organizations = {}
+        self.event_bus = event_bus
 
     def register_components(
         self,
@@ -107,5 +109,7 @@ class MemoryOrganizationComponent(BaseOrganizationComponent):
             self._organizations[id] = self._organizations[id].evolve(
                 expiration_date=expiration_date
             )
+            if self._organizations[id].is_expired:
+                self.event_bus.send(BackendEvent.ORGANIZATION_EXPIRED, organization_id=id)
         except KeyError:
             raise OrganizationNotFoundError()

--- a/parsec/backend/organization.py
+++ b/parsec/backend/organization.py
@@ -62,8 +62,9 @@ class Organization:
     def is_bootstrapped(self):
         return self.root_verify_key is not None
 
+    @property
     def is_expired(self):
-        return self.expiration_date < Pendulum.now()
+        return self.expiration_date is not None and self.expiration_date < Pendulum.now()
 
     def evolve(self, **kwargs):
         return attr.evolve(self, **kwargs)

--- a/parsec/backend/organization.py
+++ b/parsec/backend/organization.py
@@ -64,7 +64,7 @@ class Organization:
 
     @property
     def is_expired(self):
-        return self.expiration_date is not None and self.expiration_date < Pendulum.now()
+        return self.expiration_date is not None and self.expiration_date <= Pendulum.now()
 
     def evolve(self, **kwargs):
         return attr.evolve(self, **kwargs)

--- a/parsec/backend/postgresql/factory.py
+++ b/parsec/backend/postgresql/factory.py
@@ -33,7 +33,7 @@ async def components_factory(config: BackendConfig, event_bus: EventBus):
 
     webhooks = WebhooksComponent(config)
     http = HTTPComponent(config)
-    organization = PGOrganizationComponent(dbh, webhooks)
+    organization = PGOrganizationComponent(dbh, event_bus, webhooks)
     user = PGUserComponent(dbh, event_bus)
     invite = PGInviteComponent(dbh, event_bus, config)
     message = PGMessageComponent(dbh)

--- a/parsec/backend/postgresql/factory.py
+++ b/parsec/backend/postgresql/factory.py
@@ -3,6 +3,7 @@
 import trio
 import triopg
 from async_generator import asynccontextmanager
+from typing import Optional
 
 from parsec.event_bus import EventBus
 from parsec.backend.config import BackendConfig
@@ -34,7 +35,7 @@ async def components_factory(config: BackendConfig, event_bus: EventBus):
     )
 
     async def _send_event(
-        event: BackendEvent, conn: triopg._triopg.TrioConnectionProxy = None, **kwargs
+        event: BackendEvent, conn: Optional[triopg._triopg.TrioConnectionProxy] = None, **kwargs
     ):
         if conn is None:
             async with dbh.pool.acquire() as conn:

--- a/parsec/core/gui/central_widget.py
+++ b/parsec/core/gui/central_widget.py
@@ -199,6 +199,8 @@ class CentralWidget(QWidget, Ui_CentralWidget):
                 self.new_notification.emit(*notif)
             elif isinstance(cause, HandshakeOrganizationExpired):
                 tooltip = _("TEXT_BACKEND_STATE_ORGANIZATION_EXPIRED")
+                notif = ("EXPIRED", tooltip)
+                self.new_notification.emit(*notif)
             else:
                 tooltip = _("TEXT_BACKEND_STATE_UNKNOWN")
             text = _("TEXT_BACKEND_STATE_DISCONNECTED")
@@ -225,7 +227,7 @@ class CentralWidget(QWidget, Ui_CentralWidget):
             )
 
     def on_new_notification(self, notif_type, msg):
-        if notif_type == "REVOKED":
+        if notif_type in ["REVOKED", "EXPIRED"]:
             show_error(self, msg)
 
     def show_mount_widget(self):

--- a/tests/backend/test_apiv1_organization_status.py
+++ b/tests/backend/test_apiv1_organization_status.py
@@ -9,6 +9,7 @@ from parsec.api.protocol import (
     apiv1_organization_update_serializer,
 )
 from tests.backend.test_apiv1_organization import organization_create
+from parsec.backend.backend_events import BackendEvent
 
 
 async def organization_status(sock, organization_id):
@@ -57,7 +58,7 @@ async def test_organization_status_not_bootstrapped(
 
 @pytest.mark.trio
 async def test_organization_update_expiration_date(
-    coolorg, organization_factory, administration_backend_sock
+    coolorg, organization_factory, administration_backend_sock, backend
 ):
     rep = await organization_status(administration_backend_sock, coolorg.organization_id)
     assert rep == {"status": "ok", "is_bootstrapped": True, "expiration_date": None}
@@ -73,6 +74,21 @@ async def test_organization_update_expiration_date(
     assert rep == {"status": "ok"}
     rep = await organization_status(administration_backend_sock, coolorg.organization_id)
     assert rep == {"status": "ok", "is_bootstrapped": True, "expiration_date": None}
+    # Expired organization
+    with backend.event_bus.listen() as spy:
+        rep = await organization_update(
+            administration_backend_sock,
+            coolorg.organization_id,
+            expiration_date=Pendulum(1999, 12, 31),
+        )
+        assert rep == {"status": "ok"}
+        rep = await organization_status(administration_backend_sock, coolorg.organization_id)
+        assert rep == {
+            "status": "ok",
+            "is_bootstrapped": True,
+            "expiration_date": Pendulum(1999, 12, 31),
+        }
+        await spy.wait_with_timeout(BackendEvent.ORGANIZATION_EXPIRED)
 
 
 @pytest.mark.trio

--- a/tests/backend/test_apiv1_organization_status.py
+++ b/tests/backend/test_apiv1_organization_status.py
@@ -82,13 +82,14 @@ async def test_organization_update_expiration_date(
             expiration_date=Pendulum(1999, 12, 31),
         )
         assert rep == {"status": "ok"}
+        await spy.wait_with_timeout(BackendEvent.ORGANIZATION_EXPIRED)
+
         rep = await organization_status(administration_backend_sock, coolorg.organization_id)
         assert rep == {
             "status": "ok",
             "is_bootstrapped": True,
             "expiration_date": Pendulum(1999, 12, 31),
         }
-        await spy.wait_with_timeout(BackendEvent.ORGANIZATION_EXPIRED)
 
 
 @pytest.mark.trio

--- a/tests/backend/test_handshake.py
+++ b/tests/backend/test_handshake.py
@@ -242,7 +242,7 @@ async def test_handshake_expired_organization(backend, server_factory, expiredor
             result_req = await transport.recv()
             with pytest.raises(HandshakeOrganizationExpired):
                 ch.process_result_req(result_req)
-    spy.assert_event_occured(BackendEvent.ORGANIZATION_EXPIRED)
+            await spy.wait_with_timeout(BackendEvent.ORGANIZATION_EXPIRED)
 
 
 @pytest.mark.trio

--- a/tests/backend/test_handshake.py
+++ b/tests/backend/test_handshake.py
@@ -14,6 +14,7 @@ from parsec.api.protocol import (
     HandshakeBadIdentity,
     HandshakeOrganizationExpired,
 )
+from parsec.backend.backend_events import BackendEvent
 
 
 @pytest.mark.trio
@@ -229,17 +230,19 @@ async def test_handshake_expired_organization(backend, server_factory, expiredor
             root_verify_key=expiredorg.root_verify_key,
         )
 
-    async with server_factory(backend.handle_client) as server:
-        stream = server.connection_factory()
-        transport = await Transport.init_for_client(stream, server.addr.hostname)
+    with backend.event_bus.listen() as spy:
+        async with server_factory(backend.handle_client) as server:
+            stream = server.connection_factory()
+            transport = await Transport.init_for_client(stream, server.addr.hostname)
 
-        challenge_req = await transport.recv()
-        answer_req = ch.process_challenge_req(challenge_req)
+            challenge_req = await transport.recv()
+            answer_req = ch.process_challenge_req(challenge_req)
 
-        await transport.send(answer_req)
-        result_req = await transport.recv()
-        with pytest.raises(HandshakeOrganizationExpired):
-            ch.process_result_req(result_req)
+            await transport.send(answer_req)
+            result_req = await transport.recv()
+            with pytest.raises(HandshakeOrganizationExpired):
+                ch.process_result_req(result_req)
+    spy.assert_event_occured(BackendEvent.ORGANIZATION_EXPIRED)
 
 
 @pytest.mark.trio

--- a/tests/core/backend_connection/test_apiv1_anonymous_cmds.py
+++ b/tests/core/backend_connection/test_apiv1_anonymous_cmds.py
@@ -52,7 +52,7 @@ async def test_handshake_organization_expired(running_backend, expiredorg):
         with pytest.raises(BackendConnectionRefused) as exc:
             async with apiv1_backend_anonymous_cmds_factory(expiredorg.addr) as cmds:
                 await cmds.ping()
-    spy.assert_event_occured(BackendEvent.ORGANIZATION_EXPIRED)
+        await spy.wait_with_timeout(BackendEvent.ORGANIZATION_EXPIRED)
     assert str(exc.value) == "Trial organization has expired"
 
 

--- a/tests/core/backend_connection/test_apiv1_anonymous_cmds.py
+++ b/tests/core/backend_connection/test_apiv1_anonymous_cmds.py
@@ -11,6 +11,7 @@ from parsec.core.backend_connection import (
     apiv1_backend_anonymous_cmds_factory,
 )
 
+from parsec.backend.backend_events import BackendEvent
 from tests.core.backend_connection.common import ALL_CMDS
 
 
@@ -47,9 +48,11 @@ async def test_ping(running_backend, coolorg):
 
 @pytest.mark.trio
 async def test_handshake_organization_expired(running_backend, expiredorg):
-    with pytest.raises(BackendConnectionRefused) as exc:
-        async with apiv1_backend_anonymous_cmds_factory(expiredorg.addr) as cmds:
-            await cmds.ping()
+    with running_backend.backend.event_bus.listen() as spy:
+        with pytest.raises(BackendConnectionRefused) as exc:
+            async with apiv1_backend_anonymous_cmds_factory(expiredorg.addr) as cmds:
+                await cmds.ping()
+    spy.assert_event_occured(BackendEvent.ORGANIZATION_EXPIRED)
     assert str(exc.value) == "Trial organization has expired"
 
 

--- a/tests/core/backend_connection/test_apiv1_authenticated_cmds.py
+++ b/tests/core/backend_connection/test_apiv1_authenticated_cmds.py
@@ -131,7 +131,7 @@ async def test_organization_expired(running_backend, alice, expiredorg):
                 expiredorg.addr, alice.device_id, alice.signing_key
             ) as cmds:
                 await cmds.ping()
-    spy.assert_event_occured(BackendEvent.ORGANIZATION_EXPIRED)
+        await spy.wait_with_timeout(BackendEvent.ORGANIZATION_EXPIRED)
     assert str(exc.value) == "Trial organization has expired"
 
 

--- a/tests/core/backend_connection/test_apiv1_authenticated_cmds.py
+++ b/tests/core/backend_connection/test_apiv1_authenticated_cmds.py
@@ -19,6 +19,7 @@ from parsec.core.backend_connection import (
     apiv1_backend_authenticated_cmds_factory,
 )
 
+from parsec.backend.backend_events import BackendEvent
 from tests.core.backend_connection.common import ALL_CMDS
 
 
@@ -123,11 +124,14 @@ async def test_handshake_revoked_device(running_backend, alice, bob):
 
 @pytest.mark.trio
 async def test_organization_expired(running_backend, alice, expiredorg):
-    with pytest.raises(BackendConnectionRefused) as exc:
-        async with apiv1_backend_authenticated_cmds_factory(
-            expiredorg.addr, alice.device_id, alice.signing_key
-        ) as cmds:
-            await cmds.ping()
+
+    with running_backend.backend.event_bus.listen() as spy:
+        with pytest.raises(BackendConnectionRefused) as exc:
+            async with apiv1_backend_authenticated_cmds_factory(
+                expiredorg.addr, alice.device_id, alice.signing_key
+            ) as cmds:
+                await cmds.ping()
+    spy.assert_event_occured(BackendEvent.ORGANIZATION_EXPIRED)
     assert str(exc.value) == "Trial organization has expired"
 
 

--- a/tests/core/backend_connection/test_authenticated_cmds.py
+++ b/tests/core/backend_connection/test_authenticated_cmds.py
@@ -126,7 +126,7 @@ async def test_organization_expired(running_backend, alice, expiredorg):
                 expiredorg.addr, alice.device_id, alice.signing_key
             ) as cmds:
                 await cmds.ping()
-    spy.assert_event_occured(BackendEvent.ORGANIZATION_EXPIRED)
+        await spy.wait_with_timeout(BackendEvent.ORGANIZATION_EXPIRED)
     assert str(exc.value) == "Trial organization has expired"
 
 

--- a/tests/core/backend_connection/test_invited_cmds.py
+++ b/tests/core/backend_connection/test_invited_cmds.py
@@ -13,7 +13,7 @@ from parsec.core.backend_connection import (
     BackendInvitationAlreadyUsed,
     backend_invited_cmds_factory,
 )
-
+from parsec.backend.backend_events import BackendEvent
 from tests.core.backend_connection.common import ALL_CMDS
 
 
@@ -73,9 +73,12 @@ async def test_handshake_organization_expired(running_backend, expiredorg, expir
         token=invitation.token,
     )
 
-    with pytest.raises(BackendConnectionRefused) as exc:
-        async with backend_invited_cmds_factory(invitation_addr) as cmds:
-            await cmds.ping()
+    with running_backend.backend.event_bus.listen() as spy:
+        with pytest.raises(BackendConnectionRefused) as exc:
+            async with backend_invited_cmds_factory(invitation_addr) as cmds:
+                await cmds.ping()
+
+    spy.assert_event_occured(BackendEvent.ORGANIZATION_EXPIRED)
     assert str(exc.value) == "Trial organization has expired"
 
 

--- a/tests/core/backend_connection/test_invited_cmds.py
+++ b/tests/core/backend_connection/test_invited_cmds.py
@@ -77,8 +77,7 @@ async def test_handshake_organization_expired(running_backend, expiredorg, expir
         with pytest.raises(BackendConnectionRefused) as exc:
             async with backend_invited_cmds_factory(invitation_addr) as cmds:
                 await cmds.ping()
-
-    spy.assert_event_occured(BackendEvent.ORGANIZATION_EXPIRED)
+        await spy.wait_with_timeout(BackendEvent.ORGANIZATION_EXPIRED)
     assert str(exc.value) == "Trial organization has expired"
 
 

--- a/tests/core/gui/test_expired_organization.py
+++ b/tests/core/gui/test_expired_organization.py
@@ -97,7 +97,7 @@ async def test_expired_notification_from_update(
         await running_backend.backend.organization.set_expiration_date(
             alice.organization_id, pendulum.datetime(1989, 1, 1)
         )
-    spy.assert_event_occured(BackendEvent.ORGANIZATION_EXPIRED)
+        await spy.wait_with_timeout(BackendEvent.ORGANIZATION_EXPIRED)
 
     def _expired_notified():
         assert autoclose_dialog.dialogs == [("Error", "The organization has expired")]

--- a/tests/core/gui/test_expired_organization.py
+++ b/tests/core/gui/test_expired_organization.py
@@ -1,0 +1,83 @@
+# Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
+
+import pytest
+from PyQt5 import QtCore
+
+from parsec.core.backend_connection import (
+    BackendConnectionRefused,
+    backend_authenticated_cmds_factory,
+)
+from parsec.core.local_device import save_device_with_password
+from tests.common import freeze_time
+
+
+@pytest.mark.gui
+@pytest.mark.trio
+async def test_expired_notification_logging(
+    aqtbot, running_backend, backend, autoclose_dialog, expiredorgalice, gui_factory, core_config
+):
+
+    # Log has alice on an expired organization
+    save_device_with_password(core_config.config_dir, expiredorgalice, "P@ssw0rd")
+
+    gui = await gui_factory()
+    lw = gui.test_get_login_widget()
+    tabw = gui.test_get_tab()
+
+    await aqtbot.key_clicks(lw.line_edit_password, "P@ssw0rd")
+
+    async with aqtbot.wait_signals([lw.login_with_password_clicked, tabw.logged_in]):
+        await aqtbot.mouse_click(lw.button_login, QtCore.Qt.LeftButton)
+
+    central_widget = gui.test_get_central_widget()
+    assert central_widget is not None
+
+    # Assert dialog
+    def _expired_notified():
+        assert autoclose_dialog.dialogs == [("Error", "The organization has expired")]
+
+    await aqtbot.wait_until(_expired_notified)
+
+
+@pytest.mark.gui
+@pytest.mark.trio
+async def test_on_expired_notification(
+    aqtbot, running_backend, backend, autoclose_dialog, expiredorgalice, gui_factory, core_config
+):
+    save_device_with_password(core_config.config_dir, expiredorgalice, "P@ssw0rd")
+    gui = await gui_factory()
+    lw = gui.test_get_login_widget()
+    tabw = gui.test_get_tab()
+
+    # Force logging on an expired organization
+    with freeze_time("1989-12-17"):
+        await aqtbot.key_clicks(lw.line_edit_password, "P@ssw0rd")
+
+        async with aqtbot.wait_signals([lw.login_with_password_clicked, tabw.logged_in]):
+            await aqtbot.mouse_click(lw.button_login, QtCore.Qt.LeftButton)
+
+        central_widget = gui.test_get_central_widget()
+        assert central_widget is not None
+
+        # Assert logged in
+        def _notified():
+            assert autoclose_dialog.dialogs == []
+
+        await aqtbot.wait_until(_notified)
+
+    # Trigger another handshake
+    with pytest.raises(BackendConnectionRefused):
+        async with backend_authenticated_cmds_factory(
+            expiredorgalice.organization_addr,
+            expiredorgalice.device_id,
+            expiredorgalice.signing_key,
+        ) as cmds:
+            async with cmds.acquire_transport():
+                # This shall never happen, we shall have been rejected while acquiring the transport
+                assert False
+
+    # Assert dialog
+    def _expired_notified():
+        assert autoclose_dialog.dialogs == [("Error", "The organization has expired")]
+
+    await aqtbot.wait_until(_expired_notified)


### PR DESCRIPTION
#1206 

Like a user can be revoked, there is now an event to notify that a backend organization has expired.
When this event is triggered, all the current client connections on this organization id are closed.

This event can be emited:
 - When a client logging to the organization (there in the handshake we check if the organization is expired).
 - When the organization expiration date is set.

