### PR TITLE
Increase timeout for running_backend fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -726,6 +726,7 @@ def core_factory(
                     await spy.wait_with_timeout(
                         CoreEvent.BACKEND_CONNECTION_CHANGED,
                         {"status": BackendConnStatus.READY, "status_exc": spy.ANY},
+                        timeout=2.0,  # 1 second might not be enough for postgresql 12 tests running in the CI
                     )
                 assert core.are_monitors_idle()
 


### PR DESCRIPTION
Tested with `tests/backend/test_organization_stats.py::test_organization_stats`.

Measurements of lowest non-failing timeout on my machine:
- memory backend: 65-70 ms
- postgresql 10 backend: 220-230 ms
- postgresql 12 backend: 680-700 ms

Reproduce with:
```bash
while PGINSTALLATION=/usr/lib/postgresql/10/bin pytest --postgresql tests/backend/test_organization_stats.py; do :; done;
```