### PR TITLE
[GUI] Handle cases where a user does not provide a certificate or a pin - backport 2.8

### DIFF
--- a/parsec/core/gui/enrollment_query_widget.py
+++ b/parsec/core/gui/enrollment_query_widget.py
@@ -12,7 +12,11 @@ from parsec.core.gui.lang import translate
 from parsec.core.gui import desktop, validators
 
 from parsec.core.gui.ui.enrollment_query_widget import Ui_EnrollmentQueryWidget
-from parsec.core.pki.exceptions import PkiEnrollmentSubmitCertificateAlreadySubmittedError
+from parsec.core.pki.exceptions import (
+    PkiEnrollmentCertificatePinCodeUnavailableError,
+    PkiEnrollmentCertificateNotFoundError,
+    PkiEnrollmentSubmitCertificateAlreadySubmittedError,
+)
 
 
 class EnrollmentQueryWidget(QWidget, Ui_EnrollmentQueryWidget):
@@ -78,7 +82,9 @@ class EnrollmentQueryWidget(QWidget, Ui_EnrollmentQueryWidget):
                     requested_device_label=DeviceLabel(self.line_edit_device.text()),
                     force=True,
                 )
-
+        except PkiEnrollmentCertificatePinCodeUnavailableError:
+            # User declined to provide a PIN code (cancelled the prompt). We do nothing.
+            pass
         # Enrollment submission failed
         except Exception as exc:
             show_error(self, translate("TEXT_ENROLLMENT_SUBMIT_FAILED"), exc)
@@ -101,6 +107,12 @@ class EnrollmentQueryWidget(QWidget, Ui_EnrollmentQueryWidget):
             self.line_edit_user_email.setText(self.context.x509_certificate.subject_email_address)
             self.line_edit_device.setText(desktop.get_default_device())
             self.button_select_cert.setText(str(self.context.x509_certificate.certificate_id))
+        except PkiEnrollmentCertificateNotFoundError:
+            # User did not provide a certificate (cancelled the prompt). We do nothing.
+            pass
+        except PkiEnrollmentCertificatePinCodeUnavailableError:
+            # User did not provide a pin code (cancelled the prompt). We do nothing.
+            pass
         except Exception as exc:
             show_error(self, translate("TEXT_ENROLLMENT_ERROR_LOADING_CERTIFICATE"), exception=exc)
             self.widget_user_info.setVisible(False)

--- a/parsec/core/gui/instance_widget.py
+++ b/parsec/core/gui/instance_widget.py
@@ -14,6 +14,7 @@ from parsec.api.protocol import HandshakeRevokedDevice
 from parsec.core import logged_core_factory
 from parsec.core.local_device import (
     LocalDeviceError,
+    LocalDeviceCertificatePinCodeUnavailableError,
     load_device_with_password,
     load_device_with_smartcard,
 )
@@ -287,6 +288,9 @@ class InstanceWidget(QWidget):
                 message = _("TEXT_LOGIN_ERROR_ALREADY_CONNECTED")
             else:
                 self.start_core(device)
+        except LocalDeviceCertificatePinCodeUnavailableError:
+            # User cancelled the prompt
+            self.login_failed.emit()
         except LocalDeviceError as exc:
             message = _("TEXT_LOGIN_ERROR_AUTHENTICATION_FAILED")
             exception = exc
@@ -296,7 +300,6 @@ class InstanceWidget(QWidget):
         except (RuntimeError, MountpointConfigurationError, MountpointDriverCrash) as exc:
             message = _("TEXT_LOGIN_MOUNTPOINT_ERROR")
             exception = exc
-
         except Exception as exc:
             message = _("TEXT_LOGIN_UNKNOWN_ERROR")
             exception = exc

--- a/parsec/core/gui/tr/parsec_en.po
+++ b/parsec/core/gui/tr/parsec_en.po
@@ -1791,6 +1791,12 @@ msgstr "No other device is available on this computer."
 msgid "TEXT_LOGIN_NO_DEVICE_ON_MACHINE"
 msgstr "You do not have any device on this computer."
 
+msgid "TEXT_ENROLLMENT_CANNOT_FINALIZE"
+msgstr "The enrollment could not be finalized."
+
+msgid "TEXT_CANNOT_REMOVE_LOCAL_PENDING_ENROLLMENT"
+msgstr "The new PARSEC device has been created but the corresponding enrollment could not be cleaned up."
+
 msgid "TEXT_PARSEC_WINDOW_TITLE_version"
 msgstr "PARSEC {version}"
 

--- a/parsec/core/gui/tr/parsec_fr.po
+++ b/parsec/core/gui/tr/parsec_fr.po
@@ -1846,6 +1846,12 @@ msgstr ""
 msgid "TEXT_LOGIN_NO_DEVICE_ON_MACHINE"
 msgstr "Vous n'avez aucun appareil sur cet ordinateur."
 
+msgid "TEXT_ENROLLMENT_CANNOT_FINALIZE"
+msgstr "L’enrôlement n'a pas pu être finalisé."
+
+msgid "TEXT_CANNOT_REMOVE_LOCAL_PENDING_ENROLLMENT"
+msgstr "Le nouvel appareil PARSEC a été créé mais l’enrôlement correspondant n'a pas pu être nettoyer"
+
 msgid "TEXT_PARSEC_WINDOW_TITLE_version"
 msgstr "PARSEC {version}"
 

--- a/parsec/core/local_device.py
+++ b/parsec/core/local_device.py
@@ -56,6 +56,10 @@ class LocalDeviceCryptoError(LocalDeviceError):
     pass
 
 
+class LocalDeviceCertificatePinCodeUnavailableError(LocalDeviceError):
+    pass
+
+
 class LocalDeviceSignatureError(LocalDeviceError):
     pass
 
