### PR TITLE
[GUI] Fixed an error message appearing when dragging a file

### DIFF
--- a/newsfragments/2237.bugfix.rst
+++ b/newsfragments/2237.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an error message when dragging files

--- a/parsec/core/gui/files_widget.py
+++ b/parsec/core/gui/files_widget.py
@@ -23,7 +23,7 @@ from parsec.core.fs.exceptions import (
 )
 from parsec.core.gui.trio_jobs import JobResultError, QtToTrioJob
 from parsec.core.gui import desktop
-from parsec.core.gui.file_items import FileType, TYPE_DATA_INDEX, ENTRY_ID_DATA_INDEX
+from parsec.core.gui.file_items import FileType, TYPE_DATA_INDEX
 from parsec.core.gui.custom_dialogs import (
     ask_question,
     show_error,
@@ -175,10 +175,10 @@ async def _do_folder_stat(workspace_fs, path, default_selection):
         except FSFileNotFoundError:
             # The child entry as been concurrently removed, just ignore it
             continue
-        except FSRemoteManifestNotFound as exc:
+        except FSRemoteManifestNotFound:
             # Cannot get informations about this child entry, this can occur if
             # if the manifest is inconsistent (broken data or signature).
-            child_stat = {"type": "inconsistency", "id": exc.args[0]}
+            child_stat = {"type": "inconsistency", "id": EntryID.new()}
         stats[child] = child_stat
     return path, dir_stat["id"], stats, default_selection
 
@@ -1029,15 +1029,7 @@ class FilesWidget(QWidget, Ui_FilesWidget):
         if self.current_directory_id == id:
             return
 
-        for i in range(1, self.table_files.rowCount()):
-            item = self.table_files.item(i, 0)
-            if item and item.data(ENTRY_ID_DATA_INDEX) == id:
-                if (
-                    item.data(TYPE_DATA_INDEX) == FileType.File
-                    or item.data(TYPE_DATA_INDEX) == FileType.Folder
-                ):
-                    item.confined = False
-                    item.is_synced = True
+        self.table_files.set_file_status(id, synced=True, confined=False)
 
     def _on_fs_entry_updated(self, event, workspace_id=None, id=None):
         assert id is not None


### PR DESCRIPTION
Closes #2257 

An error essage about EntryID not being serializable by pickle appeared when dragging a file. It didn't seem to have any incidence as the file could still be dragged and dropped, but it still better to fix it. We do so by ensuring that the EntryID stored in the widget UserData are converted to string. We could instead try to register EntryID to Qt's meta-object system but this would just be annoying and I don't know how to do it with PyQt.