### PR TITLE
Fix database corruption and add tests for disk full errors on sqlite operations

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -153,6 +153,14 @@ jobs:
         -n auto --max-worker-restart=0 -x \
         --junitxml=test-results-postgresql.xml
     displayName: 'Tests postgresql'
+  # The full disk test are run separately since they rely on running a sqlite3 database
+  # on a fuse mountpoint which can deadlock if run with the rest of the test suite
+  - bash: |
+      set -eux
+      py.test $(pytest.base_args) \
+        tests --rundiskfull --runslow -m diskfull -x \
+        --junitxml=test-results-fulldisk.xml
+    displayName: 'Tests full disk'
   # TODO: run gui tests with xvfb
   # - bash: |
   #     set -eux

--- a/parsec/core/fs/exceptions.py
+++ b/parsec/core/fs/exceptions.py
@@ -141,7 +141,15 @@ class FSNoSynchronizationRequired(FSInternalError):
     pass
 
 
-# WorkspaceFile errors
+class FSLocalStorageClosedError(FSInternalError):
+    pass
+
+
+class FSLocalStorageOperationalError(FSInternalError):
+    pass
+
+
+# Workspace file errors
 
 
 class FSUnsupportedOperation(FSLocalOperationError, io.UnsupportedOperation):

--- a/parsec/core/fs/storage/chunk_storage.py
+++ b/parsec/core/fs/storage/chunk_storage.py
@@ -42,8 +42,10 @@ class ChunkStorage:
             yield self
         finally:
             with trio.CancelScope(shield=True):
+                # Commit the pending changes in the local database
                 try:
                     await self.localdb.commit()
+                # Ignore storage closed exceptions, since it follows an operational error
                 except FSLocalStorageClosedError:
                     pass
 

--- a/parsec/core/fs/storage/chunk_storage.py
+++ b/parsec/core/fs/storage/chunk_storage.py
@@ -25,7 +25,7 @@ class ChunkStorage:
 
     @property
     def path(self) -> Path:
-        return self.localdb.path
+        return Path(self.localdb.path)
 
     @classmethod
     @asynccontextmanager

--- a/parsec/core/fs/storage/local_database.py
+++ b/parsec/core/fs/storage/local_database.py
@@ -118,6 +118,12 @@ class LocalDatabase:
         # Lock the access to the connection object
         async with self._lock:
 
+            # The connection might not be set
+            try:
+                self._conn
+            except AttributeError:
+                return
+
             # Commit and close
             await self._run_in_thread(self._conn.commit)
             self._conn.close()

--- a/parsec/core/fs/storage/local_database.py
+++ b/parsec/core/fs/storage/local_database.py
@@ -84,7 +84,10 @@ class LocalDatabase:
             # Safely flush and close the connection
             finally:
                 with trio.CancelScope(shield=True):
-                    await self._close()
+                    try:
+                        await self._close()
+                    except FSLocalStorageClosedError:
+                        pass
 
     # Life cycle
 

--- a/parsec/core/fs/storage/manifest_storage.py
+++ b/parsec/core/fs/storage/manifest_storage.py
@@ -8,7 +8,7 @@ from structlog import get_logger
 from typing import Dict, Tuple, Set, Optional, Union, Pattern, AsyncIterator, AsyncContextManager
 from async_generator import asynccontextmanager
 
-from parsec.core.fs.exceptions import FSLocalMissError
+from parsec.core.fs.exceptions import FSLocalMissError, FSLocalStorageClosedError
 from parsec.core.types import EntryID, ChunkID, LocalDevice, BaseLocalManifest, BlockID
 from parsec.core.fs.storage.local_database import LocalDatabase, Cursor
 
@@ -55,7 +55,10 @@ class ManifestStorage:
             yield self
         finally:
             with trio.CancelScope(shield=True):
-                await self._flush_cache_ahead_of_persistance()
+                try:
+                    await self._flush_cache_ahead_of_persistance()
+                except FSLocalStorageClosedError:
+                    pass
 
     def _open_cursor(self) -> AsyncContextManager[Cursor]:
         # We want the manifest to be written to the disk as soon as possible

