### PR TITLE
Fuse and winfsp mountpoints now report 0 MB used over 1 TB

### DIFF
--- a/newsfragments/1401.misc.rst
+++ b/newsfragments/1401.misc.rst
@@ -1,0 +1,1 @@
+The winfsp and fuse mountpoints now always report 0 MB used over a 1 TB capacity. Those values are arbitrary but useful to the operating system, especially OSX.

--- a/parsec/core/mountpoint/fuse_operations.py
+++ b/parsec/core/mountpoint/fuse_operations.py
@@ -80,6 +80,18 @@ class FuseOperations(LoggingMixIn, Operations):
     def init(self, path: FsPath):
         pass
 
+    def statfs(self, path: FsPath):
+        # We have currently no way of easily getting the size of workspace
+        # Also, the total size of a workspace is not limited
+        # For the moment let's settle on 0 MB used for 1 TB available
+        return {
+            "f_bsize": 512 * 1024,  # 512 KB, i.e the default block size
+            "f_frsize": 512 * 1024,  # 512 KB, i.e the default block size
+            "f_blocks": 512 * 1024,  # 512 K blocks is 1 TB
+            "f_bfree": 512 * 1024,  # 512 K blocks is 1 TB
+            "f_bavail": 512 * 1024,  # 512 K blocks is 1 TB
+        }
+
     def getattr(self, path: FsPath, fh: Optional[int] = None):
         if self._need_exit:
             fuse_exit()

--- a/parsec/core/mountpoint/fuse_operations.py
+++ b/parsec/core/mountpoint/fuse_operations.py
@@ -121,6 +121,14 @@ class FuseOperations(LoggingMixIn, Operations):
         fuse_stat["st_gid"] = gid
         return fuse_stat
 
+    def chmod(self, path: FsPath, mod: int):
+        # TODO: silently ignore for the moment
+        return
+
+    def chown(self, path: FsPath, own: int):
+        # TODO: silently ignore for the moment
+        return
+
     def readdir(self, path: FsPath, fh: int):
         stat = self.fs_access.entry_info(path)
 

--- a/parsec/core/mountpoint/winfsp_operations.py
+++ b/parsec/core/mountpoint/winfsp_operations.py
@@ -149,12 +149,12 @@ class WinFSPOperations(BaseFileSystemOperations):
         self.event_bus = event_bus
         self.fs_access = fs_access
 
-        max_file_nodes = 1024
-        max_file_size = 16 * 1024 * 1024
-        file_nodes = 1
+        # We have currently no way of easily getting the size of workspace
+        # Also, the total size of a workspace is not limited
+        # For the moment let's settle on 0 MB used for 1 TB available
         self._volume_info = {
-            "total_size": max_file_nodes * max_file_size,
-            "free_size": (max_file_nodes - file_nodes) * max_file_size,
+            "total_size": 1 * 1024 * 1024 * 1024,  # 1 TB
+            "free_size": 1 * 1024 * 1024 * 1024,  # 1 TB
             "volume_label": volume_label,
         }
 


### PR DESCRIPTION
The winfsp and fuse mountpoints now always report 0 MB used over a 1 TB capacity. 

Those values are arbitrary but useful to the operating system, especially OSX.