### PR TITLE
Add test to check regex compat

### DIFF
--- a/oxidation/libparsec/crates/client_types/src/local_manifest.rs
+++ b/oxidation/libparsec/crates/client_types/src/local_manifest.rs
@@ -424,7 +424,7 @@ impl LocalFolderManifest {
         // Deal with additions second
         for (name, entry_id) in data.into_iter() {
             if let Some(entry_id) = entry_id {
-                if prevent_sync_pattern.0.is_match(name.as_ref()) {
+                if prevent_sync_pattern.is_match(name.as_ref()) {
                     self.local_confinement_points.insert(entry_id);
                 } else {
                     actually_updated = true;
@@ -496,7 +496,7 @@ impl LocalFolderManifest {
             .children
             .iter()
             .filter_map(|(name, entry_id)| {
-                if prevent_sync_pattern.0.is_match(name.as_ref()) {
+                if prevent_sync_pattern.is_match(name.as_ref()) {
                     Some(*entry_id)
                 } else {
                     None
@@ -716,7 +716,7 @@ impl LocalWorkspaceManifest {
         // Deal with additions second
         for (name, entry_id) in data.into_iter() {
             if let Some(entry_id) = entry_id {
-                if prevent_sync_pattern.0.is_match(name.as_ref()) {
+                if prevent_sync_pattern.is_match(name.as_ref()) {
                     self.local_confinement_points.insert(entry_id);
                 } else {
                     actually_updated = true;
@@ -788,7 +788,7 @@ impl LocalWorkspaceManifest {
             .children
             .iter()
             .filter_map(|(name, entry_id)| {
-                if prevent_sync_pattern.0.is_match(name.as_ref()) {
+                if prevent_sync_pattern.is_match(name.as_ref()) {
                     Some(*entry_id)
                 } else {
                     None

--- a/oxidation/libparsec/crates/types/src/regex.rs
+++ b/oxidation/libparsec/crates/types/src/regex.rs
@@ -20,6 +20,10 @@ impl Regex {
     pub fn from_regex_str(regex_str: &str) -> Result<Self, regex::Error> {
         Ok(Regex(regex::Regex::new(regex_str)?))
     }
+
+    pub fn is_match(&self, string: &str) -> bool {
+        self.0.is_match(string)
+    }
 }
 
 impl AsRef<str> for Regex {
@@ -56,9 +60,9 @@ mod tests {
         #[case] other_case: &str,
     ) {
         let regex = Regex::from_pattern(pattern_str).expect("Should be valid");
-        assert!(regex.0.is_match(valid_case));
-        assert!(!regex.0.is_match(bad_base));
-        assert!(regex.0.is_match(other_case));
+        assert!(regex.is_match(valid_case));
+        assert!(!regex.is_match(bad_base));
+        assert!(regex.is_match(other_case));
     }
 
     #[rstest]
@@ -70,9 +74,9 @@ mod tests {
         #[case] other_case: &str,
     ) {
         let regex = Regex::from_regex_str(regex_str).expect("Should be valid");
-        assert!(regex.0.is_match(valid_case));
-        assert!(!regex.0.is_match(bad_base));
-        assert!(regex.0.is_match(other_case));
+        assert!(regex.is_match(valid_case));
+        assert!(!regex.is_match(bad_base));
+        assert!(regex.is_match(other_case));
     }
 
     #[test]

--- a/src/binding_utils.rs
+++ b/src/binding_utils.rs
@@ -1,16 +1,12 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 (eventually AGPL-3.0) 2016-present Scille SAS
 
-// TODO: Remove these lines when all functions/macros are used
-#![allow(dead_code)]
-
 use pyo3::{
     conversion::IntoPy,
-    exceptions::{PyNotImplementedError, PyValueError},
+    exceptions::PyNotImplementedError,
     pyclass::CompareOp,
-    types::{PyFrozenSet, PyTuple},
+    types::PyFrozenSet,
     FromPyObject, {PyAny, PyObject, PyResult, Python},
 };
-use regex::Regex;
 use std::{
     collections::{hash_map::DefaultHasher, HashSet},
     hash::{Hash, Hasher},
@@ -111,25 +107,6 @@ pub fn py_to_rs_set<'a, T: FromPyObject<'a> + Eq + Hash>(set: &'a PyAny) -> PyRe
         .iter()
         .map(T::extract)
         .collect::<PyResult<std::collections::HashSet<T>>>()
-}
-
-pub fn py_to_rs_regex(regex: &PyAny) -> PyResult<Regex> {
-    let regex = regex
-        .getattr("pattern")
-        .unwrap_or(regex)
-        .extract::<&str>()?
-        .replace("\\Z", "\\z")
-        .replace("\\ ", "\x20");
-    Regex::new(&regex).map_err(|e| PyValueError::new_err(e.to_string()))
-}
-
-pub fn rs_to_py_regex<'py>(py: Python<'py>, regex: &Regex) -> PyResult<&'py PyAny> {
-    let re = py.import("re")?;
-    let args = PyTuple::new(
-        py,
-        vec![regex.as_str().replace("\\z", "\\Z").replace('\x20', "\\ ")],
-    );
-    re.call_method1("compile", args)
 }
 
 macro_rules! parse_kwargs_optional {

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -14,18 +14,110 @@ impl Regex {
     fn from_pattern(_cls: &PyType, pattern: &str) -> PyResult<Self> {
         libparsec::types::regex::Regex::from_pattern(pattern)
             .map(Regex)
-            .map_err(|_| PyValueError::new_err(format!("Invalid pattern `{}`", pattern)))
+            .map_err(|err| {
+                PyValueError::new_err(format!(
+                    "Failed to convert pattern to regex: `{}` with the following error `{}`",
+                    pattern, err
+                ))
+            })
     }
 
     #[classmethod]
     fn from_regex_str(_cls: &PyType, regex_str: &str) -> PyResult<Self> {
         libparsec::types::regex::Regex::from_regex_str(regex_str)
             .map(Regex)
-            .map_err(|_| PyValueError::new_err(format!("Invalid regex `{}`", regex_str)))
+            .map_err(|err| {
+                PyValueError::new_err(format!(
+                    "Regex creation failed: `{}` with the following error `{}`",
+                    regex_str, err
+                ))
+            })
     }
 
     #[getter]
     fn pattern(&self) -> PyResult<&str> {
         Ok(self.0.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use pyo3::{
+        exceptions::PyValueError,
+        types::{PyModule, PyTuple},
+        Py, PyAny, PyResult, Python,
+    };
+
+    const IGNORE_PATTERN_FILE_PATH: &str = "parsec/core/resources/default_pattern.ignore";
+
+    fn py_to_rs_regex(regex: &PyAny) -> PyResult<regex::Regex> {
+        let regex = regex
+            .getattr("pattern")
+            .unwrap_or(regex)
+            .extract::<&str>()?
+            .replace("\\Z", "\\z")
+            .replace("\\ ", "\x20");
+        regex::Regex::new(&regex).map_err(|e| PyValueError::new_err(e.to_string()))
+    }
+
+    fn rs_to_py_regex<'py>(py: Python<'py>, regex: &regex::Regex) -> PyResult<&'py PyAny> {
+        let re = py.import("re")?;
+        let args = PyTuple::new(
+            py,
+            vec![regex.as_str().replace("\\z", "\\Z").replace('\x20', "\\ ")],
+        );
+        re.call_method1("compile", args)
+    }
+
+    fn load_regex() -> String {
+        let file_content = std::fs::read_to_string(IGNORE_PATTERN_FILE_PATH).unwrap();
+        let mut regex_str = String::new();
+
+        for line in file_content.lines() {
+            // It's a comment or empty line
+            if line.starts_with('#') || line.is_empty() {
+                continue;
+            }
+
+            let sub_regex_str = libparsec::types::regex::Regex::from_pattern(line)
+                .unwrap()
+                .to_string();
+
+            if !regex_str.is_empty() {
+                regex_str.push('|');
+            }
+            regex_str.push_str(&sub_regex_str);
+        }
+
+        regex_str
+    }
+
+    #[test]
+    fn test_compatible_with_legacy_py_to_rs() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let reg: Py<PyAny> =
+                PyModule::from_code(py, &format!("new_regex = '{}'", load_regex()), "", "")
+                    .unwrap()
+                    .getattr("new_regex")
+                    .unwrap()
+                    .into();
+
+            let re = PyModule::import(py, "re").unwrap();
+            let compile_fn = re.getattr("compile").unwrap();
+            let compile_args = PyTuple::new(py, vec![reg]);
+
+            // Assert re can compile the new regex and transform to rust one
+            let py_reg = compile_fn
+                .call1(compile_args)
+                .expect("Cannot compile new regex with `re` module");
+            assert!(py_to_rs_regex(py_reg).is_ok());
+        });
+    }
+
+    #[test]
+    fn test_compatible_with_legacy_rs_to_py() {
+        let regex = regex::Regex::new(&load_regex()).expect("Should be valid");
+        Python::with_gil(|py| assert!(rs_to_py_regex(py, &regex).is_ok()));
     }
 }


### PR DESCRIPTION
When a user has an older cache some regex contains escapes sequences like `\Z` which are not supported by rust `regex` crate. Note that `fancy_regex` has the same issue here.

This is a proposal to fix the issue (#3212) by replacing the unsupported escapes sequences. Although it works, there may be better ways to handle this issue.