### PR TITLE
Http invitation links

### DIFF
--- a/parsec/backend/invite.py
+++ b/parsec/backend/invite.py
@@ -152,12 +152,19 @@ def generate_invite_email(
     greeter_name: Optional[str],  # Noe for device invitation
     organization_id: OrganizationID,
     invitation_url: str,
+    parsec_url: str,
 ) -> Message:
     html = get_template("invitation_mail.html").render(
-        greeter=greeter_name, organization_id=organization_id, invitation_url=invitation_url
+        greeter=greeter_name,
+        organization_id=organization_id,
+        invitation_url=invitation_url,
+        parsec_url=parsec_url,
     )
     text = get_template("invitation_mail.txt").render(
-        greeter=greeter_name, organization_id=organization_id, invitation_url=invitation_url
+        greeter=greeter_name,
+        organization_id=organization_id,
+        invitation_url=invitation_url,
+        parsec_url=parsec_url,
     )
 
     # mail settings
@@ -279,6 +286,14 @@ class BaseInviteComponent:
                 token=invitation.token,
             ).to_http_redirection_url()
 
+        def _to_url(client_ctx, invitation):
+            return BackendInvitationAddr.build(
+                backend_addr=self._config.backend_addr,
+                organization_id=client_ctx.organization_id,
+                invitation_type=invitation.TYPE,
+                token=invitation.token,
+            ).to_url()
+
         if msg["type"] == InvitationType.USER:
             if client_ctx.profile != UserProfile.ADMIN:
                 return invite_new_serializer.rep_dump({"status": "not_allowed"})
@@ -305,6 +320,7 @@ class BaseInviteComponent:
                     reply_to=reply_to,
                     organization_id=client_ctx.organization_id,
                     invitation_url=_to_http_redirection_url(client_ctx, invitation),
