### PR TITLE
Refactor FilesWidget import logic

### DIFF
--- a/newsfragments/1856.bugfix.rst
+++ b/newsfragments/1856.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a freeze when a user import a file or a folder from another parsec workspace through the file explorer provided by the application.

--- a/parsec/core/gui/trio_jobs.py
+++ b/parsec/core/gui/trio_jobs.py
@@ -74,7 +74,10 @@ class QtToTrioJob:
                     result = self._fn(*self._args, **self._kwargs)
                 else:
                     result = await self._fn(*self._args, **self._kwargs)
-                self.set_result(result)
+                if isinstance(result, JobResultError):
+                    self.set_exception(result)
+                else:
+                    self.set_result(result)
 
             except Exception as exc:
                 self.set_exception(exc)
@@ -120,7 +123,8 @@ class QtToTrioJob:
     def _set_done(self):
         self._done.set()
         signal = self._on_success if self.is_ok() else self._on_error
-        signal.emit(self)
+        if signal is not None:
+            signal.emit(self)
 
     def cancel(self):
         self.cancel_scope.cancel()


### PR DESCRIPTION
It uses the mixing of qt and trio logic within the jobs. This approach is possible now that we migrated to qtrio. 

It also fixes a deadlock issue when a file is imported from another parsec workspace.