### PR TITLE
Enable manylinux2014 compatibility for maturin build command

### DIFF
--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - .github/workflows/package-ci.yml
       - packaging
+      - build.py
   push:
     branches:
       - master

--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -70,7 +70,7 @@ jobs:
           echo "::set-output name=version::$VERSION"
 
       - name: Build wheel
-        uses: pypa/cibuildwheel@0abd6c205d5baf3066155b5bf85219147d770c61  # ping v2.9.0
+        uses: pypa/cibuildwheel@67a7175578d31df091005d66d55bd8daa4e18665  # pin v2.10.0
         with:
           output-dir: dist
         timeout-minutes: 30

--- a/build.py
+++ b/build.py
@@ -51,7 +51,7 @@ def build():
 
     release = "--release" if in_cibuildwheel() or force_maturin_release() else ""
     with tempfile.TemporaryDirectory() as distdir:
-        run(f"maturin build {release} --out {distdir}")
+        run(f"maturin build {release} --out {distdir} --compatibility manylinux2014")
 
         outputs = list(pathlib.Path(distdir).iterdir())
         if len(outputs) != 1:


### PR DESCRIPTION
This is an attempt at fixing the package-ci error on the master branch.