### PR TITLE
Add a way to hide unmounted workspaces

### DIFF
--- a/newsfragments/3056.feature.rst
+++ b/newsfragments/3056.feature.rst
@@ -1,0 +1,1 @@
+Add a way to filter out unmounted workspaces

--- a/parsec/core/gui/forms/workspaces_widget.ui
+++ b/parsec/core/gui/forms/workspaces_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>636</width>
-    <height>428</height>
+    <width>928</width>
+    <height>655</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -66,6 +66,9 @@
    </property>
    <item>
     <layout class="QVBoxLayout" name="verticalLayout_5">
+     <property name="spacing">
+      <number>10</number>
+     </property>
      <property name="topMargin">
       <number>0</number>
      </property>
@@ -164,6 +167,20 @@
           </size>
          </property>
         </spacer>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_5">
+       <item>
+        <widget class="QCheckBox" name="check_hide_unmounted">
+         <property name="text">
+          <string>TEXT_WORKSPACES_HIDE_UNMOUNTED</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
       </layout>
      </item>
@@ -384,8 +401,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>636</width>
-        <height>91</height>
+        <width>928</width>
+        <height>279</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/parsec/core/gui/tr/parsec_en.po
+++ b/parsec/core/gui/tr/parsec_en.po
@@ -3029,3 +3029,6 @@ msgstr "Create a new workspace"
 
 msgid "ACTION_WORKSPACE_GOTO_FILE_LINK"
 msgstr "Go to a file using a link"
+
+msgid "TEXT_WORKSPACES_HIDE_UNMOUNTED"
+msgstr "Hide deactivated workspaces"

--- a/parsec/core/gui/tr/parsec_fr.po
+++ b/parsec/core/gui/tr/parsec_fr.po
@@ -3110,3 +3110,6 @@ msgstr "Créer un nouvel espace de travail"
 
 msgid "ACTION_WORKSPACE_GOTO_FILE_LINK"
 msgstr "Trouver un fichier via son lien"
+
+msgid "TEXT_WORKSPACES_HIDE_UNMOUNTED"
+msgstr "Masquer les espaces de travail désactivés"

--- a/parsec/core/gui/workspace_button.py
+++ b/parsec/core/gui/workspace_button.py
@@ -249,6 +249,9 @@ class WorkspaceButton(QWidget, Ui_WorkspaceButton):
     def workspace_id(self):
         return self.workspace_fs.workspace_id
 
+    def is_mounted(self):
+        return self.switch_button.isChecked()
+
     @property
     def timestamp(self):
         return getattr(self.workspace_fs, "timestamp", None)

--- a/parsec/core/gui/workspaces_widget.py
+++ b/parsec/core/gui/workspaces_widget.py
@@ -231,6 +231,7 @@ class WorkspacesWidget(QWidget, Ui_WorkspacesWidget):
         self.unmount_error.connect(self.on_unmount_error)
         self.file_open_success.connect(self._on_file_open_success)
         self.file_open_error.connect(self._on_file_open_error)
+        self.check_hide_unmounted.stateChanged.connect(self._on_hide_unmounted_changed)
 
         self.workspace_reencryption_success.connect(self._on_workspace_reencryption_success)
         self.workspace_reencryption_error.connect(self._on_workspace_reencryption_error)
@@ -282,6 +283,9 @@ class WorkspacesWidget(QWidget, Ui_WorkspacesWidget):
         return self.layout_workspaces.count() >= 1 and isinstance(
             self.layout_workspaces.itemAt(0).widget(), WorkspaceButton
         )
+
+    def _on_hide_unmounted_changed(self, state):
+        self.refresh_workspace_layout()
 
     def goto_file_clicked(self):
         file_link = get_text_input(
@@ -431,6 +435,7 @@ class WorkspacesWidget(QWidget, Ui_WorkspacesWidget):
         # Get info for both filters
         name_filter = self.line_edit_search.text().lower() or None
         user_filter = self.filter_user_info and self.filter_user_info.user_id
+        hide_unmounted_filter = self.check_hide_unmounted.checkState() == Qt.Checked
 
         # Remove all widgets and add them back in order to make sure the order is always correct
         self.layout_workspaces.pop_all()
@@ -442,6 +447,9 @@ class WorkspacesWidget(QWidget, Ui_WorkspacesWidget):
                 continue
             # Filter by user
             if user_filter is not None and user_filter not in button.users_roles:
+                continue
+            # Filter unmounted workspaces
+            if hide_unmounted_filter and not button.is_mounted():
                 continue
             # Show and add widget to the layout
             button.show()

--- a/tests/core/gui/conftest.py
+++ b/tests/core/gui/conftest.py
@@ -380,6 +380,7 @@ def testing_main_window_cls(aqtbot):
 
         def test_get_workspaces_widget(self):
             mount_widget = self.test_get_mount_widget()
+            mount_widget.workspaces_widget.check_hide_unmounted.setChecked(False)
             return mount_widget.workspaces_widget
 
         def test_get_files_widget(self):

--- a/tests/core/gui/test_files.py
+++ b/tests/core/gui/test_files.py
@@ -199,6 +199,9 @@ def create_files_widget_testbed(monkeypatch, aqtbot, logged_gui, user_fs, wfs, f
 async def files_widget_testbed(monkeypatch, aqtbot, logged_gui):
     c_w = logged_gui.test_get_central_widget()
     w_w = logged_gui.test_get_workspaces_widget()
+
+    w_w.check_hide_unmounted.setChecked(False)
+
     workspace_name = EntryName("wksp1")
 
     # Create the workspace


### PR DESCRIPTION
Closes #1744
Closes #3056 (second one was created because 1744 was used incorrectly for another newsfragment).

Add a checkbox to hide unmounted workspaces. The checkbox is checked by default. Ideally it should remember its previous state but it requires a config by device which is quite bothersome. This solution should be good enough for now.