### PR TITLE
Fix test_invite_status_changed_event consistency with lagging PostgreSQL

### DIFF
--- a/tests/backend/invite/test_invite_status_changed_event.py
+++ b/tests/backend/invite/test_invite_status_changed_event.py
@@ -38,6 +38,10 @@ async def test_greeter_event_on_claimer_join_and_leave(
 
         with trio.fail_after(1):
             rep = await events_listen_wait(alice_backend_sock)
+            # PostgreSQL event dispatching might be lagging behind and return
+            # the IDLE event first
+            if rep.get("invitation_status") == InvitationStatus.IDLE:
+                rep = await events_listen_wait(alice_backend_sock)
         assert rep == {
             "status": "ok",
             "event": APIEvent.INVITE_STATUS_CHANGED,


### PR DESCRIPTION
fix https://dev.azure.com/Scille/parsec/_build/results?buildId=9297&view=logs&j=428b1e07-02b6-507b-4a77-51bcad7c9856&t=ea0bc151-d1c3-5c1f-9830-74ff3d5eadda&l=316
