### PR TITLE
Allow `log-level` & `log-format` CLI option to be case insensitive

### DIFF
--- a/newsfragments/3268.feature.rst
+++ b/newsfragments/3268.feature.rst
@@ -1,0 +1,2 @@
+Make CLI case insensitive on option `--log-level` & `--log-format`.
+Thus allowing to provide the argument in upper or lower case.

--- a/parsec/cli_utils.py
+++ b/parsec/cli_utils.py
@@ -133,7 +133,7 @@ def logging_config_options(default_log_level: str):
         @click.option(
             "--log-level",
             "-l",
-            type=click.Choice(LOG_LEVELS),
+            type=click.Choice(LOG_LEVELS, case_sensitive=False),
             default=default_log_level,
             show_default=True,
             envvar="PARSEC_LOG_LEVEL",
@@ -141,7 +141,7 @@ def logging_config_options(default_log_level: str):
         @click.option(
             "--log-format",
             "-f",
-            type=click.Choice(("CONSOLE", "JSON")),
+            type=click.Choice(("CONSOLE", "JSON"), case_sensitive=False),
             default="CONSOLE",
             show_default=True,
             envvar="PARSEC_LOG_FORMAT",

--- a/parsec/logging.py
+++ b/parsec/logging.py
@@ -13,7 +13,7 @@ from sentry_sdk.utils import event_from_exception
 from parsec import __version__
 
 
-# Long story short Python's logging is an overengineering mess, adding
+# Long story short Python's logging is an over-engineering mess, adding
 # structlog and Sentry brings another layer of complexity :/
 #
 # What we want to achieve here:
@@ -143,7 +143,7 @@ def _structlog_to_sentry_processor(logger, method_name: str, event: dict) -> dic
 def build_structlog_configuration(log_level: str, log_format: str, log_stream: TextIO) -> dict:
     log_level = _cook_log_level(log_level)
     # A bit of struclog architecture:
-    # - lazy proxy: component obtained through `structlog.get_logger()`, lazyness
+    # - lazy proxy: component obtained through `structlog.get_logger()`, laziness
     #     is needed given it is imported very early on (later it bind operation
     #     will initialize the logger wrapper)
     # - logger wrapper: component responsible for all the cooking (e.g. calling processors)
@@ -174,7 +174,7 @@ def configure_stdlib_logger(
     log_level = _cook_log_level(log_level)
 
     # Use structlog to format stdlib logging records.
-    # Note this is only cosmetic: stdlib is still responsible for outputing them.
+    # Note this is only cosmetic: stdlib is still responsible for outputting them.
     formatter = structlog.stdlib.ProcessorFormatter(
         foreign_pre_chain=[
             structlog.stdlib.add_log_level,


### PR DESCRIPTION
> Also resolve some typo in the code.