### PR TITLE
Flaky gui test event bus none

### DIFF
--- a/parsec/core/gui/instance_widget.py
+++ b/parsec/core/gui/instance_widget.py
@@ -212,20 +212,19 @@ class InstanceWidget(QWidget):
 
     def show_central_widget(self):
         self.clear_widgets()
-        try:
-            central_widget = CentralWidget(
-                self.core,
-                self.core_jobs_ctx,
-                self.core.event_bus,
-                systray_notification=self.systray_notification,
-                parent=self,
-            )
-        except AttributeError:
-            # The core can be set to None at any time if do_run_core get an error, is cancelled or
-            # terminate.
-            if self.core is None:
-                return
-            raise
+        # The core can be set to None at any time if do_run_core get an error, is cancelled or
+        # terminate.
+        core = self.core
+        core_jobs_ctx = self.core_jobs_ctx
+        if core is None or core_jobs_ctx is None:
+            return
+        central_widget = CentralWidget(
+            core,
+            core_jobs_ctx,
+            core.event_bus,
+            systray_notification=self.systray_notification,
+            parent=self,
+        )
         self.layout().addWidget(central_widget)
         central_widget.logout_requested.connect(self.logout)
         central_widget.show()

--- a/parsec/core/gui/instance_widget.py
+++ b/parsec/core/gui/instance_widget.py
@@ -212,13 +212,20 @@ class InstanceWidget(QWidget):
 
     def show_central_widget(self):
         self.clear_widgets()
-        central_widget = CentralWidget(
-            self.core,
-            self.core_jobs_ctx,
-            self.core.event_bus,
-            systray_notification=self.systray_notification,
-            parent=self,
-        )
+        try:
+            central_widget = CentralWidget(
+                self.core,
+                self.core_jobs_ctx,
+                self.core.event_bus,
+                systray_notification=self.systray_notification,
+                parent=self,
+            )
+        except AttributeError:
+            # The core can be set to None at any time if do_run_core get an error, is cancelled or
+            # terminate.
+            if self.core is None:
+                return
+            raise
         self.layout().addWidget(central_widget)
         central_widget.logout_requested.connect(self.logout)
         central_widget.show()

--- a/parsec/core/gui/login_widget.py
+++ b/parsec/core/gui/login_widget.py
@@ -43,6 +43,9 @@ class LoginAccountsWidget(QWidget, Ui_LoginAccountsWidget):
             ab.clicked.connect(self.account_clicked.emit)
             self.accounts_widget.layout().insertWidget(0, ab)
 
+    def reset(self):
+        pass
+
 
 class LoginPasswordInputWidget(QWidget, Ui_LoginPasswordInputWidget):
     back_clicked = pyqtSignal()
@@ -92,6 +95,9 @@ class LoginNoDevicesWidget(QWidget, Ui_LoginNoDevicesWidget):
             self.label_no_device.setText(_("TEXT_LOGIN_NO_DEVICE_ON_MACHINE"))
         self.button_create_org.clicked.connect(self.create_organization_clicked.emit)
         self.button_join_org.clicked.connect(self.join_organization_clicked.emit)
+
+    def reset(self):
+        pass
 
 
 class LoginWidget(QWidget, Ui_LoginWidget):

