### PR TITLE
Check for cancellation before setting status in BackendAuthenticatedConn

### DIFF
--- a/tests/core/gui/test_offline.py
+++ b/tests/core/gui/test_offline.py
@@ -80,11 +80,13 @@ async def test_backend_desync_notification(
     # Shift by 5 minutes
     timestamp_shift_minutes = 5
 
-    # Force sync by creating a workspace
-    await central_widget.core.user_fs.workspace_create("test1")
-
     # Wait until we get the notification
     async with aqtbot.wait_signal(central_widget.systray_notification):
+
+        # Force sync by creating a workspace
+        await central_widget.core.user_fs.workspace_create("test1")
+
+        # Wait until we're offline
         await aqtbot.wait_until(_offline, timeout=3000)
 
     # Wait for the dialog


### PR DESCRIPTION
This issue has been highlighted by the changes made in #1894 

It fixes some inconsistent failures in the CI, e.g https://github.com/Scille/parsec-cloud/runs/4534230166