### PR TITLE
Disable azure pipelines for push and PR triggers

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -30,6 +30,7 @@ jobs:
   # Step 0: Wheel build
   - job: s0_build_wheel
     displayName: Build wheel
+    condition: startsWith(variables['build.sourceBranch'], 'refs/tags/')
     timeoutInMinutes: 10
     pool:
       vmImage: ubuntu-latest
@@ -251,6 +252,7 @@ jobs:
   - job: s1_macos_test
     displayName: MacOS tests
     dependsOn: s0_build_wheel
+    condition: startsWith(variables['build.sourceBranch'], 'refs/tags/')
     timeoutInMinutes: 60
     pool:
       vmImage: macOS-12
@@ -314,6 +316,7 @@ jobs:
   - job: s1_windows_test
     displayName: Windows tests
     dependsOn: s0_build_wheel
+    condition: startsWith(variables['build.sourceBranch'], 'refs/tags/')
     timeoutInMinutes: 60
     pool:
       vmImage: windows-latest

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -132,3 +132,18 @@ jobs:
         with:
           name: ${{ runner.os }}-snap
           path: ${{ runner.temp }}/parsec*.snap
+
+  package-linux-release-pypi:
+    needs: package-linux-build-wheel
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin v3.0.0
+        with:
+          name: ${{ runner.os }}-wheel
+          path: dist
+      - name: Publish wheel on PyPI
+        uses: pypa/gh-action-pypi-publish@37f50c210e3d2f9450da2cd423303d6a14a6e29f # pin v1.5.1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_CREDENTIALS }}

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -133,23 +133,31 @@ jobs:
           name: ${{ runner.os }}-snap
           path: ${{ runner.temp }}/parsec*.snap
 
-  package-linux-release-pypi:
-    needs: package-linux-build-wheel
+  package-linux-test-snap:
+    needs: package-linux-build-snap
     runs-on: ubuntu-20.04
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:
       - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin v3.0.0
         with:
-          name: ${{ runner.os }}-wheel
+          name: ${{ runner.os }}-snap
           path: dist
-      - name: Publish wheel on PyPI
-        uses: pypa/gh-action-pypi-publish@37f50c210e3d2f9450da2cd423303d6a14a6e29f # pin v1.5.1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_CREDENTIALS }}
+
+      - name: Install Snapcraft
+        uses: samuelmeuli/action-snapcraft@10d7d0a84d9d86098b19f872257df314b0bd8e2d # pin v1.2.0
+
+      - name: Never trust a Snap
+        run: |
+          sudo snap install --classic --dangerous dist/parsec*.snap
+          parsec.cli --version
+          parsec.cli --help
+          # Make sure snap contains core but not backend
+          MODULES_NOT_AVAILABLE=$(parsec.cli --help | grep -i "not available")
+          test "$(echo $MODULES_NOT_AVAILABLE | grep -i 'backend')"
+          test -z "$(echo $MODULES_NOT_AVAILABLE | grep -i 'core')"
+          xvfb-run parsec --diagnose
 
   package-linux-release-snap:
-    needs: package-linux-build-snap
+    needs: [ package-linux-build-snap, package-linux-test-snap ]
     runs-on: ubuntu-20.04
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:
@@ -165,3 +173,19 @@ jobs:
 
       - name: Upload Snap
         run: snapcraft upload --release=edge dist/parsec*.snap
+
+  package-linux-release-pypi:
+    needs: [ package-linux-build-wheel, package-linux-test-snap ]
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin v3.0.0
+        with:
+          name: ${{ runner.os }}-wheel
+          path: dist
+
+      - name: Publish wheel on PyPI
+        uses: pypa/gh-action-pypi-publish@37f50c210e3d2f9450da2cd423303d6a14a6e29f # pin v1.5.1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_CREDENTIALS }}

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -147,3 +147,21 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_CREDENTIALS }}
+
+  package-linux-release-snap:
+    needs: package-linux-build-snap
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin v3.0.0
+        with:
+          name: ${{ runner.os }}-snap
+          path: dist
+
+      - name: Install Snapcraft
+        uses: samuelmeuli/action-snapcraft@10d7d0a84d9d86098b19f872257df314b0bd8e2d # pin v1.2.0
+        with:
+          snapcraft_token: ${{ secrets.SNAPCRAFT_CREDENTIALS }}
+
+      - name: Upload Snap
+        run: snapcraft upload --release=edge dist/parsec*.snap


### PR DESCRIPTION
The azure jobs are kept for tags, while we're validating the new GH action packaging process.

Also add `package-linux-release-pypi` and `package-linux-release-snap` steps in package-linux workflow.