### PR TITLE
Add support for confined and filtered (temporary) files and directories

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,7 @@ recursive-include parsec/backend/templates *
 recursive-include parsec/backend/static/ *
 recursive-include tests *.py *.bat *.sh *.md
 recursive-include docs *.rst conf.py Makefile make.bat
-recursive-include parsec/core/resources *.ico
+recursive-include parsec/core/resources *.ico *.ignore
 recursive-include parsec/core/gui/forms *.ui
 recursive-include parsec/core/gui/tr *.po *.ts
 recursive-include parsec/core/gui/rc *.css *.html *.mo *.otf *.png *.qrc *.svg *.ttf

--- a/newsfragments/990.feature.rst
+++ b/newsfragments/990.feature.rst
@@ -1,0 +1,3 @@
+Add support for confined (i.e temporary) files and directories.
+In this context, confined means files that are not meant to be
+synchronized with other clients

--- a/parsec/core/config.py
+++ b/parsec/core/config.py
@@ -54,8 +54,8 @@ class CoreConfig:
     data_base_dir: Path
     cache_base_dir: Path
     mountpoint_base_dir: Path
+    prevent_sync_pattern_path: Optional[Path] = None  # Use `default_pattern.ignore` by default
     preferred_org_creation_backend_addr: BackendAddr
-
     debug: bool = False
 
     backend_max_cooldown: int = 30
@@ -82,6 +82,7 @@ class CoreConfig:
     gui_confirmation_before_close: bool = True
     gui_workspace_color: bool = False
     gui_allow_multiple_instances: bool = False
+    gui_show_confined: bool = False
 
     ipc_socket_file: Path = None
     ipc_win32_mutex_name: str = "parsec-cloud"
