### PR TITLE
Fix regression with `login_with_smartcard` being async

### DIFF
--- a/parsec/core/gui/create_org_widget.py
+++ b/parsec/core/gui/create_org_widget.py
@@ -3,7 +3,7 @@
 from typing import Optional
 from structlog import get_logger
 from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtWidgets import QWidget, QApplication, QDialog
+from PyQt5.QtWidgets import QWidget, QApplication
 
 from parsec.api.protocol import OrganizationID, HumanHandle, DeviceLabel
 from parsec.core.backend_connection import (
@@ -343,12 +343,7 @@ class CreateOrgWidget(QWidget, Ui_CreateOrgWidget):
         d = GreyedDialog(w, _("TEXT_ORG_WIZARD_TITLE"), parent=parent, width=1000)
         w.dialog = d
 
-        def _on_finished(result):
-            if result == QDialog.Accepted:
-                return on_finished(w.status)
-            return on_finished(None)
-
-        d.finished.connect(_on_finished)
+        d.finished.connect(on_finished)
         # Unlike exec_, show is asynchronous and works within the main Qt loop
         d.show()
         return w

--- a/parsec/core/gui/main_window.py
+++ b/parsec/core/gui/main_window.py
@@ -371,6 +371,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):  # type: ignore[misc]
         @self._bind_async_callback
         async def _on_finished() -> None:
             nonlocal widget
+            # It's safe to access the widget status here since this does not perform a Qt call.
+            # But the underlying C++ widget might already be deleted so we should make sure not
+            # not do anything Qt related with this widget.
             if widget.status is None:
                 return
             self.reload_login_devices()
@@ -444,6 +447,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):  # type: ignore[misc]
 
         def _on_finished() -> None:
             nonlocal widget
+            # It's safe to access the widget status here since this does not perform a Qt call.
+            # But the underlying C++ widget might already be deleted so we should make sure not
+            # not do anything Qt related with this widget.
             if not widget.status:
                 return
             show_info(self, _("TEXT_ENROLLMENT_QUERY_SUCCEEDED"))
@@ -463,6 +469,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):  # type: ignore[misc]
         @self._bind_async_callback
         async def _on_finished() -> None:
             nonlocal widget
+            # It's safe to access the widget status here since this does not perform a Qt call.
+            # But the underlying C++ widget might already be deleted so we should make sure not
+            # not do anything Qt related with this widget.
             if not widget.status:
                 return
             device, auth_method, password = widget.status
@@ -492,6 +501,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):  # type: ignore[misc]
         @self._bind_async_callback
         async def _on_finished() -> None:
             nonlocal widget
+            # It's safe to access the widget status here since this does not perform a Qt call.
+            # But the underlying C++ widget might already be deleted so we should make sure not
+            # not do anything Qt related with this widget.
             if not widget.status:
                 return
             device, auth_method, password = widget.status


### PR DESCRIPTION
Fix a regression found here:
```
/home/max/parsec-cloud/parsec/core/gui/main_window.py:501: RuntimeWarning: coroutine 'InstanceWidget.login_with_smartcard' was never awaited
  tab.login_with_smartcard(kf)
```