### PR TITLE
[GUI] Don't overwrite files when importing a new file with the same name

### DIFF
--- a/newsfragments/2504.bugfix.rst
+++ b/newsfragments/2504.bugfix.rst
@@ -1,0 +1,1 @@
+Don't overwrite files when importing a new file with the same name

--- a/parsec/core/gui/files_widget.py
+++ b/parsec/core/gui/files_widget.py
@@ -850,6 +850,16 @@ class FilesWidget(QWidget, Ui_FilesWidget):
         # Open the file to import
         async with await trio.open_file(source, "rb") as f:
 
+            # Getting the file name without extension (anything after the first dot is considered to be the extension)
+            name_we, suffixes = dest.name.str.split(".", 1)
+            # Count starts at 2 (1 would be the file without a number)
+            count = 2
+            while await self.workspace_fs.exists(dest):
+                # Create the new file name by adding the count ("myfile.txt" becomes "myfile (2).txt")
+                new_file_name = EntryName("{} ({}).{}".format(name_we, count, suffixes))
+                dest = dest.parent / new_file_name
+                count += 1
+
             # Open the file to create
             async with await self.workspace_fs.open_file(dest, "wb") as dest_file:
 

--- a/tests/core/gui/test_files.py
+++ b/tests/core/gui/test_files.py
@@ -262,6 +262,23 @@ async def test_file_browsing_and_edit(
         path="/", expected_entries=["dir0/", "dir1/", "zdir2/", "file1.txt", "file2.txt"]
     )
 
+    # Import a new file with a similar name
+    monkeypatch.setattr(
+        "parsec.core.gui.custom_dialogs.QDialogInProcess.getOpenFileNames",
+        classmethod(lambda *args, **kwargs: ([out_of_parsec_data / "file1.txt"], True)),
+    )
+    async with aqtbot.wait_signal(f_w.import_success):
+        aqtbot.mouse_click(f_w.button_import_files, QtCore.Qt.LeftButton)
+    await tb.check_files_view(
+        path="/",
+        expected_entries=["dir0/", "dir1/", "zdir2/", "file1 (2).txt", "file1.txt", "file2.txt"],
+    )
+
+    await tb.delete(selection=["file1 (2).txt"])
+    await tb.check_files_view(
+        path="/", expected_entries=["dir0/", "dir1/", "zdir2/", "file1.txt", "file2.txt"]
+    )
+
     # Import folder
     monkeypatch.setattr(
         "parsec.core.gui.custom_dialogs.QDialogInProcess.getExistingDirectory",


### PR DESCRIPTION
Quickfix to avoid overwriting an existing file when importing a new one with the same name: the new file is renamed to something like "file (2).ext".
Closes #2504 