@@ -95,6 +96,7 @@ def config_factory(
     data_base_dir: Path = None,
     cache_base_dir: Path = None,
     mountpoint_base_dir: Path = None,
+    prevent_sync_pattern_path: Optional[Path] = None,
     mountpoint_enabled: bool = False,
     disabled_workspaces: FrozenSet[EntryID] = frozenset(),
     backend_max_cooldown: int = 30,
@@ -112,6 +114,7 @@ def config_factory(
     gui_workspace_color: bool = False,
     gui_allow_multiple_instances: bool = False,
     preferred_org_creation_backend_addr: Optional[BackendAddr] = None,
+    gui_show_confined: bool = False,
     environ: dict = {},
     **_,
 ) -> CoreConfig:
@@ -132,6 +135,7 @@ def config_factory(
         data_base_dir=data_base_dir,
         cache_base_dir=cache_base_dir or get_default_cache_base_dir(environ),
         mountpoint_base_dir=get_default_mountpoint_base_dir(environ),
+        prevent_sync_pattern_path=prevent_sync_pattern_path,
         mountpoint_enabled=mountpoint_enabled,
         disabled_workspaces=disabled_workspaces,
         backend_max_cooldown=backend_max_cooldown,
@@ -150,6 +154,7 @@ def config_factory(
         gui_workspace_color=gui_workspace_color,
         gui_allow_multiple_instances=gui_allow_multiple_instances,
         preferred_org_creation_backend_addr=preferred_org_creation_backend_addr,
+        gui_show_confined=gui_show_confined,
         ipc_socket_file=data_base_dir / "parsec-cloud.lock",
         ipc_win32_mutex_name="parsec-cloud",
     )
@@ -193,6 +198,11 @@ def load_config(config_dir: Path, **extra_config) -> CoreConfig:
         pass
 
     try:
+        data_conf["prevent_sync_pattern_path"] = Path(data_conf["prevent_sync_pattern_path"])
+    except (KeyError, ValueError):
+        pass
+
+    try:
         data_conf["disabled_workspaces"] = frozenset(map(EntryID, data_conf["disabled_workspaces"]))
     except (KeyError, ValueError):
         pass
@@ -231,6 +241,7 @@ def save_config(config: CoreConfig):
             {
                 "data_base_dir": str(config.data_base_dir),
                 "cache_base_dir": str(config.cache_base_dir),
+                "prevent_sync_pattern": str(config.prevent_sync_pattern_path),
                 "telemetry_enabled": config.telemetry_enabled,
                 "disabled_workspaces": list(map(str, config.disabled_workspaces)),
                 "backend_max_cooldown": config.backend_max_cooldown,
@@ -245,6 +256,7 @@ def save_config(config: CoreConfig):
                 "gui_workspace_color": config.gui_workspace_color,
                 "gui_allow_multiple_instances": config.gui_allow_multiple_instances,
                 "preferred_org_creation_backend_addr": config.preferred_org_creation_backend_addr.to_url(),
+                "gui_show_confined": config.gui_show_confined,
             },
             indent=True,
         )

--- a/parsec/core/core_events.py
+++ b/parsec/core/core_events.py
@@ -18,6 +18,7 @@ class CoreEvent(Enum):
     FS_ENTRY_SYNCED = "fs.entry.synced"
     FS_ENTRY_DOWNSYNCED = "fs.entry.downsynced"
     FS_ENTRY_MINIMAL_SYNCED = "fs.entry.minimal_synced"
+    FS_ENTRY_CONFINED = "fs.entry.confined"
     FS_ENTRY_UPDATED = "fs.entry.updated"
     FS_ENTRY_FILE_CONFLICT_RESOLVED = "fs.entry.file_conflict_resolved"
     FS_ENTRY_FILE_UPDATE_CONFLICTED = "fs.entry.file_update_conflicted"

--- a/parsec/core/fs/utils.py
+++ b/parsec/core/fs/utils.py
@@ -50,7 +50,7 @@ def is_workspace_manifest(manifest: Union[BaseManifest, BaseLocalManifest]) -> b
     return isinstance(manifest, (WorkspaceManifest, LocalWorkspaceManifest))
 
 
-def is_folderish_manifest(manifest: BaseManifest) -> bool:
+def is_folderish_manifest(manifest: Union[BaseManifest, BaseLocalManifest]) -> bool:
     return isinstance(
         manifest,
         (

--- a/parsec/core/fs/workspacefs/workspacefile.py
+++ b/parsec/core/fs/workspacefs/workspacefile.py
@@ -115,17 +115,15 @@ class WorkspaceFile:
     def closed(self) -> bool:
         return self._state == FileState.CLOSED
 
-    async def file_stat(self) -> dict:
-        """Getting file stat"""
+    async def stat(self) -> dict:
+        """Getting stat dictionnary"""
         self._check_open_state()
-        stats = await self._transactions.fd_info(self.fileno(), self._path)
-        return stats
+        return await self._transactions.fd_info(self.fileno(), self._path)
 
     async def get_size(self) -> int:
-        """Getting file length from file stat"""
+        """Getting file length"""
         self._check_open_state()
-        stats = await self.file_stat()
-        return stats["size"]
+        return await self._transactions.fd_size(self.fileno(), self._path)
 
     @property
     def state(self) -> FileState:

--- a/parsec/core/gui/file_items.py
+++ b/parsec/core/gui/file_items.py
@@ -7,6 +7,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QTableWidgetItem
 from PyQt5.QtGui import QIcon, QPainter, QColor
 
+from parsec.core.gui.lang import translate as _
 from parsec.core.gui.custom_widgets import Pixmap
 
 NAME_DATA_INDEX = Qt.UserRole
@@ -40,10 +41,14 @@ class CustomTableItem(QTableWidgetItem):
 class IconTableItem(CustomTableItem):
     SYNCED_ICON = None
     UNSYNCED_ICON = None
+    CONFINED_ICON = None
 
-    def __init__(self, is_synced, pixmap, *args, **kwargs):
+    def __init__(self, is_synced, is_confined, pixmap, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.source = pixmap
+        if not IconTableItem.CONFINED_ICON:
+            IconTableItem.CONFINED_ICON = Pixmap(":/icons/images/material/block.svg")
+            IconTableItem.CONFINED_ICON.replace_color(QColor(0, 0, 0), QColor(0xBB, 0xBB, 0xBB))
         if not IconTableItem.SYNCED_ICON:
             IconTableItem.SYNCED_ICON = Pixmap(":/icons/images/material/check.svg")
             IconTableItem.SYNCED_ICON.replace_color(QColor(0, 0, 0), QColor(50, 168, 82))
@@ -51,21 +56,36 @@ class IconTableItem(CustomTableItem):
             IconTableItem.UNSYNCED_ICON = Pixmap(":/icons/images/material/cached.svg")
             IconTableItem.UNSYNCED_ICON.replace_color(QColor(0, 0, 0), QColor(219, 20, 20))
         self._is_synced = is_synced
+        self._is_confined = is_confined
         self.switch_icon()
 
     def switch_icon(self):
-        icon = self._draw_pixmap(self.source, self.isSelected(), self.is_synced)
+        icon = self._draw_pixmap(self.source, self.isSelected(), self.is_synced, self.is_confined)
         self.setIcon(QIcon(icon))
+        if self.is_confined:
+            self.setToolTip(_("TEXT_FILE_ITEM_IS_CONFINED_TOOLTIP"))
+        elif self.is_synced:
+            self.setToolTip(_("TEXT_FILE_ITEM_IS_SYNCED_TOOLTIP"))
+        else:
+            self.setToolTip(_("TEXT_FILE_ITEM_IS_NOT_SYNCED_TOOLTIP"))
 
-    def _draw_pixmap(self, source, selected, synced):
-        color = QColor(0x33, 0x33, 0x33) if selected else QColor(0x99, 0x99, 0x99)
+    def _draw_pixmap(self, source, selected, synced, confined):
+        color = QColor(0x99, 0x99, 0x99)
+        if confined:
+            color = QColor(0xDD, 0xDD, 0xDD)
+            if selected:
+                color = QColor(0xAA, 0xAA, 0xAA)
+        elif selected:
+            color = QColor(0x33, 0x33, 0x33)
         p = Pixmap(source)
         if p.isNull():
             return
         p = Pixmap(p.scaled(120, 120, Qt.KeepAspectRatio))
         p.replace_color(QColor(0, 0, 0), color)
         painter = QPainter(p)
-        if synced:
+        if confined:
+            painter.drawPixmap(p.width() - 90, 0, 100, 100, IconTableItem.CONFINED_ICON)
+        elif synced:
             painter.drawPixmap(p.width() - 90, 0, 100, 100, IconTableItem.SYNCED_ICON)
         else:
             painter.drawPixmap(p.width() - 90, 0, 100, 100, IconTableItem.UNSYNCED_ICON)
@@ -79,6 +99,15 @@ class IconTableItem(CustomTableItem):
     @is_synced.setter
     def is_synced(self, value):
         self._is_synced = value
+        self.switch_icon()
+
+    @property
+    def is_confined(self):
+        return self._is_confined
+
+    @is_confined.setter
+    def is_confined(self, value):
+        self._is_confined = value
         self.switch_icon()
 
 
@@ -291,24 +320,33 @@ class FileTableItem(IconTableItem):
         ".zip": "zip-compressed-files-extension",
     }
 
-    def __init__(self, is_synced, file_name, *args, **kwargs):
+    def __init__(self, is_synced, is_confined, file_name, *args, **kwargs):
         ext = pathlib.Path(file_name).suffix
         icon = self.EXTENSIONS.get(ext.lower(), "blank-file")
         super().__init__(
-            is_synced, f":/file_ext/images/file_formats/{icon}.svg", "", *args, **kwargs
+            is_synced,
+            is_confined,
+            f":/file_ext/images/file_formats/{icon}.svg",
+            "",
+            *args,
+            **kwargs,
         )
         self.setData(TYPE_DATA_INDEX, FileType.File)
 
 
 class FolderTableItem(IconTableItem):
-    def __init__(self, is_synced, *args, **kwargs):
-        super().__init__(is_synced, ":/icons/images/material/folder_open.svg", "", *args, **kwargs)
+    def __init__(self, is_synced, is_confined, *args, **kwargs):
+        super().__init__(
+            is_synced, is_confined, ":/icons/images/material/folder_open.svg", "", *args, **kwargs
+        )
         self.setData(NAME_DATA_INDEX, 0)
         self.setData(TYPE_DATA_INDEX, FileType.Folder)
 
 
 class InconsistencyTableItem(IconTableItem):
-    def __init__(self, is_synced, *args, **kwargs):
-        super().__init__(is_synced, ":/icons/images/material/warning.svg", "", *args, **kwargs)
+    def __init__(self, is_synced, is_confined, *args, **kwargs):
+        super().__init__(
+            is_synced, is_confined, ":/icons/images/material/warning.svg", "", *args, **kwargs
+        )
         self.setData(NAME_DATA_INDEX, 0)
         self.setData(TYPE_DATA_INDEX, FileType.Inconsistency)

--- a/parsec/core/gui/file_table.py
+++ b/parsec/core/gui/file_table.py
@@ -79,6 +79,7 @@ class FileTable(QTableWidget):
         super().__init__(*args, **kwargs)
         self.previous_selection = []
         self.setColumnCount(len(Column))
+        self.config = None
 
         h_header = self.horizontalHeader()
         h_header.setDefaultAlignment(Qt.AlignLeft | Qt.AlignVCenter)
@@ -294,10 +295,12 @@ class FileTable(QTableWidget):
             item.setFlags(Qt.ItemIsEnabled)
             self.setItem(row_idx, col, item)
 
-    def add_folder(self, folder_name, uuid, is_synced, selected=False):
+    def add_folder(self, folder_name, uuid, is_synced, is_confined, selected=False):
+        if is_confined and not self.config.gui_show_confined:
+            return
         row_idx = self.rowCount()
         self.insertRow(row_idx)
-        item = FolderTableItem(is_synced)
+        item = FolderTableItem(is_synced, is_confined)
         item.setData(UUID_DATA_INDEX, uuid)
         self.setItem(row_idx, Column.ICON, item)
         item = CustomTableItem(folder_name)
@@ -327,11 +330,21 @@ class FileTable(QTableWidget):
             )
 
     def add_file(
-        self, file_name, uuid, file_size, created_on, updated_on, is_synced, selected=False
+        self,
+        file_name,
+        uuid,
+        file_size,
+        created_on,
+        updated_on,
+        is_synced,
+        is_confined,
+        selected=False,
     ):
+        if is_confined and not self.config.gui_show_confined:
+            return
         row_idx = self.rowCount()
         self.insertRow(row_idx)
-        item = FileTableItem(is_synced, file_name)
+        item = FileTableItem(is_synced, is_confined, file_name)
         item.setData(NAME_DATA_INDEX, 1)
         item.setData(TYPE_DATA_INDEX, FileType.File)
         item.setData(UUID_DATA_INDEX, uuid)
@@ -366,7 +379,7 @@ class FileTable(QTableWidget):
         inconsistency_color = QColor(255, 144, 155)
         row_idx = self.rowCount()
         self.insertRow(row_idx)
-        item = InconsistencyTableItem(False)
+        item = InconsistencyTableItem(False, False)
         item.setData(NAME_DATA_INDEX, 1)
         item.setData(TYPE_DATA_INDEX, FileType.Inconsistency)
         item.setData(UUID_DATA_INDEX, uuid)

--- a/parsec/core/gui/files_widget.py
+++ b/parsec/core/gui/files_widget.py
@@ -208,6 +208,7 @@ class FilesWidget(QWidget, Ui_FilesWidget):
         self.update_timer.setSingleShot(True)
         self.update_timer.timeout.connect(self.reload)
         self.default_import_path = str(pathlib.Path.home())
+        self.table_files.config = self.core.config
         self.table_files.file_moved.connect(self.on_file_moved)
         self.table_files.item_activated.connect(self.item_activated)
         self.table_files.rename_clicked.connect(self.rename_files)
@@ -711,6 +712,7 @@ class FilesWidget(QWidget, Ui_FilesWidget):
         file_found = False
         for path, stats in files_stats.items():
             selected = False
+            confined = bool(stats["confinement_point"])
             if default_selection and str(path) == default_selection:
                 selected = True
                 file_found = True
@@ -718,7 +720,7 @@ class FilesWidget(QWidget, Ui_FilesWidget):
                 self.table_files.add_inconsistency(str(path), stats["id"])
             elif stats["type"] == "folder":
                 self.table_files.add_folder(
-                    str(path), stats["id"], not stats["need_sync"], selected
+                    str(path), stats["id"], not stats["need_sync"], confined, selected
                 )
             else:
                 self.table_files.add_file(
@@ -728,6 +730,7 @@ class FilesWidget(QWidget, Ui_FilesWidget):
                     stats["created"],
                     stats["updated"],
                     not stats["need_sync"],
+                    confined,
                     selected,
                 )
         self.table_files.sortItems(old_sort, old_order)
@@ -822,6 +825,7 @@ class FilesWidget(QWidget, Ui_FilesWidget):
                     item.data(TYPE_DATA_INDEX) == FileType.File
                     or item.data(TYPE_DATA_INDEX) == FileType.Folder
                 ):
+                    item.confined = False
                     item.is_synced = True
 
     def _on_fs_updated_qt(self, event, uuid):

--- a/parsec/core/gui/forms/settings_widget.ui
+++ b/parsec/core/gui/forms/settings_widget.ui
@@ -69,8 +69,8 @@ border-radius: 8px;
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>563</width>
-        <height>526</height>
+        <width>549</width>
+        <height>563</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -398,6 +398,17 @@ border-radius: 8px;
               </property>
               <property name="text">
                <string>TEXT_SETTINGS_INTERFACE_TITLE</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_12">
+            <item>
+             <widget class="QCheckBox" name="check_box_show_confined">
+              <property name="text">
+               <string>TEXT_SETTINGS_CHECK_SHOW_CONFINED_FILES</string>
               </property>
              </widget>
             </item>

--- a/parsec/core/gui/settings_widget.py
+++ b/parsec/core/gui/settings_widget.py
@@ -36,6 +36,7 @@ class SettingsWidget(QWidget, Ui_SettingsWidget):
         self.check_box_send_data.setChecked(self.core_config.telemetry_enabled)
         self.check_box_workspace_color.setChecked(self.core_config.gui_workspace_color)
         self.button_check_version.clicked.connect(self.check_version)
+        self.check_box_show_confined.setChecked(self.core_config.gui_show_confined)
 
     def check_version(self):
         d = CheckNewVersion(self.jobs_ctx, self.event_bus, self.core_config, parent=self)
@@ -49,5 +50,6 @@ class SettingsWidget(QWidget, Ui_SettingsWidget):
             gui_language=self.combo_languages.currentData(),
             gui_check_version_at_startup=self.check_box_check_at_startup.isChecked(),
             gui_workspace_color=self.check_box_workspace_color.isChecked(),
+            gui_show_confined=self.check_box_show_confined.isChecked(),
         )
         show_info(self, _("TEXT_SETTINGS_NEED_RESTART"))

