### PR TITLE
Added share_workspace --recipiant option and human_find command

### DIFF
--- a/newsfragments/1940.feature.rst
+++ b/newsfragments/1940.feature.rst
@@ -1,0 +1,1 @@
+Added --recipiant option to share_workspace command and the human_find command in the CLI

--- a/parsec/core/cli/__init__.py
+++ b/parsec/core/cli/__init__.py
@@ -2,6 +2,7 @@
 
 import click
 
+from parsec.core.cli import human_find
 from parsec.core.cli import list_devices
 from parsec.core.cli import status_organization
 from parsec.core.cli import recovery
@@ -31,6 +32,7 @@ core_cmd.add_command(share_workspace.share_workspace, "share_workspace")
 core_cmd.add_command(list_devices.list_devices, "list_devices")
 core_cmd.add_command(recovery.export_recovery_device, "export_recovery_device")
 core_cmd.add_command(recovery.import_recovery_device, "import_recovery_device")
+core_cmd.add_command(human_find.human_find, "human_find")
 
 core_cmd.add_command(invitation.invite_user, "invite_user")
 core_cmd.add_command(invitation.invite_device, "invite_device")

--- a/parsec/core/cli/human_find.py
+++ b/parsec/core/cli/human_find.py
@@ -8,7 +8,15 @@ from parsec.core.cli.utils import cli_command_base_options, core_config_and_devi
 from parsec.cli_utils import cli_exception_handler
 
 
