### PR TITLE
mypy: Added missing types for `parsec.core.types`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -65,6 +65,14 @@ disallow_any_decorated=True
 disallow_any_generics=True
 disallow_subclassing_any=True
 
+[mypy-parsec.core.types.*]
+ignore_errors = False
+disallow_untyped_defs=True
+disallow_any_unimported=True
+disallow_any_decorated=True
+disallow_any_generics=True
+disallow_subclassing_any=True
+
 [mypy-parsec.core.mountpoint.*]
 ignore_errors = False
 disallow_untyped_defs=True

--- a/parsec/_parsec_pyi/local_manifest.pyi
+++ b/parsec/_parsec_pyi/local_manifest.pyi
@@ -228,7 +228,7 @@ class LocalFolderManifest:
         cls,
         remote: FolderManifest,
         prevent_sync_pattern: Regex,
-        local_manifest: LocalFolderManifest,
+        local_manifest: AnyLocalManifest,
         timestamp: DateTime,
     ) -> LocalFolderManifest: ...
 
@@ -300,7 +300,7 @@ class LocalWorkspaceManifest:
     def asdict(self) -> Dict[str, Any]: ...
     def dump_and_encrypt(self, key: SecretKey) -> bytes: ...
     @classmethod
-    def decrypt_and_load(self, encrypted: bytes, key: SecretKey) -> LocalWorkspaceManifest: ...
+    def decrypt_and_load(cls, encrypted: bytes, key: SecretKey) -> LocalWorkspaceManifest: ...
     @classmethod
     def new_placeholder(
         cls,
@@ -318,7 +318,7 @@ class LocalWorkspaceManifest:
         cls,
         remote: WorkspaceManifest,
         prevent_sync_pattern: Regex,
-        local_manifest: LocalWorkspaceManifest,
+        local_manifest: AnyLocalManifest,
         timestamp: DateTime,
     ) -> LocalWorkspaceManifest: ...
 

--- a/parsec/core/types/backend_address.py
+++ b/parsec/core/types/backend_address.py
@@ -12,7 +12,7 @@ from parsec._parsec import (
     BackendOrganizationFileLinkAddr,
     BackendPkiEnrollmentAddr,
 )
-from typing import Union
+from typing import Any, Optional, Union
 
 PARSEC_SCHEME = "parsec"
 
