### PR TITLE
Switch strategy for building the rust extension in build.py

### DIFF
--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -62,16 +62,6 @@ jobs:
           echo "::warning title=Wheel version::$VERSION"
           echo "::set-output name=version::$VERSION"
 
-        # For some reason, `ensurepip` in `build.py` does not work in this specific case
-        # (i.e building wheel using cibuildwheel on windows). Hence, we add `pip` to the
-        # build-system requires, so it is included in the build environment. The reason
-        # why this is not the general approach is because this fails on windows when doing
-        # a `poetry install` (since it installs the requirements using `pip install ...`
-        # instead of `python -m pip install ...`)
-      - name: (Windows) Include pip in the build dependencies
-        if: startsWith(matrix.os, 'windows-')
-        run: sed -i "s#pip; platform_system != 'Windows'#pip#" pyproject.toml
-
       - name: Build wheel
         uses: pypa/cibuildwheel@afb4329fe32181c15d34ef94bf64dad7715b44ba  # ping v2.8.1
         with:

--- a/build.py
+++ b/build.py
@@ -3,6 +3,9 @@
 import os
 import sys
 import subprocess
+import tempfile
+import zipfile
+import pathlib
 
 
 def display(line: str):
@@ -13,6 +16,7 @@ def display(line: str):
     print(f"{YELLOW_FG}{line}{DEFAULT_FG}", flush=True)
 
 
+BASEDIR = pathlib.Path(__file__).parent
 PYTHON_EXECUTABLE_PATH = sys.executable
 display(f"PYTHON_EXECUTABLE_PATH={PYTHON_EXECUTABLE_PATH}")
 
@@ -34,12 +38,34 @@ def force_maturin_release() -> bool:
 def build():
     run(f"{PYTHON_EXECUTABLE_PATH} --version")
     run(f"{PYTHON_EXECUTABLE_PATH} misc/generate_pyqt.py")
+
+    # Maturin provides two commands to compile the Rust code as a Python native module:
+    # - `maturin develop` that only compile the native module
+    # - `maturin build` that generates an entire wheel of the project
+    #
+    # Here in theory we'd like to use `maturin develop`, then leave poetry does the
+    # wheel generation. However the develop mode expects to be run from a virtualenv
+    # with pip available which makes it unreliable to call it from here.
+    # So we must ask maturin to build a wheel of the project, only to extract the
+    # native module and discard the rest !
+
     release = "--release" if in_cibuildwheel() or force_maturin_release() else ""
-    run(f"maturin build {release}")
-    if sys.platform == "win32":
-        run("unzip -o target/wheels/parsec-*.whl parsec/_parsec.pyd")
-    else:
-        run("unzip -o target/wheels/parsec-*.whl parsec/_parsec.abi3.so")
+    with tempfile.TemporaryDirectory() as distdir:
+        run(f"maturin build {release} --out {distdir}")
+
+        outputs = list(pathlib.Path(distdir).iterdir())
+        if len(outputs) != 1:
+            raise RuntimeError(f"Target dir unexpectedly contains multiple files: {outputs}")
+
+        wheel_path = outputs[0]
+        if sys.platform == "win32":
+            in_wheel_so_path = "parsec/_parsec.pyd"
+        else:
+            in_wheel_so_path = "parsec/_parsec.abi3.so"
+
+        display(f"extracting {wheel_path}:{in_wheel_so_path} -> {BASEDIR / in_wheel_so_path}")
+        with zipfile.ZipFile(wheel_path) as wheel:
+            wheel.extract(in_wheel_so_path, path=BASEDIR)
 
 
 if __name__ == "__main__":

--- a/build.py
+++ b/build.py
@@ -27,36 +27,19 @@ def in_cibuildwheel():
     return bool(int(os.environ.get("CIBUILDWHEEL", "0")))
 
 
-def check_venv():
-    # Both conda and venv are configured, pick conda
-    if os.environ.get("CONDA_PREFIX") and os.environ.get("VIRTUAL_ENV"):
-        del os.environ["VIRTUAL_ENV"]
-    # Build with cibuildwheel detected, set `VIRTUAL_ENV`
-    if in_cibuildwheel() and os.environ.get("VIRTUAL_ENV") is None:
-        os.environ["VIRTUAL_ENV"] = os.path.dirname(os.path.dirname(PYTHON_EXECUTABLE_PATH))
-        display(
-            f"Build with cibuildwheel detected, set `VIRTUAL_ENV` as: {os.environ['VIRTUAL_ENV']}"
-        )
-    if not os.environ.get("CONDA_PREFIX") and not os.environ.get("VIRTUAL_ENV"):
-        raise RuntimeError("A virtual env is required to run `maturin develop`")
-
-
 def force_maturin_release() -> bool:
     return os.environ.get("FORCE_MATURIN_RELEASE", "0") == "1"
 
 
 def build():
     run(f"{PYTHON_EXECUTABLE_PATH} --version")
-    run(f"{PYTHON_EXECUTABLE_PATH} -m ensurepip")
-    run(f"{PYTHON_EXECUTABLE_PATH} -m pip freeze")
     run(f"{PYTHON_EXECUTABLE_PATH} misc/generate_pyqt.py")
-    check_venv()
     release = "--release" if in_cibuildwheel() or force_maturin_release() else ""
-    run(f"maturin develop {release}")
-    # An alternative to `maturin develop` is:
-    # run("maturin build -r")
-    # run("unzip -o target/wheels/parsec-*.whl parsec/_parsec.abi3.so")
-    # Note that it does not require a virtualenv, as opposed to `develop`
+    run(f"maturin build {release}")
+    if sys.platform == "win32":
+        run("unzip -o target/wheels/parsec-*.whl parsec/_parsec.pyd")
+    else:
+        run("unzip -o target/wheels/parsec-*.whl parsec/_parsec.abi3.so")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,10 +175,5 @@ requires = [
     "PyQt5~=5.15",
     "Babel~=2.10",
     "docutils~=0.17",
-    # We need pip to be installed because `maturin` requires it.
-    # We don't fix a version, because we don't want to force the installation of pip
-    # Because we could get the following error: `ERROR: To modify pip, please run the following command: [...]`
-    # When doing the command `pip install pip`
-    "pip; platform_system != 'Windows'"
 ]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
A proposal to switch the strategy for building the rust extension in build.py

This approach does not require pip nor a virtualenv, which makes it much more robust.

This is especially useful for fixing the CI in parsec-extensions: https://github.com/Scille/parsec-extensions/commit/1450b88f1587f407c85583e01bbc0c81ae33f38b