### PR TITLE
Correct `needs` for job `package-linux-build-snap`

### DIFF
--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -78,7 +78,7 @@ jobs:
           path: dist/
 
   package-linux-build-snap:
-    needs: build-wheel
+    needs: package-linux-build-wheel
     runs-on: ubuntu-20.04
     env:
       WHEEL_VERSION: ${{ needs.build-wheel.outputs.wheel-version }}


### PR DESCRIPTION
We've updated the job's name `package-linux-build-wheel`
but forgot to update to update the job requirement for
`package-linux-build-snap` to reflect to new name for `build-wheel`