### PR TITLE
Dump `poetry` install logs on failure

### DIFF
--- a/.github/actions/setup-python-poetry/action.yml
+++ b/.github/actions/setup-python-poetry/action.yml
@@ -21,9 +21,13 @@ runs:
       if: runner.os != 'Windows'
       run: |
         set -eux
+        set -o pipefail
         export POETRY_HOME="$HOME/.poetry"
         mkdir -p "$POETRY_HOME"
-        curl -sSL https://install.python-poetry.org | python3 - --version=${{ inputs.poetry-version }}
+        if ! curl -sSL https://install.python-poetry.org | python3 - --version=${{ inputs.poetry-version }}; then
+          tail -n +0 ${{ github.workspace }}/poetry-installer*.log
+          exit 3
+        fi
         echo "$POETRY_HOME/bin" >> "$GITHUB_PATH"
 
     - name: (Windows) Install poetry-${{ inputs.poetry-version }}


### PR DESCRIPTION
 Sometimes installing poetry fail, but we don't have any trace.

Here we will dump the log file generated during the installation,
Thus allowing use to report error if needed.