### PR TITLE
Remove useless expiration_date field in organization_config (if org i…

### DIFF
--- a/parsec/api/protocol/organization.py
+++ b/parsec/api/protocol/organization.py
@@ -74,7 +74,6 @@ class OrganizationConfigReqSchema(BaseReqSchema):
 
 
 class OrganizationConfigRepSchema(BaseRepSchema):
-    expiration_date = fields.DateTime(allow_none=True, required=False)
     user_profile_outsider_allowed = fields.Boolean(required=True)
     # `None` stands for "no limit" here
     active_users_limit = fields.Integer(allow_none=True, required=True)

--- a/parsec/core/backend_connection/authenticated.py
+++ b/parsec/core/backend_connection/authenticated.py
@@ -177,7 +177,7 @@ class BackendAuthenticatedConn:
         # On top of that, we pre-populate the cache with a "good enough" default
         # value so organization config is guaranteed to be always available \o/
         self._organization_config = OrganizationConfig(
-            expiration_date=None, user_profile_outsider_allowed=False, active_users_limit=None
+            user_profile_outsider_allowed=False, active_users_limit=None
         )
         self.event_bus = event_bus
         self.max_cooldown = max_cooldown
@@ -296,7 +296,6 @@ class BackendAuthenticatedConn:
 
             else:
                 self._organization_config = OrganizationConfig(
-                    expiration_date=rep.get("expiration_date"),
                     user_profile_outsider_allowed=rep["user_profile_outsider_allowed"],
                     active_users_limit=rep["active_users_limit"],
                 )

--- a/parsec/core/types/organizations.py
+++ b/parsec/core/types/organizations.py
@@ -2,7 +2,6 @@
 
 import attr
 from typing import Optional
-from pendulum import DateTime
 from typing import List
 
 from parsec.api.protocol import UserProfile
@@ -27,6 +26,5 @@ class OrganizationStats:
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
 class OrganizationConfig:
-    expiration_date: DateTime
     user_profile_outsider_allowed: bool
     active_users_limit: Optional[int]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2016-2021 Scille SAS
 
-from parsec.core.core_events import CoreEvent
 import pytest
 import os
 import re
@@ -28,6 +27,7 @@ import tempfile
 from parsec.monitoring import TaskMonitoringInstrument
 from parsec.core import CoreConfig
 from parsec.core.types import BackendAddr
+from parsec.core.core_events import CoreEvent
 from parsec.core.logged_core import logged_core_factory
 from parsec.core.backend_connection import BackendConnStatus
 from parsec.core.mountpoint.manager import get_mountpoint_runner

--- a/tests/core/backend_connection/test_authenticated_conn.py
+++ b/tests/core/backend_connection/test_authenticated_conn.py
@@ -3,7 +3,6 @@
 import pytest
 import trio
 
-from pendulum import datetime
 from parsec.backend.backend_events import BackendEvent
 from parsec.api.protocol import RealmRole, HandshakeType
 from parsec.core.types import OrganizationConfig
@@ -44,7 +43,6 @@ async def test_init_with_backend_online(
     async def _mocked_organization_config(client_ctx, msg):
         if apiv22_organization_cmd_supported:
             return {
-                "expiration_date": datetime(2000, 1, 1),
                 "user_profile_outsider_allowed": True,
                 "active_users_limit": None,
                 "status": "ok",
@@ -71,7 +69,7 @@ async def test_init_with_backend_online(
     )
     assert conn.status == BackendConnStatus.LOST
     default_organization_config = OrganizationConfig(
-        expiration_date=None, user_profile_outsider_allowed=False, active_users_limit=None
+        user_profile_outsider_allowed=False, active_users_limit=None
     )
     assert conn.get_organization_config() == default_organization_config
 
@@ -97,9 +95,7 @@ async def test_init_with_backend_online(
             # Test organization config retrieval
             if apiv22_organization_cmd_supported:
                 assert conn.get_organization_config() == OrganizationConfig(
-                    expiration_date=datetime(2000, 1, 1),
-                    user_profile_outsider_allowed=True,
-                    active_users_limit=None,
+                    user_profile_outsider_allowed=True, active_users_limit=None
                 )
             else:
                 # Default value
@@ -128,7 +124,7 @@ async def test_init_with_backend_offline(event_bus, alice):
     )
     assert conn.status == BackendConnStatus.LOST
     default_organization_config = OrganizationConfig(
-        expiration_date=None, user_profile_outsider_allowed=False, active_users_limit=None
+        user_profile_outsider_allowed=False, active_users_limit=None
     )
     assert conn.get_organization_config() == default_organization_config
 

--- a/tests/schemas/api_protocol.json
+++ b/tests/schemas/api_protocol.json
@@ -713,11 +713,6 @@
                             "required": true,
                             "type": "Integer"
                         },
-                        "expiration_date": {
-                            "allow_none": true,
-                            "required": false,
-                            "type": "DateTime"
-                        },
                         "status": {
                             "allow_none": false,
                             "required": true,


### PR DESCRIPTION
…s expired you cannot execute this command anyway !)