### PR TITLE
[GUI] Fixed workspaces display

### DIFF
--- a/newsfragments/3300.bugfix.rst
+++ b/newsfragments/3300.bugfix.rst
@@ -1,0 +1,1 @@
+Disabled workspaces not longer appear enabled when logging in

--- a/newsfragments/3301.bugfix.rst
+++ b/newsfragments/3301.bugfix.rst
@@ -1,0 +1,1 @@
+Scrollbar should stay in place when enabling/disabling workspaces

--- a/parsec/core/gui/forms/workspaces_widget.ui
+++ b/parsec/core/gui/forms/workspaces_widget.ui
@@ -436,7 +436,7 @@
           <number>4</number>
          </property>
          <property name="bottomMargin">
-          <number>0</number>
+          <number>5</number>
          </property>
         </layout>
        </item>

--- a/parsec/core/gui/workspace_button.py
+++ b/parsec/core/gui/workspace_button.py
@@ -174,6 +174,8 @@ class WorkspaceButton(QWidget, Ui_WorkspaceButton):
         else:
             self.reencryption_needs = None
 
+        self.set_mountpoint_state(self.is_mounted())
+
     @property
     def owner(self):
         for user_id, (role, user_info) in self.users_roles.items():

--- a/parsec/core/gui/workspaces_widget.py
+++ b/parsec/core/gui/workspaces_widget.py
@@ -350,6 +350,10 @@ class WorkspacesWidget(QWidget, Ui_WorkspacesWidget):
             self.layout_workspaces.addWidget(label)
             return
 
+        position = 0
+        if self.scrollArea.verticalScrollBar():
+            position = self.scrollArea.verticalScrollBar().sliderPosition()
+
         # Make sure the search bar is visible
         self.line_edit_search.show()
 
@@ -378,6 +382,9 @@ class WorkspacesWidget(QWidget, Ui_WorkspacesWidget):
 
         # Force the layout to update
         self.layout_workspaces.update()
+        # Restore the scroll bar position
+        if self.scrollArea.verticalScrollBar():
+            self.scrollArea.verticalScrollBar().setSliderPosition(position)
 
     def on_list_error(self, job):
         self.spinner.hide()


### PR DESCRIPTION
Closes #3300 : unmounted workspaces did not appear greyed out when logging in
Closes #3301 : scrollbar would scroll to the bottom when unmounting a workspace

Also added a little bit of padding at the botton of the workspace layout so the bottom workspace buttons should no longer appear slightly cut.

