### PR TITLE
Yolo/rework addr

### DIFF
--- a/oxidation/crates/parsec_api_types/src/addr.rs
+++ b/oxidation/crates/parsec_api_types/src/addr.rs
@@ -37,7 +37,7 @@ macro_rules! impl_common_stuff {
             }
 
             pub fn from_http_redirection(url: &str) -> Result<Self, AddrError> {
-                // For wathever reason, Url considers illegal changing scheme
+                // For whatever reason, Url considers illegal changing scheme
                 // from http/https to a custom one, so we cannot just use
                 // `Url::set_scheme` and instead have to do this hack :(
                 let url_with_forced_custom_scheme = format!("x{}", url);
@@ -506,7 +506,7 @@ impl BackendOrganizationBootstrapAddr {
         let token = token_queries.next().map(|(_, v)| (*v).to_owned());
         // Note invalid percent-encoding is not considered a failure here:
         // the replacement character EF BF BD is used instead. This should be
-        // ok for our usecase (but it differs from Python implementation).
+        // ok for our use case (but it differs from Python implementation).
         if token_queries.next().is_some() {
             return Err("Multiple values for param `token`");
         }

--- a/oxidation/crates/parsec_api_types/src/addr.rs
+++ b/oxidation/crates/parsec_api_types/src/addr.rs
@@ -222,7 +222,7 @@ impl BaseBackendAddr {
     }
 
     /// Create a url for http request with the given path.
-    pub fn to_http_domain_url(&self, path: Option<&str>) -> Url {
+    pub fn to_http_url_with_path(&self, path: Option<&str>) -> Url {
         let mut base_url = self.to_http_url();
         let path = path.unwrap_or("");
         base_url.set_path(path);
@@ -312,8 +312,8 @@ impl BackendAddr {
         }
     }
 
-    pub fn to_http_domain_url(&self, path: Option<&str>) -> Url {
-        self.base.to_http_domain_url(path)
+    pub fn to_http_url_with_path(&self, path: Option<&str>) -> Url {
+        self.base.to_http_url_with_path(path)
     }
 
     fn _from_url(parsed: &Url, pairs: &url::form_urlencoded::Parse) -> Result<Self, AddrError> {
@@ -550,8 +550,8 @@ impl BackendOrganizationBootstrapAddr {
         self.token.as_deref()
     }
 
-    pub fn to_http_domain_url(&self, path: Option<&str>) -> Url {
-        self.base.to_http_domain_url(path)
+    pub fn to_http_url_with_path(&self, path: Option<&str>) -> Url {
+        self.base.to_http_url_with_path(path)
     }
 }
 
@@ -787,8 +787,8 @@ impl BackendPkiEnrollmentAddr {
         url
     }
 
-    pub fn to_http_domain_url(&self, path: Option<&str>) -> Url {
-        self.base.to_http_domain_url(path)
+    pub fn to_http_url_with_path(&self, path: Option<&str>) -> Url {
+        self.base.to_http_url_with_path(path)
     }
 
     pub fn organization_id(&self) -> &OrganizationID {

--- a/oxidation/crates/parsec_api_types/src/addr.rs
+++ b/oxidation/crates/parsec_api_types/src/addr.rs
@@ -23,7 +23,7 @@ macro_rules! impl_common_stuff {
             }
 
             pub fn to_http_redirection_url(&self) -> Url {
-                let mut url = self.base.to_http_url();
+                let mut url = self.base.to_http_url(None);
                 url.path_segments_mut()
                     .unwrap_or_else(|()| unreachable!())
                     .push("redirect");
@@ -212,22 +212,18 @@ impl BaseBackendAddr {
         url
     }
 
-    /// Create a url for http request.
-    pub fn to_http_url(&self) -> Url {
+    /// Create a url for http request with an optional path.
+    pub fn to_http_url(&self, path: Option<&str>) -> Url {
         let scheme = if self.use_ssl { "https" } else { "http" };
+
         let mut url = Url::parse(&format!("{}://{}", scheme, &self.hostname))
             .unwrap_or_else(|_| unreachable!());
         url.set_port(self.port).unwrap_or_else(|_| unreachable!());
-        url
-    }
 
-    /// Create a url for http request with the given path.
-    pub fn to_http_url_with_path(&self, path: Option<&str>) -> Url {
-        let mut base_url = self.to_http_url();
         let path = path.unwrap_or("");
-        base_url.set_path(path);
+        url.set_path(path);
 
-        base_url
+        url
     }
 }
 
@@ -313,7 +309,7 @@ impl BackendAddr {
     }
 
     pub fn to_http_url_with_path(&self, path: Option<&str>) -> Url {
-        self.base.to_http_url_with_path(path)
+        self.base.to_http_url(path)
     }
 
     fn _from_url(parsed: &Url, pairs: &url::form_urlencoded::Parse) -> Result<Self, AddrError> {
@@ -551,7 +547,7 @@ impl BackendOrganizationBootstrapAddr {
     }
 
     pub fn to_http_url_with_path(&self, path: Option<&str>) -> Url {
-        self.base.to_http_url_with_path(path)
+        self.base.to_http_url(path)
     }
 }
 
@@ -788,7 +784,7 @@ impl BackendPkiEnrollmentAddr {
     }
 
     pub fn to_http_url_with_path(&self, path: Option<&str>) -> Url {
-        self.base.to_http_url_with_path(path)
+        self.base.to_http_url(path)
     }
 
     pub fn organization_id(&self) -> &OrganizationID {

--- a/oxidation/crates/parsec_api_types/src/addr.rs
+++ b/oxidation/crates/parsec_api_types/src/addr.rs
@@ -298,7 +298,9 @@ fn extract_organization_id(parsed: &Url) -> Result<OrganizationID, AddrError> {
 pub struct BackendAddr {
     base: BaseBackendAddr,
 }
+
 impl_common_stuff!(BackendAddr);
+
 impl BackendAddr {
     pub fn new(hostname: String, port: Option<u16>, use_ssl: bool) -> Self {
         if hostname.is_empty() {
@@ -346,7 +348,9 @@ pub struct BackendOrganizationAddr {
     organization_id: OrganizationID,
     root_verify_key: VerifyKey,
 }
+
 impl_common_stuff!(BackendOrganizationAddr);
+
 impl BackendOrganizationAddr {
     pub fn new(
         backend_addr: BackendAddr,
@@ -567,7 +571,9 @@ pub struct BackendOrganizationFileLinkAddr {
     workspace_id: EntryID,
     encrypted_path: Vec<u8>,
 }
+
 impl_common_stuff!(BackendOrganizationFileLinkAddr);
+
 impl BackendOrganizationFileLinkAddr {
     pub fn new(
         backend_addr: BackendAddr,
@@ -660,7 +666,9 @@ pub struct BackendInvitationAddr {
     invitation_type: InvitationType,
     token: InvitationToken,
 }
+
 impl_common_stuff!(BackendInvitationAddr);
+
 impl BackendInvitationAddr {
     pub fn new(
         backend_addr: BackendAddr,
@@ -746,7 +754,9 @@ pub struct BackendPkiEnrollmentAddr {
     base: BaseBackendAddr,
     organization_id: OrganizationID,
 }
+
 impl_common_stuff!(BackendPkiEnrollmentAddr);
+
 impl BackendPkiEnrollmentAddr {
     pub fn new(backend_addr: BackendAddr, organization_id: OrganizationID) -> Self {
         Self {

--- a/oxidation/crates/parsec_api_types/src/addr.rs
+++ b/oxidation/crates/parsec_api_types/src/addr.rs
@@ -328,7 +328,7 @@ impl BackendAddr {
 
     expose_BaseBackendAddr_fields!();
 
-    pub fn _to_url(&self, url: Url) -> Url {
+    fn _to_url(&self, url: Url) -> Url {
         url
     }
 }
@@ -385,7 +385,7 @@ impl BackendOrganizationAddr {
 
     expose_BaseBackendAddr_fields!();
 
-    pub fn _to_url(&self, mut url: Url) -> Url {
+    fn _to_url(&self, mut url: Url) -> Url {
         url.path_segments_mut()
             .unwrap_or_else(|()| unreachable!())
             .push(self.organization_id.as_ref());
@@ -528,7 +528,7 @@ impl BackendOrganizationBootstrapAddr {
 
     expose_BaseBackendAddr_fields!();
 
-    pub fn _to_url(&self, mut url: Url) -> Url {
+    fn _to_url(&self, mut url: Url) -> Url {
         url.path_segments_mut()
             .unwrap_or_else(|()| unreachable!())
             .push(self.organization_id.as_ref());
@@ -626,7 +626,7 @@ impl BackendOrganizationFileLinkAddr {
 
     expose_BaseBackendAddr_fields!();
 
-    pub fn _to_url(&self, mut url: Url) -> Url {
+    fn _to_url(&self, mut url: Url) -> Url {
         url.path_segments_mut()
             .unwrap_or_else(|()| unreachable!())
             .push(self.organization_id.as_ref());
@@ -711,7 +711,7 @@ impl BackendInvitationAddr {
 
     expose_BaseBackendAddr_fields!();
 
-    pub fn _to_url(&self, mut url: Url) -> Url {
+    fn _to_url(&self, mut url: Url) -> Url {
         url.path_segments_mut()
             .unwrap_or_else(|()| unreachable!())
             .push(self.organization_id.as_ref());
@@ -778,7 +778,7 @@ impl BackendPkiEnrollmentAddr {
 
     expose_BaseBackendAddr_fields!();
 
-    pub fn _to_url(&self, mut url: Url) -> Url {
+    fn _to_url(&self, mut url: Url) -> Url {
         url.path_segments_mut()
             .unwrap_or_else(|()| unreachable!())
             .push(self.organization_id.as_ref());

--- a/oxidation/crates/parsec_api_types/src/addr.rs
+++ b/oxidation/crates/parsec_api_types/src/addr.rs
@@ -250,11 +250,9 @@ macro_rules! expose_BaseBackendAddr_fields {
             }
         }
 
+        /// `true` when the default port is overloaded.
         pub fn is_default_port(&self) -> bool {
-            match self.base.port {
-                Some(_) => false,
-                None => true,
-            }
+            self.base.port.is_none()
         }
 
         pub fn use_ssl(&self) -> bool {

--- a/oxidation/crates/parsec_api_types/src/addr.rs
+++ b/oxidation/crates/parsec_api_types/src/addr.rs
@@ -23,7 +23,7 @@ macro_rules! impl_common_stuff {
             }
 
             pub fn to_http_redirection_url(&self) -> Url {
-                let mut url = self.base.to_http_redirection_url();
+                let mut url = self.base.to_http_url();
                 url.path_segments_mut()
                     .unwrap_or_else(|()| unreachable!())
                     .push("redirect");
@@ -201,6 +201,7 @@ impl BaseBackendAddr {
         })
     }
 
+    /// create a url in parsec format (i.e.: `parsec://foo.bar[...]`)
     pub fn to_url(&self) -> Url {
         let mut url = Url::parse(&format!("{}://{}", PARSEC_SCHEME, &self.hostname))
             .unwrap_or_else(|_| unreachable!());
@@ -211,7 +212,8 @@ impl BaseBackendAddr {
         url
     }
 
-    pub fn to_http_redirection_url(&self) -> Url {
+    /// Create a url for http request.
+    pub fn to_http_url(&self) -> Url {
         let scheme = if self.use_ssl { "https" } else { "http" };
         let mut url = Url::parse(&format!("{}://{}", scheme, &self.hostname))
             .unwrap_or_else(|_| unreachable!());
@@ -219,16 +221,13 @@ impl BaseBackendAddr {
         url
     }
 
+    /// Create a url for http request with the given path.
     pub fn to_http_domain_url(&self, path: Option<&str>) -> Url {
+        let mut base_url = self.to_http_url();
         let path = path.unwrap_or("");
-        let scheme = if self.use_ssl { "https" } else { "http" };
+        base_url.set_path(path);
 
-        let mut url = Url::parse(&format!("{}://{}", scheme, &self.hostname))
-            .unwrap_or_else(|_| unreachable!());
-        url.set_port(self.port).unwrap_or_else(|_| unreachable!());
-        url.set_path(path);
-
-        url
+        base_url
     }
 }
 

--- a/oxidation/crates/parsec_api_types/tests/test_addr.rs
+++ b/oxidation/crates/parsec_api_types/tests/test_addr.rs
@@ -208,7 +208,7 @@ fn test_good_addr(testbed: &dyn Testbed) {
 )]
 fn test_backend_addr_to_http_domain_url(value: &str, path: Option<&str>, expected: &str) {
     let addr: BackendAddr = value.parse().unwrap();
-    let result = addr.to_http_domain_url(path);
+    let result = addr.to_http_url_with_path(path);
     assert_eq!(result.as_str(), expected);
 }
 

--- a/oxidation/libparsec_python/src/addrs.rs
+++ b/oxidation/libparsec_python/src/addrs.rs
@@ -72,7 +72,7 @@ impl BackendAddr {
 
     #[args(path = "\"\"")]
     fn to_http_domain_url(&self, path: &str) -> PyResult<String> {
-        Ok(self.0.to_http_domain_url(Some(path)).to_string())
+        Ok(self.0.to_http_url_with_path(Some(path)).to_string())
     }
 
     fn to_http_redirection_url(&self) -> PyResult<String> {
@@ -451,7 +451,7 @@ impl BackendOrganizationBootstrapAddr {
 
     #[args(path = "\"\"")]
     fn to_http_domain_url(&self, path: &str) -> PyResult<String> {
-        Ok(self.0.to_http_domain_url(Some(path)).to_string())
+        Ok(self.0.to_http_url_with_path(Some(path)).to_string())
     }
 
     #[classmethod]
@@ -986,7 +986,7 @@ impl BackendPkiEnrollmentAddr {
 
     #[args(path = "\"\"")]
     fn to_http_domain_url(&self, path: &str) -> PyResult<String> {
-        Ok(self.0.to_http_domain_url(Some(path)).to_string())
+        Ok(self.0.to_http_url_with_path(Some(path)).to_string())
     }
 
     #[classmethod]


### PR DESCRIPTION
- rename `to_http_domain_url` to `to_http_url_with_path` to better reflect what the method do
- rename `BaseBackendAddr::to_http_redirection_url` to `to_http_url` to better reflect what the method do
- correct some typo
- don't publicly expose `_to_url`
- more consistent spacing