--- a/parsec/core/gui/tr/parsec_en.po
+++ b/parsec/core/gui/tr/parsec_en.po
@@ -1510,6 +1510,77 @@ msgstr "Parent folder"
 msgid "TEXT_FILE_TREE_PARENT_WORKSPACE"
 msgstr "Workspaces list"
 
+msgid "TEXT_FILE_ITEM_IS_CONFINED_TOOLTIP"
+msgstr "The file will not be synced."
+
+msgid "TEXT_FILE_ITEM_IS_SYNCED_TOOLTIP"
+msgstr "The file is synced."
+
+msgid "TEXT_FILE_ITEM_IS_NOT_SYNCED_TOOLTIP"
+msgstr "The file is not synced yet."
+
+msgid "TEXT_BOOTSTRAP_ORG_INSTRUCTIONS_url-organization"
+msgstr ""
+"You are about to bootstrap the organization <b>{organization}</b>. You "
+"will be the first administrator of the organization.<br /><br />\n"
+"\n"
+"To proceed, please provide your name, your email address, a name for this"
+" device, and a password."
+
+msgid "TEXT_BOOTSTRAP_ORG_INVALID_URL"
+msgstr "This is not a valid bootstrap link."
+
+msgid "TEXT_BOOTSTRAP_ORG_INVITE_NOT_FOUND"
+msgstr "There are no organization to bootstrap with this link."
+
+msgid "TEXT_BOOTSTRAP_ORG_ALREADY_BOOTSTRAPPED"
+msgstr "This organization has already been bootstrapped."
+
+msgid "TEXT_BOOTSTRAP_ORG_USER_EXISTS"
+msgstr "This user already exists within this organization."
+
+msgid "TEXT_BOOTSTRAP_ORG_PASSWORD_MISMATCH"
+msgstr "The password and the password confirmation do no match."
+
+msgid "TEXT_BOOTSTRAP_ORG_PASSWORD_COMPLEXITY_TOO_LOW"
+msgstr "The password is not complex enough."
+
+msgid "TEXT_BOOTSTRAP_ORG_BAD_DEVICE_NAME"
+msgstr "The device name is invalid."
+
+msgid "TEXT_BOOTSTRAP_ORG_BAD_API_VERSION"
+msgstr ""
+"Your application is not compatible with this server. Try to update it to "
+"the latest version."
+
+msgid "TEXT_BOOTSTRAP_ORG_BACKEND_REFUSAL"
+msgstr "Could not bootstrap the organization."
+
+msgid "TEXT_BOOTSTRAP_ORG_BACKEND_OFFLINE"
+msgstr "The server is offline or you have no access to the internet."
+
+msgid "TEXT_BOOTSTRAP_ORG_UNKNOWN_FAILURE"
+msgstr "Could not bootstrap the organization."
+
+msgid "TEXT_BOOTSTRAP_ORG_SUCCESS_organization"
+msgstr ""
+"You organization <b>{organization}</b> has been created!<br />\n"
+"<br />\n"
+"You will now be automatically logged in.<br />\n"
+"<br />\n"
+"To help you start with PARSEC, you can read the <a "
+"href=\"https://docs.parsec.cloud/en/stable/\" title=\"User guide\">user "
+"guide</a>."
+
+msgid "ACTION_CONTINUE"
+msgstr "Continue"
+
+msgid "TEXT_BOOTSTRAP_ORG_INVALID_EMAIL"
+msgstr "The email is invalid."
+
+msgid "TEXT_BOOTSTRAP_ORG_TITLE"
+msgstr "Bootstrap the organization"
+
 msgid "ACTION_OK"
 msgstr "OK"
 
@@ -2240,6 +2311,12 @@ msgstr "Use colors for workspaces"
 
 msgid "ACTION_SAVE"
 msgstr "Save"
+
+msgid "TEXT_SETTINGS_CHECK_SHOW_CONFINED_FILES"
+msgstr "Display files that will not be synced"
+
+msgid "TEXT_WORKSPACE_SHARING_REMOVE_USER_TOOLTIP"
+msgstr "Remove the user from this workspace."
 
 msgid "TEXT_WORKSPACE_TIMESTAMPED_INSTRUCTIONS"
 msgstr "You will be able to see the workspace as it was at a given time."

--- a/parsec/core/gui/tr/parsec_fr.po
+++ b/parsec/core/gui/tr/parsec_fr.po
@@ -1550,6 +1550,77 @@ msgstr "Répertoire parent"
 msgid "TEXT_FILE_TREE_PARENT_WORKSPACE"
 msgstr "Liste des espaces de travail"
 
+msgid "TEXT_FILE_ITEM_IS_CONFINED_TOOLTIP"
+msgstr "Ce fichier ne sera pas synchronisé."
+
+msgid "TEXT_FILE_ITEM_IS_SYNCED_TOOLTIP"
+msgstr "Ce fichier est synchronisé."
+
+msgid "TEXT_FILE_ITEM_IS_NOT_SYNCED_TOOLTIP"
+msgstr "Ce fichier n'est pas encore synchronisé."
+
+msgid "TEXT_BOOTSTRAP_ORG_INSTRUCTIONS_url-organization"
+msgstr ""
+"Vous allez démarrer l'organisation <b>{organization}</b>. Vous serez le "
+"premier administrateur de l'organisation.<br /><br />\n"
+"\n"
+"Pour continuer, veuillez choisir un nom d'utilisateur, un nom d'appareil,"
+" ainsi qu'un mot de passe."
+
+msgid "TEXT_BOOTSTRAP_ORG_INVALID_URL"
+msgstr "L'URL n'est pas valide pour démarrer l'organisation."
+
+msgid "TEXT_BOOTSTRAP_ORG_INVITE_NOT_FOUND"
+msgstr "Aucune organisation ne peut être démarrée avec ce lien."
+
+msgid "TEXT_BOOTSTRAP_ORG_ALREADY_BOOTSTRAPPED"
+msgstr "Cette organisation a déjà été démarrée."
+
+msgid "TEXT_BOOTSTRAP_ORG_USER_EXISTS"
+msgstr "Ce nom d'utilisateur existe déjà au sein de cette organisation."
+
+msgid "TEXT_BOOTSTRAP_ORG_PASSWORD_MISMATCH"
+msgstr "Le mot de passe et la confirmation ne correspondent pas."
+
+msgid "TEXT_BOOTSTRAP_ORG_PASSWORD_COMPLEXITY_TOO_LOW"
+msgstr "Le mot de passe n'est pas assez complete."
+
+msgid "TEXT_BOOTSTRAP_ORG_BAD_DEVICE_NAME"
+msgstr "Le nom d'appareil n'est pas valide."
+
+msgid "TEXT_BOOTSTRAP_ORG_BAD_API_VERSION"
+msgstr ""
+"Votre application n'est pas compatible avec ce serveur. Veuillez la "
+"mettre à jour."
+
+msgid "TEXT_BOOTSTRAP_ORG_BACKEND_REFUSAL"
+msgstr "Impossible de démarrer l'organisation."
+
+msgid "TEXT_BOOTSTRAP_ORG_BACKEND_OFFLINE"
+msgstr "Le serveur est hors-ligne ou vous n'avez pas de connexion internet."
+
+msgid "TEXT_BOOTSTRAP_ORG_UNKNOWN_FAILURE"
+msgstr "Impossible de démarrer l'organisation."
+
+msgid "TEXT_BOOTSTRAP_ORG_SUCCESS_organization"
+msgstr ""
+"Votre organisation <b>{organization}</b> a été créée !<br />\n"
+"<br />\n"
+"Vous allez maintenant être automatiquement connecté.<br />\n"
+"<br />\n"
+"Pour une meilleure prise en main du logiciel, vous pouvez vous référer au"
+" <a href=\"https://docs.parsec.cloud/fr/stable/\" title=\"Guide "
+"d'utilisation\">guide d'utilisation PARSEC."
+
+msgid "ACTION_CONTINUE"
+msgstr "Continuer"
+
+msgid "TEXT_BOOTSTRAP_ORG_INVALID_EMAIL"
+msgstr "L'email n'est pas valide."
+
+msgid "TEXT_BOOTSTRAP_ORG_TITLE"
+msgstr "Démarrer l'organisation"
+
 msgid "ACTION_OK"
 msgstr "OK"
 
