### PR TITLE
Do not restart invitation process on InvitationAlreadyUsedError

### DIFF
--- a/newsfragments/1363.bugfix.rst
+++ b/newsfragments/1363.bugfix.rst
@@ -1,0 +1,1 @@
+Do not restart claimer invitation process on an InviteAlreadyUsedError

--- a/parsec/core/gui/claim_device_widget.py
+++ b/parsec/core/gui/claim_device_widget.py
@@ -9,7 +9,7 @@ from PyQt5.QtWidgets import QWidget
 
 from parsec.core.types import LocalDevice
 from parsec.core.local_device import save_device_with_password
-from parsec.core.invite import claimer_retrieve_info, InvitePeerResetError
+from parsec.core.invite import claimer_retrieve_info, InvitePeerResetError, InviteAlreadyUsedError
 from parsec.core.backend_connection import (
     backend_invited_cmds_factory,
     BackendConnectionRefused,
@@ -560,8 +560,10 @@ class ClaimDeviceWidget(QWidget, Ui_ClaimDeviceWidget):
         if job is not None and job.status == "cancelled":
             self.dialog.reject()
             return
-        # No reason to restart the process if offline, simply close the dialog
-        if job is not None and isinstance(job.exc.params.get("origin", None), BackendNotAvailable):
+        # No reason to restart the process if offline or invitation has been deleted, simply close the dialog
+        if job is not None and isinstance(
+            job.exc.params.get("origin", None), (BackendNotAvailable, InviteAlreadyUsedError)
+        ):
             self.dialog.reject()
             return
         # Let's try one more time with the same dialog

--- a/parsec/core/gui/claim_user_widget.py
+++ b/parsec/core/gui/claim_user_widget.py
@@ -10,7 +10,8 @@ from PyQt5.QtWidgets import QWidget
 from parsec.api.protocol import HumanHandle
 from parsec.core.types import LocalDevice
 from parsec.core.local_device import LocalDeviceAlreadyExistsError, save_device_with_password
-from parsec.core.invite import claimer_retrieve_info, InvitePeerResetError
+from parsec.core.invite import claimer_retrieve_info, InvitePeerResetError, InviteAlreadyUsedError
+
 from parsec.core.backend_connection import (
     backend_invited_cmds_factory,
     BackendConnectionRefused,
@@ -613,8 +614,11 @@ class ClaimUserWidget(QWidget, Ui_ClaimUserWidget):
         if job is not None and job.status == "cancelled":
             self.dialog.reject()
             return
-        # No reason to restart the process if offline, simply close the dialog
-        if job is not None and isinstance(job.exc.params.get("origin", None), BackendNotAvailable):
+        # No reason to restart the process if offline or if the invitation has been deleted
+        # simply close the dialog
+        if job is not None and isinstance(
+            job.exc.params.get("origin", None), (BackendNotAvailable, InviteAlreadyUsedError)
+        ):
             self.dialog.reject()
             return
         # Let's try one more time with the same dialog


### PR DESCRIPTION
Do not restart invitation process if `InvitationAlreadyUsedError` is raised

This solved issue #1362 : 
our cancel test expects on step2 to get a failure on `wait_peer` job because the communication channel is supposed to be closed by the backend:
In fact there is nothing that grantee that the communication channel will be closed before `wait_peer` returns an `InvitationAlreadyUsedError` due to the cancellation.


Maybe `InvitationNotFoundError` should also not trigger a re connection ?