### PR TITLE
Fix invite without human handle

### DIFF
--- a/newsfragments/3507.bugfix.rst
+++ b/newsfragments/3507.bugfix.rst
@@ -1,1 +1,1 @@
-Invite without HumanHandle should not crash
+Fixes greeting a new user into an organization with a legacy user (user that does not have an email set)

--- a/newsfragments/3507.bugfix.rst
+++ b/newsfragments/3507.bugfix.rst
@@ -1,0 +1,1 @@
+Invite without HumanHandle should not crash

--- a/src/protocol/invite.rs
+++ b/src/protocol/invite.rs
@@ -707,17 +707,17 @@ impl InviteInfoRepOk {
     }
 
     #[getter]
-    fn greeter_human_handle(_self: PyRef<'_, Self>) -> PyResult<HumanHandle> {
+    fn greeter_human_handle(_self: PyRef<'_, Self>) -> PyResult<Option<HumanHandle>> {
         match &_self.as_ref().0 {
             invite_info::Rep::Ok(invite_info::UserOrDevice::Device {
-                greeter_human_handle: Some(handle),
+                greeter_human_handle: handle,
                 ..
-            }) => Ok(HumanHandle(handle.clone())),
-            invite_info::Rep::Ok(invite_info::UserOrDevice::User {
-                greeter_human_handle: Some(handle),
+            })
+            | invite_info::Rep::Ok(invite_info::UserOrDevice::User {
+                greeter_human_handle: handle,
                 ..
-            }) => Ok(HumanHandle(handle.clone())),
-            _ => Err(PyAttributeError::new_err("rep in not ok")),
+            }) => Ok(handle.clone().map(HumanHandle)),
+            _ => Err(PyAttributeError::new_err("no greeter_human_handle attr")),
         }
     }
 }


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
Fix the invitation issue when greeter doesn't have HumanHandle

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [x] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
closes #3507 
