### PR TITLE
Invitation: inconsistent backend replies

### DIFF
--- a/newsfragments/1365.bugfix.rst
+++ b/newsfragments/1365.bugfix.rst
@@ -1,0 +1,1 @@
+Fix inconsistence backend replies from an cancelled invite command

--- a/parsec/backend/app.py
+++ b/parsec/backend/app.py
@@ -27,7 +27,7 @@ from parsec.backend.handshake import do_handshake
 from parsec.backend.memory import components_factory as mocked_components_factory
 from parsec.backend.postgresql import components_factory as postgresql_components_factory
 from parsec.backend.http import HTTPRequest
-from parsec.backend.invite import InvitationAlreadyDeletedError
+from parsec.backend.invite import CloseInviteConnection
 
 
 logger = get_logger()
@@ -169,6 +169,16 @@ class BackendApp:
                                 BackendEvent.INVITE_STATUS_CHANGED, _on_invite_status_changed
                             )
                             await self._handle_client_loop(transport, client_ctx)
+
+                except CloseInviteConnection:
+                    # If the invitation has been deleted after the invited handshake,
+                    # invitation commands can raise an InvitationAlreadyDeletedError.
+                    # This error is converted to a CloseInviteConnection
+                    # The connection shall be closed due to a BackendEvent.INVITE_STATUS_CHANGED
+                    # but nothing garantie that the event will be handled before cmd_func
+                    # errors returns. If this happen, let's also close the connection
+                    pass
+
                 finally:
                     with trio.CancelScope(shield=True):
                         await self.invite.claimer_left(
@@ -303,15 +313,6 @@ class BackendApp:
                         "errors": exc.errors,
                         "reason": "Invalid message.",
                     }
-
-                except InvitationAlreadyDeletedError:
-                    # If the invitation has been deleted after the invited handshake,
-                    # invitation commands can raise an InvitationAlreadyDeletedError.
-                    # The connection shall be closed due to a BackendEvent.INVITE_STATUS_CHANGED
-                    # but nothing garantie that the event will be handled before cmd_func
-                    # errors returns. If this happen, let's also trigger the cancelation from
-                    # the handle client loop
-                    return
 
                 except ProtocolError as exc:
                     rep = {"status": "bad_message", "reason": str(exc)}

--- a/parsec/backend/app.py
+++ b/parsec/backend/app.py
@@ -168,7 +168,7 @@ class BackendApp:
                             event_bus_ctx.connect(
                                 BackendEvent.INVITE_STATUS_CHANGED, _on_invite_status_changed
                             )
-                            await self._handle_client_loop(transport, client_ctx, cancel_scope)
+                            await self._handle_client_loop(transport, client_ctx)
                 finally:
                     with trio.CancelScope(shield=True):
                         await self.invite.claimer_left(
@@ -271,7 +271,7 @@ class BackendApp:
             # Peer is already gone, nothing to do
             pass
 
-    async def _handle_client_loop(self, transport, client_ctx, cancel_scope=None):
+    async def _handle_client_loop(self, transport, client_ctx):
         # Retrieve the allowed commands according to api version and auth type
         api_cmds = self.apis[client_ctx.handshake_type]
 
@@ -311,12 +311,7 @@ class BackendApp:
                     # but nothing garantie that the event will be handled before cmd_func
                     # errors returns. If this happen, let's also trigger the cancelation from
                     # the handle client loop
-                    if cancel_scope:
-                        raw_req = None
-                        cancel_scope.cancel()
-                        await trio.sleep(0)
-                    else:
-                        raise
+                    return
 
                 except ProtocolError as exc:
                     rep = {"status": "bad_message", "reason": str(exc)}

--- a/parsec/backend/app.py
+++ b/parsec/backend/app.py
@@ -27,6 +27,7 @@ from parsec.backend.handshake import do_handshake
 from parsec.backend.memory import components_factory as mocked_components_factory
 from parsec.backend.postgresql import components_factory as postgresql_components_factory
 from parsec.backend.http import HTTPRequest
+from parsec.backend.invite import InvitationAlreadyDeletedError
 
 
 logger = get_logger()
@@ -167,7 +168,7 @@ class BackendApp:
                             event_bus_ctx.connect(
                                 BackendEvent.INVITE_STATUS_CHANGED, _on_invite_status_changed
                             )
-                            await self._handle_client_loop(transport, client_ctx)
+                            await self._handle_client_loop(transport, client_ctx, cancel_scope)
                 finally:
                     with trio.CancelScope(shield=True):
                         await self.invite.claimer_left(
@@ -270,7 +271,7 @@ class BackendApp:
             # Peer is already gone, nothing to do
             pass
 
-    async def _handle_client_loop(self, transport, client_ctx):
+    async def _handle_client_loop(self, transport, client_ctx, cancel_scope=None):
         # Retrieve the allowed commands according to api version and auth type
         api_cmds = self.apis[client_ctx.handshake_type]
 
@@ -302,6 +303,20 @@ class BackendApp:
                         "errors": exc.errors,
                         "reason": "Invalid message.",
                     }
+
+                except InvitationAlreadyDeletedError:
+                    # If the invitation has been deleted after the invited handshake,
+                    # invitation commands can raise an InvitationAlreadyDeletedError.
+                    # The connection shall be closed due to a BackendEvent.INVITE_STATUS_CHANGED
+                    # but nothing garantie that the event will be handled before cmd_func
+                    # errors returns. If this happen, let's also trigger the cancelation from
+                    # the handle client loop
+                    if cancel_scope:
+                        raw_req = None
+                        cancel_scope.cancel()
+                        await trio.sleep(0)
+                    else:
+                        raise
 
                 except ProtocolError as exc:
                     rep = {"status": "bad_message", "reason": str(exc)}

--- a/parsec/backend/handshake.py
+++ b/parsec/backend/handshake.py
@@ -20,7 +20,12 @@ from parsec.backend.client_context import (
 )
 from parsec.backend.user import UserNotFoundError
 from parsec.backend.organization import OrganizationNotFoundError, OrganizationAlreadyExistsError
-from parsec.backend.invite import InvitationError, UserInvitation, DeviceInvitation
+from parsec.backend.invite import (
+    InvitationError,
+    UserInvitation,
+    DeviceInvitation,
+    InvitationAlreadyDeletedError,
+)
 
 
 async def do_handshake(
@@ -158,6 +163,10 @@ async def _process_invited_answer(
         invitation = await backend.invite.info(
             organization_id, token=handshake.answer_data["token"]
         )
+    except InvitationAlreadyDeletedError:
+        result_req = handshake.build_bad_identity_result_req(help="InvitationAlreadyDeletedError")
+        return None, result_req, _make_error_infos("Bad invitation")
+
     except InvitationError:
         result_req = handshake.build_bad_identity_result_req()
         return None, result_req, _make_error_infos("Bad invitation")

--- a/parsec/backend/handshake.py
+++ b/parsec/backend/handshake.py
@@ -25,6 +25,7 @@ from parsec.backend.invite import (
     UserInvitation,
     DeviceInvitation,
     InvitationAlreadyDeletedError,
+    InvitationNotFoundError,
 )
 
 
@@ -164,7 +165,15 @@ async def _process_invited_answer(
             organization_id, token=handshake.answer_data["token"]
         )
     except InvitationAlreadyDeletedError:
-        result_req = handshake.build_bad_identity_result_req(help="InvitationAlreadyDeletedError")
+        result_req = handshake.build_bad_identity_result_req(
+            help="Invalid handshake: Invitation already deleted"
+        )
+        return None, result_req, _make_error_infos("Bad invitation")
+
+    except InvitationNotFoundError:
+        result_req = handshake.build_bad_identity_result_req(
+            help="Invalid handshake: Invitation not found"
+        )
         return None, result_req, _make_error_infos("Bad invitation")
 
     except InvitationError:

--- a/parsec/backend/invite.py
+++ b/parsec/backend/invite.py
@@ -414,7 +414,7 @@ class BaseInviteComponent:
                 payload=msg["claimer_public_key"].encode(),
             )
 
-        # Let InvitayytionAlreadyDeletedError bunble up.
+        # Let InvitationAlreadyDeletedError bubble up.
 
         except InvitationNotFoundError:
             return {"status": "not_found"}
@@ -479,7 +479,7 @@ class BaseInviteComponent:
                 payload=b"",
             )
 
-        # Let InvitayytionAlreadyDeletedError bunble up.
+        # Let InvitationAlreadyDeletedError bubble up.
 
         except InvitationNotFoundError:
             return {"status": "not_found"}
@@ -571,7 +571,7 @@ class BaseInviteComponent:
                 payload=msg["claimer_nonce"],
             )
 