--- a/parsec/core/fs/storage/manifest_storage.py
+++ b/parsec/core/fs/storage/manifest_storage.py
@@ -55,8 +55,10 @@ class ManifestStorage:
             yield self
         finally:
             with trio.CancelScope(shield=True):
+                # Flush the in-memory cache before closing the storage
                 try:
                     await self._flush_cache_ahead_of_persistance()
+                # Ignore storage closed exceptions, since it follows an operational error
                 except FSLocalStorageClosedError:
                     pass
 

--- a/parsec/core/fs/storage/manifest_storage.py
+++ b/parsec/core/fs/storage/manifest_storage.py
@@ -42,7 +42,7 @@ class ManifestStorage:
 
     @property
     def path(self) -> Path:
-        return self.localdb.path
+        return Path(self.localdb.path)
 
     @classmethod
     @asynccontextmanager

--- a/parsec/core/fs/workspacefs/file_transactions.py
+++ b/parsec/core/fs/workspacefs/file_transactions.py
@@ -249,7 +249,7 @@ class FileTransactions:
                 return
 
             # Perform the resize operation
-            await self._manifest_resize(manifest, length)
+            await self._manifest_resize(manifest, length, cache_only=True)
 
         # Notify
         self._send_event(CoreEvent.FS_ENTRY_UPDATED, id=manifest.id)
@@ -294,7 +294,9 @@ class FileTransactions:
 
     # Transaction helpers
 
-    async def _manifest_resize(self, manifest: LocalFileManifest, length: int) -> None:
+    async def _manifest_resize(
+        self, manifest: LocalFileManifest, length: int, cache_only: bool = False
+    ) -> None:
         """This internal helper does not perform any locking."""
         # No-op
         if manifest.size == length:
@@ -308,7 +310,9 @@ class FileTransactions:
             await self._write_chunk(chunk, b"", offset)
 
         # Atomic change
