### PR TITLE
Add `timeout` to action `setup-rust`

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           version: ${{ env.rust-version }}
           cache-key: test&build
+        timeout-minutes: 10
 
       - name: Build rust codebase
         run: |
@@ -61,6 +62,7 @@ jobs:
         with:
           version: ${{ env.rust-version }}
           cache-key: python
+        timeout-minutes: 10
 
       - name: Install poetry
         run: |

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           version: ${{ env.rust-version }}
           cache-key: test&build
+        timeout-minutes: 10
 
       # Pyo3 need additional configuration on MacOS to be manually build
       # see https://pyo3.rs/master/building_and_distribution.html#macos

--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -30,6 +30,7 @@ jobs:
           version: ${{ env.rust-version }}
           components: rustfmt, clippy
           cache-key: qa
+        timeout-minutes: 10
 
       - name: Debug installed tools
         run: |

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           version: ${{ env.rust-version }}
           cache-key: test&build
+        timeout-minutes: 10
 
       - name: Build rust codebase
         run: |


### PR DESCRIPTION
Add `timeout` to workflow that use `setup-rust`
Example of a workflow that timeout because of a [cache step](https://github.com/Scille/parsec-cloud/runs/7689754508?check_suite_focus=true#step:3:17)