### PR TITLE
Improve windows packaging

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -519,22 +519,12 @@ jobs:
       # Must use cmd.exe here instead of bash otherwise `C:\Program Files\Git\bin\link.exe`
       # takes priority over visual studio link.exe in PATH
       - script: |
-          python freeze_program.py $(Build.SourcesDirectory) --wheel-it-dir $(Pipeline.Workspace)/wheel
+          python freeze_program.py --build-dir ./build --wheel-it-dir $(Pipeline.Workspace)/wheel
         displayName: Freeze Parsec
         workingDirectory: $(Agent.TempDirectory)/winbuild
-      - bash: |
-          set -eux
-          mkdir dist
-          cp build/manifest.ini dist/
-          cp build/install_files.nsh dist/
-          cp build/uninstall_files.nsh dist/
-          cp -R build/parsec-* dist/
-          cp build/winfsp-* dist/
-        displayName: Prepare artifact
-        workingDirectory: $(Agent.TempDirectory)/winbuild
       # Cannot do the NSIS installer part in CI given it requires to sign `parsec.exe`
-      - publish: $(Agent.TempDirectory)/winbuild/dist
-        artifact: win_$(vs.arch)_installer_content
+      - publish: $(Agent.TempDirectory)/winbuild/build/installer_inputs
+        artifact: win_$(vs.arch)_installer_inputs
 
 
   #################################################################################

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -479,7 +479,7 @@ jobs:
 
   - job: s2_windows_installer_content_build
     displayName: Windows installer content build
-    condition: startsWith(variables['build.sourceBranch'], 'refs/tags/')
+    # condition: startsWith(variables['build.sourceBranch'], 'refs/tags/')
     timeoutInMinutes: 60
     dependsOn: s0_build_wheel
     pool:

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -105,25 +105,17 @@ jobs:
         run: Get-ChildItem -Recurse -Path ${{ runner.temp }}
 
       - name: Freeze Parsec
-        run: python3 freeze_program.py ${{ github.workspace }} --wheel-it-dir ${{ github.workspace }}/dist
+        run: python freeze_program.py --build-dir ./build --wheel-it-dir ${{ github.workspace }}/dist
         working-directory: ${{ runner.temp }}
 
       - name: Debug build directory
-        run: Get-ChildItem -Path ${{ runner.temp }}\build
+        run: |
+          Get-ChildItem -Path ${{ runner.temp }}\build
+          Get-ChildItem -Path ${{ runner.temp }}\build\\installer_inputs
 
       # Cannot do the NSIS installer part in CI given it requires to sign `parsec.exe`
 
-      - name: Prepare artifact
-        run: |
-          md dist
-          Copy-Item -Path build\manifest.ini -Destination dist
-          Copy-Item -Path build\install_files.nsh -Destination dist
-          Copy-Item -Path build\uninstall_files.nsh -Destination dist
-          Copy-Item -Recurse -Path build\parsec-* -Destination dist
-          Copy-Item -Path build\winfsp-* -Destination dist
-        working-directory: ${{ runner.temp }}
-
       - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin v3.1.0
         with:
-          name: ${{ runner.os }}-${{ runner.arch }}-installer-content
-          path: ${{ runner.temp }}/dist/
+          name: ${{ runner.os }}-${{ runner.arch }}-installer-inputs
+          path: ${{ runner.temp }}/build/installer_inputs

--- a/packaging/wheel/wheel_it.py
+++ b/packaging/wheel/wheel_it.py
@@ -32,6 +32,9 @@ def main(program_source: Path, output_dir: Path):
     all_requirements = output_dir / "all-requirements.txt"
     constraints = output_dir / "constraints.txt"
 
+    # LICENSE is needed by `freeze_program.py`
+    shutil.copyfile(src=program_source / "licenses/AGPL3.txt", dst=output_dir / "LICENSE.txt")
+
     # poetry export has a --output option, but it alway consider the file relative to
     # the project directory !
     # On top of that we cannot use stdout because poetry may print random `Creating virtualenv`

--- a/packaging/windows/installer.in.nsi
+++ b/packaging/windows/installer.in.nsi
@@ -17,11 +17,11 @@
 !define OBSOLETE_MOUNTPOINT "$PROFILE\Parsec"
 
 ### TEMPLATE STUFF ###
