### PR TITLE
Allow to run `cargo test` for the root crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,7 +329,7 @@ jobs:
         run: |
           set -ex
           cargo build --workspace
-          cargo test --workspace --no-run --exclude parsec
+          cargo test --workspace --no-run
 
       - name: Test rust codebase
         if: steps.rust-changes.outputs.run == 'true'
@@ -338,7 +338,7 @@ jobs:
           set -ex
           cargo test --package libparsec_crypto --features use-sodiumoxide
           cargo test --package libparsec_crypto --features use-rustcrypto
-          cargo test --workspace --features mock-time --exclude libparsec_crypto --exclude parsec
+          cargo test --workspace --features mock-time --exclude libparsec_crypto
 
   ##############################################################################
   #                            🐜 Wasm tests                                   #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ libparsec = { version = "0.1.0", path = "oxidation/libparsec" }
 
 regex = "1.6.0"
 paste = "1.0.9"
-pyo3 = { version = "0.17.2", features = ["extension-module", "multiple-pymethods"] }
+pyo3 = { version = "0.17.2", features = ["multiple-pymethods"] }
 uuid = { version = "1.1.2", features = ["serde", "v4", "fast-rng"] }
 tokio = { version = "1.21", features = ["rt", "rt-multi-thread"] }
 lazy_static = "1.4.0"
@@ -26,6 +26,7 @@ futures = "0.3.21"
 [features]
 default = ["mock-time"]
 mock-time = ["libparsec/mock-time"]
+extension-module = ["pyo3/extension-module"]
 
 [workspace]
 members = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,9 @@ test-command = "parsec --version && parsec core list_devices"
 # For this reason we force $PATH to contain Rust bin dir.
 PATH = "$PATH:$HOME/.cargo/bin"
 
+[tool.maturin]
+features = ["extension-module"]
+
 [build-system]
 # Be careful `build-system` entry works out of poetry,
 # hence those dependencies are not resolved & pinned into `poetry.lock`


### PR DESCRIPTION
Applies the fixes suggested at <https://pyo3.github.io/pyo3/v0.17.0/faq.html#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror>.

This would allow to run `cargo test --workspace` without the `--exclude parsec` part.