### PR TITLE
Yolo/fix/wrap cmd rep load in result

### DIFF
--- a/oxidation/crates/parsec_api_protocol/tests/test_block.rs
+++ b/oxidation/crates/parsec_api_protocol/tests/test_block.rs
@@ -109,14 +109,14 @@ fn serde_block_create_req() {
 fn serde_block_create_rep(#[case] raw_expected: (&[u8], authenticated_cmds::block_create::Rep)) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::block_create::Rep::load(raw);
+    let data = authenticated_cmds::block_create::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::block_create::Rep::load(&raw2);
+    let data2 = authenticated_cmds::block_create::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -212,14 +212,14 @@ fn serde_block_read_req() {
 fn serde_block_read_rep(#[case] raw_expected: (&[u8], authenticated_cmds::block_read::Rep)) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::block_read::Rep::load(raw);
+    let data = authenticated_cmds::block_read::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::block_read::Rep::load(&raw2);
+    let data2 = authenticated_cmds::block_read::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }

--- a/oxidation/crates/parsec_api_protocol/tests/test_events.rs
+++ b/oxidation/crates/parsec_api_protocol/tests/test_events.rs
@@ -190,14 +190,14 @@ fn serde_events_listen_req() {
 fn serde_events_listen_rep(#[case] raw_expected: (&[u8], authenticated_cmds::events_listen::Rep)) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::events_listen::Rep::load(raw);
+    let data = authenticated_cmds::events_listen::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::events_listen::Rep::load(&raw2);
+    let data2 = authenticated_cmds::events_listen::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -234,14 +234,14 @@ fn serde_events_subscribe_rep() {
 
     let expected = authenticated_cmds::events_subscribe::Rep::Ok;
 
-    let data = authenticated_cmds::events_subscribe::Rep::load(&raw);
+    let data = authenticated_cmds::events_subscribe::Rep::load(&raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::events_subscribe::Rep::load(&raw2);
+    let data2 = authenticated_cmds::events_subscribe::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }

--- a/oxidation/crates/parsec_api_protocol/tests/test_invite.rs
+++ b/oxidation/crates/parsec_api_protocol/tests/test_invite.rs
@@ -115,14 +115,14 @@ fn serde_invite_new_req(#[case] raw_expected: (&[u8], authenticated_cmds::AnyCmd
 fn serde_invite_new_rep(#[case] raw_expected: (&[u8], authenticated_cmds::invite_new::Rep)) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::invite_new::Rep::load(raw);
+    let data = authenticated_cmds::invite_new::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::invite_new::Rep::load(&raw2);
+    let data2 = authenticated_cmds::invite_new::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -195,14 +195,14 @@ fn serde_invite_delete_req() {
 fn serde_invite_delete_rep(#[case] raw_expected: (&[u8], authenticated_cmds::invite_delete::Rep)) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::invite_delete::Rep::load(raw);
+    let data = authenticated_cmds::invite_delete::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::invite_delete::Rep::load(&raw2);
+    let data2 = authenticated_cmds::invite_delete::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -275,14 +275,14 @@ fn serde_invite_list_rep() {
         ],
     };
 
-    let data = authenticated_cmds::invite_list::Rep::load(&raw);
+    let data = authenticated_cmds::invite_list::Rep::load(&raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::invite_list::Rep::load(&raw2);
+    let data2 = authenticated_cmds::invite_list::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -359,14 +359,14 @@ fn serde_invite_info_req() {
 fn serde_invite_info_rep(#[case] raw_expected: (&[u8], invited_cmds::invite_info::Rep)) {
     let (raw, expected) = raw_expected;
 
-    let data = invited_cmds::invite_info::Rep::load(raw);
+    let data = invited_cmds::invite_info::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = invited_cmds::invite_info::Rep::load(&raw2);
+    let data2 = invited_cmds::invite_info::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -448,14 +448,14 @@ fn serde_invite_1_claimer_wait_peer_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = invited_cmds::invite_1_claimer_wait_peer::Rep::load(raw);
+    let data = invited_cmds::invite_1_claimer_wait_peer::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = invited_cmds::invite_1_claimer_wait_peer::Rep::load(&raw2);
+    let data2 = invited_cmds::invite_1_claimer_wait_peer::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -550,14 +550,14 @@ fn serde_invite_1_greeter_wait_peer_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::invite_1_greeter_wait_peer::Rep::load(raw);
+    let data = authenticated_cmds::invite_1_greeter_wait_peer::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::invite_1_greeter_wait_peer::Rep::load(&raw2);
+    let data2 = authenticated_cmds::invite_1_greeter_wait_peer::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -650,14 +650,16 @@ fn serde_invite_2a_claimer_send_hashed_nonce_hash_nonce_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = invited_cmds::invite_2a_claimer_send_hashed_nonce_hash_nonce::Rep::load(raw);
+    let data =
+        invited_cmds::invite_2a_claimer_send_hashed_nonce_hash_nonce::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = invited_cmds::invite_2a_claimer_send_hashed_nonce_hash_nonce::Rep::load(&raw2);
+    let data2 =
+        invited_cmds::invite_2a_claimer_send_hashed_nonce_hash_nonce::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -750,14 +752,14 @@ fn serde_invite_2a_greeter_get_hashed_nonce_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::invite_2a_greeter_get_hashed_nonce::Rep::load(raw);
+    let data = authenticated_cmds::invite_2a_greeter_get_hashed_nonce::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::invite_2a_greeter_get_hashed_nonce::Rep::load(&raw2);
+    let data2 = authenticated_cmds::invite_2a_greeter_get_hashed_nonce::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -847,14 +849,14 @@ fn serde_invite_2b_greeter_send_nonce_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::invite_2b_greeter_send_nonce::Rep::load(raw);
+    let data = authenticated_cmds::invite_2b_greeter_send_nonce::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::invite_2b_greeter_send_nonce::Rep::load(&raw2);
+    let data2 = authenticated_cmds::invite_2b_greeter_send_nonce::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -927,14 +929,14 @@ fn serde_invite_2b_claimer_send_nonce_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = invited_cmds::invite_2b_claimer_send_nonce::Rep::load(raw);
+    let data = invited_cmds::invite_2b_claimer_send_nonce::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = invited_cmds::invite_2b_claimer_send_nonce::Rep::load(&raw2);
+    let data2 = invited_cmds::invite_2b_claimer_send_nonce::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -1021,14 +1023,14 @@ fn serde_invite_3a_greeter_wait_peer_trust_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::invite_3a_greeter_wait_peer_trust::Rep::load(raw);
+    let data = authenticated_cmds::invite_3a_greeter_wait_peer_trust::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::invite_3a_greeter_wait_peer_trust::Rep::load(&raw2);
+    let data2 = authenticated_cmds::invite_3a_greeter_wait_peer_trust::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -1098,14 +1100,14 @@ fn serde_invite_3b_claimer_wait_peer_trust_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = invited_cmds::invite_3b_claimer_wait_peer_trust::Rep::load(raw);
+    let data = invited_cmds::invite_3b_claimer_wait_peer_trust::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = invited_cmds::invite_3b_claimer_wait_peer_trust::Rep::load(&raw2);
+    let data2 = invited_cmds::invite_3b_claimer_wait_peer_trust::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -1192,14 +1194,14 @@ fn serde_invite_3b_greeter_signify_trust_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::invite_3b_greeter_signify_trust::Rep::load(raw);
+    let data = authenticated_cmds::invite_3b_greeter_signify_trust::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::invite_3b_greeter_signify_trust::Rep::load(&raw2);
+    let data2 = authenticated_cmds::invite_3b_greeter_signify_trust::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -1266,14 +1268,14 @@ fn serde_invite_3a_claimer_signify_trust_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = invited_cmds::invite_3a_claimer_signify_trust::Rep::load(raw);
+    let data = invited_cmds::invite_3a_claimer_signify_trust::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = invited_cmds::invite_3a_claimer_signify_trust::Rep::load(&raw2);
+    let data2 = invited_cmds::invite_3a_claimer_signify_trust::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -1362,13 +1364,13 @@ fn serde_invite_4_greeter_communicate_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::invite_4_greeter_communicate::Rep::load(raw);
+    let data = authenticated_cmds::invite_4_greeter_communicate::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
-    let data2 = authenticated_cmds::invite_4_greeter_communicate::Rep::load(&raw2);
+    let data2 = authenticated_cmds::invite_4_greeter_communicate::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -1444,14 +1446,14 @@ fn serde_invite_4_claimer_communicate_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = invited_cmds::invite_4_claimer_communicate::Rep::load(raw);
+    let data = invited_cmds::invite_4_claimer_communicate::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = invited_cmds::invite_4_claimer_communicate::Rep::load(&raw2);
+    let data2 = invited_cmds::invite_4_claimer_communicate::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }

--- a/oxidation/crates/parsec_api_protocol/tests/test_message.rs
+++ b/oxidation/crates/parsec_api_protocol/tests/test_message.rs
@@ -57,14 +57,14 @@ fn serde_message_get_rep() {
         }],
     };
 
-    let data = authenticated_cmds::message_get::Rep::load(&raw);
+    let data = authenticated_cmds::message_get::Rep::load(&raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::message_get::Rep::load(&raw2);
+    let data2 = authenticated_cmds::message_get::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }

--- a/oxidation/crates/parsec_api_protocol/tests/test_organization.rs
+++ b/oxidation/crates/parsec_api_protocol/tests/test_organization.rs
@@ -91,14 +91,14 @@ fn serde_organization_stats_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::organization_stats::Rep::load(raw);
+    let data = authenticated_cmds::organization_stats::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::organization_stats::Rep::load(&raw2);
+    let data2 = authenticated_cmds::organization_stats::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -160,14 +160,14 @@ fn serde_organization_config_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::organization_config::Rep::load(raw);
+    let data = authenticated_cmds::organization_config::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::organization_config::Rep::load(&raw2);
+    let data2 = authenticated_cmds::organization_config::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }

--- a/oxidation/crates/parsec_api_protocol/tests/test_ping.rs
+++ b/oxidation/crates/parsec_api_protocol/tests/test_ping.rs
@@ -43,14 +43,14 @@ fn serde_authenticated_ping_rep() {
         pong: "pong".to_owned(),
     };
 
-    let data = authenticated_cmds::ping::Rep::load(&raw);
+    let data = authenticated_cmds::ping::Rep::load(&raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::ping::Rep::load(&raw2);
+    let data2 = authenticated_cmds::ping::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -93,14 +93,14 @@ fn serde_invited_ping_rep() {
         pong: "pong".to_owned(),
     };
 
-    let data = invited_cmds::ping::Rep::load(&raw);
+    let data = invited_cmds::ping::Rep::load(&raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = invited_cmds::ping::Rep::load(&raw2);
+    let data2 = invited_cmds::ping::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }

--- a/oxidation/crates/parsec_api_protocol/tests/test_realm.rs
+++ b/oxidation/crates/parsec_api_protocol/tests/test_realm.rs
@@ -104,14 +104,14 @@ fn serde_realm_create_req() {
 fn serde_realm_create_rep(#[case] raw_expected: (&[u8], authenticated_cmds::realm_create::Rep)) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::realm_create::Rep::load(raw);
+    let data = authenticated_cmds::realm_create::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::realm_create::Rep::load(&raw2);
+    let data2 = authenticated_cmds::realm_create::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -200,14 +200,14 @@ fn serde_realm_status_req() {
 fn serde_realm_status_rep(#[case] raw_expected: (&[u8], authenticated_cmds::realm_status::Rep)) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::realm_status::Rep::load(raw);
+    let data = authenticated_cmds::realm_status::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::realm_status::Rep::load(&raw2);
+    let data2 = authenticated_cmds::realm_status::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -286,14 +286,14 @@ fn serde_realm_stats_req() {
 fn serde_realm_stats_rep(#[case] raw_expected: (&[u8], authenticated_cmds::realm_stats::Rep)) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::realm_stats::Rep::load(raw);
+    let data = authenticated_cmds::realm_stats::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::realm_stats::Rep::load(&raw2);
+    let data2 = authenticated_cmds::realm_stats::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -372,14 +372,14 @@ fn serde_realm_get_role_certificates_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::realm_get_role_certificates::Rep::load(raw);
+    let data = authenticated_cmds::realm_get_role_certificates::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::realm_get_role_certificates::Rep::load(&raw2);
+    let data2 = authenticated_cmds::realm_get_role_certificates::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -527,14 +527,14 @@ fn serde_realm_update_roles_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::realm_update_roles::Rep::load(raw);
+    let data = authenticated_cmds::realm_update_roles::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::realm_update_roles::Rep::load(&raw2);
+    let data2 = authenticated_cmds::realm_update_roles::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -677,14 +677,14 @@ fn serde_realm_start_reencryption_maintenance_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::realm_start_reencryption_maintenance::Rep::load(raw);
+    let data = authenticated_cmds::realm_start_reencryption_maintenance::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::realm_start_reencryption_maintenance::Rep::load(&raw2);
+    let data2 = authenticated_cmds::realm_start_reencryption_maintenance::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -807,14 +807,15 @@ fn serde_realm_finish_reencryption_maintenance_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::realm_finish_reencryption_maintenance::Rep::load(raw);
+    let data = authenticated_cmds::realm_finish_reencryption_maintenance::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::realm_finish_reencryption_maintenance::Rep::load(&raw2);
+    let data2 =
+        authenticated_cmds::realm_finish_reencryption_maintenance::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }

--- a/oxidation/crates/parsec_api_protocol/tests/test_user.rs
+++ b/oxidation/crates/parsec_api_protocol/tests/test_user.rs
@@ -84,14 +84,14 @@ fn serde_user_get_req() {
 fn serde_user_get_rep(#[case] raw_expected: (&[u8], authenticated_cmds::user_get::Rep)) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::user_get::Rep::load(raw);
+    let data = authenticated_cmds::user_get::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::user_get::Rep::load(&raw2);
+    let data2 = authenticated_cmds::user_get::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -220,14 +220,14 @@ fn serde_user_create_req() {
 fn serde_user_create_rep(#[case] raw_expected: (&[u8], authenticated_cmds::user_create::Rep)) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::user_create::Rep::load(raw);
+    let data = authenticated_cmds::user_create::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::user_create::Rep::load(&raw2);
+    let data2 = authenticated_cmds::user_create::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -331,14 +331,14 @@ fn serde_user_revoke_req() {
 fn serde_user_revoke_rep(#[case] raw_expected: (&[u8], authenticated_cmds::user_revoke::Rep)) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::user_revoke::Rep::load(raw);
+    let data = authenticated_cmds::user_revoke::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::user_revoke::Rep::load(&raw2);
+    let data2 = authenticated_cmds::user_revoke::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -447,14 +447,14 @@ fn serde_device_create_req() {
 fn serde_device_create_rep(#[case] raw_expected: (&[u8], authenticated_cmds::device_create::Rep)) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::device_create::Rep::load(raw);
+    let data = authenticated_cmds::device_create::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::device_create::Rep::load(&raw2);
+    let data2 = authenticated_cmds::device_create::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -548,14 +548,14 @@ fn serde_human_find_req() {
 fn serde_human_find_rep(#[case] raw_expected: (&[u8], authenticated_cmds::human_find::Rep)) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::human_find::Rep::load(raw);
+    let data = authenticated_cmds::human_find::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::human_find::Rep::load(&raw2);
+    let data2 = authenticated_cmds::human_find::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }

--- a/oxidation/crates/parsec_api_protocol/tests/test_vlob.rs
+++ b/oxidation/crates/parsec_api_protocol/tests/test_vlob.rs
@@ -109,14 +109,14 @@ fn serde_vlob_create_req() {
 fn serde_vlob_create_rep(#[case] raw_expected: (&[u8], authenticated_cmds::vlob_create::Rep)) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::vlob_create::Rep::load(raw);
+    let data = authenticated_cmds::vlob_create::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::vlob_create::Rep::load(&raw2);
+    let data2 = authenticated_cmds::vlob_create::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -243,14 +243,14 @@ fn serde_vlob_read_req() {
 fn serde_vlob_read_rep(#[case] raw_expected: (&[u8], authenticated_cmds::vlob_read::Rep)) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::vlob_read::Rep::load(raw);
+    let data = authenticated_cmds::vlob_read::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::vlob_read::Rep::load(&raw2);
+    let data2 = authenticated_cmds::vlob_read::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -366,14 +366,14 @@ fn serde_vlob_update_req() {
 fn serde_vlob_update_rep(#[case] raw_expected: (&[u8], authenticated_cmds::vlob_update::Rep)) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::vlob_update::Rep::load(raw);
+    let data = authenticated_cmds::vlob_update::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::vlob_update::Rep::load(&raw2);
+    let data2 = authenticated_cmds::vlob_update::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -468,14 +468,14 @@ fn serde_vlob_poll_changes_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::vlob_poll_changes::Rep::load(raw);
+    let data = authenticated_cmds::vlob_poll_changes::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::vlob_poll_changes::Rep::load(&raw2);
+    let data2 = authenticated_cmds::vlob_poll_changes::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -572,14 +572,14 @@ fn serde_vlob_list_versions_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::vlob_list_versions::Rep::load(raw);
+    let data = authenticated_cmds::vlob_list_versions::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::vlob_list_versions::Rep::load(&raw2);
+    let data2 = authenticated_cmds::vlob_list_versions::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -718,14 +718,15 @@ fn serde_vlob_maintenance_get_reencryption_batch_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::vlob_maintenance_get_reencryption_batch::Rep::load(raw);
+    let data = authenticated_cmds::vlob_maintenance_get_reencryption_batch::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::vlob_maintenance_get_reencryption_batch::Rep::load(&raw2);
+    let data2 =
+        authenticated_cmds::vlob_maintenance_get_reencryption_batch::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }
@@ -864,14 +865,16 @@ fn serde_vlob_maintenance_save_reencryption_batch_rep(
 ) {
     let (raw, expected) = raw_expected;
 
-    let data = authenticated_cmds::vlob_maintenance_save_reencryption_batch::Rep::load(raw);
+    let data =
+        authenticated_cmds::vlob_maintenance_save_reencryption_batch::Rep::load(raw).unwrap();
 
     assert_eq!(data, expected);
 
     // Also test serialization round trip
     let raw2 = data.dump().unwrap();
 
-    let data2 = authenticated_cmds::vlob_maintenance_save_reencryption_batch::Rep::load(&raw2);
+    let data2 =
+        authenticated_cmds::vlob_maintenance_save_reencryption_batch::Rep::load(&raw2).unwrap();
 
     assert_eq!(data2, expected);
 }

--- a/oxidation/crates/parsec_serialization_format/src/parser/protocol.rs
+++ b/oxidation/crates/parsec_serialization_format/src/parser/protocol.rs
@@ -233,9 +233,6 @@ impl Cmds {
                     #[serde(tag = "status")]
                     pub enum Rep {
                         #variants_rep
-                        UnknownError {
-                            error: String,
-                        },
                     }
 
                     impl Rep {
@@ -243,13 +240,8 @@ impl Cmds {
                             ::rmp_serde::to_vec_named(self).map_err(|_| "Serialization failed")
                         }
 
-                        pub fn load(buf: &[u8]) -> Self {
-                            match ::rmp_serde::from_slice(buf) {
-                                Ok(res) => res,
-                                Err(e) => Self::UnknownError {
-                                    error: e.to_string(),
-                                },
-                            }
+                        pub fn load(buf: &[u8]) -> Result<Self, ::rmp_serde::decode::Error> {
+                            ::rmp_serde::from_slice(buf)
                         }
                     }
                 }

--- a/oxidation/libparsec_python/src/protocol/block.rs
+++ b/oxidation/libparsec_python/src/protocol/block.rs
@@ -1,5 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BSLv1.1 (eventually AGPLv3) 2016-2021 Scille SAS
 
+use pyo3::exceptions::PyValueError;
 use pyo3::import_exception;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyType};
@@ -106,7 +107,9 @@ impl BlockCreateRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(block_create::Rep::load(&buf)))
+        block_create::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -189,6 +192,8 @@ impl BlockReadRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(block_read::Rep::load(&buf)))
+        block_read::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }

--- a/oxidation/libparsec_python/src/protocol/events.rs
+++ b/oxidation/libparsec_python/src/protocol/events.rs
@@ -165,7 +165,9 @@ impl EventsListenRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(events_listen::Rep::load(&buf)))
+        events_listen::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -213,6 +215,8 @@ impl EventsSubscribeRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(events_subscribe::Rep::load(&buf)))
+        events_subscribe::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }

--- a/oxidation/libparsec_python/src/protocol/events.rs
+++ b/oxidation/libparsec_python/src/protocol/events.rs
@@ -134,7 +134,7 @@ impl EventsListenRep {
     }
 
     #[classmethod]
-    #[pyo3(name = "OkRealmRolesUdpated")]
+    #[pyo3(name = "OkRealmRolesUpdated")]
     fn ok_realm_roles_updated(_cls: &PyType, realm_id: RealmID, role: &PyAny) -> PyResult<Self> {
         let realm_id = realm_id.0;
         let role =

--- a/oxidation/libparsec_python/src/protocol/invite.rs
+++ b/oxidation/libparsec_python/src/protocol/invite.rs
@@ -1,5 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BSLv1.1 (eventually AGPLv3) 2016-2021 Scille SAS
 
+use pyo3::exceptions::PyValueError;
 use pyo3::import_exception;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyType};
@@ -119,7 +120,9 @@ impl InviteNewRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(invite_new::Rep::load(&buf)))
+        invite_new::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -197,7 +200,9 @@ impl InviteDeleteRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(invite_delete::Rep::load(&buf)))
+        invite_delete::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -299,7 +304,9 @@ impl InviteListRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(invite_list::Rep::load(&buf)))
+        invite_list::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -381,7 +388,9 @@ impl InviteInfoRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(invite_info::Rep::load(&buf)))
+        invite_info::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -449,7 +458,9 @@ impl Invite1ClaimerWaitPeerRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(invite_1_claimer_wait_peer::Rep::load(&buf)))
+        invite_1_claimer_wait_peer::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -527,7 +538,9 @@ impl Invite1GreeterWaitPeerRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(invite_1_greeter_wait_peer::Rep::load(&buf)))
+        invite_1_greeter_wait_peer::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -612,9 +625,9 @@ impl Invite2aClaimerSendHashedNonceHashNonceRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(
-            invite_2a_claimer_send_hashed_nonce_hash_nonce::Rep::load(&buf),
-        ))
+        invite_2a_claimer_send_hashed_nonce_hash_nonce::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -690,7 +703,9 @@ impl Invite2aGreeterGetHashedNonceRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(invite_2a_greeter_get_hashed_nonce::Rep::load(&buf)))
+        invite_2a_greeter_get_hashed_nonce::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -754,7 +769,9 @@ impl Invite2bClaimerSendNonceRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(invite_2b_claimer_send_nonce::Rep::load(&buf)))
+        invite_2b_claimer_send_nonce::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -830,7 +847,9 @@ impl Invite2bGreeterSendNonceRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(invite_2b_greeter_send_nonce::Rep::load(&buf)))
+        invite_2b_greeter_send_nonce::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -894,7 +913,9 @@ impl Invite3aClaimerSignifyTrustRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(invite_3a_claimer_signify_trust::Rep::load(&buf)))
+        invite_3a_claimer_signify_trust::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -965,7 +986,9 @@ impl Invite3aGreeterWaitPeerTrustRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(invite_3a_greeter_wait_peer_trust::Rep::load(&buf)))
+        invite_3a_greeter_wait_peer_trust::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -1029,7 +1052,9 @@ impl Invite3bClaimerWaitPeerTrustRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(invite_3b_claimer_wait_peer_trust::Rep::load(&buf)))
+        invite_3b_claimer_wait_peer_trust::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -1100,7 +1125,9 @@ impl Invite3bGreeterSignifyTrustRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(invite_3b_greeter_signify_trust::Rep::load(&buf)))
+        invite_3b_greeter_signify_trust::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -1164,7 +1191,9 @@ impl Invite4ClaimerCommunicateRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(invite_4_claimer_communicate::Rep::load(&buf)))
+        invite_4_claimer_communicate::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -1235,6 +1264,8 @@ impl Invite4GreeterCommunicateRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(invite_4_greeter_communicate::Rep::load(&buf)))
+        invite_4_greeter_communicate::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }

--- a/oxidation/libparsec_python/src/protocol/message.rs
+++ b/oxidation/libparsec_python/src/protocol/message.rs
@@ -1,5 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BSLv1.1 (eventually AGPLv3) 2016-2021 Scille SAS
 
+use pyo3::exceptions::PyValueError;
 use pyo3::import_exception;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyType};
@@ -88,6 +89,8 @@ impl MessageGetRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(message_get::Rep::load(&buf)))
+        message_get::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }

--- a/oxidation/libparsec_python/src/protocol/organization.rs
+++ b/oxidation/libparsec_python/src/protocol/organization.rs
@@ -1,5 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BSLv1.1 (eventually AGPLv3) 2016-2021 Scille SAS
 
+use pyo3::exceptions::PyValueError;
 use pyo3::import_exception;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyType};
@@ -110,7 +111,9 @@ impl OrganizationStatsRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(organization_stats::Rep::load(&buf)))
+        organization_stats::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -175,6 +178,8 @@ impl OrganizationConfigRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(organization_config::Rep::load(&buf)))
+        organization_config::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }

--- a/oxidation/libparsec_python/src/protocol/ping.rs
+++ b/oxidation/libparsec_python/src/protocol/ping.rs
@@ -1,5 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BSLv1.1 (eventually AGPLv3) 2016-2021 Scille SAS
 
+use pyo3::exceptions::PyValueError;
 use pyo3::import_exception;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyType};
@@ -61,7 +62,9 @@ impl InvitedPingRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(invited_cmds::ping::Rep::load(&buf)))
+        invited_cmds::ping::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -118,6 +121,8 @@ impl AuthenticatedPingRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(authenticated_cmds::ping::Rep::load(&buf)))
+        authenticated_cmds::ping::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }

--- a/oxidation/libparsec_python/src/protocol/realm.rs
+++ b/oxidation/libparsec_python/src/protocol/realm.rs
@@ -1,5 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BSLv1.1 (eventually AGPLv3) 2016-2021 Scille SAS
 
+use pyo3::exceptions::PyValueError;
 use pyo3::import_exception;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyType};
@@ -93,7 +94,9 @@ impl RealmCreateRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(realm_create::Rep::load(&buf)))
+        realm_create::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -192,7 +195,9 @@ impl RealmStatusRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(realm_status::Rep::load(&buf)))
+        realm_status::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -265,7 +270,9 @@ impl RealmStatsRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(realm_stats::Rep::load(&buf)))
+        realm_stats::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -335,7 +342,9 @@ impl RealmGetRoleCertificateRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(realm_get_role_certificates::Rep::load(&buf)))
+        realm_get_role_certificates::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -446,7 +455,9 @@ impl RealmUpdateRolesRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(realm_update_roles::Rep::load(&buf)))
+        realm_update_roles::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -590,7 +601,9 @@ impl RealmStartReencryptionMaintenanceRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(realm_start_reencryption_maintenance::Rep::load(&buf)))
+        realm_start_reencryption_maintenance::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -698,6 +711,8 @@ impl RealmFinishReencryptionMaintenanceRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(realm_finish_reencryption_maintenance::Rep::load(&buf)))
+        realm_finish_reencryption_maintenance::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }

