### PR TITLE
Pin pyqt5-sip dependency to avoid issues in the future

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -313,13 +313,13 @@ test_requirements = [
 ]
 
 
-PYQT_DEP = "PyQt5==5.14.2"
+PYQT_DEPS = ["PyQt5==5.14.2", "pyqt5-sip==12.8.0"]
 BABEL_DEP = "Babel==2.6.0"
 WHEEL_DEP = "wheel==0.34.2"
 DOCUTILS_DEP = "docutils==0.15"
 extra_requirements = {
     "core": [
-        PYQT_DEP,
+        *PYQT_DEPS,
         BABEL_DEP,
         'fusepy==3.0.1;platform_system=="Linux"',
         'winfspy==0.8.0;platform_system=="Windows"',
@@ -354,7 +354,7 @@ setup(
     python_requires="~=3.6",
     packages=find_packages(include=["parsec", "parsec.*"]),
     package_dir={"parsec": "parsec"},
-    setup_requires=[WHEEL_DEP, PYQT_DEP, BABEL_DEP, DOCUTILS_DEP],  # To generate resources bundle
+    setup_requires=[WHEEL_DEP, *PYQT_DEPS, BABEL_DEP, DOCUTILS_DEP],  # To generate resources bundle
     install_requires=requirements,
     extras_require=extra_requirements,
     cmdclass={


### PR DESCRIPTION
Address https://github.com/Scille/parsec-cloud/issues/1309#issuecomment-666334980:
> And related to this matter, I suggest to define the pyQt5-sip version to 12.8.0, in the relevant place (setup.py?). This would avoid breaking change issue in the future.

