### PR TITLE
add CI workflow to run rust build & test on linux

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,5 +1,5 @@
-name: pre-commit
-description: install & run-precommit
+name: setup-rust
+description: install rust toolchain
 
 inputs:
   version:

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -30,4 +30,4 @@ jobs:
           cargo test --package libparsec_crypto --features use-sodiumoxide
           cargo test --package libparsec_crypto --features use-rustcrypto
 
-          cargo test --workspace --features mock-time
+          cargo test --workspace --features mock-time --exclude libparsec_crypto

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -1,0 +1,31 @@
+name: linux-ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+env:
+  rust-version: 1.62.0
+
+jobs:
+  rust:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin v3.0.2
+      - uses: ./.github/actions/setup-rust
+        with:
+          version: ${{ env.rust-version }}
+          cache-key: test&build
+
+      - name: Test rust codebase
+        run: |
+          cargo test --package libparsec_crypto --features use-sodiumoxide
+          cargo test --package libparsec_crypto --features use-rustcrypto
+
+          cargo test --workspace --features mock-time
+
+      - name: Build rust codebase
+        run: |
+          cargo build --workspace

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -19,13 +19,15 @@ jobs:
           version: ${{ env.rust-version }}
           cache-key: test&build
 
+
+      - name: Build rust codebase
+        run: |
+          cargo build --workspace
+          cargo test --workspace --no-run
+
       - name: Test rust codebase
         run: |
           cargo test --package libparsec_crypto --features use-sodiumoxide
           cargo test --package libparsec_crypto --features use-rustcrypto
 
           cargo test --workspace --features mock-time
-
-      - name: Build rust codebase
-        run: |
-          cargo build --workspace

--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -64,9 +64,6 @@ jobs:
           git fetch origin master
           python .github/scripts/check_newsfragments.py ${{ github.head_ref }}
 
-      - name: Run cargo build to prepare rust's cache
-        run: cargo build --workspace
-
       - name: Patch pre-commit for line-ending
         run: |
           sed -i '/id: mixed-line-ending/a\        args:\n\          - "--fix=lf"' .pre-commit-config.yaml


### PR DESCRIPTION
- also remove the step `Run cargo build to prepare rust's cache` since
  we'll be using different cache between the qa & test/build job

closes #2634 