### PR TITLE
Parametrize snap test job with ubuntu 18, 20 and 22

### DIFF
--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -136,9 +136,13 @@ jobs:
           path: ${{ runner.temp }}/parsec*.snap
 
   package-linux-test-snap:
-    name: '🐧 Linux: 📦 Packaging (test Snap)'
+    name: '🐧 Linux: 📦 Packaging (test Snap on ${{ matrix.os }})'
     needs: package-linux-build-snap
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
     steps:
       - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin v3.0.0
         with:


### PR DESCRIPTION
Might detect issue like #2900 earlier.