### PR TITLE
Access log enhancement

### DIFF
--- a/newsfragments/2953.feature.rst
+++ b/newsfragments/2953.feature.rst
@@ -1,0 +1,1 @@
+Extended Logger to show device id when a client is authenticated

--- a/newsfragments/2953.feature.rst
+++ b/newsfragments/2953.feature.rst
@@ -1,1 +1,0 @@
-Extended Logger to show device id when a client is authenticated

--- a/parsec/backend/asgi/__init__.py
+++ b/parsec/backend/asgi/__init__.py
@@ -17,6 +17,7 @@ from hypercorn.trio import serve
 
 from parsec import __version__ as parsec_version
 from parsec.backend.app import BackendApp
+from parsec.backend.asgi.logger import ParsecLogger
 from parsec.backend.config import BackendConfig
 from parsec.backend.asgi.administration import administration_bp
 from parsec.backend.asgi.redirect import redirect_bp
@@ -45,7 +46,10 @@ def app_factory(
     backend: BackendApp, app_cls: Type[BackendQuartTrio] = BackendQuartTrio
 ) -> BackendQuartTrio:
     app = app_cls(
-        __name__, static_folder="../static", static_url_path="/static", template_folder="templates"
+        __name__,
+        static_folder="../static",
+        static_url_path="/static",
+        template_folder="templates",
     )
     app.config["MAX_CONTENT_LENGTH"] = MAX_CONTENT_LENGTH
     app.jinja_options = JINJA_ENV_CONFIG  # Overload config
