### PR TITLE
Disable news fragments check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,8 @@
+# What have changed ?
+
+<!-- Why this PR exist ? what is its goal ? -->
+
+<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
+- [ ] Does this PR affect the User ?
+
+<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -20,6 +20,9 @@ outputs:
   client-common:
     value: ${{ steps.changes.outputs.client-common }}
     description: True if a files in the ionic-client part was edited.
+  newsfragments:
+    value: ${{ steps.changes.outputs.newsfragments }}
+    description: True if a files in the newsfragment part was edited.
 
 runs:
   using: composite

--- a/.github/actions/paths-filter/filters.yml
+++ b/.github/actions/paths-filter/filters.yml
@@ -40,3 +40,6 @@ client-web:
   - oxidation/bindings/web/**
   - oxidation/client/tests/**
   - oxidation/client/jest.config.js
+
+newsfragments:
+  - newsfragments/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin v3.1.0
 
+      - uses: ./.github/actions/paths-filter
+        id: changes
+
       - uses: ./.github/actions/setup-python-poetry
         with:
           python-version: ${{ env.python-version }}
@@ -109,12 +112,7 @@ jobs:
       - name: Check Newsfragment
         if: |
           startsWith(github.ref, 'refs/pull/')
-          && !(
-            startsWith(github.head_ref, 'dependabot')
-            || startsWith(github.head_ref, 'yolo')
-            || startsWith(github.head_ref, 'release')
-            || startsWith(github.head_ref, 'revert')
-            )
+          && steps.changes.outputs.newsfragments == 'true'
         run: |
           whereis git
           git fetch origin master


### PR DESCRIPTION
- Disable the check for the news fragment bits.
- Add a pull request template to question the pr's author if the changes need a fragment.
- Update the ci to only check the news fragments if there was an edit on the folder `newsfragments`