@@ -2293,6 +2364,12 @@ msgstr "Utiliser des couleurs pour les espaces de travail"
 
 msgid "ACTION_SAVE"
 msgstr "Sauvegarder"
+
+msgid "TEXT_SETTINGS_CHECK_SHOW_CONFINED_FILES"
+msgstr "Afficher les fichiers exclus de la synchronisation"
+
+msgid "TEXT_WORKSPACE_SHARING_REMOVE_USER_TOOLTIP"
+msgstr "Retirer l'utilisateur de cet espace de travail."
 
 msgid "TEXT_WORKSPACE_TIMESTAMPED_INSTRUCTIONS"
 msgstr ""

--- a/parsec/core/resources/default_pattern.ignore
+++ b/parsec/core/resources/default_pattern.ignore
@@ -1,0 +1,92 @@
+###### Patterns of the file names to ignore #####
+
+# This file contains the default configuration for the file name to ignore in Parsec.
+# The files that matches any of those patterns will not be sychronized with other clients,
+# and will not be downloaded from other clients. Each pattern is defined using the fnmatch
+# syntax, as described here: https://docs.python.org/3.8/library/fnmatch.html
+
+
+### Temporary extensions ###
+
+*.tmp
+*.temp
+*.swp
+
+
+### Linux ###
+
+# Temporary files
+*~
+
+# Temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# Glib temporary files
+.goutputstream-*
+
+
+### macOS ###
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon with two \r
+# TODO: support the parsing of \r (https://stackoverflow.com/a/30755378/2846140)
+# Icon\r\r
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# File System Events notification mechanism
+.fseventsd
+
+
+### Windows ###
+
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN
+
+# Windows shortcuts
+*.lnk
+
+# Microsoft office lock files
+.~*
+~$*

--- a/parsec/core/types/__init__.py
+++ b/parsec/core/types/__init__.py
@@ -40,12 +40,14 @@ from parsec.api.data import FolderManifest as RemoteFolderManifest
 FileDescriptor = NewType("FileDescriptor", int)
 LocalFolderishManifests = Union[LocalFolderManifest, LocalWorkspaceManifest]
 RemoteFolderishManifests = Union[RemoteFolderManifest, RemoteWorkspaceManifest]