-        # Let InvitayytionAlreadyDeletedError bunble up.
+        # Let InvitationAlreadyDeletedError bubble up.
 
         except InvitationNotFoundError:
             return {"status": "not_found"}
@@ -624,7 +624,7 @@ class BaseInviteComponent:
                 payload=b"",
             )
 
-        # Let InvitayytionAlreadyDeletedError bunble up.
+        # Let InvitationAlreadyDeletedError bubble up.
 
         except InvitationNotFoundError:
             return {"status": "not_found"}
@@ -677,7 +677,7 @@ class BaseInviteComponent:
                 payload=b"",
             )
 
-        # Let InvitayytionAlreadyDeletedError bunble up.
+        # Let InvitationAlreadyDeletedError bubble up.
 
         except InvitationNotFoundError:
             return {"status": "not_found"}
@@ -732,7 +732,7 @@ class BaseInviteComponent:
                 payload=msg["payload"],
             )
 
-        # Let InvitayytionAlreadyDeletedError bunble up.
+        # Let InvitationAlreadyDeletedError bubble up.
 
         except InvitationNotFoundError:
             return {"status": "not_found"}

--- a/parsec/backend/invite.py
+++ b/parsec/backend/invite.py
@@ -399,6 +399,10 @@ class BaseInviteComponent:
     @api("invite_1_claimer_wait_peer", handshake_types=[HandshakeType.INVITED])
     @catch_protocol_errors
     async def api_invite_1_claimer_wait_peer(self, client_ctx, msg):
+        """
+        Raises:
+            InvitationAlreadyDeletedError
+        """
         msg = invite_1_claimer_wait_peer_serializer.req_load(msg)
 
         try:
@@ -410,11 +414,10 @@ class BaseInviteComponent:
                 payload=msg["claimer_public_key"].encode(),
             )
 
+        # Let InvitayytionAlreadyDeletedError bunble up.
+
         except InvitationNotFoundError:
             return {"status": "not_found"}
-
-        except InvitationAlreadyDeletedError:
-            return {"status": "already_deleted"}
 
         except InvitationInvalidStateError:
             return {"status": "invalid_state"}
@@ -453,6 +456,10 @@ class BaseInviteComponent:
     @api("invite_2a_claimer_send_hashed_nonce", handshake_types=[HandshakeType.INVITED])
     @catch_protocol_errors
     async def api_invite_2a_claimer_send_hashed_nonce(self, client_ctx, msg):
+        """
+        Raises:
+            InvitationAlreadyDeletedError
+        """
         msg = invite_2a_claimer_send_hashed_nonce_serializer.req_load(msg)
 
         try:
@@ -472,11 +479,10 @@ class BaseInviteComponent:
                 payload=b"",
             )
 
+        # Let InvitayytionAlreadyDeletedError bunble up.
+
         except InvitationNotFoundError:
             return {"status": "not_found"}
-
-        except InvitationAlreadyDeletedError:
-            return {"status": "already_deleted"}
 
         except InvitationInvalidStateError:
             return {"status": "invalid_state"}
@@ -550,6 +556,10 @@ class BaseInviteComponent:
     @api("invite_2b_claimer_send_nonce", handshake_types=[HandshakeType.INVITED])
     @catch_protocol_errors
     async def api_invite_2b_claimer_send_nonce(self, client_ctx, msg):
+        """
+        Raises:
+            InvitationAlreadyDeletedError
+        """
         msg = invite_2b_claimer_send_nonce_serializer.req_load(msg)
 
         try:
@@ -561,11 +571,10 @@ class BaseInviteComponent:
                 payload=msg["claimer_nonce"],
             )
 
+        # Let InvitayytionAlreadyDeletedError bunble up.
+
         except InvitationNotFoundError:
             return {"status": "not_found"}
-
-        except InvitationAlreadyDeletedError:
-            return {"status": "already_deleted"}
 
         except InvitationInvalidStateError:
             return {"status": "invalid_state"}
@@ -600,6 +609,10 @@ class BaseInviteComponent:
     @api("invite_3b_claimer_wait_peer_trust", handshake_types=[HandshakeType.INVITED])
     @catch_protocol_errors
     async def api_invite_3b_claimer_wait_peer_trust(self, client_ctx, msg):
+        """
+        Raises:
+            InvitationAlreadyDeletedError
+        """
         msg = invite_3b_claimer_wait_peer_trust_serializer.req_load(msg)
 
         try:
@@ -611,11 +624,10 @@ class BaseInviteComponent:
                 payload=b"",
             )
 
+        # Let InvitayytionAlreadyDeletedError bunble up.
+
         except InvitationNotFoundError:
             return {"status": "not_found"}
-
-        except InvitationAlreadyDeletedError:
-            return {"status": "already_deleted"}
 
         except InvitationInvalidStateError:
             return {"status": "invalid_state"}
@@ -650,6 +662,10 @@ class BaseInviteComponent:
     @api("invite_3a_claimer_signify_trust", handshake_types=[HandshakeType.INVITED])
     @catch_protocol_errors
     async def api_invite_3a_claimer_signify_trust(self, client_ctx, msg):
+        """
+        Raises:
+            InvitationAlreadyDeletedError
+        """
         msg = invite_3a_claimer_signify_trust_serializer.req_load(msg)
 
         try:
@@ -661,11 +677,10 @@ class BaseInviteComponent:
                 payload=b"",
             )
 
+        # Let InvitayytionAlreadyDeletedError bunble up.
+
         except InvitationNotFoundError:
             return {"status": "not_found"}
-
-        except InvitationAlreadyDeletedError:
-            return {"status": "already_deleted"}
 
         except InvitationInvalidStateError:
             return {"status": "invalid_state"}
