### PR TITLE
Fix email user invite generation

### DIFF
--- a/newsfragments/1400.bugfix.rst
+++ b/newsfragments/1400.bugfix.rst
@@ -1,0 +1,1 @@
+Fix email user invite generation

--- a/parsec/backend/invite.py
+++ b/parsec/backend/invite.py
@@ -150,10 +150,10 @@ def generate_invite_email(
     invitation_url: str,
 ) -> Message:
     html = get_template("invitation_mail.html").render(
-        greeter_name=greeter_name, organization_id=organization_id, invitation_url=invitation_url
+        greeter=greeter_name, organization_id=organization_id, invitation_url=invitation_url
     )
     text = get_template("invitation_mail.txt").render(
-        greeter_name=greeter_name, organization_id=organization_id, invitation_url=invitation_url
+        greeter=greeter_name, organization_id=organization_id, invitation_url=invitation_url
     )
 
     # mail settings

--- a/parsec/backend/templates/__init__.py
+++ b/parsec/backend/templates/__init__.py
@@ -1,6 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
-from jinja2 import Environment, BaseLoader, TemplateNotFound
+from jinja2 import Environment, BaseLoader, TemplateNotFound, StrictUndefined
 import importlib_resources
 
 
@@ -18,7 +18,9 @@ class PackageLoader(BaseLoader):
         return source, self.path, lambda: True
 
 
-JINJA_ENV = Environment(loader=PackageLoader("parsec.backend.http.templates"))
+JINJA_ENV = Environment(
+    loader=PackageLoader("parsec.backend.http.templates"), undefined=StrictUndefined
+)
 
 
 def get_template(name):

--- a/parsec/backend/templates/invitation_mail.txt
+++ b/parsec/backend/templates/invitation_mail.txt
@@ -1,7 +1,7 @@
 {% if greeter %}
 You have received an invitation from {{ greeter }} to join the {{ organization_id }} organization on Parsec.
 {% else %}
-You have received an invitation to add an new device to the {{ organization_id}} organization on Parsec.
+You have received an invitation to add a new device to the {{ organization_id}} organization on Parsec.
 {% endif %}
 
 If you don't already have it, you should Download the Parsec client via the following link: https://parsec.cloud/get-parsec

--- a/tests/backend/invite/test_base.py
+++ b/tests/backend/invite/test_base.py
@@ -198,6 +198,10 @@ async def test_invite_with_send_mail(alice, alice_backend_sock, email_letterbox)
     assert "To: zack@example.com" in body
     assert "Reply-To: Alicey McAliceFace <alice@example.com>" in body
     assert token.hex in body
+    assert (
+        "You have received an invitation from Alicey McAliceFace to join the CoolOrg organization on Parsec."
+        in body
+    )
 
     # Device invitation
     rep = await invite_new(alice_backend_sock, type=InvitationType.DEVICE, send_email=True)
@@ -216,6 +220,10 @@ async def test_invite_with_send_mail(alice, alice_backend_sock, email_letterbox)
     assert "To: alice@example.com" in body
     assert "Reply-To: " not in body
     assert token.hex in body
+    assert (
+        "You have received an invitation to add a new device to the CoolOrg organization on Parsec."
+        in body
+    )
 
 
 @pytest.mark.trio


### PR DESCRIPTION
There was a mismatch between the placeholder variable names in the templates and in the provided arguments in the code.