+LocalNonRootManifests = Union[LocalFileManifest, LocalFolderManifest]
 
 
 __all__ = (
     "FileDescriptor",
     "LocalFolderishManifests",
     "RemoteFolderishManifests",
+    "LocalNonRootManifests",
     # Base
     "FsPath",
     "AnyPath",

--- a/parsec/serde/fields.py
+++ b/parsec/serde/fields.py
@@ -55,6 +55,9 @@ __all__ = (
     "PrivateKey",
     "SecretKey",
     "HashDigest",
+    "FrozenList",
+    "FrozenMap",
+    "FrozenSet",
 )
 
 
@@ -258,6 +261,11 @@ class FrozenMap(Map):
 class FrozenList(List):
     def _deserialize(self, value, attr, obj):
         return tuple(super()._deserialize(value, attr, obj))
+
+
+class FrozenSet(List):
+    def _deserialize(self, value, attr, obj):
+        return frozenset(super()._deserialize(value, attr, obj))
 
 
 class Tuple(Field):

--- a/setup.py
+++ b/setup.py
@@ -371,7 +371,7 @@ setup(
         "parsec.backend.postgresql.migrations": ["*.sql"],
         "parsec.backend.templates": ["*"],
         "parsec.backend.static": ["*"],
-        "parsec.core.resources": ["*.ico"],
+        "parsec.core.resources": ["*.ico", "*.ignore"],
     },
     entry_points={
         "console_scripts": ["parsec = parsec.cli:cli"],

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -11,6 +11,7 @@ from parsec.core.backend_connection import (
 )
 from parsec.core.remote_devices_manager import RemoteDevicesManager
 from parsec.core.fs import UserFS
+from parsec.core.logged_core import get_prevent_sync_pattern
 
 
 @pytest.fixture
@@ -115,7 +116,9 @@ def user_fs_factory(local_storage_path, event_bus_factory, initialize_userfs_sto
         ) as cmds:
             path = local_storage_path(device)
             rdm = RemoteDevicesManager(cmds, device.root_verify_key)
-            async with UserFS.run(device, path, cmds, rdm, event_bus) as user_fs:
+            async with UserFS.run(
+                device, path, cmds, rdm, event_bus, get_prevent_sync_pattern()
+            ) as user_fs:
                 if not initialize_in_v0:
                     await initialize_userfs_storage_v1(user_fs.storage)
                 yield user_fs

--- a/tests/core/fs/test_fs_sync.py
+++ b/tests/core/fs/test_fs_sync.py
@@ -61,6 +61,7 @@ async def test_new_workspace(running_backend, alice, alice_user_fs, alice2_user_
         "children": [],
         "created": Pendulum(2000, 1, 2),
         "updated": Pendulum(2000, 1, 2),
+        "confinement_point": None,
     }
     assert workspace_entry == WorkspaceEntry(
         name="w",
@@ -120,6 +121,7 @@ async def test_new_empty_entry(type, running_backend, alice_user_fs, alice2_user
             "created": Pendulum(2000, 1, 2),
             "updated": Pendulum(2000, 1, 2),
             "size": 0,
+            "confinement_point": None,
         }
     else:
         assert info == {
@@ -131,6 +133,7 @@ async def test_new_empty_entry(type, running_backend, alice_user_fs, alice2_user
             "created": Pendulum(2000, 1, 2),
             "updated": Pendulum(2000, 1, 2),
             "children": [],
+            "confinement_point": None,
         }
     info2 = await workspace2.path_info("/foo")
     assert info == info2
@@ -455,6 +458,7 @@ async def test_create_already_existing_folder_vlob(running_backend, alice_user_f
         "created": Pendulum(2000, 1, 2),
         "updated": Pendulum(2000, 1, 2),
         "children": ["x"],
+        "confinement_point": None,
     }
 
     workspace2 = alice2_user_fs.get_workspace(wid)
@@ -500,6 +504,7 @@ async def test_create_already_existing_file_vlob(running_backend, alice_user_fs,
         "updated": Pendulum(2000, 1, 2),
         "base_version": 1,
         "size": 0,
+        "confinement_point": None,
     }
 
     await workspace2.sync()
@@ -562,6 +567,7 @@ async def test_create_already_existing_block(running_backend, alice_user_fs, ali
         "updated": Pendulum(2000, 1, 3),
         "base_version": 2,
         "size": 4,
+        "confinement_point": None,
     }
 
     await workspace2.sync()
@@ -599,6 +605,7 @@ async def test_sync_data_before_workspace(running_backend, alice_user_fs):
         "is_placeholder": False,
         "need_sync": False,
         "size": 2,
+        "confinement_point": None,
     }
     root_info = await w.path_info("/")
     assert root_info == {
@@ -610,6 +617,7 @@ async def test_sync_data_before_workspace(running_backend, alice_user_fs):
         "is_placeholder": False,
         "need_sync": True,
         "children": ["bar"],
+        "confinement_point": None,
     }
 
 

--- a/tests/core/fs/test_reencrypt_workspace.py
+++ b/tests/core/fs/test_reencrypt_workspace.py
@@ -189,6 +189,7 @@ async def test_no_access_during_reencryption(running_backend, alice2_user_fs, wo
         "is_placeholder": False,
         "need_sync": False,
         "children": ["foo.txt"],
+        "confinement_point": None,
     }
     with pytest.raises(FSWorkspaceInMaintenance):
         await aw.path_info("/foo.txt")
@@ -217,6 +218,7 @@ async def test_no_access_during_reencryption(running_backend, alice2_user_fs, wo
         "is_placeholder": False,
         "need_sync": True,
         "children": ["bar.txt", "foo.txt"],
+        "confinement_point": None,
     }
     with pytest.raises(FSBadEncryptionRevision):
         await aw.path_info("/foo.txt")
@@ -238,6 +240,7 @@ async def test_no_access_during_reencryption(running_backend, alice2_user_fs, wo
         "is_placeholder": False,
         "need_sync": False,
         "size": 2,
+        "confinement_point": None,
     }
 
     # Finally sync is ok

--- a/tests/core/fs/userfs/test_sharing.py
+++ b/tests/core/fs/userfs/test_sharing.py
@@ -488,6 +488,7 @@ async def test_share_workspace_then_conflict_on_rights(
         "base_version": 1,
         "need_sync": False,
         "children": [],
+        "confinement_point": None,
     }
     assert a_w_stat == a2_w_stat
 

--- a/tests/core/fs/workspacefs/test_confinement.py
+++ b/tests/core/fs/workspacefs/test_confinement.py
@@ -1,0 +1,291 @@
+# Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
+
+import re
+import pytest
+
+from parsec.core.types import FsPath
+from tests.common import create_shared_workspace
+
+
+async def assert_path_info(workspace, path, **kwargs):
+    info = await workspace.path_info(path)
+    for key, value in kwargs.items():
+        assert info[key] == value, key
+
+
+@pytest.mark.trio
+async def test_local_confinement_points(alice_workspace, running_backend):
+
+    # Apply a *.tmp pattern
+    pattern = re.compile(r".*\.tmp$")
+    await alice_workspace.set_and_apply_prevent_sync_pattern(pattern)
+    assert alice_workspace.local_storage.get_prevent_sync_pattern() == pattern
+    assert alice_workspace.local_storage.get_prevent_sync_pattern_fully_applied()
+
+    # Use foo as working directory
+    await assert_path_info(alice_workspace, "/foo", confinement_point=None, need_sync=False)
+    foo_id = await alice_workspace.path_id("/foo")
+
+    # Create a temporary file and temporary folder
+    await alice_workspace.mkdir("/foo/x.tmp")
+    await alice_workspace.touch("/foo/y.tmp")
+
+    # Check status
+    await assert_path_info(alice_workspace, "/foo", confinement_point=None, need_sync=False)
+    await assert_path_info(alice_workspace, "/foo/x.tmp", confinement_point=foo_id, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/y.tmp", confinement_point=foo_id, need_sync=True)
+
+    # Force a sync
+    await alice_workspace.sync()
+
+    # There should be nothing to synchronize
+    await assert_path_info(alice_workspace, "/foo", confinement_point=None, need_sync=False)
+    await assert_path_info(alice_workspace, "/foo/x.tmp", confinement_point=foo_id, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/y.tmp", confinement_point=foo_id, need_sync=True)
+
+    # Create a non-temporary file
+    await alice_workspace.touch("/foo/z.txt")
+
+    # Check status
+    await assert_path_info(alice_workspace, "/foo", confinement_point=None, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/x.tmp", confinement_point=foo_id, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/y.tmp", confinement_point=foo_id, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/z.txt", confinement_point=None, need_sync=True)
+
+    # Force a sync
+    await alice_workspace.sync()
+
+    # Check status
+    await assert_path_info(alice_workspace, "/foo", confinement_point=None, need_sync=False)
+    await assert_path_info(alice_workspace, "/foo/x.tmp", confinement_point=foo_id, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/y.tmp", confinement_point=foo_id, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/z.txt", confinement_point=None, need_sync=False)
+
+    # Remove a temporary file
+    await alice_workspace.rmdir("/foo/x.tmp")
+    assert not await alice_workspace.exists("/foo/x.tmp")
+
+    # Check status
+    await assert_path_info(alice_workspace, "/foo", confinement_point=None, need_sync=False)
+    await assert_path_info(alice_workspace, "/foo/y.tmp", confinement_point=foo_id, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/z.txt", confinement_point=None, need_sync=False)
+
+    # Force a sync
+    await alice_workspace.sync()
+
+    # Nothing has changed
+    await assert_path_info(alice_workspace, "/foo", confinement_point=None, need_sync=False)
+    await assert_path_info(alice_workspace, "/foo/y.tmp", confinement_point=foo_id, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/z.txt", confinement_point=None, need_sync=False)
+
+    # Rename a temporary file
+    await alice_workspace.rename("/foo/y.tmp", "/foo/y.txt")
+    assert not await alice_workspace.exists("/foo/y.tmp")
+
+    # Check status
+    await assert_path_info(alice_workspace, "/foo", confinement_point=None, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/y.txt", confinement_point=None, need_sync=True)
+    await assert_path_info(alice_workspace, "/foo/z.txt", confinement_point=None, need_sync=False)
+
+    # Force a sync
+    await alice_workspace.sync()
+
+    # Check status
+    await assert_path_info(alice_workspace, "/foo", confinement_point=None, need_sync=False)
+    await assert_path_info(alice_workspace, "/foo/y.txt", confinement_point=None, need_sync=False)
+    await assert_path_info(alice_workspace, "/foo/z.txt", confinement_point=None, need_sync=False)
+
+
+@pytest.mark.trio
+async def test_sync_with_different_patterns(running_backend, alice_user_fs, alice2_user_fs):
+    wid = await create_shared_workspace("w", alice_user_fs, alice2_user_fs)
+    workspace1 = alice_user_fs.get_workspace(wid)
+    workspace2 = alice2_user_fs.get_workspace(wid)
+
+    # Workspace 1 patterns .tmp files
+    pattern1 = re.compile(r".*\.tmp$")
+    await workspace1.set_and_apply_prevent_sync_pattern(pattern1)
+    await workspace1.sync()
+
+    # Workspace 2 patterns ~ files
+    pattern2 = re.compile(r".*~$")
+    await workspace2.set_and_apply_prevent_sync_pattern(pattern2)
+    await workspace2.sync()
+
+    # Workspace 1 create some files and directories
+    await workspace1.mkdir("/foo/xyz.tmp/bar", parents=True)
+    await workspace1.mkdir("/foo/xyz~/bar", parents=True)
+    await workspace1.mkdir("/foo/xyz/bar", parents=True)
+    await workspace1.write_bytes("/foo/xyz.tmp/bar/test.txt", b"a1")
+    await workspace1.write_bytes("/foo/xyz~/bar/test.txt", b"b1")
+    await workspace1.write_bytes("/foo/xyz/bar/test.txt", b"c1")
+
+    # Both workspaces sync
+    await workspace1.sync()
+    await workspace2.sync()
+
+    # Check workspace 2
+    assert await workspace2.listdir("/") == [FsPath("/foo")]
+    assert await workspace2.listdir("/foo") == [FsPath("/foo/xyz")]
+    assert await workspace2.listdir("/foo/xyz") == [FsPath("/foo/xyz/bar")]
+    assert await workspace2.listdir("/foo/xyz/bar") == [FsPath("/foo/xyz/bar/test.txt")]
+
+    # Check file content
+    assert await workspace2.read_bytes("/foo/xyz/bar/test.txt") == b"c1"
+
+    # Workspace 2 create the same files and directories
+    await workspace2.mkdir("/foo/xyz.tmp/bar", parents=True)
+    await workspace2.mkdir("/foo/xyz~/bar", parents=True)
+    await workspace2.write_bytes("/foo/xyz.tmp/bar/test.txt", b"a2")
+    await workspace2.write_bytes("/foo/xyz~/bar/test.txt", b"b2")
+    await workspace2.write_bytes("/foo/xyz/bar/test.txt", b"c2")
+
+    # Both workspaces sync
+    await workspace2.sync()
+    await workspace1.sync()
+
+    # Check both workspaces
+    for workspace in (workspace1, workspace2):
+        assert await workspace.listdir("/") == [FsPath("/foo")]
+        assert await workspace.listdir("/foo") == [
+            FsPath("/foo/xyz"),
+            FsPath("/foo/xyz.tmp"),
+            FsPath("/foo/xyz~"),
+        ]
+        assert await workspace.listdir("/foo/xyz") == [FsPath("/foo/xyz/bar")]
+        assert await workspace.listdir("/foo/xyz.tmp") == [FsPath("/foo/xyz.tmp/bar")]
+        assert await workspace.listdir("/foo/xyz~") == [FsPath("/foo/xyz~/bar")]
+        assert await workspace.listdir("/foo/xyz/bar") == [FsPath("/foo/xyz/bar/test.txt")]
+        assert await workspace.listdir("/foo/xyz.tmp/bar") == [FsPath("/foo/xyz.tmp/bar/test.txt")]
+        assert await workspace.listdir("/foo/xyz~/bar") == [FsPath("/foo/xyz~/bar/test.txt")]
+
+    # Check file contents
+    assert await workspace1.read_bytes("/foo/xyz.tmp/bar/test.txt") == b"a1"
+    assert await workspace1.read_bytes("/foo/xyz~/bar/test.txt") == b"b1"
+    assert await workspace1.read_bytes("/foo/xyz/bar/test.txt") == b"c2"
+    assert await workspace2.read_bytes("/foo/xyz.tmp/bar/test.txt") == b"a2"
+    assert await workspace2.read_bytes("/foo/xyz~/bar/test.txt") == b"b2"
+    assert await workspace2.read_bytes("/foo/xyz/bar/test.txt") == b"c2"
+
+
+@pytest.mark.trio
+async def test_change_pattern(alice_workspace, running_backend):
+    root_id = alice_workspace.workspace_id
+
+    # Apply a *.x pattern
+    pattern = re.compile(r".*\.x$")
+    await alice_workspace.set_and_apply_prevent_sync_pattern(pattern)
+    assert alice_workspace.local_storage.get_prevent_sync_pattern() == pattern
+    assert alice_workspace.local_storage.get_prevent_sync_pattern_fully_applied()
+
+    # Create x, y and z files
+    await alice_workspace.touch("/test1.x")
+    await alice_workspace.touch("/test1.y")
+    await alice_workspace.touch("/test1.z")
+
+    # Check status
+    await assert_path_info(alice_workspace, "/test1.x", confinement_point=root_id, need_sync=True)
+    await assert_path_info(alice_workspace, "/test1.y", confinement_point=None, need_sync=True)
+    await assert_path_info(alice_workspace, "/test1.z", confinement_point=None, need_sync=True)
+
+    # Synchronize then create more x, y and z files
+    await alice_workspace.sync()
+    await alice_workspace.touch("/test2.x")
+    await alice_workspace.touch("/test2.y")
+    await alice_workspace.touch("/test2.z")
+
+    # Check status
+    await assert_path_info(alice_workspace, "/test1.x", confinement_point=root_id, need_sync=True)
+    await assert_path_info(alice_workspace, "/test1.y", confinement_point=None, need_sync=False)
+    await assert_path_info(alice_workspace, "/test1.z", confinement_point=None, need_sync=False)
+    await assert_path_info(alice_workspace, "/test2.x", confinement_point=root_id, need_sync=True)
+    await assert_path_info(alice_workspace, "/test2.y", confinement_point=None, need_sync=True)
+    await assert_path_info(alice_workspace, "/test2.y", confinement_point=None, need_sync=True)
+
+    # Appy Y pattern
+    pattern = re.compile(r".*\.y$")
+    await alice_workspace.set_and_apply_prevent_sync_pattern(pattern)
+    assert alice_workspace.local_storage.get_prevent_sync_pattern() == pattern
+    assert alice_workspace.local_storage.get_prevent_sync_pattern_fully_applied()
+
+    # Check status
+    await assert_path_info(alice_workspace, "/test1.x", confinement_point=None, need_sync=True)
+    await assert_path_info(alice_workspace, "/test1.y", confinement_point=root_id, need_sync=False)
+    await assert_path_info(alice_workspace, "/test1.z", confinement_point=None, need_sync=False)
+    await assert_path_info(alice_workspace, "/test2.x", confinement_point=None, need_sync=True)
+    await assert_path_info(alice_workspace, "/test2.y", confinement_point=root_id, need_sync=True)
+    await assert_path_info(alice_workspace, "/test2.z", confinement_point=None, need_sync=True)
+
+    # Synchronize the workspace
+    await alice_workspace.sync()
+
+    await assert_path_info(alice_workspace, "/test1.x", confinement_point=None, need_sync=False)
+    await assert_path_info(alice_workspace, "/test1.y", confinement_point=root_id, need_sync=False)
+    await assert_path_info(alice_workspace, "/test1.z", confinement_point=None, need_sync=False)
+    await assert_path_info(alice_workspace, "/test2.x", confinement_point=None, need_sync=False)
+    await assert_path_info(alice_workspace, "/test2.y", confinement_point=root_id, need_sync=True)
+    await assert_path_info(alice_workspace, "/test2.z", confinement_point=None, need_sync=False)
+
+    # Rollback to X pattern
+    pattern = re.compile(r".*\.x$")
+    await alice_workspace.set_and_apply_prevent_sync_pattern(pattern)
+    assert alice_workspace.local_storage.get_prevent_sync_pattern() == pattern
+    assert alice_workspace.local_storage.get_prevent_sync_pattern_fully_applied()
+
+    # Check status
+    await assert_path_info(alice_workspace, "/test1.x", confinement_point=root_id, need_sync=False)
+    await assert_path_info(alice_workspace, "/test1.y", confinement_point=None, need_sync=False)
+    await assert_path_info(alice_workspace, "/test1.z", confinement_point=None, need_sync=False)
+    await assert_path_info(alice_workspace, "/test2.x", confinement_point=root_id, need_sync=False)
+    await assert_path_info(alice_workspace, "/test2.y", confinement_point=None, need_sync=True)
+    await assert_path_info(alice_workspace, "/test2.z", confinement_point=None, need_sync=False)
+
+    # Synchronize the workspace
+    await alice_workspace.sync()
+
+    await assert_path_info(alice_workspace, "/test1.x", confinement_point=root_id, need_sync=False)
+    await assert_path_info(alice_workspace, "/test1.y", confinement_point=None, need_sync=False)
+    await assert_path_info(alice_workspace, "/test1.z", confinement_point=None, need_sync=False)
+    await assert_path_info(alice_workspace, "/test2.x", confinement_point=root_id, need_sync=False)
+    await assert_path_info(alice_workspace, "/test2.y", confinement_point=None, need_sync=False)
+    await assert_path_info(alice_workspace, "/test2.z", confinement_point=None, need_sync=False)
+
+
+@pytest.mark.trio
+async def test_common_temporary_files(alice_workspace):
+    file_list = ["test.txt", "test" "t" ".test"]
+    for path in file_list:
+        path = "/" + path
+        await alice_workspace.touch(path)
+        await assert_path_info(alice_workspace, path, confinement_point=None)
+
+    confined_file_list = [
+        "test.tmp",
+        "test.temp",
+        "test.swp",
+        "test~",
+        ".fuse_hidden000001",
+        ".directory",
+        ".Trash-0001",
+        ".nfsxxx",
+        ".goutputstream-U6EGP0",
+        ".DS_Store",
+        ".AppleDouble",
+        ".LSOverride",
+        "._test",
+        ".fseventsd",
+        "Thumbs.db",
+        "test.stackdump",
+        "Desktop.ini",
+        "desktop.ini",
+        "$RECYCLE.BIN",
+        "test.lnk",
+        ".~test",
+        "~$test",
+    ]
+    for path in confined_file_list:
+        path = "/" + path
+        await alice_workspace.touch(path)
+        await assert_path_info(
+            alice_workspace, path, confinement_point=alice_workspace.workspace_id
+        )

--- a/tests/core/fs/workspacefs/test_entry_transactions.py
+++ b/tests/core/fs/workspacefs/test_entry_transactions.py
@@ -38,6 +38,7 @@ async def test_root_entry_info(alice_entry_transactions):
         "created": Pendulum(2000, 1, 1),
         "updated": Pendulum(2000, 1, 1),
         "children": [],
+        "confinement_point": None,
     }
 
 
@@ -61,6 +62,7 @@ async def test_file_create(alice_entry_transactions, alice_file_transactions, al
         "created": Pendulum(2000, 1, 1),
         "updated": Pendulum(2000, 1, 2),
         "children": ["foo.txt"],
+        "confinement_point": None,
     }
 
     foo_stat = await entry_transactions.entry_info(FsPath("/foo.txt"))
@@ -73,6 +75,7 @@ async def test_file_create(alice_entry_transactions, alice_file_transactions, al
         "created": Pendulum(2000, 1, 2),
         "updated": Pendulum(2000, 1, 2),
         "size": 0,
+        "confinement_point": None,
     }
 
 
@@ -196,6 +199,7 @@ async def test_access_not_loaded_entry(alice, bob, alice_entry_transactions):
         "is_placeholder": True,
         "need_sync": True,
         "children": [],
+        "confinement_point": None,
     }
 
 

--- a/tests/core/fs/workspacefs/test_sync_transactions.py
+++ b/tests/core/fs/workspacefs/test_sync_transactions.py
@@ -1,14 +1,18 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
-from parsec.core.core_events import CoreEvent
+import re
 import pytest
 
 from parsec.api.protocol import DeviceID
+from parsec.core.core_events import CoreEvent
 from parsec.core.types import FsPath, EntryID, Chunk, LocalFolderManifest, LocalFileManifest
 
 from parsec.core.fs.workspacefs.sync_transactions import merge_manifests
 from parsec.core.fs.workspacefs.sync_transactions import merge_folder_children
 from parsec.core.fs.exceptions import FSFileConflictError
+
+
+empty_pattern = re.compile(r"^\b$")
 
 
 def test_merge_folder_children():
@@ -61,45 +65,45 @@ def test_merge_folder_manifests():
     )
 
     # Initial base manifest
-    m1 = LocalFolderManifest.from_remote(v1)
-    assert merge_manifests(my_device, m1) == m1
+    m1 = LocalFolderManifest.from_remote(v1, empty_pattern)
+    assert merge_manifests(my_device, empty_pattern, m1) == m1
 
     # Local change
-    m2 = m1.evolve_children_and_mark_updated({"a": EntryID()})
-    assert merge_manifests(my_device, m2) == m2
+    m2 = m1.evolve_children_and_mark_updated({"a": EntryID()}, empty_pattern)
+    assert merge_manifests(my_device, empty_pattern, m2) == m2
 
     # Successful upload
     v2 = m2.to_remote(author=my_device)
-    m3 = merge_manifests(my_device, m2, v2)
-    assert m3 == LocalFolderManifest.from_remote(v2)
+    m3 = merge_manifests(my_device, empty_pattern, m2, v2)
+    assert m3 == LocalFolderManifest.from_remote(v2, empty_pattern)
 
     # Two local changes
-    m4 = m3.evolve_children_and_mark_updated({"b": EntryID()})
-    assert merge_manifests(my_device, m4) == m4
-    m5 = m4.evolve_children_and_mark_updated({"c": EntryID()})
-    assert merge_manifests(my_device, m4) == m4
+    m4 = m3.evolve_children_and_mark_updated({"b": EntryID()}, empty_pattern)
+    assert merge_manifests(my_device, empty_pattern, m4) == m4
+    m5 = m4.evolve_children_and_mark_updated({"c": EntryID()}, empty_pattern)
+    assert merge_manifests(my_device, empty_pattern, m4) == m4
 
     # M4 has been successfully uploaded
     v3 = m4.to_remote(author=my_device)
-    m6 = merge_manifests(my_device, m5, v3)
+    m6 = merge_manifests(my_device, empty_pattern, m5, v3)
     assert m6 == m5.evolve(base=v3)
 
     # The remote has changed
     v4 = v3.evolve(version=4, children={"d": EntryID(), **v3.children}, author=other_device)
-    m7 = merge_manifests(my_device, m6, v4)
+    m7 = merge_manifests(my_device, empty_pattern, m6, v4)
     assert m7.base_version == 4
     assert sorted(m7.children) == ["a", "b", "c", "d"]
     assert m7.need_sync
 
     # Successful upload
     v5 = m7.to_remote(author=my_device)
-    m8 = merge_manifests(my_device, m7, v5)
-    assert m8 == LocalFolderManifest.from_remote(v5)
+    m8 = merge_manifests(my_device, empty_pattern, m7, v5)
+    assert m8 == LocalFolderManifest.from_remote(v5, empty_pattern)
 
     # The remote has changed
     v6 = v5.evolve(version=6, children={"e": EntryID(), **v5.children}, author=other_device)
-    m9 = merge_manifests(my_device, m8, v6)
-    assert m9 == LocalFolderManifest.from_remote(v6)
+    m9 = merge_manifests(my_device, empty_pattern, m8, v6)
+    assert m9 == LocalFolderManifest.from_remote(v6, empty_pattern)
 
 
 def test_merge_manifests_with_a_placeholder():
@@ -108,20 +112,20 @@ def test_merge_manifests_with_a_placeholder():
     parent = EntryID()
 
     m1 = LocalFolderManifest.new_placeholder(my_device, parent=parent)
-    m2 = merge_manifests(my_device, m1)
+    m2 = merge_manifests(my_device, empty_pattern, m1)
     assert m2 == m1
     v1 = m1.to_remote(author=my_device)
 
-    m2a = merge_manifests(my_device, m1, v1)
-    assert m2a == LocalFolderManifest.from_remote(v1)
+    m2a = merge_manifests(my_device, empty_pattern, m1, v1)
+    assert m2a == LocalFolderManifest.from_remote(v1, empty_pattern)
 
-    m2b = m1.evolve_children_and_mark_updated({"a": EntryID()})
-    m3b = merge_manifests(my_device, m2b, v1)
+    m2b = m1.evolve_children_and_mark_updated({"a": EntryID()}, empty_pattern)
+    m3b = merge_manifests(my_device, empty_pattern, m2b, v1)
     assert m3b == m2b.evolve(base=v1)
 
     v2 = v1.evolve(version=2, author=other_device, children={"b": EntryID()})
-    m2c = m1.evolve_children_and_mark_updated({"a": EntryID()})
-    m3c = merge_manifests(my_device, m2c, v2)
+    m2c = m1.evolve_children_and_mark_updated({"a": EntryID()}, empty_pattern)
+    m3c = merge_manifests(my_device, empty_pattern, m2c, v2)
     children = {**v2.children, **m2c.children}
     assert m3c == m2c.evolve(base=v2, children=children, updated=m3c.updated)
 
@@ -139,32 +143,32 @@ def test_merge_file_manifests():
 
     # Initial base manifest
     m1 = LocalFileManifest.from_remote(v1)
-    assert merge_manifests(my_device, m1) == m1
+    assert merge_manifests(my_device, empty_pattern, m1) == m1
 
     # Local change
     m2 = evolve(m1, 1)
-    assert merge_manifests(my_device, m2) == m2
+    assert merge_manifests(my_device, empty_pattern, m2) == m2
 
     # Successful upload
     v2 = m2.to_remote(author=my_device)
-    m3 = merge_manifests(my_device, m2, v2)
+    m3 = merge_manifests(my_device, empty_pattern, m2, v2)
     assert m3 == LocalFileManifest.from_remote(v2)
 
     # Two local changes
     m4 = evolve(m3, 2)
-    assert merge_manifests(my_device, m4) == m4
+    assert merge_manifests(my_device, empty_pattern, m4) == m4
     m5 = evolve(m4, 3)
-    assert merge_manifests(my_device, m4) == m4
+    assert merge_manifests(my_device, empty_pattern, m4) == m4
 
     # M4 has been successfully uploaded
     v3 = m4.to_remote(author=my_device)
-    m6 = merge_manifests(my_device, m5, v3)
+    m6 = merge_manifests(my_device, empty_pattern, m5, v3)
     assert m6 == m5.evolve(base=v3)
 
     # The remote has changed
     v4 = v3.evolve(version=4, size=0, author=other_device)
     with pytest.raises(FSFileConflictError):
-        merge_manifests(my_device, m6, v4)
+        merge_manifests(my_device, empty_pattern, m6, v4)
 
 
 @pytest.mark.trio

--- a/tests/core/fs/workspacefs/test_workspace_fs.py
+++ b/tests/core/fs/workspacefs/test_workspace_fs.py
@@ -29,6 +29,7 @@ async def test_path_info(alice_workspace):
         "need_sync": False,
         "type": "folder",
         "updated": ANY,
+        "confinement_point": None,
     }
 
     info = await alice_workspace.path_info("/foo")
@@ -41,6 +42,7 @@ async def test_path_info(alice_workspace):
         "need_sync": False,
         "type": "folder",
         "updated": ANY,
+        "confinement_point": None,
     }
 
     info = await alice_workspace.path_info("/foo/bar")
@@ -53,6 +55,7 @@ async def test_path_info(alice_workspace):
         "need_sync": False,
         "type": "file",
         "updated": ANY,
+        "confinement_point": None,
     }
 
 
@@ -363,6 +366,8 @@ async def test_dump(alice_workspace):
                 "need_sync": False,
                 "parent": ANY,
                 "updated": ANY,
+                "local_confinement_points": frozenset(),
+                "remote_confinement_points": frozenset(),
             }
         },
         "created": ANY,
@@ -370,12 +375,14 @@ async def test_dump(alice_workspace):
         "is_placeholder": False,
         "need_sync": False,
         "updated": ANY,
+        "local_confinement_points": frozenset(),
+        "remote_confinement_points": frozenset(),
     }
 
 
 @pytest.mark.trio
 async def test_path_info_remote_loader_exceptions(monkeypatch, alice_workspace, alice):
