### PR TITLE
Remove postgresql from macOS CI (not very useful and prone to timeout…

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -181,7 +181,7 @@ jobs:
         tests/backend tests/test_cli.py --postgresql --runslow \
         -n auto --max-worker-restart=0 -x \
         --junitxml=test-results-postgresql.xml
-    displayName: 'Tests postgresql'
+    displayName: 'Tests PostgreSQL'
   # The full disk test are run separately since they rely on running a sqlite3 database
   # on a fuse mountpoint which can deadlock if run with the rest of the test suite
   # TEMPORARILY DISABLED BECAUSE THEY CAUSE ISSUES
@@ -238,10 +238,8 @@ jobs:
       pip install pip>=20.3 --user --upgrade
       pip install -r pre-requirements.txt
       brew install \
-        postgres \
         desktop-file-utils  # Provides `update-desktop-database` used by `tests/scripts/run_testenv.sh`
       brew install --cask osxfuse
-      psql --version
     displayName: 'Bootstrap'
   - bash: |
       set -eux
@@ -261,14 +259,6 @@ jobs:
         -n auto --max-worker-restart=0 -x \
         --junitxml=test-results-memory.xml
     displayName: 'Tests memory'
-  - bash: |
-      set -eux
-      # `test_cli.py` uses `--postgresql` option to test DB migration cli
-      py.test $(pytest.base_args) \
-        tests/backend tests/test_cli.py --postgresql --runslow \
-        -n auto --max-worker-restart=0 -x \
-        --junitxml=test-results-postgresql.xml
-    displayName: 'Tests postgresql'
   #- bash: |
   #    set -eux
   #    py.test $(pytest.base_args) \


### PR DESCRIPTION
… errors)