-        await self.local_storage.set_manifest(manifest.id, manifest, removed_ids=removed_ids)
+        await self.local_storage.set_manifest(
+            manifest.id, manifest, removed_ids=removed_ids, cache_only=cache_only
+        )
 
     async def _manifest_reshape(
         self, manifest: LocalFileManifest, cache_only: bool = False

--- a/parsec/core/fs/workspacefs/workspacefile.py
+++ b/parsec/core/fs/workspacefs/workspacefile.py
@@ -277,3 +277,6 @@ class WorkspaceFile:
         result = await self._transactions.fd_write(self.fileno(), data, self._offset)
         self._offset += result
         return result
+
+    async def flush(self) -> None:
+        await self._transactions.fd_flush(self.fileno())

--- a/parsec/core/fs/workspacefs/workspacefile.py
+++ b/parsec/core/fs/workspacefs/workspacefile.py
@@ -115,16 +115,16 @@ class WorkspaceFile:
             return
         # Make sure the state is set to CLOSED
         try:
-            # Make sure the fd is closed is called even if the flushing fails
+            # Make sure the file descriptor is closed even if the flushing fails
             try:
-                # Ignore FSLocalStorageClosedError exceptions
+                # Ignore storage closed exceptions, since it follows an operational error
                 try:
                     # Flush the file (typically causes the manifest to be reshaped)
                     await self._transactions.fd_flush(self.fileno())
                 except FSLocalStorageClosedError:
                     return
             finally:
-                # Ignore FSLocalStorageClosedError exceptions
+                # Ignore storage closed exceptions, since it follows an operational error
                 try:
                     # Close the file
                     await self._transactions.fd_close(self.fileno())

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ markers =
     gui: marks tests as GUI (enable with '--rungui')
     slow: marks tests as slow (enable with '--runslow')
     mountpoint: marks tests as mountpoint (enable with '--runmountpoint')
+    diskfull: marks tests as diskfull (enable with '--rundiskfull')
     postgresql: marks tests as postgresql only (enable with '--postgresql')
     raid0_blockstore
     raid1_blockstore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -418,7 +418,7 @@ def persistent_mockup(monkeypatch):
 
     async def _create_connection(storage):
         storage_set.add(storage)
-        return mockup_context.get(storage.path)
+        storage._conn = mockup_context.get(storage.path)
 
     async def _close(storage):
         # Idempotent operation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -425,6 +425,9 @@ def persistent_mockup(monkeypatch):
         storage_set.discard(storage)
         storage._conn = None
 
+    async def get_disk_usage(storage):
+        return 0
+
     @asynccontextmanager
     async def thread_pool_runner(max_workers):
         assert max_workers == 1
@@ -437,6 +440,7 @@ def persistent_mockup(monkeypatch):
     monkeypatch.setattr(local_database, "thread_pool_runner", thread_pool_runner)
     monkeypatch.setattr(LocalDatabase, "_create_connection", _create_connection)
     monkeypatch.setattr(LocalDatabase, "_close", _close)
+    monkeypatch.setattr(LocalDatabase, "get_disk_usage", get_disk_usage)
 
     yield mockup_context
     mockup_context.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,7 @@ def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", help="Don't skip slow tests")
     parser.addoption("--runmountpoint", action="store_true", help="Don't skip FUSE/WinFSP tests")
     parser.addoption("--rungui", action="store_true", help="Don't skip GUI tests")
+    parser.addoption("--rundiskfull", action="store_true", help="Don't skip the disk full tests")
     parser.addoption(
         "--realcrypto", action="store_true", help="Don't mock crypto operation to save time"
     )
@@ -196,6 +197,9 @@ def pytest_runtest_setup(item):
             pytest.skip("need --runmountpoint option to run")
         elif not get_mountpoint_runner():
             pytest.skip("FUSE/WinFSP not available")
+    if item.get_closest_marker("diskfull"):
+        if not item.config.getoption("--rundiskfull"):
+            pytest.skip("need --rundiskfull option to run")
     if item.get_closest_marker("gui"):
         if not item.config.getoption("--rungui"):
             pytest.skip("need --rungui option to run")

--- a/tests/core/fs/storage/test_workspace_storage.py
+++ b/tests/core/fs/storage/test_workspace_storage.py
@@ -469,25 +469,25 @@ async def test_vacuum(tmpdir, alice, workspace_id):
 
         # Make sure the storage is empty
         data = b"\x00" * data_size
-        assert aws.data_localdb.get_disk_usage() < data_size
+        assert await aws.data_localdb.get_disk_usage() < data_size
 
         # Set and commit a chunk of 1MB
         await aws.set_chunk(chunk.id, data)
         await aws.data_localdb.commit()
-        assert aws.data_localdb.get_disk_usage() > data_size
+        assert await aws.data_localdb.get_disk_usage() > data_size
 
         # Run the vacuum
         await aws.run_vacuum()
-        assert aws.data_localdb.get_disk_usage() > data_size
+        assert await aws.data_localdb.get_disk_usage() > data_size
 
         # Clear the chunk 1MB
         await aws.clear_chunk(chunk.id)
         await aws.data_localdb.commit()
-        assert aws.data_localdb.get_disk_usage() > data_size
+        assert await aws.data_localdb.get_disk_usage() > data_size
 
         # Run the vacuum
         await aws.run_vacuum()
-        assert aws.data_localdb.get_disk_usage() < data_size
+        assert await aws.data_localdb.get_disk_usage() < data_size
 
         # Make sure vacuum can run even if a transaction has started
         await aws.set_chunk(chunk.id, data)
@@ -499,7 +499,7 @@ async def test_vacuum(tmpdir, alice, workspace_id):
         await aws.cache_localdb.run_vacuum()
 
     # Make sure disk usage can be called on a closed storage
-    assert aws.data_localdb.get_disk_usage() < data_size
+    assert await aws.data_localdb.get_disk_usage() < data_size
 
 
 @pytest.mark.trio

--- a/tests/core/fs/test_disk_full.py
+++ b/tests/core/fs/test_disk_full.py
@@ -58,7 +58,7 @@ async def alice_fs_context(loopback_fs, event_bus_factory, alice):
 
 @pytest.mark.trio
 @pytest.mark.linux
-@pytest.mark.mountpoint
+@pytest.mark.diskfull
 async def test_workspace_fs_with_disk_full_simple(alice_fs_context, loopback_fs):
     """Make sure the sqlite database can recover from a full disk error."""
     async with alice_fs_context() as fs:
@@ -82,7 +82,7 @@ async def test_workspace_fs_with_disk_full_simple(alice_fs_context, loopback_fs)
 
 @pytest.mark.trio
 @pytest.mark.linux
-@pytest.mark.mountpoint
+@pytest.mark.diskfull
 async def test_workspace_fs_with_disk_full_large_write(alice_fs_context, loopback_fs):
     """Make sure the sqlite database can recover from a full disk error."""
     async with alice_fs_context() as fs:
@@ -114,7 +114,7 @@ async def test_workspace_fs_with_disk_full_large_write(alice_fs_context, loopbac
 
 @pytest.mark.trio
 @pytest.mark.linux
-@pytest.mark.mountpoint
+@pytest.mark.diskfull
 async def test_workspace_fs_with_disk_full_issue_1535(
     alice_fs_context, loopback_fs, running_backend
 ):
@@ -146,7 +146,7 @@ async def test_workspace_fs_with_disk_full_issue_1535(
 @pytest.mark.trio
 @pytest.mark.slow
 @pytest.mark.linux
-@pytest.mark.mountpoint
+@pytest.mark.diskfull
 async def test_workspace_fs_with_disk_full_systematic(alice_fs_context, loopback_fs):
     """A more systematic but slower search for corruption."""
     for number_of_write_before_full in range(50):
@@ -165,7 +165,7 @@ async def test_workspace_fs_with_disk_full_systematic(alice_fs_context, loopback
 @pytest.mark.trio
 @pytest.mark.slow
 @pytest.mark.linux
-@pytest.mark.mountpoint
+@pytest.mark.diskfull
 async def test_workspace_fs_with_disk_full_systematic_with_flush(alice_fs_context, loopback_fs):
     """A more systematic but slower search for corruption."""
     for number_of_write_before_full in range(50):
@@ -188,7 +188,7 @@ async def test_workspace_fs_with_disk_full_systematic_with_flush(alice_fs_contex
 @pytest.mark.trio
 @pytest.mark.slow
 @pytest.mark.linux
-@pytest.mark.mountpoint
+@pytest.mark.diskfull
 async def test_workspace_fs_with_disk_full_systematic_with_sync(
     alice_fs_context, loopback_fs, running_backend
 ):

--- a/tests/core/fs/test_disk_full.py
+++ b/tests/core/fs/test_disk_full.py
@@ -1,0 +1,144 @@
+# Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
+
+import trio
+import pytest
+import sqlite3
+from async_generator import asynccontextmanager
+
+try:
+    from tests.fuse_loopback import loopback_fs
+except ImportError:
+    pytest.skip("Fuse is required", allow_module_level=True)
+
+
+from parsec.core.fs import UserFS
+from parsec.core.logged_core import get_prevent_sync_pattern
+from parsec.core.remote_devices_manager import RemoteDevicesManager
+from parsec.core.backend_connection import backend_authenticated_cmds_factory
+
+fixtures = (loopback_fs,)
+
+
+@pytest.fixture
+async def alice_fs_context(loopback_fs, event_bus_factory, alice):
+
+    event_bus = event_bus_factory()
+    path = loopback_fs.path / alice.device_name
+    await trio.Path(path).mkdir()
+
+    @asynccontextmanager
+    async def _alice_context():
+        async with backend_authenticated_cmds_factory(
+            alice.organization_addr, alice.device_id, alice.signing_key
+        ) as cmds:
+            rdm = RemoteDevicesManager(cmds, alice.root_verify_key)
+            async with UserFS.run(
+                alice, path, cmds, rdm, event_bus, get_prevent_sync_pattern()
+            ) as user_fs:
+                yield user_fs
+
+    async with _alice_context() as user_fs:
+        wid = await user_fs.workspace_create("w")
+
+    @asynccontextmanager
+    async def _alice_fs_context(allow_sqlite_error_at_exit=False):
+        try:
+            exiting = False
+            async with _alice_context() as user_fs:
+                yield user_fs.get_workspace(wid)
+                exiting = True
+        except sqlite3.OperationalError:
+            if not exiting:
+                raise
+            if not allow_sqlite_error_at_exit:
+                raise
+
+    return _alice_fs_context
+
+
+@pytest.mark.trio
+@pytest.mark.linux
+@pytest.mark.mountpoint
+async def test_workspace_fs_with_disk_full_simple(alice_fs_context, loopback_fs):
+    async with alice_fs_context() as fs:
+        await fs.write_bytes("/test.txt", b"abc")
+        assert await fs.read_bytes("/test.txt") == b"abc"
+
+    async with alice_fs_context() as fs:
+        assert await fs.read_bytes("/test.txt") == b"abc"
+        loopback_fs.full = True
+        with pytest.raises(sqlite3.OperationalError):
+            await fs.write_bytes("/test.txt", b"efg")
+
+    with pytest.raises(sqlite3.OperationalError):
+        async with alice_fs_context() as fs:
+            pass
+
+    loopback_fs.full = False
+    async with alice_fs_context() as fs:
+        assert await fs.read_bytes("/test.txt") == b"abc"
+
+
+@pytest.mark.trio
+@pytest.mark.linux
+@pytest.mark.mountpoint
+@pytest.mark.parametrize("number_of_write_before_full", range(50))
+async def test_workspace_fs_with_disk_full_extended(
+    alice_fs_context, loopback_fs, number_of_write_before_full
+):
+    async with alice_fs_context() as fs:
+        await fs.write_bytes("/test.txt", b"aaa")
+        loopback_fs.number_of_write_before_full = number_of_write_before_full
+        with pytest.raises(sqlite3.OperationalError):
+            while True:
+                await fs.write_bytes("/test.txt", b"bbb")
+
+    loopback_fs.full = False
+    async with alice_fs_context() as fs:
+        assert await fs.read_bytes("/test.txt") in (b"aaa", b"bbb", b"")
+
+
+@pytest.mark.trio
+@pytest.mark.linux
+@pytest.mark.mountpoint
+@pytest.mark.parametrize("number_of_write_before_full", range(50))
+async def test_workspace_fs_with_disk_full_reloaded(
+    alice_fs_context, loopback_fs, number_of_write_before_full
+):
+    async with alice_fs_context() as fs:
+        await fs.write_bytes("/test.txt", b"")
+        loopback_fs.number_of_write_before_full = number_of_write_before_full
+        with pytest.raises(sqlite3.OperationalError):
+            async with await fs.open_file("/test.txt", "wb") as f:
+                while True:
+                    await f.write(b"aaa")
+                    await f.write(b"aaa")
+                    await f.flush()
+
+    loopback_fs.full = False
+    async with alice_fs_context() as fs:
+        result = await fs.read_bytes("/test.txt")
+        assert result == b"a" * len(result)
+
+
+@pytest.mark.trio
+@pytest.mark.linux
+@pytest.mark.mountpoint
+@pytest.mark.parametrize("number_of_write_before_full", range(50))
+async def test_workspace_fs_with_disk_full_ultimate(
+    alice_fs_context, loopback_fs, number_of_write_before_full, running_backend
+):
+    async with alice_fs_context(allow_sqlite_error_at_exit=True) as fs:
+        await fs.write_bytes("/test.txt", b"")
+        loopback_fs.number_of_write_before_full = number_of_write_before_full
+        with pytest.raises(sqlite3.OperationalError):
+            async with await fs.open_file("/test.txt", "wb") as f:
+                while True:
+                    await f.write(b"aaa")
+                    await f.write(b"aaa")
+                    await fs.sync()
+
+    loopback_fs.full = False
+    async with alice_fs_context() as fs:
+        result = await fs.read_bytes("/test.txt")
+        assert result == b"a" * len(result)

--- a/tests/fuse_loopback.py
+++ b/tests/fuse_loopback.py
@@ -1,0 +1,177 @@
+# Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
+
+import time
+import os.path
+from errno import EACCES
+from pathlib import Path
+from threading import Lock
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from fuse import FUSE, FuseOSError, Operations, LoggingMixIn, fuse_exit
+
+
+class Loopback(LoggingMixIn, Operations):
+    def __init__(self, root):
+        self.root = os.path.realpath(root)
+        self.rwlock = Lock()
+
+    def __call__(self, op, path, *args):
+        return super(Loopback, self).__call__(op, self.root + path, *args)
+
+    def access(self, path, mode):
+        if not os.access(path, mode):
+            raise FuseOSError(EACCES)
+
+    chmod = os.chmod
+    chown = os.chown
+
+    def create(self, path, mode):
+        return os.open(path, os.O_RDWR | os.O_CREAT | os.O_TRUNC, mode)
+
+    def flush(self, path, fh):
+        return os.fsync(fh)
+
+    def fsync(self, path, datasync, fh):
+        if datasync != 0:
+            return os.fdatasync(fh)
+        else:
+            return os.fsync(fh)
+
+    def getattr(self, path, fh=None):
+        st = os.lstat(path)
+        return dict(
+            (key, getattr(st, key))
+            for key in (
+                "st_atime",
+                "st_ctime",
+                "st_gid",
+                "st_mode",
+                "st_mtime",
+                "st_nlink",
+                "st_size",
+                "st_uid",
+            )
+        )
+
+    getxattr = None
+
+    def link(self, target, source):
+        return os.link(self.root + source, target)
+
+    listxattr = None
+    mkdir = os.mkdir
+    mknod = os.mknod
+    open = os.open
+
+    def read(self, path, size, offset, fh):
+        with self.rwlock:
+            os.lseek(fh, offset, 0)
+            return os.read(fh, size)
+
+    def readdir(self, path, fh):
+        return [".", ".."] + os.listdir(path)
+
+    readlink = os.readlink
+
+    def release(self, path, fh):
+        return os.close(fh)
+
+    def rename(self, old, new):
+        return os.rename(old, self.root + new)
+
+    rmdir = os.rmdir
+
+    def statfs(self, path):
+        stv = os.statvfs(path)
+        return dict(
+            (key, getattr(stv, key))
+            for key in (
+                "f_bavail",
+                "f_bfree",
+                "f_blocks",
+                "f_bsize",
+                "f_favail",
+                "f_ffree",
+                "f_files",
+                "f_flag",
+                "f_frsize",
+                "f_namemax",
+            )
+        )
+
+    def symlink(self, target, source):
+        return os.symlink(source, target)
+
+    def truncate(self, path, length, fh=None):
+        with open(path, "r+") as f:
+            f.truncate(length)
+
+    unlink = os.unlink
+    utimens = os.utime
+
+    def write(self, path, data, offset, fh):
+        with self.rwlock:
+            os.lseek(fh, offset, 0)
+            return os.write(fh, data)
+
+
+class ControlledLoopback(Loopback):
+    def __init__(self, source, mountpoint):
+        self.path = mountpoint
+        self.full = False
+        self.number_of_write_before_full = None
+        self.use_ns = True
+        self._exiting = False
+        super().__init__(source)
+
+    def getattr(self, path, fh=None):
+        if self._exiting:
+            fuse_exit()
+        return super().getattr(path, fh)
+
+    def schedule_exit(self):
+        self._exiting = True
+
+    def write(self, path, data, offset, fh):
+        if self.number_of_write_before_full is not None:
+            if self.number_of_write_before_full == 0:
+                self.full = True
+                self.number_of_write_before_full = None
+            elif self.number_of_write_before_full > 0:
+                self.number_of_write_before_full -= 1
+        if self.full:
+            return 0
+        return super().write(path, data, offset, fh)
+
+    def ioctl(self, path, cmd, arg, fd, *args):
+        return super().ioctl(path, cmd, arg, fd, *args)
+
+    def __call__(self, op, *args):
+        return super().__call__(op, *args)
+
+
+@pytest.fixture
+def loopback_fs(tmp_path):
+    source_path = Path(tmp_path) / "source"
+    mountpoint_path = Path(tmp_path) / "mountpoint"
+    source_path.mkdir()
+    mountpoint_path.mkdir()
+    st_dev = mountpoint_path.stat().st_dev
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        loopback = ControlledLoopback(source_path, mountpoint_path)
+        future = executor.submit(
+            lambda: FUSE(loopback, str(loopback.path), foreground=True, auto_unmount=True)
+        )
+        while mountpoint_path.stat().st_dev == st_dev:
+            time.sleep(0.001)
+        yield loopback
+        loopback.schedule_exit()
+        try:
+            (mountpoint_path / "__exit__").exists()
+        except OSError:
+            pass
+        future.result()
+        while mountpoint_path.stat().st_dev != st_dev:
+            time.sleep(0.001)


### PR DESCRIPTION
Fix issue #1537 and add more tests to detect database corruption after a failed write operation in a local sqlite database.