--- a/oxidation/libparsec_python/src/protocol/user.rs
+++ b/oxidation/libparsec_python/src/protocol/user.rs
@@ -1,5 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BSLv1.1 (eventually AGPLv3) 2016-2021 Scille SAS
 
+use pyo3::exceptions::PyValueError;
 use pyo3::import_exception;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyType};
@@ -109,7 +110,9 @@ impl UserGetRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(user_get::Rep::load(&buf)))
+        user_get::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -221,7 +224,9 @@ impl UserCreateRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(user_create::Rep::load(&buf)))
+        user_create::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -298,7 +303,9 @@ impl UserRevokeRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(user_revoke::Rep::load(&buf)))
+        user_revoke::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -387,7 +394,9 @@ impl DeviceCreateRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(device_create::Rep::load(&buf)))
+        device_create::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -535,6 +544,8 @@ impl HumanFindRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(human_find::Rep::load(&buf)))
+        human_find::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }

--- a/oxidation/libparsec_python/src/protocol/vlob.rs
+++ b/oxidation/libparsec_python/src/protocol/vlob.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use pyo3::exceptions::PyValueError;
 use pyo3::import_exception;
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
@@ -131,7 +132,9 @@ impl VlobCreateRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(vlob_create::Rep::load(&buf)))
+        vlob_create::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -272,7 +275,9 @@ impl VlobReadRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(vlob_read::Rep::load(&buf)))
+        vlob_read::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -393,7 +398,9 @@ impl VlobUpdateRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(vlob_update::Rep::load(&buf)))
+        vlob_update::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -481,7 +488,9 @@ impl VlobPollChangesRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(vlob_poll_changes::Rep::load(&buf)))
+        vlob_poll_changes::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -563,7 +572,9 @@ impl VlobListVersionsRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(vlob_list_versions::Rep::load(&buf)))
+        vlob_list_versions::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -682,9 +693,9 @@ impl VlobMaintenanceGetReencryptionBatchRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(vlob_maintenance_get_reencryption_batch::Rep::load(
-            &buf,
-        )))
+        vlob_maintenance_get_reencryption_batch::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 
@@ -851,8 +862,8 @@ impl VlobMaintenanceSaveReencryptionBatchRep {
 
     #[classmethod]
     fn load(_cls: &PyType, buf: Vec<u8>) -> PyResult<Self> {
-        Ok(Self(vlob_maintenance_save_reencryption_batch::Rep::load(
-            &buf,
-        )))
+        vlob_maintenance_save_reencryption_batch::Rep::load(&buf)
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }


### PR DESCRIPTION
`Rep::load` now return a `Result` instead of including a variant `UnknownError`

this change is required for #2419 because, on the rust side it's expected that the load may failed, but looking for the specific variant is a anti pattern because we have the `Result` enum that do that for us. 