### PR TITLE
Yolo/allow to only sign the message

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -202,6 +202,11 @@ jobs:
     displayName: 'Bootstrap'
   - bash: |
       set -eux
+
+      # Test parsec-api-crypto with both features
+      cargo test -p parsec_api_crypto --features use-sodiumoxide
+      cargo test -p parsec_api_crypto --features use-rustcrypto
+
       cargo test --workspace --features mock-time
     workingDirectory: $(Build.SourcesDirectory)/oxidation
     displayName: 'Rust Tests'

--- a/oxidation/crates/parsec_api_crypto/src/rustcrypto/sign.rs
+++ b/oxidation/crates/parsec_api_crypto/src/rustcrypto/sign.rs
@@ -44,11 +44,17 @@ impl SigningKey {
         Self(Keypair::generate(&mut rand_07::thread_rng()))
     }
 
+    /// Sign the message and prefix it with the signature.
     pub fn sign(&self, data: &[u8]) -> Vec<u8> {
         let mut signed = Vec::with_capacity(SIGNATURE_LENGTH + data.len());
         signed.extend(self.0.sign(data).to_bytes());
         signed.extend_from_slice(data);
         signed
+    }
+
+    /// Sign the message and return only the signature.
+    pub fn sign_only_signature(&self, data: &[u8]) -> [u8; SIGNATURE_LENGTH] {
+        self.0.sign(data).to_bytes()
     }
 }
 