@@ -28,13 +28,15 @@ BackendAddrType = Union[
 
 
 class BackendOrganizationAddrField(fields.Field):
-    def _deserialize(self, value, attr, data):
+    def _deserialize(self, value: Any, attr: str, data: object) -> BackendOrganizationAddr:
         try:
             return BackendOrganizationAddr.from_url(value)
         except ValueError as exc:
             raise ValidationError(str(exc)) from exc
 
-    def _serialize(self, value, attr, data):
+    def _serialize(
+        self, value: Optional[BackendOrganizationAddr], attr: str, data: dict[str, object]
+    ) -> Optional[str]:
         if value is None:
             return None
 
@@ -42,13 +44,15 @@ class BackendOrganizationAddrField(fields.Field):
 
 
 class BackendAddrField(fields.Field):
-    def _deserialize(self, value, attr, data):
+    def _deserialize(self, value: Any, attr: str, data: object) -> BackendAddr:
         try:
             return BackendAddr.from_url(value)
         except ValueError as exc:
             raise ValidationError(str(exc)) from exc
 
-    def _serialize(self, value, attr, data):
+    def _serialize(
+        self, value: Optional[BackendAddr], attr: str, data: dict[str, object]
+    ) -> Optional[str]:
         if value is None:
             return None
 
@@ -56,13 +60,15 @@ class BackendAddrField(fields.Field):
 
 
 class BackendPkiEnrollmentAddrField(fields.Field):
-    def _deserialize(self, value, attr, data):
+    def _deserialize(self, value: Any, attr: str, data: object) -> BackendPkiEnrollmentAddr:
         try:
             return BackendPkiEnrollmentAddr.from_url(value)
         except ValueError as exc:
             raise ValidationError(str(exc)) from exc
 
-    def _serialize(self, value, attr, data):
+    def _serialize(
+        self, value: Optional[BackendPkiEnrollmentAddr], attr: str, data: object
+    ) -> Optional[str]:
         if value is None:
             return None
 

--- a/parsec/core/types/backend_address.py
+++ b/parsec/core/types/backend_address.py
@@ -35,7 +35,7 @@ class BackendOrganizationAddrField(fields.Field):
             raise ValidationError(str(exc)) from exc
 
     def _serialize(
-        self, value: Optional[BackendOrganizationAddr], attr: str, data: dict[str, object]
+        self, value: Optional[BackendOrganizationAddr], attr: str, data: object
     ) -> Optional[str]:
         if value is None:
             return None
@@ -50,9 +50,7 @@ class BackendAddrField(fields.Field):
         except ValueError as exc:
             raise ValidationError(str(exc)) from exc
 
-    def _serialize(
-        self, value: Optional[BackendAddr], attr: str, data: dict[str, object]
-    ) -> Optional[str]:
+    def _serialize(self, value: Optional[BackendAddr], attr: str, data: object) -> Optional[str]:
         if value is None:
             return None
 

--- a/parsec/core/types/backend_address.py
+++ b/parsec/core/types/backend_address.py
@@ -12,7 +12,7 @@ from parsec._parsec import (
     BackendOrganizationFileLinkAddr,
     BackendPkiEnrollmentAddr,
 )
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
 PARSEC_SCHEME = "parsec"
 
@@ -28,8 +28,11 @@ BackendAddrType = Union[
 
 
 class BackendOrganizationAddrField(fields.Field):
-    def _deserialize(self, value: Any, attr: str, data: object) -> BackendOrganizationAddr:
+    def _deserialize(self, value: object, attr: str, data: object) -> BackendOrganizationAddr:
         try:
+            if not isinstance(value, str):
+                raise ValidationError(f"expected 'str' for got '{type(value)}'")
+
             return BackendOrganizationAddr.from_url(value)
         except ValueError as exc:
             raise ValidationError(str(exc)) from exc
@@ -44,8 +47,11 @@ class BackendOrganizationAddrField(fields.Field):
 
 
 class BackendAddrField(fields.Field):
-    def _deserialize(self, value: Any, attr: str, data: object) -> BackendAddr:
+    def _deserialize(self, value: object, attr: str, data: object) -> BackendAddr:
         try:
+            if not isinstance(value, str):
+                raise ValidationError(f"expected 'str' for got '{type(value)}'")
+
             return BackendAddr.from_url(value)
         except ValueError as exc:
             raise ValidationError(str(exc)) from exc
@@ -58,8 +64,11 @@ class BackendAddrField(fields.Field):
 
 
 class BackendPkiEnrollmentAddrField(fields.Field):
-    def _deserialize(self, value: Any, attr: str, data: object) -> BackendPkiEnrollmentAddr:
+    def _deserialize(self, value: object, attr: str, data: object) -> BackendPkiEnrollmentAddr:
         try:
+            if not isinstance(value, str):
+                raise ValidationError(f"expected 'str' for got '{type(value)}'")
+
             return BackendPkiEnrollmentAddr.from_url(value)
         except ValueError as exc:
             raise ValidationError(str(exc)) from exc

--- a/parsec/core/types/pki.py
+++ b/parsec/core/types/pki.py
@@ -1,7 +1,7 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
 from __future__ import annotations
 
-from typing import Iterable, List, Optional, Dict
+from typing import Iterable, List, Optional, Dict, Union
 from pathlib import Path
 from uuid import UUID
 from parsec._parsec import DateTime
@@ -35,9 +35,9 @@ class X509Certificate:
         certificate_id = fields.String(required=True, allow_none=True)
 
         @post_load
-        def make_obj(self, data):
+        def make_obj(self, data: Dict[str, Union[str, Dict[str, str], bytes]]) -> X509Certificate:
             data.pop("type", None)
-            return X509Certificate(**data)
+            return X509Certificate(**data)  # type: ignore[arg-type]
 
     issuer: Dict[str, str]
     subject: Dict[str, str]
@@ -45,7 +45,7 @@ class X509Certificate:
     certificate_sha1: bytes
     certificate_id: Optional[str]
 
-    def is_available_locally(self):
+    def is_available_locally(self) -> bool:
         """Certificates that are received from another peer are not available locally."""
         return self.certificate_id is not None
 
@@ -91,9 +91,12 @@ class LocalPendingEnrollment(BaseLocalData):
         ciphertext = fields.Bytes(required=True)  # An encrypted PendingDeviceKeys
 
         @post_load
-        def make_obj(self, data):
+        def make_obj(
+            self,
+            data: Dict[str, object],
+        ) -> LocalPendingEnrollment:
             data.pop("type", None)
-            return LocalPendingEnrollment(**data)
+            return LocalPendingEnrollment(**data)  # type: ignore[arg-type]
 
     x509_certificate: X509Certificate
     addr: BackendPkiEnrollmentAddr
@@ -135,7 +138,7 @@ class LocalPendingEnrollment(BaseLocalData):
             yield path
 
     @classmethod
-    def load_from_path(cls, path: Path):
+    def load_from_path(cls, path: Path) -> LocalPendingEnrollment:
         """
         Raises:
             PkiEnrollmentLocalPendingError

--- a/parsec/serde/fields.py
+++ b/parsec/serde/fields.py
@@ -80,7 +80,7 @@ class BaseEnumField(Field):
 
         return value.value
 
-    def _deserialize(self, value: str, attr: str, data: dict[str, object]) -> Enum:
+    def _deserialize(self, value: object, attr: str, data: dict[str, object]) -> Enum:
         if not isinstance(value, str):
             raise ValidationError("Not string")
 
@@ -113,7 +113,7 @@ def bytes_based_field_factory(value_type: Any) -> Type[Field]:
 
         return value
 
-    def _deserialize(self: Any, value: bytes, attr: str, data: dict[str, object]) -> Any:
+    def _deserialize(self: Any, value: bytes, attr: str, data: dict[str, object]) -> Field:
         if not isinstance(value, bytes):
             raise ValidationError("Not bytes")
 
@@ -169,7 +169,7 @@ def rust_enum_field_factory(value_type: Any) -> Type[Field]:
         else:
             raise ValidationError(f"Not a InvitationStatus")
 
-    def _deserialize(self: Any, value: Any, attr: str, data: dict[str, object]) -> Any:
+    def _deserialize(self: Any, value: object, attr: str, data: dict[str, object]) -> Any:
         if not isinstance(value, str):
             raise ValidationError("Not string")
 
@@ -195,7 +195,7 @@ def uuid_based_field_factory(value_type: Any) -> Type[Field]:
         assert isinstance(value, value_type)
         return value.uuid
 
-    def _deserialize(self: Any, value: _UUID, attr: str, data: dict[str, object]) -> Any:
+    def _deserialize(self: Any, value: object, attr: str, data: dict[str, object]) -> Field:
         if not isinstance(value, _UUID):
             raise ValidationError("Not an UUID")
 
@@ -217,7 +217,10 @@ def uuid_based_field_factory(value_type: Any) -> Type[Field]:
 class Path(Field):
     """Absolute path"""
 
-    def _deserialize(self, value: str, attr: str, data: dict[str, object]) -> str:
+    def _deserialize(self, value: object, attr: str, data: dict[str, object]) -> str:
+        if not isinstance(value, str):
+            raise ValidationError(f"expected 'str' but got {type(value)}")
+
         if not value.startswith("/"):
             raise ValidationError("Path must be absolute")
         if value != "/":
@@ -230,7 +233,7 @@ class Path(Field):
 class UUID(Field):
     """UUID already handled by pack/unpack"""
 
-    def _deserialize(self, value: _UUID, attr: str, data: dict[str, object]) -> _UUID:
+    def _deserialize(self, value: object, attr: str, data: dict[str, object]) -> _UUID:
         if not isinstance(value, _UUID):
             raise ValidationError("Not an UUID")
         return value
@@ -239,7 +242,7 @@ class UUID(Field):
 class DateTime(Field):
     """DateTime already handled by pack/unpack"""
 
-    def _deserialize(self, value: RsDateTime, attr: str, data: dict[str, object]) -> RsDateTime:
+    def _deserialize(self, value: object, attr: str, data: dict[str, object]) -> RsDateTime:
         if not isinstance(value, RsDateTime):
             raise ValidationError("Not a datetime")
 

--- a/parsec/stubs/marshmallow/fields.pyi
+++ b/parsec/stubs/marshmallow/fields.pyi
@@ -1,7 +1,7 @@
-from __future__ import annotations
-from typing import Any
-
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
 
 missing_: object
 
@@ -10,25 +10,25 @@ class Field:
 
     def __init__(
         self,
-        default=missing_,
-        attribute=None,
-        load_from=None,
-        dump_to=None,
-        error=None,
-        validate=None,
-        required=False,
-        allow_none=None,
-        load_only=False,
-        dump_only=False,
-        missing=missing_,
-        error_messages=None,
-        **metadata,
+        default: object = missing_,
+        attribute: Optional[str] = None,
+        load_from: Optional[str] = None,
+        dump_to: Optional[str] = None,
+        error: Optional[Any] = None,
+        validate: Optional[Callable[[Any], bool]] = None,
+        required: bool = False,
+        allow_none: Optional[bool] = None,
+        load_only: bool = False,
+        dump_only: bool = False,
+        missing: object = missing_,
+        error_messages: Optional[dict[str, object]] = None,
+        **metadata: Any,
     ): ...
-    def serialize(self, attr, obj, accessor=None): ...
-    def deserialize(self, value): ...
-    def _serialize(self, value, attr: str, obj: object): ...
-    def _deserialize(self, value, attr: str, obj: dict[str, object]): ...
-    def __deepcopy__(self, memo): ...
+    def serialize(self, attr: str, obj: str, accessor: Optional[Callable[..., object]] = None): ...
+    def deserialize(self, value: Any, attr: Optional[str] = None, data: Optional[Any] = None): ...
+    def _serialize(self, value: Any, attr: str, obj: object): ...
+    def _deserialize(self, value: Any, attr: str, obj: dict[str, object]): ...
+    def __deepcopy__(self, memo: Any): ...
     def fail(self, key: str, **kwargs: Any) -> None: ...
 
 class Int(Field): ...


### PR DESCRIPTION
This adds mypy types for module `parsec.core.types`. This close #3284.