+                    parsec_url=_to_url(client_ctx, invitation),
                 )
                 await send_email(
                     email_config=self._config.email_config,
@@ -328,6 +344,7 @@ class BaseInviteComponent:
                     reply_to=None,
                     organization_id=client_ctx.organization_id,
                     invitation_url=_to_http_redirection_url(client_ctx, invitation),
+                    parsec_url=_to_url(client_ctx, invitation),
                 )
                 await send_email(
                     email_config=self._config.email_config,

--- a/parsec/backend/templates/invitation_mail.html
+++ b/parsec/backend/templates/invitation_mail.html
@@ -423,7 +423,12 @@ the Parsec client via the following link:
 <br>
 <br>
 For more information you can consult the <a href="https://docs.parsec.cloud" target="_blank">Parsec documentation</a>
-
+<br>
+<br>
+<div style="padding: 5px 5px 10px 5px; color: #666; font-size: 0.8em; font-style: italic;">
+    If the button does not work properly you can also copy and paste this link in the address bar of your parsec. <br>
+    <a target="_blank" href="{{parsec_url}}">{{parsec_url}}</a>
+</div>
                             </p>
                         </td>
                         </tr>

--- a/parsec/backend/templates/invitation_mail.txt
+++ b/parsec/backend/templates/invitation_mail.txt
@@ -17,3 +17,6 @@ then follow the steps on the Parsec client.
 {% endif %}
 
 For more information you can consult the Parsec documentation: https://docs.parsec.cloud
+
+  If the button does not work properly you can also copy and paste this link in the address bar of your parsec.
+  {{ parsec_url }}

--- a/parsec/core/gui/tr/parsec_en.po
+++ b/parsec/core/gui/tr/parsec_en.po
@@ -1596,7 +1596,7 @@ msgid "TEXT_JOIN_ORG_INVALID_URL"
 msgstr "The link is invalid."
 
 msgid "TEXT_INVALID_URL"
-msgstr "The link is invalid.  (expected format : parsec://hote:port/organisation?action=action&..)"
+msgstr "The link is invalid (expected format: parsec://hote:port/organisation?action=action&..)"
 
 msgid "TEXT_ERROR_REPORTING_TITLE"
 msgstr "Error reporting"

--- a/parsec/core/gui/tr/parsec_en.po
+++ b/parsec/core/gui/tr/parsec_en.po
@@ -1596,7 +1596,7 @@ msgid "TEXT_JOIN_ORG_INVALID_URL"
 msgstr "The link is invalid."
 
 msgid "TEXT_INVALID_URL"
-msgstr "The link is invalid."
+msgstr "The link is invalid.  (expected format : parsec://hote:port/organisation?action=action&..)"
 
 msgid "TEXT_ERROR_REPORTING_TITLE"
 msgstr "Error reporting"
@@ -2492,4 +2492,3 @@ msgstr "Create a new workspace"
 
 msgid "ACTION_WORKSPACE_GOTO_FILE_LINK"
 msgstr "Go to a file using a link"
-

--- a/parsec/core/gui/tr/parsec_en.po
+++ b/parsec/core/gui/tr/parsec_en.po
@@ -1596,7 +1596,7 @@ msgid "TEXT_JOIN_ORG_INVALID_URL"
 msgstr "The link is invalid."
 
 msgid "TEXT_INVALID_URL"
-msgstr "The link is invalid (expected format: parsec://hote:port/organisation?action=action&..)"
+msgstr "The link is invalid (expected format: parsec://host:port/organisation?action=action&..)"
 
 msgid "TEXT_ERROR_REPORTING_TITLE"
 msgstr "Error reporting"

--- a/parsec/core/gui/tr/parsec_fr.po
+++ b/parsec/core/gui/tr/parsec_fr.po
@@ -1643,7 +1643,7 @@ msgid "TEXT_JOIN_ORG_INVALID_URL"
 msgstr "L'URL n'est pas valide."
 
 msgid "TEXT_INVALID_URL"
-msgstr "L'URL n'est pas valide. (format attendu: parsec://hote:port/organisation?action=action&..)"
+msgstr "L'URL n'est pas valide (format attendu : parsec://hote:port/organisation?action=action&..)"
 
 msgid "TEXT_ERROR_REPORTING_TITLE"
 msgstr "Rapport d'erreur"

--- a/parsec/core/gui/tr/parsec_fr.po
+++ b/parsec/core/gui/tr/parsec_fr.po
@@ -1643,7 +1643,7 @@ msgid "TEXT_JOIN_ORG_INVALID_URL"
 msgstr "L'URL n'est pas valide."
 
 msgid "TEXT_INVALID_URL"
-msgstr "L'URL n'est pas valide."
+msgstr "L'URL n'est pas valide. (format attendu: parsec://hote:port/organisation?action=action&..)"
 
 msgid "TEXT_ERROR_REPORTING_TITLE"
 msgstr "Rapport d'erreur"
@@ -2557,4 +2557,3 @@ msgstr "Créer un nouvel espace de travail"
 
 msgid "ACTION_WORKSPACE_GOTO_FILE_LINK"
 msgstr "Trouver un fichier via son lien"
-

--- a/setup.py
+++ b/setup.py
@@ -337,8 +337,8 @@ extra_requirements = {
         "triopg==0.5.0",
         "trio-asyncio==0.11.0",
         # S3
-        "boto3==1.12.34",
-        "botocore==1.15.34",
+        "boto3==1.17.27",
+        "botocore==1.20.27",
         # Swift
         "python-swiftclient==3.5.0",
         "pbr==4.0.2",

--- a/tests/core/gui/devices_widget/test_claim.py
+++ b/tests/core/gui/devices_widget/test_claim.py
@@ -639,4 +639,7 @@ async def test_claim_device_with_bad_start_arg(
 
     assert len(autoclose_dialog.dialogs) == 1
     assert autoclose_dialog.dialogs[0][0] == "Error"
-    assert autoclose_dialog.dialogs[0][1] == "The link is invalid."
+    assert (
+        autoclose_dialog.dialogs[0][1]
+        == "The link is invalid (expected format: parsec://host:port/organisation?action=action&..)"
+    )

--- a/tests/core/gui/users_widget/test_claim.py
+++ b/tests/core/gui/users_widget/test_claim.py
@@ -686,4 +686,7 @@ async def test_claim_user_with_bad_start_arg(event_bus, core_config, gui_factory
 
     assert len(autoclose_dialog.dialogs) == 1
     assert autoclose_dialog.dialogs[0][0] == "Error"
-    assert autoclose_dialog.dialogs[0][1] == "The link is invalid."
+    assert (
+        autoclose_dialog.dialogs[0][1]
+        == "The link is invalid (expected format: parsec://host:port/organisation?action=action&..)"
+    )


### PR DESCRIPTION
After some discussion about this issue, we decided that we don't have to handle the http(s) links in the parsec client.
Indeed, the http(s) url has been build only to redirect the user to the client and avoid the copy/paste action.
In case of the button doesn't work, we have to provide to the users the true parsec url in the mail.
In this PR, I improve the invalid url message to explain the expected format and I add the parsec url in the mail in case of the user need to copy past it in the client.
