### PR TITLE
Updated boto and botocore requirements

### DIFF
--- a/requirement/backend_requirement.txt
+++ b/requirement/backend_requirement.txt
@@ -3,8 +3,8 @@ jinja2==3.1.2
 triopg==0.6.0
 trio-asyncio==0.12.0
 # S3
-boto3==1.23.1
-botocore==1.26.5
+boto3==1.24.0
+botocore==1.27.0
 # Swift
 python-swiftclient==3.13.1
 pbr==5.9.0


### PR DESCRIPTION
Dependabot struggles to update both at the same time (#2396 and #2399) because of what seems like a circular dependency. So we update them both manually at the same time.