### PR TITLE
Fixed version in additional_dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: v0.812
     hooks:
     - id: mypy
-      additional_dependencies: [trio_typing, pendulum]
+      additional_dependencies: ['trio_typing==0.5.1', 'pendulum==2.1.2']
       # Mypy will complain if it find two files with the same name which
       # are not part of a package (typically occurs for packaging script helpers)
       files: ^(parsec|tests)/


### PR DESCRIPTION
The version in the pre commit config were not fixed previously, which lead to CI errors when trio typing updated to 0.7.0