-!define OUTPUT_DIR "{ output_dir_path }"
-!define PROGRAM_INSTALLER_INPUTS  "{ installer_inputs_path }"
-!define PROGRAM_VERSION "{ program_version }"
-!define PROGRAM_PLATFORM "{ platform }"
-!define WINFSP_INSTALLER_NAME "{ winfsp_installer_name }"
+!define OUTPUT_DIR "{output_dir_path}"
+!define PROGRAM_INSTALLER_INPUTS  "{installer_inputs_path}"
+!define PROGRAM_VERSION "{program_version}"
+!define PROGRAM_PLATFORM "{platform}"
+!define WINFSP_INSTALLER_NAME "{winfsp_installer_name}"
 ### END OF TEMPLATE STUFF ###
 # Sanity check
 !ifndef OUTPUT_DIR
@@ -331,10 +331,10 @@ SectionEnd
 # Hidden: Remove obsolete entries
 Section "-Remove obsolete entries" Section4
     # Remove obsolete parsec registry configuration
-    DeleteRegKey HKCU "Software\Classes\CLSID\{${{APPGUID}}}"
-    DeleteRegKey HKCU "Software\Classes\Wow6432Node\CLSID\{${{APPGUID}}}"
-    DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\{${{APPGUID}}}"
-    DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel\{${{APPGUID}}}"
+    DeleteRegKey HKCU "Software\Classes\CLSID\{{${{APPGUID}}}}"
+    DeleteRegKey HKCU "Software\Classes\Wow6432Node\CLSID\{{${{APPGUID}}}}"
+    DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\{{${{APPGUID}}}}"
+    DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel\{{${{APPGUID}}}}"
     ClearErrors
     # Remove obsolete mountpoint folder
     Delete "${{OBSOLETE_MOUNTPOINT}}\desktop.ini"
@@ -387,9 +387,9 @@ Section Uninstall
 
   # Explorer shortcut keys potentially set by the application's settings
   DeleteRegKey HKCU "Software\Classes\CLSID\{{${{APPGUID}}}}"
