### PR TITLE
Add force option to diskutil unmount calls

### DIFF
--- a/newsfragments/1644.bugfix.rst
+++ b/newsfragments/1644.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a mountpoint issue in MacOS that could cause errors during login or unmounting a workspace.

--- a/parsec/core/mountpoint/fuse_runner.py
+++ b/parsec/core/mountpoint/fuse_runner.py
@@ -232,7 +232,7 @@ async def _stop_fuse_thread(
         # The schedule_exit() solution doesn't work on macOS, instead freezes the application for
         # 120 seconds before a timeout occurs. The solution used is to call this function (macOS
         # equivalent to fusermount) in a subprocess to unmount.
-        await trio.run_process(["diskutil", "unmount", str(mountpoint_path)])
+        await trio.run_process(["diskutil", "unmount", "force", str(mountpoint_path)])
     else:
         # Schedule an exit in the fuse operations
         fuse_operations.schedule_exit()

--- a/parsec/core/mountpoint/manager.py
+++ b/parsec/core/mountpoint/manager.py
@@ -272,7 +272,7 @@ async def cleanup_macos_mountpoint_folder(base_mountpoint_path):
         dir_path = str(base_mountpoint_path) + "/" + str(dirs)
         stats = os.statvfs(dir_path)
         if stats.f_blocks == 0 and stats.f_ffree == 0 and stats.f_bavail == 0:
-            await trio.run_process(["diskutil", "unmount", dir_path])
+            await trio.run_process(["diskutil", "unmount", "force", dir_path])
             if dirs in os.listdir(base_mountpoint_path):  # checking if there is something to delete
                 await trio.run_process(["rm", "-d", dir_path])  # otherwise an empty dir remains
 


### PR DESCRIPTION
This can prevent errors during login after a crash, or in various situations where a mountpoint can't unmount without it (when a terminal's cwd is inside the mountpoint for instance)