@@ -702,6 +717,10 @@ class BaseInviteComponent:
     @api("invite_4_claimer_communicate", handshake_types=[HandshakeType.INVITED])
     @catch_protocol_errors
     async def api_invite_4_claimer_communicate(self, client_ctx, msg):
+        """
+        Raises:
+            InvitationAlreadyDeletedError
+        """
         msg = invite_4_claimer_communicate_serializer.req_load(msg)
 
         try:
@@ -713,11 +732,10 @@ class BaseInviteComponent:
                 payload=msg["payload"],
             )
 
+        # Let InvitayytionAlreadyDeletedError bunble up.
+
         except InvitationNotFoundError:
             return {"status": "not_found"}
-
-        except InvitationAlreadyDeletedError:
-            return {"status": "already_deleted"}
 
         except InvitationInvalidStateError:
             return {"status": "invalid_state"}

--- a/parsec/backend/invite.py
+++ b/parsec/backend/invite.py
@@ -405,7 +405,7 @@ class BaseInviteComponent:
     async def api_invite_1_claimer_wait_peer(self, client_ctx, msg):
         """
         Raises:
-            InvitationAlreadyDeletedError
+            CloseInviteConnection
         """
         msg = invite_1_claimer_wait_peer_serializer.req_load(msg)
 
@@ -464,7 +464,7 @@ class BaseInviteComponent:
     async def api_invite_2a_claimer_send_hashed_nonce(self, client_ctx, msg):
         """
         Raises:
-            InvitationAlreadyDeletedError
+            CloseInviteConnection
         """
         msg = invite_2a_claimer_send_hashed_nonce_serializer.req_load(msg)
 
@@ -566,7 +566,7 @@ class BaseInviteComponent:
     async def api_invite_2b_claimer_send_nonce(self, client_ctx, msg):
         """
         Raises:
-            InvitationAlreadyDeletedError
+            CloseInviteConnection
         """
         msg = invite_2b_claimer_send_nonce_serializer.req_load(msg)
 
@@ -621,7 +621,7 @@ class BaseInviteComponent:
     async def api_invite_3b_claimer_wait_peer_trust(self, client_ctx, msg):
         """
         Raises:
-            InvitationAlreadyDeletedError
+            CloseInviteConnection
         """
         msg = invite_3b_claimer_wait_peer_trust_serializer.req_load(msg)
 
@@ -676,7 +676,7 @@ class BaseInviteComponent:
     async def api_invite_3a_claimer_signify_trust(self, client_ctx, msg):
         """
         Raises:
-            InvitationAlreadyDeletedError
+            CloseInviteConnection
         """
         msg = invite_3a_claimer_signify_trust_serializer.req_load(msg)
 
@@ -733,7 +733,7 @@ class BaseInviteComponent:
     async def api_invite_4_claimer_communicate(self, client_ctx, msg):
         """
         Raises:
-            InvitationAlreadyDeletedError
+            CloseInviteConnection
         """
         msg = invite_4_claimer_communicate_serializer.req_load(msg)
 

--- a/parsec/backend/invite.py
+++ b/parsec/backend/invite.py
@@ -56,6 +56,10 @@ logger = get_logger()
 PEER_EVENT_MAX_WAIT = 300  # 5mn
 
 
+class CloseInviteConnection(Exception):
+    pass
+
+
 class InvitationError(Exception):
     pass
 
@@ -414,7 +418,9 @@ class BaseInviteComponent:
                 payload=msg["claimer_public_key"].encode(),
             )
 
-        # Let InvitationAlreadyDeletedError bubble up.
+        except InvitationAlreadyDeletedError as exc:
+            # Notify parent that the connection shall be close because the invitation token is no logger valide.
+            raise CloseInviteConnection from exc
 
         except InvitationNotFoundError:
             return {"status": "not_found"}
@@ -479,7 +485,9 @@ class BaseInviteComponent:
                 payload=b"",
             )
 
-        # Let InvitationAlreadyDeletedError bubble up.
+        except InvitationAlreadyDeletedError as exc:
+            # Notify parent that the connection shall be close because the invitation token is no logger valide.
+            raise CloseInviteConnection from exc
 
         except InvitationNotFoundError:
             return {"status": "not_found"}
@@ -571,7 +579,9 @@ class BaseInviteComponent:
                 payload=msg["claimer_nonce"],
             )
 
-        # Let InvitationAlreadyDeletedError bubble up.
+        except InvitationAlreadyDeletedError as exc:
+            # Notify parent that the connection shall be close because the invitation token is no logger valide.
+            raise CloseInviteConnection from exc
 
         except InvitationNotFoundError:
             return {"status": "not_found"}
@@ -624,7 +634,9 @@ class BaseInviteComponent:
                 payload=b"",
             )
 
-        # Let InvitationAlreadyDeletedError bubble up.
+        except InvitationAlreadyDeletedError as exc:
+            # Notify parent that the connection shall be close because the invitation token is no logger valide.
+            raise CloseInviteConnection from exc
 
         except InvitationNotFoundError:
             return {"status": "not_found"}
@@ -677,7 +689,9 @@ class BaseInviteComponent:
                 payload=b"",
             )
 
-        # Let InvitationAlreadyDeletedError bubble up.
+        except InvitationAlreadyDeletedError as exc:
+            # Notify parent that the connection shall be close because the invitation token is no logger valide.
+            raise CloseInviteConnection from exc
 
         except InvitationNotFoundError:
             return {"status": "not_found"}
@@ -732,7 +746,9 @@ class BaseInviteComponent:
                 payload=msg["payload"],
             )
 
-        # Let InvitationAlreadyDeletedError bubble up.
+        except InvitationAlreadyDeletedError as exc:
+            # Notify parent that the connection shall be close because the invitation token is no logger valide.
+            raise CloseInviteConnection from exc
 
         except InvitationNotFoundError:
             return {"status": "not_found"}

