### PR TITLE
Remove lonely prs from the script creating tasks in triage

### DIFF
--- a/.github/scripts/notary/lib.sh
+++ b/.github/scripts/notary/lib.sh
@@ -57,7 +57,8 @@ function add_item_to_project() {
     gh api graphql \
         -f project="$project_id" \
         -f item="$item_id" \
-        -f query="$(<$QUERY_FILE)" | cat
+        -f query="$(<$QUERY_FILE)" \
+        --jq .data.addProjectV2ItemById.item | cat
 }
 
 # Get project status field id with the desired field value id

--- a/.github/scripts/notary/script.sh
+++ b/.github/scripts/notary/script.sh
@@ -10,9 +10,12 @@ PROJECT_ORGA=${1}
 PROJECT_NUMBER=${2}
 
 set -o pipefail
+echo "Debug tool version"
+set -x
 gh --version
 jq --version
 base64 --version
+set +x
 
 echo -n '' > issues_wrong_project.json
 

--- a/.github/scripts/notary/script.sh
+++ b/.github/scripts/notary/script.sh
@@ -17,6 +17,7 @@ jq --version
 base64 --version
 set +x
 
+echo "Looking for issues that are assigned to the wrong project."
 echo -n '' > issues_wrong_project.json
 
 for type in issue; do

--- a/.github/scripts/notary/script.sh
+++ b/.github/scripts/notary/script.sh
@@ -26,6 +26,11 @@ done
 
 jq -r '. | @base64' issues_wrong_project.json > issues_wrong_project.json.b64
 
+ISSUES_TO_ADD=$(wc -l issues_wrong_project.json.b64 | cut -f 1 -d ' ')
+if [ $ISSUES_TO_ADD -eq 0 ]; then
+    echo "No issues to add !"
+    exit 0
+fi
 
 PROJECT_DATA=$(get_project_v2 $PROJECT_ORGA $PROJECT_NUMBER)
 PROJECT_ID=$(jq -r .id <<<"$PROJECT_DATA")

--- a/.github/scripts/notary/script.sh
+++ b/.github/scripts/notary/script.sh
@@ -45,8 +45,9 @@ for raw_row in $(<issues_wrong_project.json.b64); do
     TITLE=$(jq -r .title <<<"$row")
     TYPE=$(jq -r .type <<<"$row")
 
-    echo "Adding $TYPE \"$TITLE\" to project $PROJECT_TITLE"
+    echo -n "Adding $TYPE \"$TITLE\" to project $PROJECT_TITLE > "
     add_item_to_project $PROJECT_ID $ID
+    echo
     RC=$?
     if [ $RC -ne 0 ]; then
         echo "Failed to add $TYPE \"$TITLE\" to project $PROJECT_TITLE" >&2

--- a/.github/scripts/notary/script.sh
+++ b/.github/scripts/notary/script.sh
@@ -16,7 +16,7 @@ base64 --version
 
 echo -n '' > issues_wrong_project.json
 
-for type in issue pr; do
+for type in issue; do
     gh $type list \
         --json id,title,number \
         --search "-project:\"$PROJECT_ORGA/$PROJECT_NUMBER\"" \


### PR DESCRIPTION
- Don't look for PR to add to the project
- Improve script output
  - Inform you when it start looking for issues to add.
  - Inform you when it have no issues to add to the project.
  