--- a/tests/core/gui/conftest.py
+++ b/tests/core/gui/conftest.py
@@ -329,8 +329,15 @@ def gui_factory(
 
 
 @pytest.fixture
-async def gui(gui_factory, event_bus, core_config):
-    return await gui_factory(event_bus, core_config)
+async def gui(aqtbot, gui_factory, event_bus, core_config):
+    _gui = await gui_factory(event_bus, core_config)
+
+    def _gui_displayed():
+        assert _gui.isVisible()
+        assert not _gui.isHidden()
+
+    await aqtbot.wait_until(_gui_displayed)
+    return _gui
 
 
 @pytest.fixture

--- a/tests/core/gui/test_create_organization.py
+++ b/tests/core/gui/test_create_organization.py
@@ -81,7 +81,7 @@ async def test_create_organization(
     # The org creation window is usually opened using a sub-menu.
     # Sub-menus can be a bit challenging to open in tests so we cheat
     # using the keyboard shortcut Ctrl+N that has the same effect.
-    await aqtbot.key_click(gui, "n", QtCore.Qt.ControlModifier)
+    await aqtbot.key_click(gui, "n", QtCore.Qt.ControlModifier, 200)
 
     co_w = await catch_create_org_widget()
 
@@ -109,7 +109,7 @@ async def test_create_organization_offline(
     gui, aqtbot, running_backend, catch_create_org_widget, autoclose_dialog
 ):
     with running_backend.offline():
-        await aqtbot.key_click(gui, "n", QtCore.Qt.ControlModifier)
+        await aqtbot.key_click(gui, "n", QtCore.Qt.ControlModifier, 200)
 
         co_w = await catch_create_org_widget()
         assert co_w
@@ -128,7 +128,8 @@ async def test_create_organization_offline(
 async def test_create_organization_previous_clicked(
     gui, aqtbot, running_backend, catch_create_org_widget, autoclose_dialog
 ):
-    await aqtbot.key_click(gui, "n", QtCore.Qt.ControlModifier, 0)
+    print("Sending")
+    await aqtbot.key_click(gui, "n", QtCore.Qt.ControlModifier, 200)
 
     co_w = await catch_create_org_widget()
 
@@ -282,7 +283,7 @@ async def test_create_organization_already_bootstrapped(
     # The org bootstrap window is usually opened using a sub-menu.
     # Sub-menus can be a bit challenging to open in tests so we cheat
     # using the keyboard shortcut Ctrl+O that has the same effect.
-    await aqtbot.key_click(gui, "o", QtCore.Qt.ControlModifier)
+    await aqtbot.key_click(gui, "o", QtCore.Qt.ControlModifier, 200)
 
     co_w = await catch_create_org_widget()
     await aqtbot.wait_until(co_w.user_widget.isVisible)
@@ -324,7 +325,7 @@ async def test_create_organization_custom_backend(
     # The org creation window is usually opened using a sub-menu.
     # Sub-menus can be a bit challenging to open in tests so we cheat
     # using the keyboard shortcut Ctrl+N that has the same effect.
-    await aqtbot.key_click(gui, "n", QtCore.Qt.ControlModifier)
+    await aqtbot.key_click(gui, "n", QtCore.Qt.ControlModifier, 200)
 
     co_w = await catch_create_org_widget()
 

--- a/tests/core/gui/test_workspaces.py
+++ b/tests/core/gui/test_workspaces.py
@@ -235,7 +235,7 @@ async def test_mountpoint_open_in_explorer_button(aqtbot, running_backend, logge
         assert wk_button.button_open.isEnabled()
         assert wk_button.switch_button.isChecked()
 
-    await aqtbot.wait_until(_mounted)
+    await aqtbot.wait_until(_mounted, timeout=2000)
     _on_switch_clicked_mock.assert_called_once()
     _on_switch_clicked_mock.reset_mock()
 
@@ -257,5 +257,5 @@ async def test_mountpoint_open_in_explorer_button(aqtbot, running_backend, logge
         assert not wk_button.switch_button.isChecked()
         assert not wk_button.button_open.isEnabled()
 
-    await aqtbot.wait_until(_unmounted)
+    await aqtbot.wait_until(_unmounted, timeout=2000)
     _on_switch_clicked_mock.assert_called_once()


### PR DESCRIPTION
Try to fix ci errors:
[Reset error](https://dev.azure.com/Scille/parsec/_build/results?buildId=3487&view=logs&j=5ba45810-c0e9-5996-abe7-b2cb0c9b6baa&t=98a05ba0-83e8-5985-e9d7-1cce7a13f66e)
[No core](https://dev.azure.com/Scille/parsec/_build/results?buildId=3382&view=logs&j=5ba45810-c0e9-5996-abe7-b2cb0c9b6baa&t=98a05ba0-83e8-5985-e9d7-1cce7a13f66e)
[Invitation widget timeout](https://dev.azure.com/Scille/parsec/_build/results?buildId=3603&view=logs&j=5ba45810-c0e9-5996-abe7-b2cb0c9b6baa&t=98a05ba0-83e8-5985-e9d7-1cce7a13f66e)
[increase mountpoint timeout](https://dev.azure.com/Scille/parsec/_build/results?buildId=3611&view=logs&j=5ba45810-c0e9-5996-abe7-b2cb0c9b6baa&t=98a05ba0-83e8-5985-e9d7-1cce7a13f66e)



Gui tests ran 10 times without failure there:
https://dev.azure.com/Scille/parsec/_build/results?buildId=3618&view=logs&j=5ba45810-c0e9-5996-abe7-b2cb0c9b6baa




still missing a fix:
https://dev.azure.com/Scille/parsec/_build/results?buildId=3622&view=logs&j=5ba45810-c0e9-5996-abe7-b2cb0c9b6baa&t=98a05ba0-83e8-5985-e9d7-1cce7a13f66e