-    manifest = await alice_workspace.transactions._get_manifest_from_path(FsPath("/foo/bar"))
+    manifest, _ = await alice_workspace.transactions._get_manifest_from_path(FsPath("/foo/bar"))
     async with alice_workspace.local_storage.lock_entry_id(manifest.id):
         await alice_workspace.local_storage.clear_manifest(manifest.id)
 

--- a/tests/core/fs/workspacefs/test_workspacefile.py
+++ b/tests/core/fs/workspacefs/test_workspacefile.py
@@ -607,7 +607,15 @@ async def test_name(alice_workspace, trio_file):
     await f.close()
 
 
-# TODO
+@pytest.mark.trio
+async def test_stat(alice_workspace):
+    f = await alice_workspace.open_file("/foo/bar", "wb")
+    stat = await f.stat()
+    assert stat["size"] == 0
+    assert stat["type"] == "file"
+    assert stat["confinement_point"] is None
+
+
 # @pytest.mark.trio
 # async def test_move_file_from_workspace_to_another_workspace(
 #     alice_workspace, bob_workspace, trio_file

--- a/tests/core/fs/workspacefs_timestamped/test_entry_transactions_timestamped.py
+++ b/tests/core/fs/workspacefs_timestamped/test_entry_transactions_timestamped.py
@@ -19,6 +19,7 @@ async def test_root_entry_info(alice_workspace_t2, alice_workspace_t4):
         "created": Pendulum(1999, 12, 31),
         "updated": Pendulum(1999, 12, 31),
         "children": ["foo"],
