### PR TITLE
Handle saving from Apple softwares on FUSE drives

### DIFF
--- a/newsfragments/2211.bugfix.rst
+++ b/newsfragments/2211.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug preventing file saving with Apple softwares such as TextEdit or Preview.

--- a/parsec/core/mountpoint/fuse_runner.py
+++ b/parsec/core/mountpoint/fuse_runner.py
@@ -143,13 +143,25 @@ async def fuse_mountpoint_runner(
                     if sys.platform == "darwin":
                         fuse_platform_options = {
                             "local": True,
+                            "defer_permissions": True,
                             "volname": workspace_fs.get_workspace_name(),
                             "volicon": str(parsec_icns_path.absolute()),
                         }
                         # osxfuse-specific options :
-                        # - local : allows mountpoint to show up correctly in finder (+ desktop)
-                        # - volname : specify volume name (default is OSXFUSE [...])
-                        # - volicon : specify volume icon (default is macOS drive icon)
+                        # local: allows mountpoint to show up correctly in finder (+ desktop)
+                        # volname: specify volume name (default is OSXFUSE [...])
+                        # volicon: specify volume icon (default is macOS drive icon)
+
+                    # On defer_permissions: "The defer_permissions option [...] causes macFUSE to assume that all
+                    # accesses are allowed; it will forward all operations to the file system, and it is up to
+                    # somebody else to eventually allow or deny the operations." See
+                    # https://github.com/osxfuse/osxfuse/wiki/Mount-options#default_permissions-and-defer_permissions
+                    # This option is necessary on MacOS to give the right permissions to files inside FUSE drives,
+                    # otherwise it impedes upon saving and auto-saving from Apple softwares (TextEdit, Preview...)
+                    # due to the gid of files seemingly not having writing rights from the software perspective.
+                    # One other solution found for this issue was to change the gid of the mountpoint and its files
+                    # from staff (default) to wheel (admin gid). Checking defer_permissions allows to ignore the gid
+                    # issue entirely and lets Parsec itself handle read/write rights inside workspaces.
 
                     else:
                         fuse_platform_options = {"auto_unmount": True}

--- a/parsec/core/mountpoint/thread_fs_access.py
+++ b/parsec/core/mountpoint/thread_fs_access.py
@@ -168,3 +168,8 @@ class ThreadFSAccess:
 
     def fd_flush(self, fh):
         return self._run(self.workspace_fs.transactions.fd_flush, fh)
+
+    # High-level helpers
+
+    def workspace_move(self, source, destination):
+        return self._run(self.workspace_fs.move, source, destination)


### PR DESCRIPTION
Tests have been done with TextEdit, the Mac equivalent to NotePad. The issue and solution is shared among all of Mac's native editing softwares.

Upon saving, TextEdit creates a `filename.txt.sb-xxx-xxx` temp folder which seems to handle saves and auto-saves from TextEdit. It is meant to work on HFS drives, which isn’t the format currently used. (It seems auto-saves aren’t attempted, or at least they don’t raise any errors)

Only opening / closing the file with TextEdit is possible and doesn’t raise errors.

Issues come when trying to do a manual save from TextEdit:

If uncaught (current situation), the file `filename.txt` is renamed as `filename.txt.sb-xxx-xxx`, which is a hidden file, and since the extension changed, it becomes unusable for the user. My guess would be that the renaming is done to save the previous state as temp file, before writing the new version on the drive which currently fails. From what I’ve gathered the drive’s format might be the culprit.

Immediately after, the following exceptions can be caught when wrapping `FuseOperations`’ `rename` function in a try/except:

```
Cross-device link: /filename.txt.sb-xxx-xxx/filename.txt -> /filename.txt.sb-xxx-xxx/filename.txt
Cross-device link: /filename.txt.sb-xxx-xxx/._filename.txt -> /filename.txt.sb-xxx-xxx/._filename.txt
```

With the current « fix », the first error is caught and the file isn’t renamed anymore. Nothing happens and the file stays in the previous version. The new exception is raised twice, for `filename.txt` and `._filename.txt`, followed by the two `FSCrossDeviceError`.

_______________________________________________________________________________________________________

The solution:

Turns out the issue originated from permission issues in the FUSE drives. The `gid` used for the drives was not allowed to edit/save files on such drives, which can be remedied with the `default_permissions` option in the FUSE call. Otherwise, the alternative would've been to default to `wheel` gid for the mountpoints, which is the "admin" group id.