### PR TITLE
Fix click errors on MacOS 11 & 12 and update MacOS PyInstaller

### DIFF
--- a/packaging/macOS/README.md
+++ b/packaging/macOS/README.md
@@ -39,10 +39,11 @@ You can also use the `-i` or `--install` option to directly install the applicat
 ### 3 - Sign the application
 
 ```shell
-$ codesign --deep -s <identity> --timestamp -v --entitlements entitlements.plist -o runtime dist/parsec.app
+$ codesign --deep --force -s <identity> --timestamp -v --entitlements entitlements.plist -o runtime dist/parsec.app
 ```
 
 `identity` being the signing certificate, to be downloaded with proper access here : https://developer.apple.com/account/resources/certificates/list
+From PyInstaller versions >=4.4, the bundle will already be signed. To avoid notarization issues with this signature, the `--force` option is used to override it.
 
 You can check the codesign using:
 ```shell

--- a/packaging/macOS/launch_script.py
+++ b/packaging/macOS/launch_script.py
@@ -11,21 +11,7 @@ multiprocessing.freeze_support()
 
 
 from parsec.cli import cli
-from click import core
 
-core._verify_python3_env = lambda: None
-# This prevents click from raising encoding errors at startup.
-# It would be better to wrap the original _verify_python3_env so that we could
-# log an error when it raises an exception instead of silence it. This would
-# allow us to have more insight of when those errors occurs (OS version,
-# locales used etc.)
-# However the crash occurs before we initialize sentry logging, so it would be a
-# mess to catch the exception, save it on the side, then retrieve and log it
-# after sentry initialization...
-# On top of that, we don't really care about unicode in click here (we are
-# expecting to receive no arguments from argv or a single url which is should
-# not contain unicode, similarly we output ascii logs to stdout but nobody read
-# them anyway when starting the application this way)
 
 os.environ["SENTRY_URL"] = "https://863e60bbef39406896d2b7a5dbd491bb@sentry.io/1212848"
 os.environ["PREFERRED_ORG_CREATION_BACKEND_ADDR"] = "parsec://saas.parsec.cloud/"

--- a/packaging/macOS/macos_pyinstaller.sh
+++ b/packaging/macOS/macos_pyinstaller.sh
@@ -4,7 +4,7 @@ BASEDIR=$(dirname $(greadlink -f "$0") )
 # Note: greadlink requires coreutils to be installed
 
 cd $BASEDIR/../..
-python3 -m pip install 'pyinstaller==4.2'
+python3 -m pip install 'pyinstaller==4.7'
 # Pyinstaller read the imports in the codebase recursively then copy the
 # corresponding needed packages from the current virtualenv.
 python3 -m pip install .[core]

--- a/packaging/macOS/parsec.spec
+++ b/packaging/macOS/parsec.spec
@@ -62,6 +62,8 @@ app = BUNDLE(coll,
             'CFBundleURLSchemes': ['parsec']
          }
       ],
+      # Encoding is specified here to force UTF-8 when launching app instead of
+      # default ascii, which caused issues with click
       'LSEnvironment': {
          'LANG': 'en_US.UTF-8',
          'LC_CTYPE': 'en_US.UTF-8'

--- a/packaging/macOS/parsec.spec
+++ b/packaging/macOS/parsec.spec
@@ -61,6 +61,10 @@ app = BUNDLE(coll,
             'CFBundleURLName': 'com.scille.parsec',
             'CFBundleURLSchemes': ['parsec']
          }
-      ]
+      ],
+      'LSEnvironment': {
+         'LANG': 'en_US.UTF-8',
+         'LC_CTYPE': 'en_US.UTF-8'
+      },
    },
 )


### PR DESCRIPTION
When building on MacOS 11 and 12, the `click` error persists even with the current workaround.

The default encoding when launching apps from the Finder/taskbar is `ascii` regardless of which is used in Python, hence the error [here](https://github.com/pallets/click/blob/main/src/click/_unicodefun.py). Setting the correct flags in the `.spec` file solves the issue and allows the previous fix to be removed.

Probably linked to #1703.