-async def _human_find(config, device, query, page, per_page, omit_revoked, omit_non_human):
+async def _human_find(
+    config,
+    device,
+    query,
+    page: int = 1,
+    per_page: int = 100,
+    omit_revoked: bool = False,
+    omit_non_human: bool = False,
+):
     async with logged_core_factory(config, device) as core:
         user_info_tab, nb = await core.find_humans(
             query, page, per_page, omit_revoked, omit_non_human
@@ -20,18 +28,9 @@ async def _human_find(config, device, query, page, per_page, omit_revoked, omit_
 
 
 @click.command(short_help="search user id from email address")
-@click.option("--query", required=True, type=str, help="Search through names and email addresses")
+@click.argument("query", type=str)
 @core_config_and_device_options
 @cli_command_base_options
-def human_find(
-    config,
-    device,
-    query: str = None,
-    page: int = 1,
-    per_page: int = 100,
-    omit_revoked: bool = False,
-    omit_non_human: bool = False,
-    **kwargs,
-) -> dict:
+def human_find(config, device, query, **kwargs) -> dict:
     with cli_exception_handler(config.debug):
-        trio_run(_human_find, config, device, query, page, per_page, omit_revoked, omit_non_human)
+        trio_run(_human_find, config, device, query)

--- a/parsec/core/cli/human_find.py
+++ b/parsec/core/cli/human_find.py
@@ -1,0 +1,37 @@
+# Parsec Cloud (https://parsec.cloud) Copyright (c) AGPLv3 2016-2021 Scille SAS
+
+import click
+
+from parsec.utils import trio_run
+from parsec.core import logged_core_factory
+from parsec.core.cli.utils import cli_command_base_options, core_config_and_device_options
+from parsec.cli_utils import cli_exception_handler
+
+
+async def _human_find(config, device, query, page, per_page, omit_revoked, omit_non_human):
+    async with logged_core_factory(config, device) as core:
+        user_info_tab, nb = await core.find_humans(
+            query, page, per_page, omit_revoked, omit_non_human
+        )
+    for user in user_info_tab:
+        click.echo(f"{user.human_handle} - UserID: {user.user_id}")
+    if not nb:
+        click.echo("No human found!")
+
+
+@click.command(short_help="search user id from email address")
+@click.option("--query", required=True, type=str, help="Search through names and email addresses")
+@core_config_and_device_options
+@cli_command_base_options
+def human_find(
+    config,
+    device,
+    query: str = None,
+    page: int = 1,
+    per_page: int = 100,
+    omit_revoked: bool = False,
+    omit_non_human: bool = False,
+    **kwargs,
+) -> dict:
+    with cli_exception_handler(config.debug):
+        trio_run(_human_find, config, device, query, page, per_page, omit_revoked, omit_non_human)

--- a/parsec/core/cli/human_find.py
+++ b/parsec/core/cli/human_find.py
@@ -19,7 +19,7 @@ async def _human_find(
 ):
     async with logged_core_factory(config, device) as core:
         user_info_tab, nb = await core.find_humans(
-            query, page, per_page, omit_revoked, omit_non_human
+            query, page=1, per_page=100, omit_revoked=omit_revoked, omit_non_human=False
         )
     for user in user_info_tab:
         is_revoked = " (revoked)" if user.revoked_on is not None else ""

--- a/parsec/core/cli/share_workspace.py
+++ b/parsec/core/cli/share_workspace.py
@@ -19,13 +19,13 @@ async def _share_workspace(config, device, name, user_id, recipiant, user_role):
     async with logged_core_factory(config, device) as core:
         workspace = core.find_workspace_from_name(name)
         if recipiant:
-            user_info_tab, nb = await core.find_humans(recipiant, 1, 100, False, False)
+            user_info_tab, nb = await core.find_humans(
+                recipiant, page=1, per_page=100, omit_revoked=True, omit_non_human=False
+            )
             if nb == 0:
                 raise RuntimeError("Unknown recipiant")
             if nb != 1:
                 for user in user_info_tab:
-                    if user.revoked_on is not None:
-                        continue
                     click.echo(f"{user.human_handle} - UserID: {user.user_id}")
                 raise RuntimeError("Specify the user more precisely or use the --user-id option")
             user_id = user_info_tab[0].user_id

--- a/parsec/core/cli/share_workspace.py
+++ b/parsec/core/cli/share_workspace.py
@@ -13,24 +13,36 @@ from parsec.core.types import WorkspaceRole
 WORKSPACE_ROLE_CHOICES = {"NONE": None, **{role.value: role for role in WorkspaceRole}}
 
 
-async def _share_workspace(config, device, name, user_id, user_role):
+async def _share_workspace(config, device, name, user_id, recipiant, user_role):
+    if recipiant and user_id or not recipiant and not user_id:
+        raise click.ClickException("Either recipiant or user_id should be used, but not both")
     async with logged_core_factory(config, device) as core:
         workspace = core.find_workspace_from_name(name)
+        if recipiant:
+            user_info_tab, nb = await core.find_humans(recipiant, 1, 100, False, False)
+            if nb == 0:
+                raise RuntimeError("This recipiant doesn't exist, use the email address")
+            if nb != 1:
+                for user in user_info_tab:
+                    click.echo(f"{user.human_handle} - UserID: {user.user_id}")
+                raise RuntimeError("Specify the user more precisely or use the --user_id option")
+            user_id = user_info_tab[0].user_id
         await core.user_fs.workspace_share(workspace.id, user_id, user_role)
 
 
 @click.command(short_help="share workspace")
 @click.option("--workspace-name")
-@click.option("--user-id", type=UserID, required=True)
+@click.option("--user-id", type=UserID)
+@click.option("--recipiant", help="Name or email to whom the workspace is shared")
 @click.option(
     "--role", required=True, type=click.Choice(WORKSPACE_ROLE_CHOICES.keys(), case_sensitive=False)
 )
 @core_config_and_device_options
 @cli_command_base_options
-def share_workspace(config, device, workspace_name, user_id, role, **kwargs):
+def share_workspace(config, device, workspace_name, user_id, recipiant, role, **kwargs):
     """
     Create a new workspace for the given device.
     """
     role = WORKSPACE_ROLE_CHOICES[role]
     with cli_exception_handler(config.debug):
-        trio_run(_share_workspace, config, device, workspace_name, user_id, role)
+        trio_run(_share_workspace, config, device, workspace_name, user_id, recipiant, role)


### PR DESCRIPTION
share_workspace --recipiant option is used to share a workspace using the human handle of a user (name or email address) instead of the user_id
The human_find command print user_id and human_handle corresponding to the query