@@ -97,7 +101,9 @@ def _patch_server_header(backend_config: BackendConfig, hyper_config: HyperConfi
     # ...then patch `response_headers()` to add our custom server header
     vanilla_response_headers = hyper_config.response_headers
 
-    def response_headers_with_parsec_server_header(protocol: str) -> List[Tuple[bytes, bytes]]:
+    def response_headers_with_parsec_server_header(
+        protocol: str,
+    ) -> List[Tuple[bytes, bytes]]:
         headers = vanilla_response_headers(protocol)
         headers.append(server_header_tuple)
         return headers
@@ -123,7 +129,8 @@ async def serve_backend_with_asgi(
             # Timestamp is added by the log processor configured in `parsec.logging`,
             # here we configure peer address + req line + rep status + rep body size + time
             # (e.g. "GET 88.0.12.52:54160 /foo 1.1 404 823o 12343ms")
-            "access_log_format": "%(h)s %(r)s %(s)s %(b)so %(D)sus",
+            "logger_class": ParsecLogger,
+            "access_log_format": "%(h)s %(r)s %(s)s %(b)so %(D)sus (author: %(author)s)",
             "errorlog": logging.getLogger("hypercorn.error"),
             "certfile": str(ssl_certfile) if ssl_certfile else None,
             "keyfile": str(ssl_keyfile) if ssl_certfile else None,

--- a/parsec/backend/asgi/__init__.py
+++ b/parsec/backend/asgi/__init__.py
@@ -130,7 +130,7 @@ async def serve_backend_with_asgi(
             # here we configure peer address + req line + rep status + rep body size + time
             # (e.g. "GET 88.0.12.52:54160 /foo 1.1 404 823o 12343ms")
             "logger_class": ParsecLogger,
-            "access_log_format": "%(h)s %(r)s %(s)s %(b)so %(D)sus (author: %(author)s)",
+            "access_log_format": "%(h)s %(r)s %(s)s %(b)so %(D)sus %(author)s",
             "errorlog": logging.getLogger("hypercorn.error"),
             "certfile": str(ssl_certfile) if ssl_certfile else None,
             "keyfile": str(ssl_keyfile) if ssl_certfile else None,

--- a/parsec/backend/asgi/logger.py
+++ b/parsec/backend/asgi/logger.py
@@ -33,7 +33,7 @@ class ParsecLogger(Logger):
     def _find_author_header(self, headers: Iterable[Tuple[bytes, bytes]]) -> Optional[bytes]:
         for (name, value) in headers:
             # latin1 (ISO-8859-1) is standard http charset
-            if name.decode("latin1").lower() == "author":
+            if name.decode("latin1") == "Author":
                 return value
 
         return None

--- a/parsec/backend/asgi/logger.py
+++ b/parsec/backend/asgi/logger.py
@@ -39,11 +39,13 @@ class ParsecLogger(Logger):
         return None
 
     def _try_decode_base64(self, value: Union[bytes, None]) -> Optional[str]:
+        DEFAULT_MESSAGE = "anonymous or invalid"
         if value is None:
-            return "anonymous or invalid"
+            return DEFAULT_MESSAGE
 
         try:
             return base64.b64decode(value.decode(), validate=True).decode()
-        except binascii.Error as e:
-            print(e)
-            return None
+        except binascii.Error:
+            return DEFAULT_MESSAGE
+        except UnicodeDecodeError:
+            return DEFAULT_MESSAGE

--- a/parsec/backend/asgi/logger.py
+++ b/parsec/backend/asgi/logger.py
@@ -1,0 +1,49 @@
+# Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 (eventually AGPL-3.0) 2016-present Scille SAS
+
+from hypercorn.logging import Logger, AccessLogAtoms
+from typing import TYPE_CHECKING, Mapping, Iterable, Optional, Tuple, Union
+
+import base64
+import binascii
+
+if TYPE_CHECKING:
+    from hypercorn.config import Config
+    from hypercorn.typing import ResponseSummary, WWWScope
+
+
+class ParsecLogger(Logger):
+    def __init__(self, config: "Config") -> None:
+        super().__init__(config)
+
+    def atoms(
+        self, request: "WWWScope", response: "ResponseSummary", request_time: float
+    ) -> Mapping[str, str]:
+        """Create and return an access log atoms dictionary.
+        This can be overidden and customised if desired. It should
+        return a mapping between an access log format key and a value.
+        """
+        access_log = AccessLogAtoms(request, response, request_time)
+        id_value = self._find_author_header(request["headers"])
+
+        id = self._try_decode_base64(id_value)
+        access_log[b"Author".decode("latin1").lower()] = id
+
+        return access_log
+
+    def _find_author_header(self, headers: Iterable[Tuple[bytes, bytes]]) -> Optional[bytes]:
+        for (name, value) in headers:
+            # latin1 (ISO-8859-1) is standard http charset
+            if name.decode("latin1").lower() == "author":
+                return value
+
+        return None
+
+    def _try_decode_base64(self, value: Union[bytes, None]) -> Optional[str]:
+        if value is None:
+            return "anonymous or invalid"
+
+        try:
+            return base64.b64decode(value.decode(), validate=True).decode()
+        except binascii.Error as e:
+            print(e)
+            return None

--- a/parsec/backend/asgi/logger.py
+++ b/parsec/backend/asgi/logger.py
@@ -1,20 +1,16 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 (eventually AGPL-3.0) 2016-present Scille SAS
 
 from hypercorn.logging import Logger, AccessLogAtoms
-from typing import TYPE_CHECKING, Mapping, Iterable, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Mapping, Optional
 
 import base64
 import binascii
 
 if TYPE_CHECKING:
-    from hypercorn.config import Config
     from hypercorn.typing import ResponseSummary, WWWScope
 
 
 class ParsecLogger(Logger):
-    def __init__(self, config: "Config") -> None:
-        super().__init__(config)
-
     def atoms(
         self, request: "WWWScope", response: "ResponseSummary", request_time: float
     ) -> Mapping[str, str]:
@@ -23,29 +19,15 @@ class ParsecLogger(Logger):
         return a mapping between an access log format key and a value.
         """
         access_log = AccessLogAtoms(request, response, request_time)
-        id_value = self._find_author_header(request["headers"])
-
-        id = self._try_decode_base64(id_value)
-        access_log[b"Author".decode("latin1").lower()] = id
+        if "{author}i" in access_log:
+            decoded = self._try_decode_base64(access_log["{author}i"])
+            if decoded:
+                access_log["author"] = decoded
 
         return access_log
 
-    def _find_author_header(self, headers: Iterable[Tuple[bytes, bytes]]) -> Optional[bytes]:
-        for (name, value) in headers:
-            # latin1 (ISO-8859-1) is standard http charset
-            if name.decode("latin1") == "Author":
-                return value
-
-        return None
-
-    def _try_decode_base64(self, value: Union[bytes, None]) -> Optional[str]:
-        DEFAULT_MESSAGE = "anonymous or invalid"
-        if value is None:
-            return DEFAULT_MESSAGE
-
+    def _try_decode_base64(self, value: str) -> Optional[str]:
         try:
-            return base64.b64decode(value.decode(), validate=True).decode()
-        except binascii.Error:
-            return DEFAULT_MESSAGE
-        except UnicodeDecodeError:
-            return DEFAULT_MESSAGE
+            return base64.b64decode(value, validate=True).decode()
+        except (binascii.Error, UnicodeDecodeError):
+            return None

--- a/parsec/backend/ping.py
+++ b/parsec/backend/ping.py
@@ -17,7 +17,11 @@ from parsec.backend.utils import catch_protocol_errors, api, ClientType
 class BasePingComponent:
     @api(
         "ping",
-        client_types=[ClientType.AUTHENTICATED, ClientType.INVITED],
+        client_types=[
+            ClientType.AUTHENTICATED,
+            ClientType.INVITED,
+            ClientType.APIV1_ANONYMOUS,
+        ],
     )
     @catch_protocol_errors
     @api_typed_msg_adapter(

--- a/tests/backend/test_logger.py
+++ b/tests/backend/test_logger.py
@@ -1,6 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
 
-from typing import Mapping
+from typing import Mapping, Optional
 from hypercorn.config import Config as HyperConfig
 
 import base64
@@ -10,14 +10,14 @@ from hypercorn.typing import ResponseSummary, HTTPScope
 from parsec.backend.asgi.logger import ParsecLogger
 
 
-def _create_http_scope(author: bytes = bytes(), add_author: bool = True) -> HTTPScope:
+def _create_http_scope(author: Optional[bytes] = None) -> HTTPScope:
     scope = HTTPScope()
     scope["type"] = "http"
     scope["method"] = "GET"
     scope["query_string"] = b"/"
     scope["path"] = ""
     scope["scheme"] = ""
-    scope["headers"] = [(b"Author", author)] if add_author else []
+    scope["headers"] = [(b"Author", author)] if author is not None else []
 
     return scope
 
@@ -60,6 +60,6 @@ def test_bad_base64_author():
 
 def test_no_author_header():
     logger = ParsecLogger(HyperConfig())
-    mapped = logger.atoms(_create_http_scope(add_author=False), _create_empty_response(), 0.0)
+    mapped = logger.atoms(_create_http_scope(), _create_empty_response(), 0.0)
 
     _assert_anonymous_or_invalid(mapped)

--- a/tests/backend/test_logger.py
+++ b/tests/backend/test_logger.py
@@ -1,10 +1,8 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
 
-from typing import Mapping, Optional
-from hypercorn.config import Config as HyperConfig
-
+from typing import Optional
 import base64
-
+from hypercorn.config import Config as HyperConfig
 from hypercorn.typing import ResponseSummary, HTTPScope
 
 from parsec.backend.asgi.logger import ParsecLogger
@@ -28,11 +26,6 @@ def _create_empty_response() -> ResponseSummary:
     return resp
 
 
-def _assert_anonymous_or_invalid(mapped: Mapping[str, str]):
-    assert "author" in mapped
-    assert mapped["author"] == "anonymous or invalid"
-
-
 def test_base64_author():
     logger = ParsecLogger(HyperConfig())
 
@@ -44,22 +37,17 @@ def test_base64_author():
 
 
 def test_bad_base64_author():
-    import secrets
-
     logger = ParsecLogger(HyperConfig())
 
-    # We use a sequence of 10 random bytes to simulate a bad base64 encoded author name
-    author_bytes = secrets.token_bytes(10)
+    # Invalid base64 sequence
+    author_bytes = b"<dummy>"
     mapped = logger.atoms(_create_http_scope(author_bytes), _create_empty_response(), 0.0)
 
-    _assert_anonymous_or_invalid(mapped)
-
-    assert "author" in mapped
-    assert mapped["author"] == "anonymous or invalid"
+    assert "author" not in mapped
 
 
 def test_no_author_header():
     logger = ParsecLogger(HyperConfig())
     mapped = logger.atoms(_create_http_scope(), _create_empty_response(), 0.0)
 
-    _assert_anonymous_or_invalid(mapped)
+    assert "author" not in mapped

--- a/tests/backend/test_logger.py
+++ b/tests/backend/test_logger.py
@@ -1,0 +1,65 @@
+# Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
+
+from typing import Mapping
+from hypercorn.config import Config as HyperConfig
+
+import base64
+
+from hypercorn.typing import ResponseSummary, HTTPScope
+
+from parsec.backend.asgi.logger import ParsecLogger
+
+
+def _create_http_scope(author: bytes = bytes(), add_author: bool = True) -> HTTPScope:
+    scope = HTTPScope()
+    scope["type"] = "http"
+    scope["method"] = "GET"
+    scope["query_string"] = b"/"
+    scope["path"] = ""
+    scope["scheme"] = ""
+    scope["headers"] = [(b"Author", author)] if add_author else []
+
+    return scope
+
+
+def _create_empty_response() -> ResponseSummary:
+    resp = ResponseSummary()
+    resp["status"] = 200
+    return resp
+
+
+def _assert_anonymous_or_invalid(mapped: Mapping[str, str]):
+    assert "author" in mapped
+    assert mapped["author"] == "anonymous or invalid"
+
+
+def test_base64_author():
+    logger = ParsecLogger(HyperConfig())
+
+    author_bytes = base64.b64encode(b"alice@work")
+    mapped = logger.atoms(_create_http_scope(author_bytes), _create_empty_response(), 0.0)
+
+    assert "author" in mapped
+    assert mapped["author"] == "alice@work"
+
+
+def test_bad_base64_author():
+    import secrets
+
+    logger = ParsecLogger(HyperConfig())
+
+    # We use a sequence of 10 random bytes to simulate a bad base64 encoded author name
+    author_bytes = secrets.token_bytes(10)
+    mapped = logger.atoms(_create_http_scope(author_bytes), _create_empty_response(), 0.0)
+
+    _assert_anonymous_or_invalid(mapped)
+
+    assert "author" in mapped
+    assert mapped["author"] == "anonymous or invalid"
+
+
+def test_no_author_header():
+    logger = ParsecLogger(HyperConfig())
+    mapped = logger.atoms(_create_http_scope(add_author=False), _create_empty_response(), 0.0)
+
+    _assert_anonymous_or_invalid(mapped)

--- a/tests/common/backend.py
+++ b/tests/common/backend.py
@@ -23,7 +23,11 @@ from parsec.core.types import BackendAddr, LocalDevice
 from parsec.backend.app import BackendApp
 from parsec.backend import backend_app_factory
 from parsec.backend.asgi import app_factory
-from parsec.backend.config import BackendConfig, MockedEmailConfig, MockedBlockStoreConfig
+from parsec.backend.config import (
+    BackendConfig,
+    MockedEmailConfig,
+    MockedBlockStoreConfig,
+)
 
 from tests.common.freeze_time import freeze_time
 from tests.common.trio_clock import real_clock_timeout
@@ -85,7 +89,11 @@ async def server_factory(handle_client: Callable):
 
         listeners = await nursery.start(
             partial(
-                trio.serve_tcp, handle_client, port=0, host="127.0.0.1", handler_nursery=nursery
+                trio.serve_tcp,
+                handle_client,
+                port=0,
+                host="127.0.0.1",
+                handler_nursery=nursery,
             )
         )
         yield listeners[0].socket.getsockname()[1]


### PR DESCRIPTION
As mentioned in [issue 2953](https://github.com/Scille/parsec-cloud/issues/2953) it's better to have device id in logs when users are logged in.
This PR adds a custom implementation over the default Hypercorn `access logger`. A custom logger is required as the device id is base64 encoded in the HTTP author header.