### PR TITLE
Reduce verbosity of backend's InvitedClientContext logger

### DIFF
--- a/parsec/backend/client_context.py
+++ b/parsec/backend/client_context.py
@@ -140,7 +140,7 @@ class InvitedClientContext(BaseClientContext):
             conn_id=self.conn_id,
             handshake_type=self.handshake_type.value,
             organization_id=self.organization_id,
-            invitation=self.invitation,
+            invitation_token=self.invitation.token,
         )
 
     def __repr__(self):


### PR DESCRIPTION
without this fix, logs look like this:
```
DEBUG    parsec.api.transport:app.py:405 2021-08-11 08:34:10 [debug    ] Response                       [parsec.api.transport] conn_id=6f223af02d754cf8a2c7a03bdb5de2ef handshake_type=INVITED invitation=DeviceInvitation(greeter_user_id=<UserID 'alice'>, greeter_human_handle=<HumanHandle Alicey McAliceFace <alice@example.com> >, token=UUID('fd52e5c2-2b0a-4f5b-9189-68e14bdb1a0f'), created_on=datetime.datetime(2021, 8, 11, 8, 34, 10, 484840, tzinfo=datetime.timezone.utc), status=<InvitationStatus.READY: 'READY'>) organization_id=CoolOrg rep={'pong': 'foo', 'status': 'ok'}
```