### PR TITLE
[GUI] Handle cases where a user does not provide a certificate or a pin

### DIFF
--- a/parsec/core/gui/enrollment_query_widget.py
+++ b/parsec/core/gui/enrollment_query_widget.py
@@ -12,7 +12,11 @@ from parsec.core.gui.lang import translate
 from parsec.core.gui import desktop, validators
 
 from parsec.core.gui.ui.enrollment_query_widget import Ui_EnrollmentQueryWidget
-from parsec.core.pki.exceptions import PkiEnrollmentSubmitCertificateAlreadySubmittedError
+from parsec.core.pki.exceptions import (
+    PkiEnrollmentCertificatePinCodeUnavailableError,
+    PkiEnrollmentCertificateNotFoundError,
+    PkiEnrollmentSubmitCertificateAlreadySubmittedError,
+)
 
 
 class EnrollmentQueryWidget(QWidget, Ui_EnrollmentQueryWidget):
@@ -78,7 +82,9 @@ class EnrollmentQueryWidget(QWidget, Ui_EnrollmentQueryWidget):
                     requested_device_label=DeviceLabel(self.line_edit_device.text()),
                     force=True,
                 )
-
+        except PkiEnrollmentCertificatePinCodeUnavailableError:
+            # User declined to provide a PIN code (cancelled the prompt). We do nothing.
+            pass
         # Enrollment submission failed
         except Exception as exc:
             show_error(self, translate("TEXT_ENROLLMENT_SUBMIT_FAILED"), exc)
@@ -101,6 +107,9 @@ class EnrollmentQueryWidget(QWidget, Ui_EnrollmentQueryWidget):
             self.line_edit_user_email.setText(self.context.x509_certificate.subject_email_address)
             self.line_edit_device.setText(desktop.get_default_device())
             self.button_select_cert.setText(str(self.context.x509_certificate.certificate_id))
+        except PkiEnrollmentCertificateNotFoundError:
+            # User did not provide a certificate (cancelled the prompt). We do nothing.
+            pass
         except Exception as exc:
             show_error(self, translate("TEXT_ENROLLMENT_ERROR_LOADING_CERTIFICATE"), exception=exc)
             self.widget_user_info.setVisible(False)

--- a/parsec/core/gui/instance_widget.py
+++ b/parsec/core/gui/instance_widget.py
@@ -12,6 +12,7 @@ from parsec.api.protocol import HandshakeRevokedDevice
 from parsec.core import logged_core_factory
 from parsec.core.local_device import (
     LocalDeviceError,
+    LocalDevicePinCodeUnavailableError,
     load_device_with_password,
     load_device_with_smartcard,
 )
@@ -279,6 +280,9 @@ class InstanceWidget(QWidget):
                 message = _("TEXT_LOGIN_ERROR_ALREADY_CONNECTED")
             else:
                 self.start_core(device)
+        except LocalDevicePinCodeUnavailableError:
+            # User cancelled the prompt
+            pass
         except LocalDeviceError as exc:
             message = _("TEXT_LOGIN_ERROR_AUTHENTICATION_FAILED")
             exception = exc

--- a/parsec/core/local_device.py
+++ b/parsec/core/local_device.py
@@ -56,6 +56,10 @@ class LocalDeviceCryptoError(LocalDeviceError):
     pass
 
 
+class LocalDevicePinCodeUnavailableError(LocalDeviceError):
+    pass
+
+
 class LocalDeviceSignatureError(LocalDeviceError):
     pass
 
@@ -559,6 +563,7 @@ def load_device_with_smartcard_sync(key_file: Path) -> LocalDevice:
         LocalDeviceCryptoError
         LocalDeviceValidationError
         LocalDevicePackingError
+        LocalDevicePinCodeUnavailableError
     """
     return _load_smartcard_extension().load_device_with_smartcard(key_file)
 
@@ -570,6 +575,7 @@ async def load_device_with_smartcard(key_file: Path) -> LocalDevice:
         LocalDeviceCryptoError
         LocalDeviceValidationError
         LocalDevicePackingError
+        LocalDevicePinCodeUnavailableError
     """
     return await trio.to_thread.run_sync(load_device_with_smartcard_sync, key_file)
 
