### PR TITLE
Devices keys filenames are no longer meaningful

### DIFF
--- a/newsfragments/1366.misc.rst
+++ b/newsfragments/1366.misc.rst
@@ -1,0 +1,8 @@
+Devices keys filenames are no longer meaningful.
+
+Device key files used to be stored in a directory named after the device slug
+in a file also named after the same device slug. As a result, the device path
+used to be very long (about 200 characters).
+
+Device key files are now stored directly in the devices directory using the
+device slughash and the `.keys` extension. The path is now much shorter

--- a/parsec/core/local_device.py
+++ b/parsec/core/local_device.py
@@ -204,8 +204,11 @@ def _load_device_file(key_file_path: Path) -> Optional[AvailableDevice]:
 def _iter_available_devices(config_dir: Path) -> Iterator[AvailableDevice]:
     # Set of seen slugs
     seen = set()
-    # Loop over `.keys` files in devices directory and subdirectories
-    for key_file_path in get_devices_dir(config_dir).rglob("*.keys"):
+    # Consider `.keys` files in devices directory and subdirectories
+    key_file_paths = list(get_devices_dir(config_dir).rglob("*.keys"))
+    # Sort paths so the discovery order is deterministic
+    # In the case of duplicate files, that means only the first discovered device is considered
+    for key_file_path in sorted(key_file_paths):
         # Load the device file
         device = _load_device_file(key_file_path)
         # Try with the legacy deserializer if necessary

--- a/parsec/core/types/local_device.py
+++ b/parsec/core/types/local_device.py
@@ -75,6 +75,15 @@ class LocalDevice(BaseLocalData):
 
     @property
     def slug(self) -> str:
+        """The slug is unique identifier for a particular device.
+
+        It is composed of a small part of the RVK hash, the organization ID
+        and the device ID, although it shouldn't be assumed that this information
+        can be recovered from the slug as this might change in the future.
+
+        The purpose of the slog is simply to tell whether `LocalDevice` and
+        `AvailableDevice` objects corresponds to the same device.
+        """
         # Add a hash to avoid clash when the backend is reseted
         # and we recreate a device with same organization/device_id
         # organization and device_id than a previous one

--- a/tests/core/test_local_device.py
+++ b/tests/core/test_local_device.py
@@ -1,16 +1,18 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
+import os
 import pytest
-from uuid import UUID
 from pathlib import Path
+from uuid import UUID, uuid4
 
 from parsec.crypto import SigningKey
 from parsec.serde import packb, unpackb
-from parsec.api.protocol import OrganizationID, DeviceID
+from parsec.api.protocol import OrganizationID, DeviceID, HumanHandle
 from parsec.core.types import LocalDevice
 from parsec.core.local_device import (
     AvailableDevice,
     get_key_file,
+    get_default_key_file,
     get_devices_dir,
     list_available_devices,
     load_device_with_password,
@@ -78,6 +80,7 @@ def test_list_devices(organization_factory, local_device_factory, config_dir):
             device_id=d.device_id,
             human_handle=d.human_handle,
             device_label=d.device_label,
+            slug=d.slug,
         )
         for d in [o1d11, o1d12, o1d21, o2d11, o2d12, o2d21]
     }
@@ -99,25 +102,28 @@ def test_list_devices_support_legacy_file_without_labels(config_dir):
         device_id=DeviceID("Zack@PC1"),
         human_handle=None,
         device_label=None,
+        slug=slug,
     )
     assert devices == [expected_device]
 
 
 def test_available_device_display(config_dir, alice):
     without_labels = AvailableDevice(
-        key_file_path=get_key_file(config_dir, alice),
+        key_file_path=get_default_key_file(config_dir, alice),
         organization_id=alice.organization_id,
         device_id=alice.device_id,
         human_handle=None,
         device_label=None,
+        slug=alice.slug,
     )
 
     with_labels = AvailableDevice(
-        key_file_path=get_key_file(config_dir, alice),
+        key_file_path=get_default_key_file(config_dir, alice),
         organization_id=alice.organization_id,
         device_id=alice.device_id,
         human_handle=alice.human_handle,
         device_label=alice.device_label,
+        slug=alice.slug,
     )
 
     assert without_labels.device_display == alice.device_name
@@ -132,11 +138,12 @@ def test_available_devices_slughash_uniqueness(
 ):
     def _to_available(device):
         return AvailableDevice(
-            key_file_path=get_key_file(config_dir, device),
+            key_file_path=get_default_key_file(config_dir, device),
             organization_id=device.organization_id,
             device_id=device.device_id,
             human_handle=device.human_handle,
             device_label=device.device_label,
+            slug=device.slug,
         )
 
     def _assert_different_as_available(d1, d2):
@@ -202,13 +209,12 @@ def test_load_bad_password(config_dir, alice):
 
 
 def test_load_bad_data(config_dir, alice):
-    alice_key = get_key_file(config_dir, alice)
+    alice_key = get_default_key_file(config_dir, alice)
     alice_key.parent.mkdir(parents=True)
     alice_key.write_bytes(b"dummy")
 
     with pytest.raises(LocalDevicePackingError):
-        key_file = get_key_file(config_dir, alice)
-        load_device_with_password(key_file, "S3Cr37")
+        load_device_with_password(alice_key, "S3Cr37")
 
 
 def test_password_save_already_existing(config_dir, alice):
@@ -220,7 +226,7 @@ def test_password_save_already_existing(config_dir, alice):
 
 def test_password_load_not_found(config_dir, alice):
     with pytest.raises(LocalDeviceNotFoundError):
-        key_file = get_key_file(config_dir, alice)
+        key_file = get_default_key_file(config_dir, alice)
         load_device_with_password(key_file, "S3Cr37")
 
 

--- a/tests/core/test_local_device.py
+++ b/tests/core/test_local_device.py
@@ -331,3 +331,22 @@ def test_list_devices_support_legacy_file_with_meaningful_name(config_dir):
     )
     assert devices == [expected_device]
     assert get_key_file(config_dir, expected_device) == key_file_path
+
+
+def test_multiple_files_same_device(config_dir, alice):
+    path = save_device_with_password(config_dir, alice, "test")
+
+    # File names contain the slughash
+    assert path.stem == alice.slughash
+
+    # .. but are no longer meaningful
+    (path.parent / "testing.keys").write_bytes(path.read_bytes())
+
+    # Make sure we don't list duplicates
+    devices = list_available_devices(config_dir)
+    assert len(devices) == 1
+
+    # Remove orignal file
+    path.unlink()
+    devices = list_available_devices(config_dir)
+    assert len(devices) == 1


### PR DESCRIPTION
Key files used to be stored in a directory named after the device slug in a file also named after the same device slug. The total length is more than 160 characters depending on the organization name.

Key files are now stored directly in the devices directory using the device slughash and the `.keys` extension. The total length is 37
characters.

This fixes issue #1356.