### PR TITLE
Fix blocking IO calls to sqlite when uploading large files

### DIFF
--- a/newsfragments/1713.bugfix.rst
+++ b/newsfragments/1713.bugfix.rst
@@ -1,0 +1,1 @@
+Fix blocking calls related to the local storage that might slow down the application.

--- a/parsec/core/fs/storage/chunk_storage.py
+++ b/parsec/core/fs/storage/chunk_storage.py
@@ -100,7 +100,7 @@ class ChunkStorage:
         async with self._open_cursor() as cursor:
             # Use a thread as executing a statement that modifies the content of the database might,
             # in some case, block for several hundreds of milliseconds
-            await trio.to_thread.run_sync(
+            await self.localdb.run_in_thread(
                 cursor.execute,
                 """
                 UPDATE chunks SET accessed_on = ? WHERE chunk_id = ?;
@@ -124,7 +124,7 @@ class ChunkStorage:
         async with self._open_cursor() as cursor:
             # Use a thread as executing a statement that modifies the content of the database might,
             # in some case, block for several hundreds of milliseconds
-            await trio.to_thread.run_sync(
+            await self.localdb.run_in_thread(
                 cursor.execute,
                 """INSERT OR REPLACE INTO
                 chunks (chunk_id, size, offline, accessed_on, data)
@@ -136,7 +136,7 @@ class ChunkStorage:
         async with self._open_cursor() as cursor:
             # Use a thread as executing a statement that modifies the content of the database might,
             # in some case, block for several hundreds of milliseconds
-            await trio.to_thread.run_sync(
+            await self.localdb.run_in_thread(
                 cursor.execute, "DELETE FROM chunks WHERE chunk_id = ?", (chunk_id.bytes,)
             )
             cursor.execute("SELECT changes()")
@@ -190,7 +190,7 @@ class BlockStorage(ChunkStorage):
             # Insert the chunk
             # Use a thread as executing a statement that modifies the content of the database might,
             # in some case, block for several hundreds of milliseconds
-            await trio.to_thread.run_sync(
+            await self.localdb.run_in_thread(
                 cursor.execute,
                 """INSERT OR REPLACE INTO
                 chunks (chunk_id, size, offline, accessed_on, data)
@@ -211,7 +211,7 @@ class BlockStorage(ChunkStorage):
             limit = extra_blocks + self.block_limit // 10
             # Use a thread as executing a statement that modifies the content of the database might,
             # in some case, block for several hundreds of milliseconds
-            await trio.to_thread.run_sync(
+            await self.localdb.run_in_thread(
                 cursor.execute,
                 """
                 DELETE FROM chunks WHERE chunk_id IN (

--- a/parsec/core/fs/storage/chunk_storage.py
+++ b/parsec/core/fs/storage/chunk_storage.py
@@ -117,7 +117,6 @@ class ChunkStorage:
         return self.local_symkey.decrypt(ciphered)
 
     async def set_chunk(self, chunk_id: ChunkID, raw: bytes) -> None:
-        assert isinstance(raw, (bytes, bytearray))
         ciphered = self.local_symkey.encrypt(raw)
 
         # Update database
@@ -181,7 +180,6 @@ class BlockStorage(ChunkStorage):
     # Upgraded set method
 
     async def set_chunk(self, chunk_id: ChunkID, raw: bytes) -> None:
-        assert isinstance(raw, (bytes, bytearray))
         ciphered = self.local_symkey.encrypt(raw)
 
         # Update database

--- a/parsec/core/fs/storage/chunk_storage.py
+++ b/parsec/core/fs/storage/chunk_storage.py
@@ -57,7 +57,7 @@ class ChunkStorage:
         # writes data as blocks of 4K. The manifest being kept in
         # memory during the writing, this means that the data and
         # metadata is typically not flushed to the disk until an
-        # an acutal flush operation is performed.
+        # an actual flush operation is performed.
         return self.localdb.open_cursor(commit=False)
 
     # Database initialization
@@ -155,7 +155,7 @@ class BlockStorage(ChunkStorage):
     def _open_cursor(self) -> AsyncContextManager[Cursor]:
         # It doesn't matter for blocks to be commited as soon as they're added
         # since they exists in the remote storage anyway. But it's simply more
-        # convenient to perform the commit right away as does't cost much (at
+        # convenient to perform the commit right away as it does't cost much (at
         # least compare to the downloading of the block).
         return self.localdb.open_cursor(commit=True)
 

--- a/parsec/core/fs/storage/local_database.py
+++ b/parsec/core/fs/storage/local_database.py
@@ -84,20 +84,22 @@ class LocalDatabase:
         # An operational error has been detected
         except OperationalError as exception:
 
-            # Close the sqlite3 connection
-            try:
-                await self.run_in_thread(self._conn.close)
+            with trio.CancelScope(shield=True):
 
-            # Ignore second operational error (it should not happen though)
-            except OperationalError:
-                pass
+                # Close the sqlite3 connection
+                try:
+                    await self.run_in_thread(self._conn.close)
 
-            # Mark the local database as closed
-            finally:
-                del self._conn
+                # Ignore second operational error (it should not happen though)
+                except OperationalError:
+                    pass
 
-            # Raise the dedicated operational error
-            raise FSLocalStorageOperationalError from exception
+                # Mark the local database as closed
+                finally:
+                    del self._conn
+
+                # Raise the dedicated operational error
+                raise FSLocalStorageOperationalError from exception
 
     # Life cycle
 

--- a/parsec/core/fs/storage/manifest_storage.py
+++ b/parsec/core/fs/storage/manifest_storage.py
@@ -277,7 +277,7 @@ class ManifestStorage:
             # This is one order of magnitude higher than the thread overhead
             # which is about 1 ms
             if manifest.size_estimate() > 50:
-                ciphered = await trio.to_thread.run_sync(
+                ciphered = await self.localdb.run_in_thread(
                     manifest.dump_and_encrypt, self.device.local_symkey
                 )
             else:
@@ -286,7 +286,7 @@ class ManifestStorage:
             # Insert into the local database
             # Use a thread as executing a statement that modifies the content of the database might,
             # in some case, block for several hundreds of milliseconds
-            await trio.to_thread.run_sync(
+            await self.localdb.run_in_thread(
                 cursor.execute,
                 """INSERT OR REPLACE INTO vlobs (vlob_id, blob, need_sync, base_version, remote_version)
                 VALUES (

--- a/parsec/core/fs/storage/manifest_storage.py
+++ b/parsec/core/fs/storage/manifest_storage.py
@@ -276,7 +276,10 @@ class ManifestStorage:
             ciphered = manifest.dump_and_encrypt(self.device.local_symkey)
 
             # Insert into the local database
-            cursor.execute(
+            # Use a thread as executing a statement that modifies the content of the database might,
+            # in some case, block for several hundreds of milliseconds
+            await trio.to_thread.run_sync(
+                cursor.execute,
                 """INSERT OR REPLACE INTO vlobs (vlob_id, blob, need_sync, base_version, remote_version)
                 VALUES (
                     ?, ?, ?, ?,

--- a/parsec/core/fs/workspacefs/sync_transactions.py
+++ b/parsec/core/fs/workspacefs/sync_transactions.py
@@ -208,13 +208,13 @@ class SyncTransactions(EntryTransactions):
         self, remote_manifest: RemoteFolderishManifests
     ) -> AsyncIterator[EntryID]:
         # Check children placeholder
-        for chield_entry_id in remote_manifest.children.values():
+        for child_entry_id in remote_manifest.children.values():
             try:
-                child_manifest = await self.local_storage.get_manifest(chield_entry_id)
+                child_manifest = await self.local_storage.get_manifest(child_entry_id)
             except FSLocalMissError:
                 continue
             if child_manifest.is_placeholder:
-                yield chield_entry_id
+                yield child_entry_id
 
     async def get_minimal_remote_manifest(self, entry_id: EntryID) -> Optional[BaseRemoteManifest]:
         manifest = await self.local_storage.get_manifest(entry_id)

--- a/parsec/core/mountpoint/fuse_runner.py
+++ b/parsec/core/mountpoint/fuse_runner.py
@@ -239,9 +239,9 @@ async def _stop_fuse_thread(
         process_args = ["diskutil", "unmount", "force", str(mountpoint_path)]
         process = await trio.open_process(process_args)
 
-        # Perform 100 attempts of 10 ms, i.e a 1 second timeout
+        # Perform 300 attempts of 10 ms, i.e a 3 second timeout
         # A while loop wouldn't be ideal here, especially since this code is protected against cancellation
-        for _ in range(100):
+        for _ in range(300):
             # Check if the attempt succeeded for 10 ms
             if await trio.to_thread.run_sync(fuse_thread_stopped.wait, 0.01):
                 break

--- a/parsec/core/types/manifest.py
+++ b/parsec/core/types/manifest.py
@@ -254,6 +254,9 @@ class BaseLocalManifest(BaseLocalData):
     def is_placeholder(self):
         return self.base.version == 0
 
+    def size_estimate(self):
+        return 1
+
     # Evolve methods
 
     def evolve_and_mark_updated(self: LocalManifestTypeVar, **data) -> LocalManifestTypeVar:
@@ -430,6 +433,9 @@ class LocalFileManifest(BaseLocalManifest):
                 assert chunk.stop <= chunk.raw_offset + chunk.raw_size
                 current = chunk.stop
         assert current == self.size
+
+    def size_estimate(self):
+        return 1 + len(self.base.blocks) + sum(map(len, self.blocks))
 
     # Remote methods
 
@@ -670,6 +676,9 @@ class LocalFolderManifest(BaseLocalManifest, LocalFolderishManifestMixin):
     def parent(self):
         return self.base.parent
 
+    def size_estimate(self):
+        return 1 + len(self.base.children) + len(self.children)
+
     # Remote methods
 
     @classmethod
@@ -769,6 +778,11 @@ class LocalWorkspaceManifest(BaseLocalManifest, LocalFolderishManifestMixin):
             local_confinement_points=frozenset(),
             remote_confinement_points=frozenset(),
         )
+
+    # Properties
+
+    def size_estimate(self):
+        return 1 + len(self.base.children) + len(self.children)
 
     # Evolve methods
 
@@ -870,6 +884,9 @@ class LocalUserManifest(BaseLocalManifest):
 
     def get_workspace_entry(self, workspace_id: EntryID) -> WorkspaceEntry:
         return next((w for w in self.workspaces if w.id == workspace_id), None)
+
+    def size_estimate(self):
+        return 1 + len(self.base.workspaces) + len(self.workspaces)
 
     # Evolve methods
 

--- a/parsec/core/types/manifest.py
+++ b/parsec/core/types/manifest.py
@@ -254,9 +254,6 @@ class BaseLocalManifest(BaseLocalData):
     def is_placeholder(self):
         return self.base.version == 0
 
-    def size_estimate(self):
-        return 1
-
     # Evolve methods
 
     def evolve_and_mark_updated(self: LocalManifestTypeVar, **data) -> LocalManifestTypeVar:
@@ -433,9 +430,6 @@ class LocalFileManifest(BaseLocalManifest):
                 assert chunk.stop <= chunk.raw_offset + chunk.raw_size
                 current = chunk.stop
         assert current == self.size
-
-    def size_estimate(self):
-        return 1 + len(self.base.blocks) + sum(map(len, self.blocks))
 
     # Remote methods
 
@@ -676,9 +670,6 @@ class LocalFolderManifest(BaseLocalManifest, LocalFolderishManifestMixin):
     def parent(self):
         return self.base.parent
 
-    def size_estimate(self):
-        return 1 + len(self.base.children) + len(self.children)
-
     # Remote methods
 
     @classmethod
@@ -778,11 +769,6 @@ class LocalWorkspaceManifest(BaseLocalManifest, LocalFolderishManifestMixin):
             local_confinement_points=frozenset(),
             remote_confinement_points=frozenset(),
         )
-
-    # Properties
-
-    def size_estimate(self):
-        return 1 + len(self.base.children) + len(self.children)
 
     # Evolve methods
 
@@ -884,9 +870,6 @@ class LocalUserManifest(BaseLocalManifest):
 
     def get_workspace_entry(self, workspace_id: EntryID) -> WorkspaceEntry:
         return next((w for w in self.workspaces if w.id == workspace_id), None)
-
-    def size_estimate(self):
-        return 1 + len(self.base.workspaces) + len(self.workspaces)
 
     # Evolve methods
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -432,6 +432,10 @@ def persistent_mockup(monkeypatch):
     async def get_disk_usage(storage):
         return 0
 
+    async def run_in_thread(storage, fn, *args):
+        return fn(*args)
+
+    monkeypatch.setattr(LocalDatabase, "run_in_thread", run_in_thread)
     monkeypatch.setattr(LocalDatabase, "_create_connection", _create_connection)
     monkeypatch.setattr(LocalDatabase, "_close", _close)
     monkeypatch.setattr(LocalDatabase, "get_disk_usage", get_disk_usage)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ from parsec.core.types import BackendAddr
 from parsec.core.logged_core import logged_core_factory
 from parsec.core.backend_connection import BackendConnStatus
 from parsec.core.mountpoint.manager import get_mountpoint_runner
-from parsec.core.fs.storage import LocalDatabase, local_database, UserStorage
+from parsec.core.fs.storage import LocalDatabase, UserStorage
 
 from parsec.backend import backend_app_factory
 from parsec.backend.config import (
@@ -432,16 +432,6 @@ def persistent_mockup(monkeypatch):
     async def get_disk_usage(storage):
         return 0
 
-    @asynccontextmanager
-    async def thread_pool_runner(max_workers):
-        assert max_workers == 1
-
-        async def run_in_thread(fn, *args):
-            return fn(*args)
-
-        yield run_in_thread
-
-    monkeypatch.setattr(local_database, "thread_pool_runner", thread_pool_runner)
     monkeypatch.setattr(LocalDatabase, "_create_connection", _create_connection)
     monkeypatch.setattr(LocalDatabase, "_close", _close)
     monkeypatch.setattr(LocalDatabase, "get_disk_usage", get_disk_usage)


### PR DESCRIPTION
Also remove thread pool executor from the local database module since trio now caches its threads.

Fix #1698, #1699, #1700 and partially #1701.