### PR TITLE
MacOS app fixes

### DIFF
--- a/newsfragments/1519.bugfix.rst
+++ b/newsfragments/1519.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed Dock icon behaviour on MacOS when app was closed with red X.

--- a/parsec/core/gui/app.py
+++ b/parsec/core/gui/app.py
@@ -171,7 +171,7 @@ def run_gui(config: CoreConfig, start_arg: str = None, diagnose: bool = False):
             # Another instance of Parsec already started, nothing more to do
             return
 
-        if systray_available():
+        if systray_available() and sys.platform != "darwin":
             systray = Systray(parent=win)
             win.systray_notification.connect(systray.on_systray_notification)
             systray.on_close.connect(win.close_app)

--- a/parsec/core/gui/app.py
+++ b/parsec/core/gui/app.py
@@ -171,6 +171,7 @@ def run_gui(config: CoreConfig, start_arg: str = None, diagnose: bool = False):
             # Another instance of Parsec already started, nothing more to do
             return
 
+        # Systray is not displayed on MacOS, having natively a menu with similar functions.
         if systray_available() and sys.platform != "darwin":
             systray = Systray(parent=win)
             win.systray_notification.connect(systray.on_systray_notification)

--- a/parsec/core/gui/main_window.py
+++ b/parsec/core/gui/main_window.py
@@ -680,7 +680,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         if self.minimize_on_close and not self.need_close:
             self.hide()
             event.ignore()
-            if not self.minimize_on_close_notif_already_send:
+            if not self.minimize_on_close_notif_already_send and platform.system() != "Darwin":
                 self.minimize_on_close_notif_already_send = True
                 self.systray_notification.emit(
                     "Parsec", _("TEXT_TRAY_PARSEC_STILL_RUNNING_MESSAGE"), 2000

--- a/parsec/core/gui/main_window.py
+++ b/parsec/core/gui/main_window.py
@@ -680,6 +680,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         if self.minimize_on_close and not self.need_close:
             self.hide()
             event.ignore()
+
+            # This notification is disabled on Mac since minimizing apps on
+            # close is the standard behaviour on this OS.
             if not self.minimize_on_close_notif_already_send and platform.system() != "Darwin":
                 self.minimize_on_close_notif_already_send = True
                 self.systray_notification.emit(

--- a/parsec/core/gui/parsec_application.py
+++ b/parsec/core/gui/parsec_application.py
@@ -1,5 +1,7 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2019 Scille SAS
 
+import sys
+
 from PyQt5.QtWidgets import QApplication
 from PyQt5.QtCore import QFile, QEvent
 from PyQt5.QtGui import QFont, QFontDatabase, QPalette, QColor
@@ -24,7 +26,7 @@ class ParsecApp(QApplication):
 
     def event(self, e):
         """Handle macOS FileOpen events."""
-        if e.type() == QEvent.ApplicationActivate:
+        if sys.platform == "darwin" and e.type() == QEvent.ApplicationActivate:
             # Necessary to reopen window with dock icon after being closed with
             # red X on MacOS
             self.get_main_window().show_top()

--- a/parsec/core/gui/parsec_application.py
+++ b/parsec/core/gui/parsec_application.py
@@ -28,7 +28,17 @@ class ParsecApp(QApplication):
         """Handle macOS FileOpen events."""
         if sys.platform == "darwin" and e.type() == QEvent.ApplicationActivate:
             # Necessary to reopen window with dock icon after being closed with
-            # red X on MacOS
+            # red X on MacOS.
+            # There are three events related to the dock icon click:
+            # ApplicationActivate, ApplicationDeactivate and ApplicationStateChange.
+            # The events ApplicationDeactivate and ApplicationStateChange are
+            # tied to whenever the window state changes from foreground to
+            # background. Inversely, the events ApplicationActivate and
+            # ApplicationStateChange can be caught when switching from
+            # background to foreground, or clicking the dock icon.
+            # Even though ApplicationActivate is said to be deprecated, it's
+            # seemingly the only event we can use for this particular case,
+            # ApplicationStateChange not being specific enough.
             self.get_main_window().show_top()
         if e.type() != QEvent.FileOpen or e.url().scheme() != "parsec":
             return super().event(e)

--- a/parsec/core/gui/parsec_application.py
+++ b/parsec/core/gui/parsec_application.py
@@ -24,6 +24,10 @@ class ParsecApp(QApplication):
 
     def event(self, e):
         """Handle macOS FileOpen events."""
+        if e.type() == QEvent.ApplicationActivate:
+            # Necessary to reopen window with dock icon after being closed with
+            # red X on MacOS
+            self.get_main_window().show_top()
         if e.type() != QEvent.FileOpen or e.url().scheme() != "parsec":
             return super().event(e)
         try:


### PR DESCRIPTION
This aims at enhancing the app's behaviour to be more like usual Mac apps:

- Clicking the red X on Mac apps closes the window and leaves the process running in background. In this situation, clicking the Dock icon should pop the window back up, which wasn't the case. This is handled here with the `ApplicationActivate` event.
- Removal of the systray for MacOS as there is already is a default menu on the system with the same functions.
- Removal of the system notification when minimizing the app for MacOS, as this is default on most apps.

The app behaviour when `Minimize in tray` option is unchecked remains unchanged.

Closes #1519 