### PR TITLE
Renamed BlockStoreComponent arguments

### DIFF
--- a/parsec/backend/blockstore.py
+++ b/parsec/backend/blockstore.py
@@ -40,14 +40,16 @@ class BaseBlockStoreComponent:
     (and not only the ones that failed the first time)
     """
 
-    async def read(self, organization_id: OrganizationID, id: BlockID) -> bytes:
+    async def read(self, organization_id: OrganizationID, block_id: BlockID) -> bytes:
         """
         Raises:
             BlockStoreError
         """
         raise NotImplementedError()
 
-    async def create(self, organization_id: OrganizationID, id: BlockID, block: bytes) -> None:
+    async def create(
+        self, organization_id: OrganizationID, block_id: BlockID, block: bytes
+    ) -> None:
         """
         Raises:
             BlockStoreError

--- a/parsec/backend/postgresql/block.py
+++ b/parsec/backend/postgresql/block.py
@@ -238,22 +238,24 @@ class PGBlockStoreComponent(BaseBlockStoreComponent):
     def __init__(self, dbh: PGHandler):
         self.dbh = dbh
 
-    async def read(self, organization_id: OrganizationID, id: BlockID) -> bytes:
+    async def read(self, organization_id: OrganizationID, block_id: BlockID) -> bytes:
         async with self.dbh.pool.acquire() as conn:
             ret = await conn.fetchrow(
-                *_q_get_block_data(organization_id=organization_id.str, block_id=id.uuid)
+                *_q_get_block_data(organization_id=organization_id.str, block_id=block_id.uuid)
             )
             if not ret:
                 raise BlockStoreError("Block not found")
 
             return ret[0]
 
-    async def create(self, organization_id: OrganizationID, id: BlockID, block: bytes) -> None:
+    async def create(
+        self, organization_id: OrganizationID, block_id: BlockID, block: bytes
+    ) -> None:
         async with self.dbh.pool.acquire() as conn:
             try:
                 ret = await conn.execute(
                     *_q_insert_block_data(
-                        organization_id=organization_id.str, block_id=id.uuid, data=block
+                        organization_id=organization_id.str, block_id=block_id.uuid, data=block
                     )
                 )
                 if ret != "INSERT 0 1":

--- a/parsec/backend/postgresql/sequester_export.py
+++ b/parsec/backend/postgresql/sequester_export.py
@@ -514,7 +514,7 @@ LIMIT $4
             cooked_rows = []
             for row in rows:
                 block = await self.input_blockstore.read(
-                    organization_id=self.organization_id, id=BlockID(row["block_id"])
+                    organization_id=self.organization_id, block_id=BlockID(row["block_id"])
                 )
                 cooked_rows.append(
                     (

--- a/parsec/backend/raid0_blockstore.py
+++ b/parsec/backend/raid0_blockstore.py
@@ -11,13 +11,15 @@ class RAID0BlockStoreComponent(BaseBlockStoreComponent):
     def __init__(self, blockstores: List[BaseBlockStoreComponent]):
         self.blockstores = blockstores
 
-    def _get_blockstore(self, id: UUID) -> BaseBlockStoreComponent:
-        return self.blockstores[id.int % len(self.blockstores)]
+    def _get_blockstore(self, block_id: UUID) -> BaseBlockStoreComponent:
+        return self.blockstores[block_id.int % len(self.blockstores)]
 
-    async def read(self, organization_id: OrganizationID, id: BlockID) -> bytes:
-        blockstore = self._get_blockstore(id.uuid)
-        return await blockstore.read(organization_id, id)
+    async def read(self, organization_id: OrganizationID, block_id: BlockID) -> bytes:
+        blockstore = self._get_blockstore(block_id.uuid)
+        return await blockstore.read(organization_id, block_id)
 
-    async def create(self, organization_id: OrganizationID, id: BlockID, block: bytes) -> None:
-        blockstore = self._get_blockstore(id.uuid)
-        await blockstore.create(organization_id, id, block)
+    async def create(
+        self, organization_id: OrganizationID, block_id: BlockID, block: bytes
+    ) -> None:
+        blockstore = self._get_blockstore(block_id.uuid)
+        await blockstore.create(organization_id, block_id, block)

--- a/parsec/backend/swift_blockstore.py
+++ b/parsec/backend/swift_blockstore.py
@@ -46,8 +46,8 @@ class SwiftBlockStoreComponent(BaseBlockStoreComponent):
         self.swift_client.head_container(container)
         self._logger = logger.bind(blockstore_type="Swift", authurl=auth_url)
 
-    async def read(self, organization_id: OrganizationID, id: BlockID) -> bytes:
-        slug = build_swift_slug(organization_id=organization_id, id=id)
+    async def read(self, organization_id: OrganizationID, block_id: BlockID) -> bytes:
+        slug = build_swift_slug(organization_id=organization_id, id=block_id)
         try:
             _, obj = await trio.to_thread.run_sync(
                 self.swift_client.get_object, self._container, slug
@@ -57,15 +57,17 @@ class SwiftBlockStoreComponent(BaseBlockStoreComponent):
             self._logger.warning(
                 "Block read error",
                 organization_id=str(organization_id),
-                block_id=str(id),
+                block_id=str(block_id),
                 exc_info=exc,
             )
             raise BlockStoreError(exc) from exc
 
         return obj
 
-    async def create(self, organization_id: OrganizationID, id: BlockID, block: bytes) -> None:
-        slug = build_swift_slug(organization_id=organization_id, id=id)
+    async def create(
+        self, organization_id: OrganizationID, block_id: BlockID, block: bytes
+    ) -> None:
+        slug = build_swift_slug(organization_id=organization_id, id=block_id)
         try:
             await trio.to_thread.run_sync(
                 partial(self.swift_client.put_object, self._container, slug, block)
@@ -75,7 +77,7 @@ class SwiftBlockStoreComponent(BaseBlockStoreComponent):
             self._logger.warning(
                 "Block create error",
                 organization_id=str(organization_id),
-                block_id=str(id),
+                block_id=str(block_id),
                 exc_info=exc,
             )
             raise BlockStoreError(exc) from exc


### PR DESCRIPTION
`MemoryBlockStoreComponent` argument was named `block_id`, but in all other `BlockStoreComponents`, this argument was just named `id`. This caused a problem if you wanted to used named arguments on an abstract `BaseBlockStoreComponent`, ie `blockstore.read(organization_id=org_id, id=block_id)` would fail with `MemoryBlockStoreComponent` but succeed with others.

Since `block_id` is a better name, `id` arguments were renamed to `block_id`.