### PR TITLE
Remove `ubuntu-18.04` usage in the CI

### DIFF
--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -169,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
     steps:
       - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin v3.0.0
         with:


### PR DESCRIPTION
Remove `ubuntu-18.04` as it has started it's brownout periods.

> Meaning that jobs using it will fail time to time, see actions/runner-images#6002

This already impact our CI see:

- https://github.com/Scille/parsec-cloud/actions/runs/3250758297
- https://github.com/Scille/parsec-cloud/actions/runs/3250749569
- https://github.com/Scille/parsec-cloud/actions/runs/3250664543
- https://github.com/Scille/parsec-cloud/actions/runs/3250445645

O7 CMDR