### PR TITLE
Add f_namemax to fuse statfs operation 

### DIFF
--- a/newsfragments/1854.bugfix.rst
+++ b/newsfragments/1854.bugfix.rst
@@ -1,0 +1,1 @@
+Fix incorrect maximum file length detection on linux, e.g in the Nautilus file explorer.

--- a/parsec/core/mountpoint/fuse_operations.py
+++ b/parsec/core/mountpoint/fuse_operations.py
@@ -147,6 +147,7 @@ class FuseOperations(LoggingMixIn, Operations):
             "f_blocks": 512 * 1024,  # 512 K blocks is 1 TB
             "f_bfree": 512 * 1024,  # 512 K blocks is 1 TB
             "f_bavail": 512 * 1024,  # 512 K blocks is 1 TB
+            "f_namemax": 255,  # 255 bytes as maximum length for filenames
         }
 
     def getattr(self, path: FsPath, fh: Optional[int] = None):


### PR DESCRIPTION
... for proper maximum filename length detection on linux.

For instance, a missing value caused some issue with nautilus:
![image](https://user-images.githubusercontent.com/7490006/133580227-7297897f-3ddf-44e3-9c06-2edf374e2cf3.png)
