### PR TITLE
Fix a regression that broke the "mount workspace at a given timestamp" button

### DIFF
--- a/newsfragments/1723.bugfix.rst
+++ b/newsfragments/1723.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a regression that broke the "Remount workspace at a given timestamp" button.

--- a/parsec/core/gui/workspace_button.py
+++ b/parsec/core/gui/workspace_button.py
@@ -139,7 +139,7 @@ class WorkspaceButton(QWidget, Ui_WorkspaceButton):
                     label = getattr(self, "file{}_name".format(i))
                     label.setText(f)
         else:
-            widget_temp = self.widget_empty.layout().widgetAt(0)
+            widget_temp = self.widget_empty.layout().itemAt(0).widget()
             widget_temp.label_timestamp.setText(format_datetime(self.timestamp))
 
         self.label_role.setText(get_role_translation(self.current_role))


### PR DESCRIPTION
Fix issue #1723, a regression introduced in #1688.