### PR TITLE
Show version in macos app

### DIFF
--- a/packaging/macOS/parsec.spec
+++ b/packaging/macOS/parsec.spec
@@ -1,6 +1,7 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
 import os
+exec(open("../../parsec/_version.py", encoding="utf8").read())
 
 a = Analysis(['launch_script.py'],
    pathex=[os.path.dirname(os.path.abspath('parsec.spec'))],
@@ -50,6 +51,7 @@ app = BUNDLE(coll,
       'CFBundleIdentifier': 'com.scille.parsec',
       'CFBundleName': 'Parsec',
       'CFBundleDisplayName': 'Parsec',
+      'CFBundleShortVersionString': __version__,
       'CFBundleURLTypes': [
          {
             'CFBundleTypeRole': 'Shell',

--- a/packaging/macOS/parsec.spec
+++ b/packaging/macOS/parsec.spec
@@ -1,7 +1,10 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
 import os
-exec(open("../../parsec/_version.py", encoding="utf8").read())
+
+ # Awesome hack to load `__version__`
+__version__ = None
+exec(open("../../parsec/_version.py", encoding="utf-8").read())
 
 a = Analysis(['launch_script.py'],
    pathex=[os.path.dirname(os.path.abspath('parsec.spec'))],


### PR DESCRIPTION
If not mentioned, the displayed version of the macOS app will be 0.0.0 instead of the current one.