### PR TITLE
Rename jobs name

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -13,7 +13,7 @@ env:
   postgre-version: 12
 
 jobs:
-  rust:
+  linux-ci-rust:
     # Using ubuntu 20 for consistency with the python job
     runs-on: ubuntu-20.04
     steps:
@@ -34,7 +34,7 @@ jobs:
           cargo test --package libparsec_crypto --features use-rustcrypto
           cargo test --workspace --features mock-time --exclude libparsec_crypto
 
-  python:
+  linux-ci-python:
     # Using ubuntu 20 in order to have postgresql-12 available as an APT package
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -12,7 +12,7 @@ env:
   poetry-version: 1.1.13
 
 jobs:
-  python-only:
+  macos-ci-python:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin v3.0.2

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -14,7 +14,7 @@ env:
   poetry-version: 1.1.13
 
 jobs:
-  build-wheel:
+  package-linux-build-wheel:
     runs-on: ubuntu-22.04
     env:
       # Need feature from poetry 1.2.x that aren't present in 1.1.x
@@ -77,7 +77,7 @@ jobs:
           name: ${{ runner.os }}-wheel
           path: dist/
 
-  package-linux:
+  package-linux-build-snap:
     needs: build-wheel
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -20,7 +20,7 @@ env:
     -vv
 
 jobs:
-  python-only:
+  windows-ci-python:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin v3.0.2


### PR DESCRIPTION
Rename Github Action workflow's jobs to be able to select them in the `require status check` in the configuration of this repository before allowing to merge