### PR TITLE
Chore

### DIFF
--- a/oxidation/libparsec/crates/types/src/certif.rs
+++ b/oxidation/libparsec/crates/types/src/certif.rs
@@ -16,7 +16,6 @@ use crate::{
     DateTime, DeviceID, DeviceLabel, HumanHandle, RealmID, RealmRole, UserID, UserProfile,
 };
 
-#[allow(unused_macros)]
 macro_rules! impl_verify_and_load_allow_root {
     ($name:ident) => {
         impl $name {

--- a/src/addrs.rs
+++ b/src/addrs.rs
@@ -7,7 +7,6 @@ use pyo3::{
 };
 use std::str::FromStr;
 
-#[allow(deprecated)]
 use crate::{
     api_crypto::VerifyKey,
     ids::{EntryID, OrganizationID},

--- a/src/binding_utils.rs
+++ b/src/binding_utils.rs
@@ -2,13 +2,10 @@
 
 // TODO: Remove these lines when all functions/macros are used
 #![allow(dead_code)]
-#![allow(unused_macros)]
-#![allow(unused_imports)]
 
 use pyo3::{
     conversion::IntoPy,
     exceptions::{PyNotImplementedError, PyValueError},
-    prelude::PyModule,
     pyclass::CompareOp,
     types::{PyFrozenSet, PyTuple},
     FromPyObject, {PyAny, PyObject, PyResult, Python},

--- a/src/invite.rs
+++ b/src/invite.rs
@@ -7,7 +7,6 @@ use pyo3::{
 };
 use uuid::Uuid;
 
-#[allow(deprecated)]
 use crate::{
     api_crypto::{PrivateKey, PublicKey, SecretKey, VerifyKey},
     binding_utils::py_to_rs_user_profile,


### PR DESCRIPTION
- Remove rust config macro that was allowing for `unused_macro`
- Remove rust config macro that was allowing for `unused_import`
- Remove rust config macro that was allowing for `deprecated` code