### PR TITLE
Do not compile the "prevent sync" pattern from the local database

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -18,6 +18,14 @@ disallow_any_decorated=True
 disallow_any_generics=True
 disallow_subclassing_any=True
 
+[mypy-parsec.core.logged_core]
+ignore_errors = False
+disallow_untyped_defs=True
+disallow_any_unimported=True
+disallow_any_decorated=True
+disallow_any_generics=True
+disallow_subclassing_any=True
+
 [mypy-parsec.core.fs.*]
 ignore_errors = False
 disallow_untyped_defs=True

--- a/parsec/_parsec_pyi/local_device.pyi
+++ b/parsec/_parsec_pyi/local_device.pyi
@@ -107,6 +107,7 @@ class LocalDevice:
 
 class UserInfo:
     def __init__(
+        self,
         user_id: UserID,
         human_handle: Optional[HumanHandle],
         profile: UserProfile,
@@ -140,6 +141,7 @@ class UserInfo:
 
 class DeviceInfo:
     def __init__(
+        self,
         device_id: DeviceID,
         device_label: Optional[DeviceLabel],
         created_on: DateTime,

--- a/parsec/core/logged_core.py
+++ b/parsec/core/logged_core.py
@@ -67,13 +67,9 @@ from parsec.core.messages_monitor import monitor_messages
 from parsec.core.sync_monitor import monitor_sync
 from parsec.core.fs import UserFS
 from parsec.core.fs.exceptions import FSWorkspaceNotFoundError
-
+from parsec.core.fs.storage.workspace_storage import FAILSAFE_PATTERN_FILTER
 
 logger = get_logger()
-
-FAILSAFE_PATTERN_FILTER = Regex.from_regex_str(
-    r"^\b$"
-)  # Matches nothing (https://stackoverflow.com/a/2302992/2846140)
 
 
 def _get_prevent_sync_pattern(prevent_sync_pattern_path: Path) -> Optional[Regex]:

--- a/parsec/core/mountpoint/manager.py
+++ b/parsec/core/mountpoint/manager.py
@@ -349,7 +349,7 @@ async def mountpoint_manager_factory(
     mount_on_workspace_created: bool = False,
     mount_on_workspace_shared: bool = False,
     unmount_on_workspace_revoked: bool = False,
-    exclude_from_mount_all: list = (),
+    exclude_from_mount_all: frozenset = frozenset(),
 ):
     config = {"debug": debug}
 

--- a/tests/core/fs/workspacefs/test_confinement.py
+++ b/tests/core/fs/workspacefs/test_confinement.py
@@ -1,6 +1,5 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
 
-import re
 import pytest
 
 from parsec._parsec import Regex
@@ -22,9 +21,6 @@ async def test_local_confinement_points(alice_workspace, running_backend):
     # Apply a *.tmp pattern
     pattern = Regex.from_regex_str(".*\\.tmp$")
     await alice_workspace.set_and_apply_prevent_sync_pattern(pattern)
-    print(
-        alice_workspace.local_storage.get_prevent_sync_pattern().pattern, "second", pattern.pattern
-    )
     assert alice_workspace.local_storage.get_prevent_sync_pattern() == pattern
     assert alice_workspace.local_storage.get_prevent_sync_pattern_fully_applied()
 
@@ -109,12 +105,12 @@ async def test_sync_with_different_patterns(running_backend, alice_user_fs, alic
     workspace2 = alice2_user_fs.get_workspace(wid)
 
     # Workspace 1 patterns .tmp files
-    pattern1 = re.compile(r".*\.tmp$")
+    pattern1 = Regex.from_regex_str(r".*\.tmp$")
     await workspace1.set_and_apply_prevent_sync_pattern(pattern1)
     await workspace1.sync()
 
     # Workspace 2 patterns ~ files
-    pattern2 = re.compile(r".*~$")
+    pattern2 = Regex.from_regex_str(r".*~$")
     await workspace2.set_and_apply_prevent_sync_pattern(pattern2)
     await workspace2.sync()
 

--- a/tests/core/test_logged_core.py
+++ b/tests/core/test_logged_core.py
@@ -169,11 +169,11 @@ async def test_get_organization_stats(running_backend, alice_core, bob_core):
         realms=3,
         users=3,
         active_users=3,
-        users_per_profile_detail=(
+        users_per_profile_detail=[
             UsersPerProfileDetailItem(active=2, profile=UserProfile.ADMIN, revoked=0),
             UsersPerProfileDetailItem(active=1, profile=UserProfile.STANDARD, revoked=0),
             UsersPerProfileDetailItem(active=0, profile=UserProfile.OUTSIDER, revoked=0),
-        ),
+        ],
     )
 
     # ...but not mere mortals !

--- a/tests/core/test_sync_monitor.py
+++ b/tests/core/test_sync_monitor.py
@@ -1,11 +1,11 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
 
-import re
 import trio
 import pytest
 from unittest.mock import ANY, Mock
 from urllib.error import URLError, HTTPError
 
+from parsec._parsec import Regex
 from parsec.api.data import EntryName
 from parsec.api.protocol import RealmID, VlobID
 from parsec.backend.backend_events import BackendEvent
@@ -380,7 +380,7 @@ async def test_sync_confined_children_after_rename(
     alice_w = alice_core.user_fs.get_workspace(wid)
 
     # Set a filter
-    pattern = re.compile(r".*\.tmp$")
+    pattern = Regex.from_regex_str(r".*\.tmp$")
     await alice_w.set_and_apply_prevent_sync_pattern(pattern)
 
     # Create a confined path


### PR DESCRIPTION
Fix #3212 by not compiling the prevent sync pattern from the local database since it's fragile and unnecessary.