### PR TITLE
Added a prefix to test env name so it can be more easily recognized

### DIFF
--- a/tests/scripts/run_testenv.py
+++ b/tests/scripts/run_testenv.py
@@ -47,7 +47,7 @@ DEFAULT_BLOCKSTORE = "MOCKED"
 
 async def new_environment(source_file=None):
     export_lines = []
-    tempdir = tempfile.mkdtemp()
+    tempdir = tempfile.mkdtemp(prefix="parsec-testenv-")
     if sys.platform == "win32":
         export = "set"
         env = {"APPDATA": tempdir}


### PR DESCRIPTION
Since tmp folders created with `tests/scripts/run_testenv.py` cannot be automatically deleted, I added a little prefix to be able to recognize them.