### PR TITLE
[GUI] Fixed snackbar visibility when window is not in focus and how snackbars are handled

### DIFF
--- a/parsec/core/gui/main_window.py
+++ b/parsec/core/gui/main_window.py
@@ -11,7 +11,6 @@ from PyQt5.QtWidgets import QWidget, QMainWindow, QMenu, QShortcut, QMenuBar
 
 from parsec import __version__ as PARSEC_VERSION
 from parsec.core.gui.enrollment_query_widget import EnrollmentQueryWidget
-from parsec.core.gui.snackbar_widget import SnackbarManager
 from parsec.core.types.backend_address import BackendPkiEnrollmentAddr
 from parsec.event_bus import EventBus, EventCallback
 from parsec.api.protocol import InvitationType
@@ -40,6 +39,7 @@ from parsec.core.gui.claim_device_widget import ClaimDeviceWidget
 from parsec.core.gui.license_widget import LicenseWidget
 from parsec.core.gui.about_widget import AboutWidget
 from parsec.core.gui.settings_widget import SettingsWidget
+from parsec.core.gui.snackbar_widget import SnackbarManager
 from parsec.core.gui.custom_dialogs import (
     ask_question,
     show_error,
@@ -129,6 +129,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):  # type: ignore[misc]
         self.tab_center.setCornerWidget(self.add_tab_button, Qt.Corner.TopLeftCorner)
 
         self.tab_center.currentChanged.connect(self.on_current_tab_changed)
+        self.snackbar_manager = SnackbarManager(self)
         self._define_shortcuts()
         self.ensurePolished()
 

--- a/parsec/core/gui/parsec_application.py
+++ b/parsec/core/gui/parsec_application.py
@@ -7,7 +7,6 @@ from PyQt5.QtCore import QFile, QEvent
 from PyQt5.QtGui import QFont, QFontDatabase, QPalette, QColor
 from structlog import get_logger
 
-
 logger = get_logger()
 
 

--- a/parsec/core/gui/snackbar_widget.py
+++ b/parsec/core/gui/snackbar_widget.py
@@ -11,7 +11,6 @@ from PyQt5.QtCore import (
     pyqtSignal,
     pyqtProperty,
     QEasingCurve,
-    QPoint,
     QObject,
     QSize,
 )
@@ -101,7 +100,7 @@ class SnackbarWidget(QWidget, Ui_SnackbarWidget):
         painter.drawRoundedRect(rect, 10, 10)
 
     def move_popup(self):
-        main_window = ParsecApp.get_main_window()
+        main_window = self.parentWidget()
         if not main_window:
             return
         offset = 10
@@ -113,8 +112,7 @@ class SnackbarWidget(QWidget, Ui_SnackbarWidget):
         y = main_window.size().height() - ((height + offset) * (self.index + 1))
         # Hide the snackbar if the main window does not have enough space to show it
         self.set_visible(y > 30 and main_window.isVisible())
-        pos = main_window.mapToGlobal(QPoint(x, y))
-        self.setGeometry(pos.x(), pos.y(), width, height)
+        self.setGeometry(x, y, width, height)
 
     def _on_timeout(self):
         if self.animate:
@@ -149,14 +147,11 @@ class SnackbarWidget(QWidget, Ui_SnackbarWidget):
 
 
 class SnackbarManager(QObject):
-    _manager = None
-
-    def __init__(self):
-        super().__init__()
+    def __init__(self, main_window):
+        super().__init__(parent=main_window)
         self.snackbars = []
-        ParsecApp.get_main_window().installEventFilter(self)
-        self.setParent(ParsecApp.get_main_window())
-        self.destroyed.connect(self._on_destroyed)
+        main_window.installEventFilter(self)
+        self.destroyed.connect(self.clear)
 
     def eventFilter(self, obj, event):
         if (
@@ -178,13 +173,14 @@ class SnackbarManager(QObject):
         return False
 
     def add_snackbar(self, snackbar):
+        snackbar.setParent(self.parent())
         snackbar._dismissed.connect(self._on_dismissed)
         self.snackbars.insert(0, snackbar)
         for i, sb in enumerate(self.snackbars):
             sb.set_index(i)
         snackbar.show()
 
-    def _on_destroyed(self, _):
+    def clear(self):
         self.snackbars = []
 
     def _remove_snackbar(self, snackbar):
@@ -200,37 +196,37 @@ class SnackbarManager(QObject):
             sb.set_index(i)
 
     @classmethod
-    def get_manager(cls):
-        # Create the manager the first time it's used.
-        # Else it will try to plug itself onto the main window
-        # that does not exist yet.
-        if not cls._manager:
-            cls._manager = cls()
-        return cls._manager
-
-    @classmethod
     def inform(cls, msg, timeout=3000, action_text=None, action=None, animate=True):
+        main_window = ParsecApp.get_main_window()
+        if not main_window:
+            return
         pix = Pixmap(":/icons/images/material/info.svg")
         pix.replace_color(QColor(0, 0, 0), QColor(73, 153, 208))
         snackbar = SnackbarWidget(
             msg, icon=pix, timeout=timeout, action_text=action_text, action=action, animate=animate
         )
-        cls.get_manager().add_snackbar(snackbar)
+        main_window.snackbar_manager.add_snackbar(snackbar)
 
     @classmethod
     def congratulate(cls, msg, timeout=3000, action_text=None, action=None, animate=True):
+        main_window = ParsecApp.get_main_window()
+        if not main_window:
+            return
         pix = Pixmap(":/icons/images/material/check_circle.svg")
         pix.replace_color(QColor(0, 0, 0), QColor(73, 208, 86))
         snackbar = SnackbarWidget(
             msg, icon=pix, timeout=timeout, action_text=action_text, action=action, animate=animate
         )
-        cls.get_manager().add_snackbar(snackbar)
+        main_window.snackbar_manager.add_snackbar(snackbar)
 
     @classmethod
     def warn(cls, msg, timeout=3000, action_text=None, action=None, animate=True):
+        main_window = ParsecApp.get_main_window()
+        if not main_window:
+            return
         pix = Pixmap(":/icons/images/material/report_problem.svg")
         pix.replace_color(QColor(0, 0, 0), QColor(208, 102, 73))
         snackbar = SnackbarWidget(
             msg, icon=pix, timeout=timeout, action_text=action_text, action=action, animate=animate
         )
-        cls.get_manager().add_snackbar(snackbar)
+        main_window.snackbar_manager.add_snackbar(snackbar)


### PR DESCRIPTION
Better fix for #2530 

Snackbars now have the MainWindow as a parent, meaning they will more closely follow its state instead of appearing above every other windows on Windows.

Also, the snackbars were stored in a global variable. This caused problems, especially while testing, because the C++ Qt object would be deleted when the window was closed at the end of a test while the Python object would stay alive. Snackbars are now stored in an object whose lifetime depends on the main window.

closes #2530 