+        "confinement_point": None,
     }
 
     stat4 = await alice_workspace_t4.transactions.entry_info(FsPath("/"))
@@ -31,6 +32,7 @@ async def test_root_entry_info(alice_workspace_t2, alice_workspace_t4):
         "created": Pendulum(1999, 12, 31),
         "updated": Pendulum(2000, 1, 4),
         "children": ["files", "foo"],
+        "confinement_point": None,
     }
 
 

--- a/tests/core/fs/workspacefs_timestamped/test_workspacefs_timestamped.py
+++ b/tests/core/fs/workspacefs_timestamped/test_workspacefs_timestamped.py
@@ -22,6 +22,7 @@ async def test_path_info(alice_workspace, timestamp_0, alice_workspace_t1, alice
         "need_sync": False,
         "type": "folder",
         "updated": ANY,
+        "confinement_point": None,
     }
 
     info = await alice_workspace_t1.path_info("/foo")
@@ -34,6 +35,7 @@ async def test_path_info(alice_workspace, timestamp_0, alice_workspace_t1, alice
         "need_sync": False,
         "type": "folder",
         "updated": ANY,
+        "confinement_point": None,
     }
 
     with pytest.raises(FileNotFoundError):
@@ -49,6 +51,7 @@ async def test_path_info(alice_workspace, timestamp_0, alice_workspace_t1, alice
         "need_sync": False,
         "type": "folder",
         "updated": ANY,
+        "confinement_point": None,
     }
 
     info = await alice_workspace_t2.path_info("/foo/bar")
