### PR TITLE
Added `unverified_load()` to load remote manifests

### DIFF
--- a/oxidation/libparsec/crates/types/src/manifest.rs
+++ b/oxidation/libparsec/crates/types/src/manifest.rs
@@ -590,4 +590,16 @@ impl Manifest {
         }
         Ok(obj)
     }
+
+    pub fn unverified_load(data: &[u8]) -> Result<Self, DataError> {
+        let compressed = VerifyKey::unsecure_unwrap(data).unwrap();
+
+        let mut deserialized = Vec::new();
+
+        ZlibDecoder::new(compressed)
+            .read_to_end(&mut deserialized)
+            .map_err(|_| DataError::Compression)?;
+
+        Ok(rmp_serde::from_slice(&deserialized).unwrap())
+    }
 }

--- a/oxidation/libparsec/crates/types/src/manifest.rs
+++ b/oxidation/libparsec/crates/types/src/manifest.rs
@@ -558,14 +558,8 @@ impl Manifest {
         expected_version: Option<u32>,
     ) -> Result<Self, DataError> {
         let compressed = author_verify_key.verify(signed)?;
-        let mut deserialized = Vec::new();
 
-        ZlibDecoder::new(&compressed[..])
-            .read_to_end(&mut deserialized)
-            .map_err(|_| DataError::Compression)?;
-
-        let obj: Self =
-            rmp_serde::from_slice(&deserialized).map_err(|_| DataError::Serialization)?;
+        let obj = Manifest::deserialize_data(&compressed)?;
 
         macro_rules! internal_verify {
             ($obj:ident) => {{
@@ -591,15 +585,22 @@ impl Manifest {
         Ok(obj)
     }
 
+    /// Load the manifest without checking the signature header.
     pub fn unverified_load(data: &[u8]) -> Result<Self, DataError> {
         let compressed = VerifyKey::unsecure_unwrap(data).unwrap();
 
+        Manifest::deserialize_data(compressed)
+    }
+
+    fn deserialize_data(data: &[u8]) -> Result<Self, DataError> {
         let mut deserialized = Vec::new();
 
-        ZlibDecoder::new(compressed)
+        ZlibDecoder::new(data)
             .read_to_end(&mut deserialized)
             .map_err(|_| DataError::Compression)?;
 
-        Ok(rmp_serde::from_slice(&deserialized).unwrap())
+        Ok(rmp_serde::from_slice(&deserialized)
+            .map_err(|_| DataError::Serialization)
+            .unwrap())
     }
 }

--- a/oxidation/libparsec/crates/types/tests/test_manifest.rs
+++ b/oxidation/libparsec/crates/types/tests/test_manifest.rs
@@ -513,3 +513,51 @@ fn test_file_manifest_verify(
         expected_result
     );
 }
+
+#[rstest]
+fn file_manifest_unverified_load() {
+    // Test the unverified_load() function on a file manifest.
+    // File manifest has been generated with Parsec 1.12, it is provided raw as it is a bit hard
+    // to generate (would need to create keys and all that). We're only interested in the
+    // deserialization of raw unciphered data to a FileManifest.
+
+    let serialized_manifest = hex!(
+        "af080459a4924e3934f2cfcbe90ce658ef42954f2abe9dab2524a417bfd833959a9c4de3c9abe34
+        c1447152be9398944b6a1c4dca7609ce47e0782f881a1c209789c015d01a2fe8ba474797065ad666
+        96c655f6d616e6966657374a6617574686f72d941623365306562343134623063343466316239363
+        33337373232633135366563364030613239373331356163366634633766613538333962303031633
+        93530623233a974696d657374616d70d70141d8c7d36e7af26fa26964d80269f15a0d48c040bf884
+        a5d41eb8b528fa6706172656e74d80224a5fac2b57a4be2b88550e077ee524ca776657273696f6e0
+        1a763726561746564d70141d8c7bcaada06eaa775706461746564d70141d8c7bcaadb9e3da473697
+        a6505a9626c6f636b73697a65ce00080000a6626c6f636b739185a26964d802e53a7750ed014b67b
+        c7683abb0801d95a36b6579c4205c0ab829952db2b6f9d2a8dfcbaafa356290e6b0555a0ca8804b4
+        a665f86cb00a66f666673657400a473697a6505a6646967657374c420f2ca1bb6c7e907d06dafe46
+        87e579fce76b37e4e93b7605022da52e6ccc26fd2e5299be8"
+    );
+
+    let manifest = Manifest::unverified_load(&serialized_manifest).unwrap();
+
+    let file_manifest = match manifest {
+        Manifest::File(fm) => fm,
+        _ => panic!("Should be a file manifest"),
+    };
+
+    assert_eq!(
+        file_manifest.author,
+        DeviceID {
+            user_id: UserID::from_str("b3e0eb414b0c44f1b96337722c156ec6").unwrap(),
+            device_name: DeviceName::from_str("0a297315ac6f4c7fa5839b001c950b23").unwrap()
+        }
+    );
+    assert_eq!(
+        file_manifest.id,
+        EntryID::from_str("69f15a0d48c040bf884a5d41eb8b528f").unwrap()
+    );
+    assert_eq!(
+        file_manifest.parent,
+        EntryID::from_str("24a5fac2b57a4be2b88550e077ee524c").unwrap()
+    );
+    assert_eq!(file_manifest.version, 1);
+    assert_eq!(file_manifest.size, 5);
+    assert_eq!(file_manifest.blocks.len(), 1);
+}

--- a/parsec/_parsec.pyi
+++ b/parsec/_parsec.pyi
@@ -72,6 +72,7 @@ from parsec._parsec_pyi.manifest import (
     manifest_decrypt_and_load,
     manifest_decrypt_verify_and_load,
     manifest_verify_and_load,
+    manifest_unverified_load,
 )
 
 from parsec._parsec_pyi.time import (
@@ -338,6 +339,7 @@ __all__ = [
     "manifest_decrypt_and_load",
     "manifest_decrypt_verify_and_load",
     "manifest_verify_and_load",
+    "manifest_unverified_load",
     # Time
     "DateTime",
     "LocalDateTime",

--- a/parsec/_parsec_pyi/manifest.pyi
+++ b/parsec/_parsec_pyi/manifest.pyi
@@ -292,3 +292,6 @@ def manifest_verify_and_load(
     expected_id: Optional[EntryID] = None,
     expected_version: Optional[int] = None,
 ) -> AnyRemoteManifest: ...
+def manifest_unverified_load(
+    data: bytes,
+) -> AnyRemoteManifest: ...

--- a/parsec/api/data/manifest.py
+++ b/parsec/api/data/manifest.py
@@ -14,6 +14,7 @@ from parsec._parsec import (
     manifest_decrypt_and_load,
     manifest_verify_and_load,
     manifest_decrypt_verify_and_load,
+    manifest_unverified_load,
 )
 
 if TYPE_CHECKING:
@@ -36,6 +37,7 @@ __all__ = [
     "manifest_decrypt_and_load",
     "manifest_decrypt_verify_and_load",
     "manifest_verify_and_load",
+    "manifest_unverified_load",
 ]
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ fn entrypoint(_py: Python, m: &PyModule) -> PyResult<()> {
         m
     )?)?;
     m.add_function(wrap_pyfunction!(manifest::manifest_verify_and_load, m)?)?;
+    m.add_function(wrap_pyfunction!(manifest::manifest_unverified_load, m)?)?;
 
     // Block
     m.add_class::<protocol::BlockCreateReq>()?;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1189,6 +1189,16 @@ pub(crate) fn manifest_verify_and_load<'py>(
     unwrap_manifest(py, blob)
 }
 
+#[pyfunction]
+pub(crate) fn manifest_unverified_load(py: Python, data: &[u8]) -> PyResult<PyObject> {
+    let blob = match Manifest::unverified_load(data) {
+        Ok(value) => value,
+        Err(err) => return Err(DataError::new_err(err.to_string())),
+    };
+
+    unwrap_manifest(py, blob)
+}
+
 fn unwrap_manifest(py: Python, manifest: Manifest) -> PyResult<PyObject> {
     match manifest {
         Manifest::File(file) => Ok(FileManifest(file).into_py(py)),


### PR DESCRIPTION
Rust implementation of what used to be `BaseManifest.unsafe_load()`. It deserializes raw unciphered binary to a manifest.