### PR TITLE
Rework `build.py` on the Rust compile profile selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ env:
     --side-effects-timeout=10
     -vv
     -x
-  # Compile Rust extensions in release speeds up Python tests a lot
-  FORCE_MATURIN_RELEASE: 1
 
 jobs:
 


### PR DESCRIPTION
Allow to configure the rust build profile using the environment variable `CARGO_PROFILE`. If the environment is not present we fallback to using the value defined in `DEFAULT_CARGO_PROFILE` which will be the `release` profile.