-  DeleteRegKey HKCU "Software\Classes\Wow6432Node\CLSID\{{${{APPGUID}}}"
-  DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\{{${{APPGUID}}}"
-  DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel\{{${{APPGUID}}}"
+  DeleteRegKey HKCU "Software\Classes\Wow6432Node\CLSID\{{${{APPGUID}}}}"
+  DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\{{${{APPGUID}}}}"
+  DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel\{{${{APPGUID}}}}"
 
 SectionEnd
 

--- a/packaging/windows/make_installer.py
+++ b/packaging/windows/make_installer.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     nsis_config_path = build_dir / "installer.nsi"
     nsis_config = nsis_config_in.format(**build_manifest)
     nsis_config_path.write_text(nsis_config, encoding="utf8")
-    assert nsis_config_path.read_bytes() != nsis_config_in.read_bytes()  # Sanity check
+    assert nsis_config_path.read_bytes() != bytes(nsis_config_in, 'utf-8')  # Sanity check
 
     # Copy NSIS resources
     for res in ("icon.ico", "installer-side.bmp", "installer-top.bmp"):
@@ -99,7 +99,7 @@ if __name__ == "__main__":
                 raise SystemExit("Some file are not signed, aborting")
         # Generate installer
         print("### Building installer ###")
-        run(f"makensis { nsis_config }")
+        run(f"makensis { nsis_config_path }")
         # Sign installer
         print("### Signing installer ###")
         (installer,) = build_dir.glob("parsec-*-setup.exe")

--- a/packaging/windows/make_installer.py
+++ b/packaging/windows/make_installer.py
@@ -3,6 +3,7 @@
 import json
 import argparse
 import itertools
+import shutil
 import subprocess
 from shutil import which
 from pathlib import Path
@@ -54,13 +55,19 @@ if __name__ == "__main__":
     assert which("makensis"), "makensis command not in PATH !"
 
     # Configure the NSIS script
-    nsis_config_in = (BASE_DIR / "installer.in.nsi").read_text(encoding="utf8")
+    nsis_config_in_path = BASE_DIR / "installer.in.nsi"
+    nsis_config_in = nsis_config_in_path.read_text(encoding="utf8")
     build_manifest = json.loads((installer_inputs / "manifest.json").read_text(encoding="utf8"))
     build_manifest["output_dir_path"] = build_dir
     build_manifest["installer_inputs_path"] = installer_inputs
-    nsis_config = build_dir / "installer.nsi"
-    nsis_config.write_text(nsis_config_in.format(**build_manifest), encoding="utf8")
-    assert nsis_config.read_bytes() != nsis_config_in.read_bytes()  # Sanity check
+    nsis_config_path = build_dir / "installer.nsi"
+    nsis_config = nsis_config_in.format(**build_manifest)
+    nsis_config_path.write_text(nsis_config, encoding="utf8")
+    assert nsis_config_path.read_bytes() != nsis_config_in.read_bytes()  # Sanity check
+
+    # Copy NSIS resources
+    for res in ("icon.ico", "installer-side.bmp", "installer-top.bmp"):
+        shutil.copyfile(src=BASE_DIR / res, dst=build_dir / res)
 
     if args.sign_mode == "none":
         print("### Building installer ###")

--- a/packaging/windows/make_installer.py
+++ b/packaging/windows/make_installer.py
@@ -1,6 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
 
-import re
+import json
 import argparse
 import itertools
 import subprocess
@@ -43,10 +43,24 @@ if __name__ == "__main__":
         "--sign-mode", choices=("all", "exe", "none"), default="none", type=lambda x: x.lower()
     )
     parser.add_argument("--build-dir", type=Path, default=DEFAULT_BUILD_DIR)
+    parser.add_argument("--installer-inputs", type=Path, default=None)
     args = parser.parse_args()
     build_dir: Path = args.build_dir
+    if args.installer_inputs:
+        installer_inputs: Path = args.installer_inputs
+    else:
+        installer_inputs: Path = build_dir / "installer_inputs"
 
     assert which("makensis"), "makensis command not in PATH !"
+
+    # Configure the NSIS script
+    nsis_config_in = (BASE_DIR / "installer.in.nsi").read_text(encoding="utf8")
+    build_manifest = json.loads((installer_inputs / "manifest.json").read_text(encoding="utf8"))
+    build_manifest["output_dir_path"] = build_dir
+    build_manifest["installer_inputs_path"] = installer_inputs
+    nsis_config = build_dir / "installer.nsi"
+    nsis_config.write_text(nsis_config_in.format(**build_manifest), encoding="utf8")
+    assert nsis_config.read_bytes() != nsis_config_in.read_bytes()  # Sanity check
 
     if args.sign_mode == "none":
         print("### Building installer ###")
@@ -54,26 +68,22 @@ if __name__ == "__main__":
         print(
             f"{YELLOW_FG}/!\\{DEFAULT_FG} Installer generated with no signature {YELLOW_FG}/!\\{DEFAULT_FG}"
         )
-        (installer,) = build_dir.glob("parsec-*-setup.exe")
+        (installer,) = installer_inputs.glob("parsec-*-setup.exe")
         print(f"{installer} is ready")
 
     else:
         assert which("signtool"), "signtool command not in PATH !"
 
-        build_manifest = (build_dir / "manifest.ini").read_text()
-        match = re.match(r"^target = \"(.*)\"$", build_manifest, re.MULTILINE)
-        if not match:
-            raise SystemExit("Build manifest not found, aborting")
-        freeze_program = Path(match.group(1))
+        installer_content = installer_inputs / "installer_content"
         # Retrieve frozen program and sign all .dll and .exe
         print("### Signing application executable ###")
-        sign(freeze_program / APPLICATION_EXE)
+        sign(installer_content / APPLICATION_EXE)
         # Make sure everything is signed
         if args.sign_mode == "all":
             print("### Checking all shipped exe/dll are signed ###")
             not_signed = []
             for file in itertools.chain(
-                freeze_program.rglob("*.exe"), freeze_program.rglob("*.dll")
+                installer_content.rglob("*.exe"), installer_content.rglob("*.dll")
             ):
                 if not is_signed(file):
                     not_signed.append(file)
@@ -82,7 +92,7 @@ if __name__ == "__main__":
                 raise SystemExit("Some file are not signed, aborting")
         # Generate installer
         print("### Building installer ###")
-        run(f"makensis { BASE_DIR / 'installer.nsi' }")
+        run(f"makensis { nsis_config }")
         # Sign installer
         print("### Signing installer ###")
         (installer,) = build_dir.glob("parsec-*-setup.exe")


### PR DESCRIPTION
Improve freeze_program.py/make_installer.py and NSIS scripts now that the output of freeze_program is generated on the CI, then fetched on a local machine to run make_installer.py

On top of that, wheel_it.py has been slightly modified so that freeze_program.py can be run with only the output of wheel_it.py (i.e. without the need for the program's sources)