### PR TITLE
Prevent Qt from parsing special characters in navigation bar

### DIFF
--- a/parsec/core/gui/navigation_bar_widget.py
+++ b/parsec/core/gui/navigation_bar_widget.py
@@ -95,7 +95,7 @@ class NavigationBarWidget(QWidget):
                 )
             label = None
             if idx != len(parts) - 1:
-                obj_name = part.replace(" ", "_")
+                obj_name = str(idx)
                 label = ClickableLabel(part)
                 label.clicked.connect(self._on_label_clicked(idx))
                 label.setObjectName(f"label_{obj_name}")


### PR DESCRIPTION
Fixes #2025 

With the current code, if a folder has special characters in its name, Qt is unable to parse them during the `setStyleSheet` call resulting in errors and the name not being displayed in the navigation bar.

Proposed solution is to replace said name by the numerical index in the loop, not changing the navigation bar behaviour and correctly setting the colors.