### PR TITLE
Fix the split-second appearing of an empty form when showing the workspace list

### DIFF
--- a/parsec/core/gui/workspace_button.py
+++ b/parsec/core/gui/workspace_button.py
@@ -48,9 +48,9 @@ class WorkspaceButton(QWidget, Ui_WorkspaceButton):
     open_clicked = pyqtSignal(WorkspaceFS)
     switch_clicked = pyqtSignal(bool, WorkspaceFS, object)
 
-    def __init__(self, workspace_fs):
+    def __init__(self, workspace_fs, parent=None):
         # Initialize UI
-        super().__init__()
+        super().__init__(parent=parent)
         self.setupUi(self)
 
         # Read-only attributes

--- a/parsec/core/gui/workspaces_widget.py
+++ b/parsec/core/gui/workspaces_widget.py
@@ -348,7 +348,7 @@ class WorkspacesWidget(QWidget, Ui_WorkspacesWidget):
 
             # Create and bind button if it doesn't exist
             if button is None:
-                button = WorkspaceButton(workspace_fs)
+                button = WorkspaceButton(workspace_fs, parent=self)
                 button.clicked.connect(self.load_workspace)
                 if self.core.device.is_outsider:
                     button.button_share.hide()


### PR DESCRIPTION
(by passing a parent to `WorkspaceButton`)

![form](https://user-images.githubusercontent.com/7490006/131643379-063c89fc-bd43-45c0-9a8e-043c56a93a23.png)
