### PR TITLE
Add type `RequiredOption` & `NonRequiredOption` to rust protocol

### DIFF
--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/device_create.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/device_create.json
@@ -23,28 +23,28 @@
             "invalid_certification": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "bad_user_id": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "invalid_data": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "already_exists": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             }

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/events_listen.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/events_listen.json
@@ -20,7 +20,7 @@
             "cancelled": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
@@ -103,7 +103,7 @@
                                 "type": "RealmID"
                             },
                             "role": {
-                                "type": "Option<RealmRole>"
+                                "type": "RequiredOption<RealmRole>"
                             }
                         }
                     },

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/human_find.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/human_find.json
@@ -9,7 +9,7 @@
             "cmd": "human_find",
             "fields": {
                 "query": {
-                    "type": "Option<String>"
+                    "type": "RequiredOption<String>"
                 },
                 "omit_revoked": {
                     "type": "Boolean"
@@ -46,7 +46,7 @@
             "not_allowed": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             }
@@ -58,7 +58,7 @@
                         "type": "UserID"
                     },
                     "human_handle": {
-                        "type": "Option<HumanHandle>"
+                        "type": "RequiredOption<HumanHandle>"
                     },
                     "revoked": {
                         "type": "Boolean"

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/organization_config.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/organization_config.json
@@ -17,14 +17,14 @@
                     },
                     // `None` stands for "no limit" here
                     "active_users_limit": {
-                        "type": "Option<Size>"
+                        "type": "RequiredOption<Size>"
                     },
                     "sequester_authority_certificate": {
-                        "type": "Option<Bytes>",
+                        "type": "RequiredOption<Bytes>",
                         "introduced_in": "2.8"
                     },
                     "sequester_services_certificates": {
-                        "type": "Option<List<Bytes>>",
+                        "type": "RequiredOption<List<Bytes>>",
                         "introduced_in": "2.8"
                     }
                 }

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/organization_stats.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/organization_stats.json
@@ -35,7 +35,7 @@
             "not_allowed": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/pki_enrollment_accept.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/pki_enrollment_accept.json
@@ -41,49 +41,49 @@
             "not_allowed": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "invalid_payload_data": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "invalid_certification": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "invalid_data": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "no_longer_available": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "already_exists": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
@@ -132,49 +132,49 @@
             "not_allowed": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "invalid_payload_data": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "invalid_certification": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "invalid_data": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "no_longer_available": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "already_exists": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/pki_enrollment_info.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/pki_enrollment_info.json
@@ -20,7 +20,7 @@
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             }
@@ -105,7 +105,7 @@
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             }

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/pki_enrollment_list.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/pki_enrollment_list.json
@@ -19,7 +19,7 @@
             "not_allowed": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             }

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/pki_enrollment_reject.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/pki_enrollment_reject.json
@@ -18,21 +18,21 @@
             "not_allowed": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "no_longer_available": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             }
@@ -57,21 +57,21 @@
             "not_allowed": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "no_longer_available": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             }

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/realm_create.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/realm_create.json
@@ -19,21 +19,21 @@
             "invalid_certification": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "invalid_data": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
@@ -41,7 +41,7 @@
             "bad_timestamp": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     },
                     "ballpark_client_early_offset": {
                         "type": "Float",

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/realm_finish_reencryption_maintenance.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/realm_finish_reencryption_maintenance.json
@@ -23,7 +23,7 @@
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
@@ -31,14 +31,14 @@
             "not_in_maintenance": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "maintenance_error": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             }

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/realm_get_role_certificates.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/realm_get_role_certificates.json
@@ -26,7 +26,7 @@
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             }

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/realm_start_reencryption_maintenance.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/realm_start_reencryption_maintenance.json
@@ -29,7 +29,7 @@
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
@@ -37,14 +37,14 @@
             "participant_mismatch": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "maintenance_error": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
@@ -52,7 +52,7 @@
             "bad_timestamp": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     },
                     "ballpark_client_early_offset": {
                         "type": "Float",

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/realm_stats.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/realm_stats.json
@@ -29,7 +29,7 @@
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             }

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/realm_status.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/realm_status.json
@@ -21,13 +21,13 @@
                         "type": "Boolean"
                     },
                     "maintenance_type": {
-                        "type": "Option<MaintenanceType>"
+                        "type": "RequiredOption<MaintenanceType>"
                     },
                     "maintenance_started_on": {
-                        "type": "Option<DateTime>"
+                        "type": "RequiredOption<DateTime>"
                     },
                     "maintenance_started_by": {
-                        "type": "Option<DeviceID>"
+                        "type": "RequiredOption<DeviceID>"
                     },
                     "encryption_revision": {
                         "type": "Index"
@@ -38,7 +38,7 @@
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             }

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/realm_update_roles.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/realm_update_roles.json
@@ -13,7 +13,7 @@
                     "type": "Bytes"
                 },
                 "recipient_message": {
-                    "type": "Option<Bytes>"
+                    "type": "RequiredOption<Bytes>"
                 }
             }
         },