--- a/parsec/core/backend_connection/__init__.py
+++ b/parsec/core/backend_connection/__init__.py
@@ -5,6 +5,8 @@ from parsec.core.backend_connection.exceptions import (
     BackendProtocolError,
     BackendNotAvailable,
     BackendConnectionRefused,
+    BackendInvitationNotFound,
+    BackendInvitationAlreadyUsed,
     BackendNotFoundError,
 )
 from parsec.core.backend_connection.authenticated import (
@@ -35,6 +37,8 @@ __all__ = (
     "BackendProtocolError",
     "BackendNotAvailable",
     "BackendConnectionRefused",
+    "BackendInvitationNotFound",
+    "BackendInvitationAlreadyUsed",
     "BackendNotFoundError",
     # Authenticated
     "BackendAuthenticatedCmds",

--- a/parsec/core/backend_connection/exceptions.py
+++ b/parsec/core/backend_connection/exceptions.py
@@ -17,6 +17,14 @@ class BackendConnectionRefused(BackendConnectionError):
     pass
 
 
+class BackendInvitationAlreadyUsed(BackendConnectionRefused):
+    pass
+
+
+class BackendInvitationNotFound(BackendConnectionRefused):
+    pass
+
+
 # TODO: hack needed by `LoggedCore.get_user_info`
 class BackendNotFoundError(BackendConnectionError):
     pass

--- a/parsec/core/backend_connection/invited.py
+++ b/parsec/core/backend_connection/invited.py
@@ -8,7 +8,7 @@ from parsec.api.protocol import INVITED_CMDS
 from parsec.core.types import BackendInvitationAddr
 from parsec.core.backend_connection.transport import connect_as_invited
 from parsec.core.backend_connection.exceptions import BackendNotAvailable
-from parsec.core.backend_connection.expose_cmds import expose_cmds
+from parsec.core.backend_connection.expose_cmds import expose_cmds_with_retrier
 
 
 class BackendInvitedCmds:
@@ -17,7 +17,7 @@ class BackendInvitedCmds:
         self.acquire_transport = acquire_transport
 
     for cmd_name in INVITED_CMDS:
-        vars()[cmd_name] = expose_cmds(cmd_name)
+        vars()[cmd_name] = expose_cmds_with_retrier(cmd_name)
 
 
 @asynccontextmanager

--- a/parsec/core/backend_connection/transport.py
+++ b/parsec/core/backend_connection/transport.py
@@ -30,6 +30,8 @@ from parsec.core.backend_connection.exceptions import (
     BackendConnectionError,
     BackendNotAvailable,
     BackendConnectionRefused,
+    BackendInvitationAlreadyUsed,
+    BackendInvitationNotFound,
     BackendProtocolError,
 )
 
@@ -166,7 +168,12 @@ async def _do_handshake(transport: Transport, handshake):
         raise BackendNotAvailable(exc) from exc
 
     except HandshakeError as exc:
-        raise BackendConnectionRefused(str(exc)) from exc
+        if str(exc) == "Invalid handshake: Invitation not found":
+            raise BackendInvitationNotFound(str(exc)) from exc
+        elif str(exc) == "Invalid handshake: Invitation already deleted":
+            raise BackendInvitationAlreadyUsed(str(exc)) from exc
+        else:
+            raise BackendConnectionRefused(str(exc)) from exc
 
     except ProtocolError as exc:
         transport.logger.exception("Protocol error during handshake")

--- a/parsec/core/gui/claim_device_widget.py
+++ b/parsec/core/gui/claim_device_widget.py
@@ -562,7 +562,8 @@ class ClaimDeviceWidget(QWidget, Ui_ClaimDeviceWidget):
             return
         # No reason to restart the process if offline or invitation has been deleted, simply close the dialog
         if job is not None and isinstance(
-            job.exc.params.get("origin", None), (BackendNotAvailable, InviteAlreadyUsedError)
+            job.exc.params.get("origin", None),
+            (BackendNotAvailable, BackendConnectionRefused, InviteAlreadyUsedError),
         ):
             self.dialog.reject()
             return

--- a/parsec/core/gui/claim_device_widget.py
+++ b/parsec/core/gui/claim_device_widget.py
@@ -9,10 +9,11 @@ from PyQt5.QtWidgets import QWidget
 
 from parsec.core.types import LocalDevice
 from parsec.core.local_device import save_device_with_password
-from parsec.core.invite import claimer_retrieve_info, InvitePeerResetError, InviteAlreadyUsedError
+from parsec.core.invite import claimer_retrieve_info, InvitePeerResetError
 from parsec.core.backend_connection import (
     backend_invited_cmds_factory,
     BackendConnectionRefused,
+    BackendInvitationAlreadyUsed,
     BackendNotAvailable,
 )
 from parsec.core.gui import validators
@@ -49,6 +50,9 @@ class Claimer:
             async with backend_invited_cmds_factory(
                 addr=addr, keepalive=config.backend_connection_keepalive
             ) as cmds:
+                # Trigger handshake
+                await cmds.ping()
+
                 r = await self.main_oob_recv.receive()
 
                 assert r == self.Step.RetrieveInfo
@@ -113,6 +117,8 @@ class Claimer:
                     await self.job_oob_send.send((False, exc, None))
         except BackendNotAvailable as exc:
             raise JobResultError(status="backend-not-available", origin=exc)
+        except BackendInvitationAlreadyUsed as exc:
+            raise JobResultError(status="invitation-already-used", origin=exc)
         except BackendConnectionRefused as exc:
             raise JobResultError(status="invitation-not-found", origin=exc)
 
@@ -254,6 +260,8 @@ class ClaimDeviceCodeExchangeWidget(QWidget, Ui_ClaimDeviceCodeExchangeWidget):
                 exc = job.exc.params.get("origin", None)
                 if isinstance(exc, InvitePeerResetError):
                     msg = _("TEXT_CLAIM_DEVICE_PEER_RESET")
+                if isinstance(exc, BackendInvitationAlreadyUsed):
+                    msg = _("TEXT_INVITATION_ALREADY_USED")
             show_error(self, msg, exception=exc)
         self.failed.emit(job)
 
@@ -310,6 +318,8 @@ class ClaimDeviceCodeExchangeWidget(QWidget, Ui_ClaimDeviceCodeExchangeWidget):
                 exc = job.exc.params.get("origin", None)
                 if isinstance(exc, InvitePeerResetError):
                     msg = _("TEXT_CLAIM_DEVICE_PEER_RESET")
+                if isinstance(exc, BackendInvitationAlreadyUsed):
+                    msg = _("TEXT_INVITATION_ALREADY_USED")
             show_error(self, msg, exception=exc)
         self.failed.emit(job)
 
@@ -421,6 +431,8 @@ class ClaimDeviceProvideInfoWidget(QWidget, Ui_ClaimDeviceProvideInfoWidget):
                 exc = job.exc.params.get("origin", None)
                 if isinstance(exc, InvitePeerResetError):
                     msg = _("TEXT_CLAIM_DEVICE_PEER_RESET")
+                if isinstance(exc, BackendInvitationAlreadyUsed):
+                    msg = _("TEXT_INVITATION_ALREADY_USED")
             show_error(self, msg, exception=exc)
         self.check_infos()
         self.widget_info.setDisabled(False)
@@ -481,6 +493,8 @@ class ClaimDeviceInstructionsWidget(QWidget, Ui_ClaimDeviceInstructionsWidget):
                 exc = job.exc.params.get("origin", None)
                 if isinstance(exc, InvitePeerResetError):
                     msg = _("TEXT_CLAIM_DEVICE_PEER_RESET")
+                if isinstance(exc, BackendInvitationAlreadyUsed):
+                    msg = _("TEXT_INVITATION_ALREADY_USED")
             self.button_start.setDisabled(False)
             self.button_start.setText(_("ACTION_START"))
             show_error(self, msg, exception=exc)
@@ -562,8 +576,7 @@ class ClaimDeviceWidget(QWidget, Ui_ClaimDeviceWidget):
             return
         # No reason to restart the process if offline or invitation has been deleted, simply close the dialog
         if job is not None and isinstance(
-            job.exc.params.get("origin", None),
-            (BackendNotAvailable, BackendConnectionRefused, InviteAlreadyUsedError),
+            job.exc.params.get("origin", None), (BackendNotAvailable, BackendConnectionRefused)
         ):
             self.dialog.reject()
             return
@@ -638,7 +651,9 @@ class ClaimDeviceWidget(QWidget, Ui_ClaimDeviceWidget):
         exc = None
         if job.status == "invitation-not-found":
             msg = _("TEXT_CLAIM_DEVICE_INVITATION_NOT_FOUND")
-        elif self.claim_job.status == "backend-not-available":
+        elif job.status == "invitation-already-used":
+            msg = _("TEXT_INVITATION_ALREADY_USED")
+        elif job.status == "backend-not-available":
             msg = _("TEXT_INVITATION_BACKEND_NOT_AVAILABLE")
         else:
             msg = _("TEXT_CLAIM_DEVICE_UNKNOWN_ERROR")

--- a/parsec/core/gui/claim_user_widget.py
+++ b/parsec/core/gui/claim_user_widget.py
@@ -617,7 +617,8 @@ class ClaimUserWidget(QWidget, Ui_ClaimUserWidget):
         # No reason to restart the process if offline or if the invitation has been deleted
         # simply close the dialog
         if job is not None and isinstance(
-            job.exc.params.get("origin", None), (BackendNotAvailable, InviteAlreadyUsedError)
+            job.exc.params.get("origin", None),
+            (BackendNotAvailable, BackendConnectionRefused, InviteAlreadyUsedError),
         ):
             self.dialog.reject()
             return

--- a/parsec/core/gui/claim_user_widget.py
+++ b/parsec/core/gui/claim_user_widget.py
@@ -10,11 +10,11 @@ from PyQt5.QtWidgets import QWidget
 from parsec.api.protocol import HumanHandle
 from parsec.core.types import LocalDevice
 from parsec.core.local_device import LocalDeviceAlreadyExistsError, save_device_with_password
-from parsec.core.invite import claimer_retrieve_info, InvitePeerResetError, InviteAlreadyUsedError
-
+from parsec.core.invite import claimer_retrieve_info, InvitePeerResetError
 from parsec.core.backend_connection import (
     backend_invited_cmds_factory,
     BackendConnectionRefused,
+    BackendInvitationAlreadyUsed,
     BackendNotAvailable,
 )
 from parsec.core.gui import validators
@@ -52,6 +52,8 @@ class Claimer:
             async with backend_invited_cmds_factory(
                 addr=addr, keepalive=config.backend_connection_keepalive
             ) as cmds:
+                # Trigger handshake
+                await cmds.ping()
                 r = await self.main_oob_recv.receive()
 
                 assert r == self.Step.RetrieveInfo
@@ -116,6 +118,8 @@ class Claimer:
                     await self.job_oob_send.send((False, exc, None))
         except BackendNotAvailable as exc:
             raise JobResultError(status="backend-not-available", origin=exc)
+        except BackendInvitationAlreadyUsed as exc:
+            raise JobResultError(status="invitation-already-used", origin=exc)
         except BackendConnectionRefused as exc:
             raise JobResultError(status="invitation-not-found", origin=exc)
 
@@ -294,6 +298,8 @@ class ClaimUserCodeExchangeWidget(QWidget, Ui_ClaimUserCodeExchangeWidget):
                 exc = job.exc.params.get("origin", None)
                 if isinstance(exc, InvitePeerResetError):
                     msg = _("TEXT_CLAIM_USER_PEER_RESET")
+                if isinstance(exc, BackendInvitationAlreadyUsed):
+                    msg = _("TEXT_INVITATION_ALREADY_USED")
             show_error(self, msg, exception=exc)
         self.failed.emit(job)
 
@@ -346,6 +352,8 @@ class ClaimUserCodeExchangeWidget(QWidget, Ui_ClaimUserCodeExchangeWidget):
                 exc = job.exc.params.get("origin", None)
                 if isinstance(exc, InvitePeerResetError):
                     msg = _("TEXT_CLAIM_USER_PEER_RESET")
+                if isinstance(exc, BackendInvitationAlreadyUsed):
+                    msg = _("TEXT_INVITATION_ALREADY_USED")
             show_error(self, msg, exception=exc)
         self.failed.emit(job)
 
@@ -372,6 +380,8 @@ class ClaimUserCodeExchangeWidget(QWidget, Ui_ClaimUserCodeExchangeWidget):
                 exc = job.exc.params.get("origin", None)
                 if isinstance(exc, InvitePeerResetError):
                     msg = _("TEXT_CLAIM_USER_PEER_RESET")
+                if isinstance(exc, BackendInvitationAlreadyUsed):
+                    msg = _("TEXT_INVITATION_ALREADY_USED")
             show_error(self, msg, exception=exc)
         self.failed.emit(job)
 
@@ -463,6 +473,8 @@ class ClaimUserProvideInfoWidget(QWidget, Ui_ClaimUserProvideInfoWidget):
                 exc = job.exc.params.get("origin", None)
                 if isinstance(exc, InvitePeerResetError):
                     msg = _("TEXT_CLAIM_USER_PEER_RESET")
+                if isinstance(exc, BackendInvitationAlreadyUsed):
+                    msg = _("TEXT_INVITATION_ALREADY_USED")
             show_error(self, msg, exception=exc)
         self.check_infos()
         self.widget_info.setDisabled(False)
@@ -523,6 +535,8 @@ class ClaimUserInstructionsWidget(QWidget, Ui_ClaimUserInstructionsWidget):
                 exc = job.exc.params.get("origin", None)
                 if isinstance(exc, InvitePeerResetError):
                     msg = _("TEXT_CLAIM_USER_PEER_RESET")
+                if isinstance(exc, BackendInvitationAlreadyUsed):
+                    msg = _("TEXT_INVITATION_ALREADY_USED")
             self.button_start.setDisabled(False)
             self.button_start.setText(_("ACTION_START"))
             show_error(self, msg, exception=exc)
@@ -595,6 +609,8 @@ class ClaimUserWidget(QWidget, Ui_ClaimUserWidget):
                 exc = job.exc.params.get("origin", None)
                 if isinstance(exc, InvitePeerResetError):
                     msg = _("TEXT_CLAIM_USER_PEER_RESET")
+                if isinstance(exc, BackendInvitationAlreadyUsed):
+                    msg = _("TEXT_INVITATION_ALREADY_USED")
             show_error(self, msg, exception=exc)
         # No point in retrying the process here, simply close the dialog
         self.dialog.reject()
@@ -617,8 +633,7 @@ class ClaimUserWidget(QWidget, Ui_ClaimUserWidget):
         # No reason to restart the process if offline or if the invitation has been deleted
         # simply close the dialog
         if job is not None and isinstance(
-            job.exc.params.get("origin", None),
-            (BackendNotAvailable, BackendConnectionRefused, InviteAlreadyUsedError),
+            job.exc.params.get("origin", None), (BackendNotAvailable, BackendConnectionRefused)
         ):
             self.dialog.reject()
             return
@@ -701,6 +716,8 @@ class ClaimUserWidget(QWidget, Ui_ClaimUserWidget):
         exc = None
         if job.status == "invitation-not-found":
             msg = _("TEXT_CLAIM_USER_INVITATION_NOT_FOUND")
+        elif job.status == "invitation-already-used":
+            msg = _("TEXT_INVITATION_ALREADY_USED")
         elif job.status == "backend-not-available":
             msg = _("TEXT_INVITATION_BACKEND_NOT_AVAILABLE")
         else:

--- a/parsec/core/gui/tr/parsec_en.po
+++ b/parsec/core/gui/tr/parsec_en.po
@@ -229,6 +229,9 @@ msgstr "The user was successfully greeter in your organization."
 msgid "TEXT_INVITATION_BACKEND_NOT_AVAILABLE"
 msgstr "The connection to the server has been lost. Please restart the process."
 
+msgid "TEXT_INVITATION_ALREADY_USED"
+msgstr "The invitation is no longer valid."
+
 msgid "TEXT_GREET_USER_UNKNOWN_ERROR"
 msgstr "Internal error. Please restart the process."
 

--- a/parsec/core/gui/tr/parsec_fr.po
+++ b/parsec/core/gui/tr/parsec_fr.po
@@ -242,6 +242,9 @@ msgstr "L'utilisateur a été créé avec succès !"
 msgid "TEXT_INVITATION_BACKEND_NOT_AVAILABLE"
 msgstr "La connexion au serveur a été perdue. Veuillez redémarrer le processus."
 
+msgid "TEXT_INVITATION_ALREADY_USED"
+msgstr "L'invitation n'est plus valide."
+
 msgid "TEXT_GREET_USER_UNKNOWN_ERROR"
 msgstr "Erreur interne. Veuillez redémarrer le processus."
 

--- a/tests/backend/invite/test_exchange_bad_access.py
+++ b/tests/backend/invite/test_exchange_bad_access.py
@@ -172,5 +172,6 @@ async def test_claimer_exchange_bad_access(alice, backend, backend_invited_sock_
             on=Pendulum(2000, 1, 2),
             reason=InvitationDeletedReason.ROTTEN,
         )
-        rep = await call()
-        assert rep == {"status": "already_deleted"}
+        with pytest.raises(TransportError):
+            # Transport is always closed when invitation is closed after this handshake
+            await call()

--- a/tests/core/backend_connection/test_invited_cmds.py
+++ b/tests/core/backend_connection/test_invited_cmds.py
@@ -88,7 +88,7 @@ async def test_handshake_unknown_organization(running_backend, coolorg):
     with pytest.raises(BackendConnectionRefused) as exc:
         async with backend_invited_cmds_factory(invitation_addr) as cmds:
             await cmds.ping()
-    assert str(exc.value) == "Invalid handshake information"
+    assert str(exc.value) == "Invalid handshake: Invitation not found"
 
 
 @pytest.mark.trio

--- a/tests/core/gui/devices_widget/test_claim.py
+++ b/tests/core/gui/devices_widget/test_claim.py
@@ -468,7 +468,7 @@ async def test_claim_device_invitation_cancelled(
             assert not self.claim_device_instructions_widget.isVisible()
 
         async def cancelled_step_1_start_claim(self):
-            expected_message = translate("TEXT_CLAIM_DEVICE_WAIT_PEER_ERROR")
+            expected_message = translate("TEXT_INVITATION_ALREADY_USED")
             cdi_w = self.claim_device_instructions_widget
 
             await self._cancel_invitation()
@@ -479,7 +479,7 @@ async def test_claim_device_invitation_cancelled(
             return None
 
         async def cancelled_step_2_start_greeter(self):
-            expected_message = translate("TEXT_CLAIM_DEVICE_WAIT_PEER_ERROR")
+            expected_message = translate("TEXT_INVITATION_ALREADY_USED")
             await self._cancel_invitation()
 
             await aqtbot.wait_until(partial(self._claim_restart, expected_message))
@@ -487,7 +487,7 @@ async def test_claim_device_invitation_cancelled(
             return None
 
         async def cancelled_step_3_exchange_greeter_sas(self):
-            expected_message = translate("TEXT_CLAIM_DEVICE_SIGNIFY_TRUST_ERROR")
+            expected_message = translate("TEXT_INVITATION_ALREADY_USED")
             cdce_w = self.claim_device_code_exchange_widget
             await self._cancel_invitation()
 
@@ -505,7 +505,7 @@ async def test_claim_device_invitation_cancelled(
             return None
 
         async def cancelled_step_5_provide_claim_info(self):
-            expected_message = translate("TEXT_CLAIM_DEVICE_CLAIM_ERROR")
+            expected_message = translate("TEXT_INVITATION_ALREADY_USED")
             cdpi_w = self.claim_device_provide_info_widget
             device_label = self.requested_device_label
 
@@ -521,7 +521,7 @@ async def test_claim_device_invitation_cancelled(
             return None
 
         async def cancelled_step_6_validate_claim_info(self):
-            expected_message = translate("TEXT_CLAIM_DEVICE_CLAIM_ERROR")
+            expected_message = translate("TEXT_INVITATION_ALREADY_USED")
             await self._cancel_invitation()
 
             await aqtbot.wait_until(partial(self._claim_restart, expected_message))
@@ -562,8 +562,33 @@ async def test_claim_device_already_deleted(
 
     def _assert_dialogs():
         assert len(autoclose_dialog.dialogs) == 1
+        assert autoclose_dialog.dialogs == [("Error", translate("TEXT_INVITATION_ALREADY_USED"))]
+
+    await aqtbot.wait_until(_assert_dialogs)
+
+
+@pytest.mark.gui
+@pytest.mark.trio
+async def test_claim_device_offline_backend(
+    aqtbot, running_backend, backend, autoclose_dialog, alice, gui
+):
+
+    invitation = await backend.invite.new_for_device(
+        organization_id=alice.organization_id, greeter_user_id=alice.user_id
+    )
+    invitation_addr = BackendInvitationAddr.build(
+        backend_addr=alice.organization_addr,
+        organization_id=alice.organization_id,
+        invitation_type=InvitationType.DEVICE,
+        token=invitation.token,
+    )
+    with running_backend.offline():
+        await aqtbot.run(gui.add_instance, invitation_addr.to_url())
+
+    def _assert_dialogs():
+        assert len(autoclose_dialog.dialogs) == 1
         assert autoclose_dialog.dialogs == [
-            ("Error", translate("TEXT_CLAIM_USER_FAILED_TO_RETRIEVE_INFO"))
+            ("Error", translate("TEXT_INVITATION_BACKEND_NOT_AVAILABLE"))
         ]
 
     await aqtbot.wait_until(_assert_dialogs)
@@ -587,7 +612,7 @@ async def test_claim_device_unknown_invitation(
     def _assert_dialogs():
         assert len(autoclose_dialog.dialogs) == 1
         assert autoclose_dialog.dialogs == [
-            ("Error", translate("TEXT_CLAIM_USER_FAILED_TO_RETRIEVE_INFO"))
+            ("Error", translate("TEXT_CLAIM_DEVICE_INVITATION_NOT_FOUND"))
         ]
 
     await aqtbot.wait_until(_assert_dialogs)

--- a/tests/core/test_invite.py
+++ b/tests/core/test_invite.py
@@ -451,24 +451,24 @@ async def test_claimer_handle_cancel_event(
                 async def _do_claimer_wait_peer():
                     with pytest.raises(BackendConnectionRefused) as exc_info:
                         await claimer_initial_ctx.do_wait_peer()
-                    assert exc_info.value.args[0] == "InvitationAlreadyDeletedError"
+                    assert str(exc_info.value) == "Invalid handshake: Invitation already deleted"
 
                 async def _do_claimer_signify_trust():
                     with pytest.raises(BackendConnectionRefused) as exc_info:
                         await claimer_in_progress_ctx.do_signify_trust()
-                    assert exc_info.value.args[0] == "InvitationAlreadyDeletedError"
+                    assert str(exc_info.value) == "Invalid handshake: Invitation already deleted"
 
                 async def _do_claimer_wait_peer_trust():
                     with pytest.raises(BackendConnectionRefused) as exc_info:
                         await claimer_in_progress_ctx.do_wait_peer_trust()
-                    assert exc_info.value.args[0] == "InvitationAlreadyDeletedError"
+                    assert str(exc_info.value) == "Invalid handshake: Invitation already deleted"
 
                 async def _do_claimer_claim_device():
                     with pytest.raises(BackendConnectionRefused) as exc_info:
                         await claimer_in_progress_ctx.do_claim_device(
                             requested_device_label="TheSecretDevice"
                         )
-                    assert exc_info.value.args[0] == "InvitationAlreadyDeletedError"
+                    assert str(exc_info.value) == "Invalid handshake: Invitation already deleted"
 
                 steps = {
                     "wait_peer": _do_claimer_wait_peer,
@@ -567,7 +567,7 @@ async def test_claimer_handle_command_failure(
         with trio.fail_after(1):
             await _cancel_invitation()
             await deleted_event.wait()
-            with pytest.raises(BackendConnectionRefused):
+            with pytest.raises(BackendConnectionRefused) as exc_info:
                 if fail_on_step == "wait_peer":
                     await claimer_initial_ctx.do_wait_peer()
                 elif fail_on_step == "signify_trust":
@@ -580,3 +580,4 @@ async def test_claimer_handle_command_failure(
                     )
                 else:
                     raise AssertionError(f"Unknown step {fail_on_step}")
+            assert str(exc_info.value) == "Invalid handshake: Invitation already deleted"

--- a/tests/core/test_invite.py
+++ b/tests/core/test_invite.py
@@ -3,8 +3,10 @@
 import pytest
 import trio
 
+from pendulum import now as pendulum_now
 from parsec.api.data import UserProfile
-from parsec.api.protocol import HumanHandle, InvitationType
+from parsec.api.protocol import HumanHandle, InvitationType, InvitationDeletedReason
+
 from parsec.core.backend_connection import backend_invited_cmds_factory
 from parsec.core.types import BackendInvitationAddr, LocalDevice, WorkspaceRole
 from parsec.core.invite import (
@@ -15,6 +17,10 @@ from parsec.core.invite import (
     DeviceGreetInitialCtx,
     UserGreetInitialCtx,
 )
+
+from parsec.backend.backend_events import BackendEvent
+from parsec.core.backend_connection.exceptions import BackendConnectionRefused
+from parsec.api.protocol import InvitationStatus
 
 
 @pytest.mark.trio
@@ -371,3 +377,206 @@ async def test_claimer_handle_reset(backend, running_backend, alice, alice_backe
 
                 # Claimer redo step 1
                 claimer_in_progress_ctx = await claimer_initial_ctx.do_wait_peer()
+
+
+@pytest.mark.trio
+@pytest.mark.parametrize(
+    "fail_on_step", ["wait_peer", "signify_trust", "wait_peer_trust", "claim_device"]
+)
+async def test_claimer_handle_cancel_event(
+    backend, running_backend, alice, alice_backend_cmds, fail_on_step
+):
+    invitation = await backend.invite.new_for_device(
+        organization_id=alice.organization_id, greeter_user_id=alice.user_id
+    )
+    invitation_addr = BackendInvitationAddr.build(
+        backend_addr=alice.organization_addr,
+        organization_id=alice.organization_id,
+        invitation_type=InvitationType.DEVICE,
+        token=invitation.token,
+    )
+
+    async def _cancel_invitation():
+        await backend.invite.delete(
+            organization_id=alice.organization_id,
+            greeter=alice.user_id,
+            token=invitation_addr.token,
+            on=pendulum_now(),
+            reason=InvitationDeletedReason.CANCELLED,
+        )
+
+    async with backend_invited_cmds_factory(addr=invitation_addr) as claimer_cmds:
+        greeter_initial_ctx = UserGreetInitialCtx(
+            cmds=alice_backend_cmds, token=invitation_addr.token
+        )
+        claimer_initial_ctx = await claimer_retrieve_info(claimer_cmds)
+
+        claimer_in_progress_ctx = None
+        greeter_in_progress_ctx = None
+
+        async def _do_claimer():
+            nonlocal claimer_in_progress_ctx
+            if fail_on_step == "wait_peer":
+                return
+            claimer_in_progress_ctx = await claimer_initial_ctx.do_wait_peer()
+            if fail_on_step == "signify_trust":
+                return
+            claimer_in_progress_ctx = await claimer_in_progress_ctx.do_signify_trust()
+            if fail_on_step == "wait_peer_trust":
+                return
+            claimer_in_progress_ctx = await claimer_in_progress_ctx.do_wait_peer_trust()
+
+        async def _do_greeter():
+            nonlocal greeter_in_progress_ctx
+            if fail_on_step == "wait_peer":
+                return
+            greeter_in_progress_ctx = await greeter_initial_ctx.do_wait_peer()
+            if fail_on_step == "signify_trust":
+                return
+            greeter_in_progress_ctx = await greeter_in_progress_ctx.do_wait_peer_trust()
+            if fail_on_step == "wait_peer_trust":
+                return
+            greeter_in_progress_ctx = await greeter_in_progress_ctx.do_signify_trust()
+
+        with trio.fail_after(1):
+            async with trio.open_nursery() as nursery:
+
+                nursery.start_soon(_do_claimer)
+                nursery.start_soon(_do_greeter)
+
+        with trio.fail_after(1):
+
+            async with trio.open_nursery() as nursery:
+
+                async def _do_claimer_wait_peer():
+                    with pytest.raises(BackendConnectionRefused) as exc_info:
+                        await claimer_initial_ctx.do_wait_peer()
+                    assert exc_info.value.args[0] == "InvitationAlreadyDeletedError"
+
+                async def _do_claimer_signify_trust():
+                    with pytest.raises(BackendConnectionRefused) as exc_info:
+                        await claimer_in_progress_ctx.do_signify_trust()
+                    assert exc_info.value.args[0] == "InvitationAlreadyDeletedError"
+
+                async def _do_claimer_wait_peer_trust():
+                    with pytest.raises(BackendConnectionRefused) as exc_info:
+                        await claimer_in_progress_ctx.do_wait_peer_trust()
+                    assert exc_info.value.args[0] == "InvitationAlreadyDeletedError"
+
+                async def _do_claimer_claim_device():
+                    with pytest.raises(BackendConnectionRefused) as exc_info:
+                        await claimer_in_progress_ctx.do_claim_device(
+                            requested_device_label="TheSecretDevice"
+                        )
+                    assert exc_info.value.args[0] == "InvitationAlreadyDeletedError"
+
+                steps = {
+                    "wait_peer": _do_claimer_wait_peer,
+                    "signify_trust": _do_claimer_signify_trust,
+                    "wait_peer_trust": _do_claimer_wait_peer_trust,
+                    "claim_device": _do_claimer_claim_device,
+                }
+                _do_claimer = steps[fail_on_step]
+
+                with backend.event_bus.listen() as spy:
+                    nursery.start_soon(_do_claimer)
+                    # Be sure that _do_claimer got valid invitations before cancelation
+                    await spy.wait_with_timeout(BackendEvent.INVITE_CONDUIT_UPDATED)
+                    await _cancel_invitation()
+                    await spy.wait_with_timeout(BackendEvent.INVITE_STATUS_CHANGED)
+
+
+@pytest.mark.trio
+@pytest.mark.parametrize(
+    "fail_on_step", ["wait_peer", "signify_trust", "wait_peer_trust", "claim_device"]
+)
+async def test_claimer_handle_command_failure(
+    backend, running_backend, alice, alice_backend_cmds, monkeypatch, fail_on_step
+):
+    invitation = await backend.invite.new_for_device(
+        organization_id=alice.organization_id, greeter_user_id=alice.user_id
+    )
+    invitation_addr = BackendInvitationAddr.build(
+        backend_addr=alice.organization_addr,
+        organization_id=alice.organization_id,
+        invitation_type=InvitationType.DEVICE,
+        token=invitation.token,
+    )
+
+    async def _cancel_invitation():
+        await backend.invite.delete(
+            organization_id=alice.organization_id,
+            greeter=alice.user_id,
+            token=invitation_addr.token,
+            on=pendulum_now(),
+            reason=InvitationDeletedReason.CANCELLED,
+        )
+
+    async with backend_invited_cmds_factory(addr=invitation_addr) as claimer_cmds:
+        greeter_initial_ctx = UserGreetInitialCtx(
+            cmds=alice_backend_cmds, token=invitation_addr.token
+        )
+        claimer_initial_ctx = await claimer_retrieve_info(claimer_cmds)
+
+        claimer_in_progress_ctx = None
+        greeter_in_progress_ctx = None
+
+        async def _do_claimer():
+            nonlocal claimer_in_progress_ctx
+            if fail_on_step == "wait_peer":
+                return
+            claimer_in_progress_ctx = await claimer_initial_ctx.do_wait_peer()
+            if fail_on_step == "signify_trust":
+                return
+            claimer_in_progress_ctx = await claimer_in_progress_ctx.do_signify_trust()
+            if fail_on_step == "wait_peer_trust":
+                return
+            claimer_in_progress_ctx = await claimer_in_progress_ctx.do_wait_peer_trust()
+
+        async def _do_greeter():
+            nonlocal greeter_in_progress_ctx
+            if fail_on_step == "wait_peer":
+                return
+            greeter_in_progress_ctx = await greeter_initial_ctx.do_wait_peer()
+            if fail_on_step == "signify_trust":
+                return
+            greeter_in_progress_ctx = await greeter_in_progress_ctx.do_wait_peer_trust()
+            if fail_on_step == "wait_peer_trust":
+                return
+            greeter_in_progress_ctx = await greeter_in_progress_ctx.do_signify_trust()
+
+        with trio.fail_after(1):
+
+            async with trio.open_nursery() as nursery:
+                nursery.start_soon(_do_claimer)
+                nursery.start_soon(_do_greeter)
+
+        deleted_event = trio.Event()
+
+        async def _send_event(*args, **kwargs):
+            if BackendEvent.INVITE_STATUS_CHANGED in args and (
+                kwargs.get("status") == InvitationStatus.DELETED
+                or kwargs.get("status_str") == InvitationStatus.DELETED.value
+            ):
+                deleted_event.set()
+            await trio.sleep(0)
+
+        backend.invite._send_event = _send_event
+        monkeypatch.setattr("parsec.backend.postgresql.invite.send_signal", _send_event)
+
+        with trio.fail_after(1):
+            await _cancel_invitation()
+            await deleted_event.wait()
+            with pytest.raises(BackendConnectionRefused):
+                if fail_on_step == "wait_peer":
+                    await claimer_initial_ctx.do_wait_peer()
+                elif fail_on_step == "signify_trust":
+                    await claimer_in_progress_ctx.do_signify_trust()
+                elif fail_on_step == "wait_peer_trust":
+                    await claimer_in_progress_ctx.do_wait_peer_trust()
+                elif fail_on_step == "claim_device":
+                    await claimer_in_progress_ctx.do_claim_device(
+                        requested_device_label="TheSecretDevice"
+                    )
+                else:
+                    raise AssertionError(f"Unknown step {fail_on_step}")

--- a/tests/core/test_invite.py
+++ b/tests/core/test_invite.py
@@ -19,7 +19,7 @@ from parsec.core.invite import (
 )
 
 from parsec.backend.backend_events import BackendEvent
-from parsec.core.backend_connection.exceptions import BackendConnectionRefused
+from parsec.core.backend_connection.exceptions import BackendInvitationAlreadyUsed
 from parsec.api.protocol import InvitationStatus
 
 
@@ -449,22 +449,22 @@ async def test_claimer_handle_cancel_event(
             async with trio.open_nursery() as nursery:
 
                 async def _do_claimer_wait_peer():
-                    with pytest.raises(BackendConnectionRefused) as exc_info:
+                    with pytest.raises(BackendInvitationAlreadyUsed) as exc_info:
                         await claimer_initial_ctx.do_wait_peer()
                     assert str(exc_info.value) == "Invalid handshake: Invitation already deleted"
 
                 async def _do_claimer_signify_trust():
-                    with pytest.raises(BackendConnectionRefused) as exc_info:
+                    with pytest.raises(BackendInvitationAlreadyUsed) as exc_info:
                         await claimer_in_progress_ctx.do_signify_trust()
                     assert str(exc_info.value) == "Invalid handshake: Invitation already deleted"
 
                 async def _do_claimer_wait_peer_trust():
-                    with pytest.raises(BackendConnectionRefused) as exc_info:
+                    with pytest.raises(BackendInvitationAlreadyUsed) as exc_info:
                         await claimer_in_progress_ctx.do_wait_peer_trust()
                     assert str(exc_info.value) == "Invalid handshake: Invitation already deleted"
 
                 async def _do_claimer_claim_device():
-                    with pytest.raises(BackendConnectionRefused) as exc_info:
+                    with pytest.raises(BackendInvitationAlreadyUsed) as exc_info:
                         await claimer_in_progress_ctx.do_claim_device(
                             requested_device_label="TheSecretDevice"
                         )
@@ -567,7 +567,7 @@ async def test_claimer_handle_command_failure(
         with trio.fail_after(1):
             await _cancel_invitation()
             await deleted_event.wait()
-            with pytest.raises(BackendConnectionRefused) as exc_info:
+            with pytest.raises(BackendInvitationAlreadyUsed) as exc_info:
                 if fail_on_step == "wait_peer":
                     await claimer_initial_ctx.do_wait_peer()
                 elif fail_on_step == "signify_trust":


### PR DESCRIPTION
Always close connection, never returns, when an invitation is cancelled after the invitation handshake.

Add a retrier on the client side on BackendNotAvailable for invitation commands.