### PR TITLE
Add python magic method implementation for `LocalDateTime`

### DIFF
--- a/oxidation/libparsec/crates/types/src/time.rs
+++ b/oxidation/libparsec/crates/types/src/time.rs
@@ -405,7 +405,7 @@ impl Sub for DateTime {
  * LocalDateTime
  */
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Hash)]
 pub struct LocalDateTime(chrono::DateTime<chrono::Local>);
 
 impl From<DateTime> for LocalDateTime {

--- a/src/time.rs
+++ b/src/time.rs
@@ -220,6 +220,9 @@ impl DateTime {
 pub(crate) struct LocalDateTime(pub libparsec::types::LocalDateTime);
 
 crate::binding_utils::gen_proto!(LocalDateTime, __repr__);
+crate::binding_utils::gen_proto!(LocalDateTime, __str__);
+crate::binding_utils::gen_proto!(LocalDateTime, __richcmp__, ord);
+crate::binding_utils::gen_proto!(LocalDateTime, __hash__);
 
 #[pymethods]
 impl LocalDateTime {


### PR DESCRIPTION


- Make `LocalDateTime` comparable.
- Allow `LocalDateTime` to be hashed.
- `LocalDateTime` can be represented as an `str`.