@@ -559,6 +563,7 @@ def load_device_with_smartcard_sync(key_file: Path) -> LocalDevice:
         LocalDeviceCryptoError
         LocalDeviceValidationError
         LocalDevicePackingError
+        LocalDeviceCertificatePinCodeUnavailableError
     """
     return _load_smartcard_extension().load_device_with_smartcard(key_file)
 
@@ -570,6 +575,7 @@ async def load_device_with_smartcard(key_file: Path) -> LocalDevice:
         LocalDeviceCryptoError
         LocalDeviceValidationError
         LocalDevicePackingError
+        LocalDeviceCertificatePinCodeUnavailableError
     """
     return await trio.to_thread.run_sync(load_device_with_smartcard_sync, key_file)
 
@@ -587,6 +593,7 @@ async def save_device_with_smartcard_in_config(
         LocalDeviceCryptoError
         LocalDeviceValidationError
         LocalDevicePackingError
+        LocalDeviceCertificatePinCodeUnavailableError
     """
     key_file = get_default_key_file(config_dir, device)
     # Why do we use `force=True` here ?

--- a/parsec/core/pki/accepter.py
+++ b/parsec/core/pki/accepter.py
@@ -187,6 +187,7 @@ class PkiEnrollementAccepterValidSubmittedCtx:
             PkiEnrollmentCertificateError
             PkiEnrollmentCertificateCryptoError
             PkiEnrollmentCertificateNotFoundError
+            PkiEnrollmentCertificatePinCodeUnavailableError
         """
         # Create the certificate for the new user
         user_certificate, redacted_user_certificate, device_certificate, redacted_device_certificate, user_confirmation = _create_new_user_certificates(

--- a/parsec/core/pki/exceptions.py
+++ b/parsec/core/pki/exceptions.py
@@ -12,6 +12,7 @@ PkiEnrollmentError: all PKI enrollment related errors
     +- PkiEnrollmentCertificateValidationError: when the provided certificate cannot be validated using the configured trust roots
     +- PkiEnrollmentCertificateSignatureError: when the provided signature does not correspond to the certificate public key
     +- PkiEnrollmentCertificateCryptoError: when any of the required certificate-replated crypto operation fails
+    +- PkiEnrollmentCertificatePinCodeUnavailableError: when the user declines to provide the secret key password
 +- PkiEnrollmentPayloadError: all the enrollment payload errors
     +- PkiEnrollmentPayloadValidationError: when some enrollement information cannot be properly loaded
 +- PkiEnrollmentRemoteError: all the errors coming from a enrollment command on the backend
@@ -40,13 +41,7 @@ PkiEnrollmentError: all PKI enrollment related errors
 
 
 class PkiEnrollmentError(Exception):
-    @property
-    def message(self):
-        """All PkiEnrollmentError should have a message as first argument."""
-        return str(self.args[0])
-
-    def __str__(self):
-        return self.message
+    pass
 
 
 # Local pending enrollment errors
@@ -92,6 +87,10 @@ class PkiEnrollmentCertificateSignatureError(PkiEnrollmentCertificateError):
 
 
 class PkiEnrollmentCertificateCryptoError(PkiEnrollmentCertificateError):
+    pass
+
+
+class PkiEnrollmentCertificatePinCodeUnavailableError(PkiEnrollmentCertificateError):
     pass
 
 

--- a/parsec/core/pki/plumbing.py
+++ b/parsec/core/pki/plumbing.py
@@ -36,6 +36,7 @@ async def pki_enrollment_select_certificate(
     """
     Raises:
         PkiEnrollmentCertificateNotFoundError
+        PkiEnrollmentCertificatePinCodeUnavailableError
         PkiEnrollmentCertificateCryptoError
         PkiEnrollmentCertificateError
     """
@@ -50,6 +51,7 @@ async def pki_enrollment_sign_payload(payload: bytes, x509_certificate: X509Cert
     """
     Raises:
         PkiEnrollmentCertificateNotFoundError
+        PkiEnrollmentCertificatePinCodeUnavailableError
         PkiEnrollmentCertificateCryptoError
         PkiEnrollmentCertificateError
     """
@@ -100,6 +102,7 @@ async def pki_enrollment_load_local_pending_secret_part(
         PkiEnrollmentCertificateNotFoundError
         PkiEnrollmentCertificateCryptoError
         PkiEnrollmentCertificateError
+        PkiEnrollmentCertificatePinCodeUnavailableError
         PkiEnrollmentLocalPendingCryptoError
     """
     extension = _load_smartcard_extension()

--- a/parsec/core/pki/submitter.py
+++ b/parsec/core/pki/submitter.py
@@ -87,6 +87,7 @@ class PkiEnrollmentSubmitterInitialCtx:
             PkiEnrollmentCertificateError
             PkiEnrollmentCertificateCryptoError
             PkiEnrollmentCertificateNotFoundError
+            PkiEnrollmentCertificatePinCodeUnavailableError
 
             PkiEnrollmentLocalPendingError
             PkiEnrollmentLocalPendingCryptoError
@@ -435,6 +436,7 @@ class PkiEnrollmentSubmitterAcceptedStatusCtx(BasePkiEnrollmentSubmitterStatusCt
             PkiEnrollmentCertificateNotFoundError
             PkiEnrollmentCertificateCryptoError
             PkiEnrollmentCertificateError
+            PkiEnrollmentCertificatePinCodeUnavailableError
             PkiEnrollmentLocalPendingCryptoError
         """
         signing_key, private_key = await pki_enrollment_load_local_pending_secret_part(


### PR DESCRIPTION
Backport of https://github.com/Scille/parsec-cloud/pull/2239 for 2.8