### PR TITLE
Improve handling of HTTP `server` header in backend server

### DIFF
--- a/parsec/backend/asgi/__init__.py
+++ b/parsec/backend/asgi/__init__.py
@@ -1,18 +1,23 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 (eventually AGPL-3.0) 2016-present Scille SAS
 
-from typing import Type, Optional
+from typing import Type, Optional, List, Tuple
+from pathlib import Path
+import logging
+import trio
 from quart import (
     render_template,
-    Response,
     ResponseReturnValue,
     request,
     redirect as quart_redirect,
     ctx,
 )
 from quart_trio import QuartTrio
+from hypercorn.config import Config as HyperConfig
+from hypercorn.trio import serve
 
 from parsec import __version__ as parsec_version
 from parsec.backend.app import BackendApp
+from parsec.backend.config import BackendConfig
 from parsec.backend.asgi.administration import administration_bp
 from parsec.backend.asgi.redirect import redirect_bp
 from parsec.backend.asgi.rpc import rpc_bp
@@ -50,11 +55,6 @@ def app_factory(
     app.register_blueprint(rpc_bp)
     app.register_blueprint(ws_bp)
 
-    if backend.config.debug:
-        server_header = f"parsec/{parsec_version}"
-    else:
-        server_header = "parsec"
-
     # Do https redirection if incoming request doesn't follow forward proto rules
     if backend.config.forward_proto_enforce_https:
         header_key, header_expected_value = backend.config.forward_proto_enforce_https
@@ -68,11 +68,6 @@ def app_factory(
                     return quart_redirect(request.url.replace("http://", "https://", 1), code=301)
             return None
 
-    @app.after_request
-    def add_server_header(response: Response) -> Response:
-        response.headers["server"] = server_header
-        return response
-
     @app.route("/", methods=["GET"])
     async def root():
         return await render_template("index.html")
@@ -84,4 +79,63 @@ def app_factory(
     return app
 
 
-__all__ = ("app_factory",)
+def _patch_server_header(backend_config: BackendConfig, hyper_config: HyperConfig) -> None:
+    # By default, Hypercorn uses `hypercorn-h11` as `server` header.
+    # This cannot be customized but only disabled, so we have to rely on function
+    # patching to provide our own custom server header.
+
+    # Our shinny custom server header !
+    if backend_config.debug:
+        server_header_value = f"parsec/{parsec_version}"
+    else:
+        server_header_value = "parsec"
+    server_header_tuple = (b"server", server_header_value.encode("ascii"))
+
+    # Disable `response_headers()` from adding Hypercorn default server header...
+    hyper_config.include_server_header = False
+
+    # ...then patch `response_headers()` to add our custom server header
+    vanilla_response_headers = hyper_config.response_headers
+
+    def response_headers_with_parsec_server_header(protocol: str) -> List[Tuple[bytes, bytes]]:
+        headers = vanilla_response_headers(protocol)
+        headers.append(server_header_tuple)
+        return headers
+
+    hyper_config.response_headers = response_headers_with_parsec_server_header  # type: ignore[assignment]
+
+
+async def serve_backend_with_asgi(
+    backend: BackendApp,
+    host: str,
+    port: int,
+    ssl_certfile: Optional[Path] = None,
+    ssl_keyfile: Optional[Path] = None,
+    task_status=trio.TASK_STATUS_IGNORED,
+) -> None:
+    app = app_factory(backend)
+    # Note: Hypercorn comes with default values for incoming data size to
+    # avoid DoS abuse, so just trust them on that ;-)
+    hyper_config = HyperConfig.from_mapping(
+        {
+            "bind": [f"{host}:{port}"],
+            "accesslog": logging.getLogger("hypercorn.access"),
+            # Timestamp is added by the log processor configured in `parsec.logging`,
+            # here we configure peer address + req line + rep status + rep body size + time
+            # (e.g. "GET 88.0.12.52:54160 /foo 1.1 404 823o 12343ms")
+            "access_log_format": "%(h)s %(r)s %(s)s %(b)so %(D)sus",
+            "errorlog": logging.getLogger("hypercorn.error"),
+            "certfile": str(ssl_certfile) if ssl_certfile else None,
+            "keyfile": str(ssl_keyfile) if ssl_certfile else None,
+        }
+    )
+    _patch_server_header(backend.config, hyper_config=hyper_config)
+
+    await serve(app, hyper_config, task_status=task_status)
+
+    # `hypercorn.serve` catches KeyboardInterrupt and returns, so re-raise
+    # the keyboard interrupt to continue shutdown
+    raise KeyboardInterrupt
+
+
+__all__ = ("app_factory", "serve_backend_with_asgi")

--- a/parsec/backend/cli/run.py
+++ b/parsec/backend/cli/run.py
@@ -7,9 +7,6 @@ from typing import Optional, Tuple
 from functools import partial
 import tempfile
 from pathlib import Path
-from hypercorn.config import Config as HyperConfig
-from hypercorn.trio import serve
-import logging
 
 from parsec.utils import trio_run
 from parsec.cli_utils import (
@@ -19,8 +16,8 @@ from parsec.cli_utils import (
     debug_config_options,
 )
 from parsec.backend.cli.utils import db_backend_options, blockstore_backend_options
-from parsec.backend import backend_app_factory, BackendApp
-from parsec.backend.asgi import app_factory
+from parsec.backend import backend_app_factory
+from parsec.backend.asgi import serve_backend_with_asgi
 from parsec.backend.config import (
     BackendConfig,
     EmailConfig,
@@ -416,7 +413,7 @@ async def _run_backend(
                 retry_policy.success()
 
                 # Serve backend through TCP
-                await _serve_backend_with_asgi(
+                await serve_backend_with_asgi(
                     backend=backend,
                     host=host,
                     port=port,
@@ -433,32 +430,3 @@ async def _run_backend(
                 f"Database connection lost ({exc}), retrying in {retry_policy.pause_before_retry} seconds"
             )
             await retry_policy.pause()
-
-
-async def _serve_backend_with_asgi(
-    backend: BackendApp,
-    host: str,
-    port: int,
-    ssl_certfile: Optional[Path],
-    ssl_keyfile: Optional[Path],
-) -> None:
-    app = app_factory(backend)
-    # Note: Hypercorn comes with default values for incoming data size to
-    # avoid DoS abuse, so just trust them on that ;-)
-    hyper_config = HyperConfig.from_mapping(
-        {
-            "bind": [f"{host}:{port}"],
-            "accesslog": logging.getLogger("hypercorn.access"),
-            # Timestamp is added by the log processor configured in `parsec.logging`,
-            # here we configure peer address + req line + rep status + rep body size + time
-            # (e.g. "GET 88.0.12.52:54160 /foo 1.1 404 823o 12343ms")
-            "access_log_format": "%(h)s %(r)s %(s)s %(b)so %(D)sus",
-            "errorlog": logging.getLogger("hypercorn.error"),
-            "certfile": str(ssl_certfile) if ssl_certfile else None,
-            "keyfile": str(ssl_keyfile) if ssl_certfile else None,
-        }
-    )
-    await serve(app, hyper_config)
-    # `hypercorn.serve` catches KeyboardInterrupt and returns, so re-raise
-    # the keyboard interrupt to continue shutdown
-    raise KeyboardInterrupt


### PR DESCRIPTION
Currently, there is two server headers in the parsec server response:

```shell
$ curl --head http://127.0.0.1:6777/foo
HTTP/1.1 404 
content-type: text/html; charset=utf-8
content-length: 823
server: parsec/v2.11.0+dev
date: Tue, 09 Aug 2022 09:19:26 GMT
server: hypercorn-h11
```