### PR TITLE
Add workaround to keep client backward compatibility when using an ol…

### DIFF
--- a/parsec/core/backend_connection/authenticated.py
+++ b/parsec/core/backend_connection/authenticated.py
@@ -286,12 +286,19 @@ class BackendAuthenticatedConn:
 
             rep = await cmds.organization_config(transport)
             if rep["status"] != "ok":
-                raise BackendConnectionRefused(f"Error while fetching organization config: {rep}")
+                # Authenticated's organization_config command has been introduced in API v2.2
+                # So a cheap trick to keep backward compatibility here is to
+                # stick with the pre-populated organization config cached value.
+                if rep["status"] != "unknown_command":
+                    raise BackendConnectionRefused(
+                        f"Error while fetching organization config: {rep}"
+                    )
 
-            self._organization_config = OrganizationConfig(
-                expiration_date=rep["expiration_date"],
-                user_profile_outsider_allowed=rep["user_profile_outsider_allowed"],
-            )
+            else:
+                self._organization_config = OrganizationConfig(
+                    expiration_date=rep["expiration_date"],
+                    user_profile_outsider_allowed=rep["user_profile_outsider_allowed"],
+                )
 
             rep = await cmds.events_subscribe(transport)
             if rep["status"] != "ok":

--- a/parsec/core/backend_connection/authenticated.py
+++ b/parsec/core/backend_connection/authenticated.py
@@ -173,7 +173,7 @@ class BackendAuthenticatedConn:
         self._monitors_idle_event.set()  # No monitors
         self._backend_connection_failures = 0
         self._organization_config = OrganizationConfig(
-            expiration_date=False, user_profile_outsider_allowed=False
+            expiration_date=None, user_profile_outsider_allowed=False
         )
         # organization config is very unlikely to change, hence we query it
         # once when backend connection bootstraps, then keep the value in cache.

--- a/tests/core/backend_connection/test_authenticated_conn.py
+++ b/tests/core/backend_connection/test_authenticated_conn.py
@@ -3,8 +3,10 @@
 import pytest
 import trio
 
+from pendulum import datetime
 from parsec.backend.backend_events import BackendEvent
-from parsec.api.protocol import RealmRole
+from parsec.api.protocol import RealmRole, HandshakeType
+from parsec.core.types import OrganizationConfig
 from parsec.core.backend_connection import (
     BackendAuthenticatedConn,
     BackendConnStatus,
@@ -31,9 +33,28 @@ async def alice_backend_conn(alice, event_bus_factory, running_backend_ready):
 
 
 @pytest.mark.trio
-async def test_init_with_backend_online(running_backend, event_bus, alice):
+@pytest.mark.parametrize("apiv22_organization_cmd_supported", (True, False))
+async def test_init_with_backend_online(
+    running_backend, event_bus, alice, apiv22_organization_cmd_supported
+):
     monitor_initialized = False
     monitor_teardown = False
+
+    # Mock organization config command
+    async def _mocked_organization_config(client_ctx, msg):
+        if apiv22_organization_cmd_supported:
+            return {
+                "expiration_date": datetime(2000, 1, 1),
+                "user_profile_outsider_allowed": True,
+                "status": "ok",
+            }
+        else:
+            # Backend with API support <2.2, the client should be able to fallback
+            return {"status": "unknown_command"}
+
+    running_backend.backend.apis[HandshakeType.AUTHENTICATED][
+        "organization_config"
+    ] = _mocked_organization_config
 
     async def _monitor(*, task_status=trio.TASK_STATUS_IGNORED):
         nonlocal monitor_initialized, monitor_teardown
@@ -48,6 +69,11 @@ async def test_init_with_backend_online(running_backend, event_bus, alice):
         alice.organization_addr, alice.device_id, alice.signing_key, event_bus
     )
     assert conn.status == BackendConnStatus.LOST
+    default_organization_config = OrganizationConfig(
+        expiration_date=None, user_profile_outsider_allowed=False
+    )
+    assert conn.get_organization_config() == default_organization_config
+
     conn.register_monitor(_monitor)
     with event_bus.listen() as spy:
         async with conn.run():
@@ -66,6 +92,15 @@ async def test_init_with_backend_online(running_backend, event_bus, alice):
             assert conn.status == BackendConnStatus.READY
             assert monitor_initialized
             assert not monitor_teardown
+
+            # Test organization config retrieval
+            if apiv22_organization_cmd_supported:
+                assert conn.get_organization_config() == OrganizationConfig(
+                    expiration_date=datetime(2000, 1, 1), user_profile_outsider_allowed=True
+                )
+            else:
+                # Default value
+                assert conn.get_organization_config() == default_organization_config
 
             # Test command
             rep = await conn.cmds.ping("foo")
@@ -89,6 +124,11 @@ async def test_init_with_backend_offline(event_bus, alice):
         alice.organization_addr, alice.device_id, alice.signing_key, event_bus
     )
     assert conn.status == BackendConnStatus.LOST
+    default_organization_config = OrganizationConfig(
+        expiration_date=None, user_profile_outsider_allowed=False
+    )
+    assert conn.get_organization_config() == default_organization_config
+
     with event_bus.listen() as spy:
         async with conn.run():
             await spy.wait_with_timeout(
@@ -96,6 +136,7 @@ async def test_init_with_backend_offline(event_bus, alice):
                 {"status": BackendConnStatus.LOST, "status_exc": spy.ANY},
             )
             assert conn.status == BackendConnStatus.LOST
+            assert conn.get_organization_config() == default_organization_config
 
             # Test command not possible
             with pytest.raises(BackendNotAvailable):


### PR DESCRIPTION
…d server without organization_config cmd support (API <2.2)