### PR TITLE
Add missing snap dependency libxkbcommon-x11-0 (required for xubuntu)

### DIFF
--- a/packaging/snap/snap/snapcraft.yaml
+++ b/packaging/snap/snap/snapcraft.yaml
@@ -54,3 +54,4 @@ parts:
       - libfreetype6
       - libpng16-16
       - libfontconfig
+      - libxkbcommon-x11-0


### PR DESCRIPTION
closes #1472 

Snap output tested on xubuntu.
snap test artifact: https://dev.azure.com/Scille/parsec/_build/results?buildId=4717&view=artifacts&type=publishedArtifacts