### PR TITLE
Correct deprecation of command `set-output`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,8 @@ jobs:
           steps.changes.outputs.python == 'true'
           || steps.changes.outputs.rust-ext == 'true'
           || github.ref == 'refs/heads/master'
-        run: echo "::set-output name=run::true"
+        run: echo "run=true" >> $GITHUB_OUTPUT
+        shell: bash
 
       - name: (🐧 Linux) Configure PostgreSQL APT repository
         if: >-
@@ -316,7 +317,8 @@ jobs:
           steps.changes.outputs.rust == 'true'
           || steps.changes.outputs.rust-ext == 'true'
           || github.ref == 'refs/heads/master'
-        run: echo "::set-output name=run::true"
+        run: echo "run=true" >> $GITHUB_OUTPUT
+        shell: bash
 
       - uses: ./.github/actions/setup-rust
         if: steps.rust-changes.outputs.run == 'true'
@@ -404,7 +406,8 @@ jobs:
           steps.changes.outputs.wasm == 'true'
           || steps.changes.outputs.github == 'true'
           || github.ref == 'refs/head/master'
-        run: echo "::set-output name=run::true"
+        run: echo "run=true" >> $GITHUB_OUTPUT
+        shell: bash
 
       - uses: ./.github/actions/setup-rust
         if: steps.wasm-pack-changes.outputs.run == 'true'
@@ -461,7 +464,8 @@ jobs:
           steps.changes.outputs.client-web == 'true'
           || steps.changes.outputs.client-common == 'true'
           || github.ref == 'refs/heads/master'
-        run: echo "::set-output name=run::true"
+        run: echo "run=true" >> $GITHUB_OUTPUT
+        shell: bash
 
       - name: Install dependencies
         if: steps.web-change.outputs.run == 'true'

--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
           echo "::warning title=Wheel version::$VERSION"
-          echo "::set-output name=version::$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Build wheel
         uses: pypa/cibuildwheel@7c45799919d2dcd7ac59433924d763dd24d97483  # ping v2.10.2


### PR DESCRIPTION
The command `set-output` in **Github Action** has started its process to be fully deprecated. The command was replaced with a special file to set the output accessible via the `GITHUB_OUTPUT` environment var.

see <https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/> for references