@@ -587,6 +593,7 @@ async def save_device_with_smartcard_in_config(
         LocalDeviceCryptoError
         LocalDeviceValidationError
         LocalDevicePackingError
+        LocalDevicePinCodeUnavailableError
     """
     key_file = get_default_key_file(config_dir, device)
     # Why do we use `force=True` here ?

--- a/parsec/core/pki/accepter.py
+++ b/parsec/core/pki/accepter.py
@@ -187,6 +187,7 @@ class PkiEnrollementAccepterValidSubmittedCtx:
             PkiEnrollmentCertificateError
             PkiEnrollmentCertificateCryptoError
             PkiEnrollmentCertificateNotFoundError
+            PkiEnrollmentCertificatePinCodeUnavailableError
         """
         # Create the certificate for the new user
         user_certificate, redacted_user_certificate, device_certificate, redacted_device_certificate, user_confirmation = _create_new_user_certificates(

--- a/parsec/core/pki/exceptions.py
+++ b/parsec/core/pki/exceptions.py
@@ -12,6 +12,7 @@ PkiEnrollmentError: all PKI enrollment related errors
     +- PkiEnrollmentCertificateValidationError: when the provided certificate cannot be validated using the configured trust roots
     +- PkiEnrollmentCertificateSignatureError: when the provided signature does not correspond to the certificate public key
     +- PkiEnrollmentCertificateCryptoError: when any of the required certificate-replated crypto operation fails
+    +- PkiEnrollmentCertificatePinCodeUnavailableError: when the user declines to provide the secret key password
 +- PkiEnrollmentPayloadError: all the enrollment payload errors
     +- PkiEnrollmentPayloadValidationError: when some enrollement information cannot be properly loaded
 +- PkiEnrollmentRemoteError: all the errors coming from a enrollment command on the backend
@@ -92,6 +93,10 @@ class PkiEnrollmentCertificateSignatureError(PkiEnrollmentCertificateError):
 
 
 class PkiEnrollmentCertificateCryptoError(PkiEnrollmentCertificateError):
+    pass
+
+
+class PkiEnrollmentCertificatePinCodeUnavailableError(PkiEnrollmentCertificateError):
     pass
 
 

--- a/parsec/core/pki/plumbing.py
+++ b/parsec/core/pki/plumbing.py
@@ -52,6 +52,7 @@ async def pki_enrollment_sign_payload(payload: bytes, x509_certificate: X509Cert
         PkiEnrollmentCertificateNotFoundError
         PkiEnrollmentCertificateCryptoError
         PkiEnrollmentCertificateError
+        PkiEnrollmentCertificatePinCodeUnavailableError
     """
     extension = _load_smartcard_extension()
     # Signing require a private key, so a prompt is likely to be used for unlocking it
@@ -100,6 +101,7 @@ async def pki_enrollment_load_local_pending_secret_part(
         PkiEnrollmentCertificateNotFoundError
         PkiEnrollmentCertificateCryptoError
         PkiEnrollmentCertificateError
+        PkiEnrollmentCertificatePinCodeUnavailableError
         PkiEnrollmentLocalPendingCryptoError
     """
     extension = _load_smartcard_extension()

--- a/parsec/core/pki/submitter.py
+++ b/parsec/core/pki/submitter.py
@@ -87,6 +87,7 @@ class PkiEnrollmentSubmitterInitialCtx:
             PkiEnrollmentCertificateError
             PkiEnrollmentCertificateCryptoError
             PkiEnrollmentCertificateNotFoundError
+            PkiEnrollmentCertificatePinCodeUnavailableError
 
             PkiEnrollmentLocalPendingError
             PkiEnrollmentLocalPendingCryptoError
@@ -435,6 +436,7 @@ class PkiEnrollmentSubmitterAcceptedStatusCtx(BasePkiEnrollmentSubmitterStatusCt
             PkiEnrollmentCertificateNotFoundError
             PkiEnrollmentCertificateCryptoError
             PkiEnrollmentCertificateError
+            PkiEnrollmentCertificatePinCodeUnavailableError
             PkiEnrollmentLocalPendingCryptoError
         """
         signing_key, private_key = await pki_enrollment_load_local_pending_secret_part(


### PR DESCRIPTION
Handled cases in the GUI where a user cancels the certificate selection or declines to provide the private key pin code. We usually do nothing in those cases instead of displaying an error.

Changes were only made in the pki enrollment and the login process, not for authentication change or device recovery.