### PR TITLE
Remove `restore-keys` in actions `setup-rust`

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -46,7 +46,6 @@ runs:
       uses: actions/cache@c3f1317a9e7b1ef106c153ac8c0f00fed3ddbc0d # pin v3.0.4
       with:
         key: ${{ runner.os }}-rust-${{ inputs.version }}-${{ inputs.cache-key }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: ${{ runner.os }}-rust-${{ inputs.version }}-${{ inputs.cache-key }}
         path: |
           target
           ~/.cargo/bin


### PR DESCRIPTION
Removing the `restore-keys` entry will force the `actions/cache` to use
a clear cache every-time the `key` change at the cost of longer first
time run (i.e.: the first run when the key have change, the next runs
aren't affected).