@@ -22,21 +22,21 @@
             "not_allowed": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "invalid_certification": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "invalid_data": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
@@ -44,14 +44,14 @@
             "incompatible_profile": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
@@ -67,7 +67,7 @@
             "bad_timestamp": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     },
                     "ballpark_client_early_offset": {
                         "type": "Float",

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/user_create.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/user_create.json
@@ -30,35 +30,35 @@
             "not_allowed": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "invalid_certification": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "invalid_data": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "already_exists": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "active_users_limit_reached": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             }

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/user_get.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/user_get.json
@@ -21,7 +21,7 @@
                         "type": "Bytes"
                     },
                     "revoked_user_certificate": {
-                        "type": "Option<Bytes>"
+                        "type": "RequiredOption<Bytes>"
                     },
                     "device_certificates": {
                         "type": "List<Bytes>"

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/user_revoke.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/user_revoke.json
@@ -19,14 +19,14 @@
             "not_allowed": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "invalid_certification": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
@@ -34,7 +34,7 @@
             "already_revoked": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             }

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/vlob_create.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/vlob_create.json
@@ -34,7 +34,7 @@
                 // Key is sequester service ID, value is blob encrypted with the service key
                 // New in API version 2.8/3.2 (Parsec 2.11.0)
                 "sequester_blob": {
-                    "type": "Option<Map<SequesterServiceID, Bytes>>",
+                    "type": "RequiredOption<Map<SequesterServiceID, Bytes>>",
                     "introduced_in": "2.8"
                 }
             }
@@ -44,7 +44,7 @@
             "already_exists": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
@@ -61,7 +61,7 @@
             "bad_timestamp": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     },
                     "ballpark_client_early_offset": {
                         "type": "Float",

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/vlob_list_versions.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/vlob_list_versions.json
@@ -26,7 +26,7 @@
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/vlob_maintenance_get_reencryption_batch.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/vlob_maintenance_get_reencryption_batch.json
@@ -32,14 +32,14 @@
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "not_in_maintenance": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
@@ -47,7 +47,7 @@
             "maintenance_error": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             }

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/vlob_maintenance_save_reencryption_batch.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/vlob_maintenance_save_reencryption_batch.json
@@ -35,14 +35,14 @@
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
             "not_in_maintenance": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
@@ -50,7 +50,7 @@
             "maintenance_error": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             }

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/vlob_poll_changes.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/vlob_poll_changes.json
@@ -32,7 +32,7 @@
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/vlob_read.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/vlob_read.json
@@ -16,10 +16,10 @@
                     "type": "VlobID"
                 },
                 "version": {
-                    "type": "Option<Version>"
+                    "type": "RequiredOption<Version>"
                 },
                 "timestamp": {
-                    "type": "Option<DateTime>"
+                    "type": "RequiredOption<DateTime>"
                 }
             }
         },
@@ -50,7 +50,7 @@
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/vlob_update.json
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/vlob_update.json
@@ -28,7 +28,7 @@
                 // Key is sequester service ID, value is blob encrypted with the service key
                 // New in API version 2.8/3.2 (Parsec 2.11.0)
                 "sequester_blob": {
-                    "type": "Option<Map<SequesterServiceID, Bytes>>",
+                    "type": "RequiredOption<Map<SequesterServiceID, Bytes>>",
                     "introduced_in": "2.8"
                 }
             }
@@ -38,7 +38,7 @@
             "not_found": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     }
                 }
             },
@@ -56,7 +56,7 @@
             "bad_timestamp": {
                 "fields": {
                     "reason": {
-                        "type": "Option<String>"
+                        "type": "NonRequiredOption<String>"
                     },
                     "ballpark_client_early_offset": {
                         "type": "Float",

--- a/oxidation/libparsec/crates/protocol/schema/invited_cmds/invite_info.json
+++ b/oxidation/libparsec/crates/protocol/schema/invited_cmds/invite_info.json
@@ -28,7 +28,7 @@
                                 "type": "UserID"
                             },
                             "greeter_human_handle": {
-                                "type": "Option<HumanHandle>"
+                                "type": "RequiredOption<HumanHandle>"
                             }
                         }
                     },
@@ -39,7 +39,7 @@
                                 "type": "UserID"
                             },
                             "greeter_human_handle": {
-                                "type": "Option<HumanHandle>"
+                                "type": "RequiredOption<HumanHandle>"
                             }
                         }
                     }


### PR DESCRIPTION
- The type `RequiredOption` mean for a field that it is always present but its value can be null.
- The type `NonRequiredOption` mean that a field can be absent or its value to be null.