### PR TITLE
Added condition to QClipboard.Selection

### DIFF
--- a/parsec/core/gui/desktop.py
+++ b/parsec/core/gui/desktop.py
@@ -50,5 +50,7 @@ def get_locale_language():
 
 
 def copy_to_clipboard(text):
-    QGuiApplication.clipboard().setText(text, QClipboard.Clipboard)
-    QGuiApplication.clipboard().setText(text, QClipboard.Selection)
+    clipboard = QGuiApplication.clipboard()
+    clipboard.setText(text, QClipboard.Clipboard)
+    if clipboard.supportsSelection():
+        clipboard.setText(text, QClipboard.Selection)


### PR DESCRIPTION
On MacOS (and supposedly Windows), `QClipboard.Selection` isn't supported as explained [here](https://doc.qt.io/qt-5/qclipboard.html#notes-for-windows-and-macos-users), resulting in the following error : `Data set on unsupported clipboard mode. QMimeData object will be deleted.`