--- a/oxidation/crates/parsec_api_crypto/src/sodiumoxide/sign.rs
+++ b/oxidation/crates/parsec_api_crypto/src/sodiumoxide/sign.rs
@@ -21,7 +21,7 @@ impl SigningKey {
     /// Size of the secret key.
     /// `SEEDBYTES` is the size of the private key alone where `SECRETKEYBYTES` also contains the public part
     pub const SIZE: usize = ed25519::SEEDBYTES;
-    pub const SIGNATURE_LENGTH: usize = ed25519::SIGNATUREBYTES;
+    pub const SIGNATURE_SIZE: usize = ed25519::SIGNATUREBYTES;
 
     pub fn verify_key(&self) -> VerifyKey {
         VerifyKey::try_from(self.0.public_key().0).unwrap()
@@ -37,7 +37,7 @@ impl SigningKey {
     }
 
     /// Sign the message and return only the signature.
-    pub fn sign_only_signature(&self, data: &[u8]) -> [u8; Self::SIGNATURE_LENGTH] {
+    pub fn sign_only_signature(&self, data: &[u8]) -> [u8; Self::SIGNATURE_SIZE] {
         use sodiumoxide::crypto::sign::Signer;
 
         self.0.sign(data).to_bytes()
@@ -101,7 +101,7 @@ impl VerifyKey {
     pub const SIZE: usize = ed25519::PUBLICKEYBYTES;
 
     pub fn unsecure_unwrap(signed: &[u8]) -> Option<&[u8]> {
-        signed.get(SigningKey::SIGNATURE_LENGTH..)
+        signed.get(SigningKey::SIGNATURE_SIZE..)
     }
 
     pub fn verify(&self, signed: &[u8]) -> Result<Vec<u8>, CryptoError> {

--- a/oxidation/crates/parsec_api_crypto/src/sodiumoxide/sign.rs
+++ b/oxidation/crates/parsec_api_crypto/src/sodiumoxide/sign.rs
@@ -31,8 +31,16 @@ impl SigningKey {
         Self(gen_keypair().1)
     }
 
+    /// Sign the message and prefix it with the signature.
     pub fn sign(&self, data: &[u8]) -> Vec<u8> {
         sign(data, &self.0)
+    }
+
+    /// Sign the message and return only the signature.
+    pub fn sign_only_signature(&self, data: &[u8]) -> [u8; SIGNATUREBYTES] {
+        use sodiumoxide::crypto::sign::Signer;
+
+        self.0.sign(data).to_bytes()
     }
 }
 

--- a/oxidation/crates/parsec_api_crypto/tests/sign.rs
+++ b/oxidation/crates/parsec_api_crypto/tests/sign.rs
@@ -1,7 +1,7 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BSLv1.1 (eventually AGPLv3) 2016-2021 Scille SAS
 
 use hex_literal::hex;
-use pretty_assertions::assert_eq;
+// use pretty_assertions::assert_eq;
 use serde_test::{assert_tokens, Token};
 use std::convert::TryFrom;
 
@@ -50,6 +50,24 @@ fn signature_verification_spec() {
 
     let unwrappedtext = VerifyKey::unsecure_unwrap(&signedtext).unwrap();
     assert_eq!(unwrappedtext, b"all your base are belong to us");
+}
+
+#[test]
+fn signature_only() {
+    let sk = SigningKey::generate();
+
+    let data = b"Hello world, I would like to sign this message!";
+    let signed = sk.sign_only_signature(data);
+    let expected_signed_message = sk.sign(data);
+    let expected_signature = &expected_signed_message[..64];
+
+    assert_eq!(signed, expected_signature);
+
+    let vk = sk.verify_key();
+    let signed_message = Vec::from_iter(signed.iter().chain(data).copied());
+    let res = vk.verify(&signed_message);
+
+    assert_eq!(res, Ok(data.to_vec()));
 }
 
 test_msgpack_serialization!(

--- a/oxidation/crates/parsec_api_crypto/tests/sign.rs
+++ b/oxidation/crates/parsec_api_crypto/tests/sign.rs
@@ -43,13 +43,13 @@ fn signature_verification_spec() {
         "78958e49abad190be2d51bab73af07f87682cfcd65cceedd27e4b2a94bfd8537"
     ));
     // Signedtext generated with base python implementation
-    let signedtext = hex!("32d26711dc973e8df13bbafddc23fc26efe4aca1b86a4e0e7dad7c03df7ffc25d24b865478d164f8868ad0e087587e2c45e45d5598c7929b4605699bbab4b109616c6c20796f75722062617365206172652062656c6f6e6720746f207573");
+    let signed_text = hex!("32d26711dc973e8df13bbafddc23fc26efe4aca1b86a4e0e7dad7c03df7ffc25d24b865478d164f8868ad0e087587e2c45e45d5598c7929b4605699bbab4b109616c6c20796f75722062617365206172652062656c6f6e6720746f207573");
 
-    let text = vk.verify(&signedtext).unwrap();
+    let text = vk.verify(&signed_text).unwrap();
     assert_eq!(text, b"all your base are belong to us");
 
-    let unwrappedtext = VerifyKey::unsecure_unwrap(&signedtext).unwrap();
-    assert_eq!(unwrappedtext, b"all your base are belong to us");
+    let unwrapped_text = VerifyKey::unsecure_unwrap(&signed_text).unwrap();
+    assert_eq!(unwrapped_text, b"all your base are belong to us");
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn signature_only() {
     let data = b"Hello world, I would like to sign this message!";
     let signed = sk.sign_only_signature(data);
     let expected_signed_message = sk.sign(data);
-    let expected_signature = &expected_signed_message[..64];
+    let expected_signature = &expected_signed_message[..SigningKey::SIGNATURE_LENGTH];
 
     assert_eq!(signed, expected_signature);
 

--- a/oxidation/crates/parsec_api_crypto/tests/sign.rs
+++ b/oxidation/crates/parsec_api_crypto/tests/sign.rs
@@ -59,7 +59,7 @@ fn signature_only() {
     let data = b"Hello world, I would like to sign this message!";
     let signed = sk.sign_only_signature(data);
     let expected_signed_message = sk.sign(data);
-    let expected_signature = &expected_signed_message[..SigningKey::SIGNATURE_LENGTH];
+    let expected_signature = &expected_signed_message[..SigningKey::SIGNATURE_SIZE];
 
     assert_eq!(signed, expected_signature);
 

--- a/oxidation/crates/parsec_api_crypto/tests/sign.rs
+++ b/oxidation/crates/parsec_api_crypto/tests/sign.rs
@@ -1,7 +1,7 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BSLv1.1 (eventually AGPLv3) 2016-2021 Scille SAS
 
 use hex_literal::hex;
-// use pretty_assertions::assert_eq;
+use pretty_assertions::assert_eq;
 use serde_test::{assert_tokens, Token};
 use std::convert::TryFrom;
 


### PR DESCRIPTION
Allow to only get the signature of a message.

Requirement for #2419 