@@ -61,6 +64,7 @@ async def test_path_info(alice_workspace, timestamp_0, alice_workspace_t1, alice
         "need_sync": False,
         "type": "file",
         "updated": ANY,
+        "confinement_point": None,
     }
 
     with pytest.raises(FileNotFoundError):

--- a/tests/core/gui/conftest.py
+++ b/tests/core/gui/conftest.py
@@ -281,6 +281,7 @@ def gui_factory(
             gui_last_version=parsec_version,
             mountpoint_enabled=True,
             gui_language="en",
+            gui_show_confined=False,
         )
         event_bus = event_bus or EventBus()
         # Language config rely on global var, must reset it for each test !

--- a/tests/core/gui/test_file_table.py
+++ b/tests/core/gui/test_file_table.py
@@ -59,7 +59,7 @@ def test_file_table_sort(qtbot, core_config):
     w = FileTable(parent=None)
     qtbot.addWidget(w)
     w.add_parent_workspace()
-    w.add_folder("Dir1", uuid.uuid4(), True)
+    w.add_folder("Dir1", uuid.uuid4(), True, False)
     w.add_file(
         "File1.txt",
         uuid.uuid4(),
@@ -67,6 +67,7 @@ def test_file_table_sort(qtbot, core_config):
         pendulum.datetime(2000, 1, 15),
         pendulum.datetime(2000, 1, 20),
         True,
+        False,
     )
     w.add_file(
         "AnotherFile.txt",
@@ -75,6 +76,7 @@ def test_file_table_sort(qtbot, core_config):
         pendulum.datetime(2000, 1, 10),
         pendulum.datetime(2000, 1, 25),
         True,
+        False,
     )
     assert w.rowCount() == 4
     assert w.item(0, 1).text() == "Workspaces list"

--- a/tests/core/test_sync_monitor.py
+++ b/tests/core/test_sync_monitor.py
@@ -1,5 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
+import re
 import trio
 import pytest
 from unittest.mock import ANY
@@ -245,3 +246,84 @@ async def test_reconnect_with_remote_changes(
             in_order=False,
             timeout=60,  # autojump, so not *really* 60s
         )
+
+
+@pytest.mark.trio
+async def test_sync_confined_children_after_rename(
+    autojump_clock, alice, running_backend, alice_core
+):
+    # Create a workspace
+    wid = await alice_core.user_fs.workspace_create("w")
+    alice_w = alice_core.user_fs.get_workspace(wid)
+
+    # Set a filter
+    pattern = re.compile(r".*\.tmp$")
+    await alice_w.set_and_apply_prevent_sync_pattern(pattern)
+
+    # Create a confined path
+    await alice_w.mkdir("/test.tmp/a/b/c", parents=True)
+
+    # Wait for sync monitor to be idle
+    await alice_core.wait_idle_monitors()
+
+    # Make sure the root is synced
+    info = await alice_w.path_info("/")
+    assert not info["need_sync"]
+    assert not info["confinement_point"]
+
+    # Make sure the rest of the path is confined
+    for path in ["/test.tmp", "/test.tmp/a", "/test.tmp/a/b", "/test.tmp/a/b/c"]:
+        info = await alice_w.path_info(path)
+        assert info["need_sync"]
+        assert info["confinement_point"]
+
+    # Rename to another confined path
+    await alice_w.rename("/test.tmp", "/test2.tmp")
+
+    # Wait for sync monitor to be idle
+    await alice_core.wait_idle_monitors()
+
+    # Make sure the root is synced
+    info = await alice_w.path_info("/")
+    assert not info["need_sync"]
+    assert not info["confinement_point"]
+
+    # Make sure the rest of the path is confined
+    for path in ["/test2.tmp", "/test2.tmp/a", "/test2.tmp/a/b", "/test2.tmp/a/b/c"]:
+        info = await alice_w.path_info(path)
+        assert info["need_sync"]
+        assert info["confinement_point"]
+
+    # Rename to non-confined path
+    await alice_w.rename("/test2.tmp", "/test2")
+
+    # Wait for sync monitor to be idle
+    await alice_core.wait_idle_monitors()
+
+    # Make sure the root is synced
+    info = await alice_w.path_info("/")
+    assert not info["need_sync"]
+    assert not info["confinement_point"]
+
+    # Make sure the rest of the path is confined
+    for path in ["/test2", "/test2/a", "/test2/a/b", "/test2/a/b/c"]:
+        info = await alice_w.path_info(path)
+        assert not info["need_sync"]
+        assert not info["confinement_point"]
+
+    # Rename to a confined path
+    await alice_w.rename("/test2", "/test3.tmp")
+
+    # Wait for sync monitor to be idle
+    await alice_core.wait_idle_monitors()
+
+    # Make sure the root is synced
+    info = await alice_w.path_info("/")
+    assert not info["need_sync"]
+    assert not info["confinement_point"]
+
+    # Make sure the rest of the path is confined
+    for path in ["/test3.tmp", "/test3.tmp/a", "/test3.tmp/a/b", "/test3.tmp/a/b/c"]:
+        info = await alice_w.path_info(path)
+        assert not info["need_sync"]
+        assert info["confinement_point"]

--- a/tests/schemas/core_data.json
+++ b/tests/schemas/core_data.json
@@ -361,10 +361,30 @@
                 "required": true,
                 "type": "FrozenMap"
             },
+            "local_confinement_points": {
+                "allow_none": false,
+                "container_type": {
+                    "allow_none": false,
+                    "required": true,
+                    "type": "EntryIDField"
+                },
+                "required": false,
+                "type": "FrozenSet"
+            },
             "need_sync": {
                 "allow_none": false,
                 "required": true,
                 "type": "Boolean"
+            },
+            "remote_confinement_points": {
+                "allow_none": false,
+                "container_type": {
+                    "allow_none": false,
+                    "required": true,
+                    "type": "EntryIDField"
+                },
+                "required": false,
+                "type": "FrozenSet"
             },
             "type": {
                 "allow_none": false,
@@ -631,10 +651,30 @@
                 "required": true,
                 "type": "FrozenMap"
             },
+            "local_confinement_points": {
+                "allow_none": false,
+                "container_type": {
+                    "allow_none": false,
+                    "required": true,
+                    "type": "EntryIDField"
+                },
+                "required": false,
+                "type": "FrozenSet"
+            },
             "need_sync": {
                 "allow_none": false,
                 "required": true,
                 "type": "Boolean"
+            },
+            "remote_confinement_points": {
+                "allow_none": false,
+                "container_type": {
+                    "allow_none": false,
+                    "required": true,
+                    "type": "EntryIDField"
+                },
+                "required": false,
+                "type": "FrozenSet"
             },
             "type": {
                 "allow_none": false,

--- a/tests/scripts/run_testenv.py
+++ b/tests/scripts/run_testenv.py
@@ -100,6 +100,7 @@ async def generate_gui_config(backend_address):
         "gui_tray_enabled": False,
         "gui_last_version": PARSEC_VERSION,
         "preferred_org_creation_backend_addr": backend_address.to_url(),
+        "gui_show_confined": True,
     }
     await config_file.write_text(json.dumps(config, indent=4))
 


### PR DESCRIPTION
Fix #990

Follow-up on #1252, closed by mistake

Add support for confined and filtered (i.e temporary) files and directories.
In this context:
- confined entries: local files and directories that are not meant to be synchronized with other clients
- filtered entries: remote files and directories synced by other clients that should not appear locally


It includes:
- [x] Add confined entry set to local manifest
- [x] Add filtered entry set to local manifest (filtering entries from other clients)
- [x] Define a confinement pattern list
- [x] Add dedicated icons in the GUI for confined files
- [x] Update sync monitor to manage the syncing of no-longer-confined entries
- [x] Implement the procedure for changing filter pattern
- [x] Make the pattern list configurable (optional)
