### PR TITLE
Rework rust caching in CI

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -9,7 +9,6 @@ inputs:
   components:
     description: Comma-separated string of additional components to install e.g. `clippy`, `rustfmt`
     required: false
-    default: rustfmt, clippy
 
   profile:
     description: Execute `rustup set profile {value}` before installing the toolchain, ex. `minimal`
@@ -25,6 +24,11 @@ inputs:
     description: Comma-separated string of additional targets to install e.g. `wasm32-unknown-unknown`
     required: false
 
+  os:
+    description: Operating system name
+    required: true
+    default: ${{ runner.os }}
+
 outputs:
   cache-hit:
     description: A boolean value to indicate an exact match was found for the key.
@@ -37,21 +41,34 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Sanitize inputs to be used in cache key
+      id: sanitize
+      shell: bash
+      run:
+        echo 'components=${{ inputs.components }}' | sed 's/, */-/g' >> $GITHUB_OUTPUT
+
+    - name: Cache Rust tools
+      id: cache-rust-tools
+      uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin v3.0.11
+      with:
+        key: ${{ inputs.os }}_rust-tools_${{ inputs.version }}_${{ steps.sanitize.outputs.components }}_${{ inputs.target }}
+        path: |
+          ~/.cargo/bin
+
     - name: Cache Rust
       id: cache-rust
-      uses: actions/cache@c3f1317a9e7b1ef106c153ac8c0f00fed3ddbc0d # pin v3.0.4
+      uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin v3.0.11
       with:
-        key: ${{ runner.os }}-rust-${{ inputs.version }}-${{ inputs.cache-key }}-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ inputs.os }}_rust-dependencies_${{ inputs.version }}_${{ inputs.target }}_${{ inputs.cache-key }}_${{ hashFiles('**/Cargo.lock') }}
         path: |
           target
-          ~/.cargo/bin
           ~/.cargo/registry/index
           ~/.cargo/registry/cache
           ~/.cargo/git/db
 
     - name: Install rust toolchain
       id: rust-toolchain
-      uses: dtolnay/rust-toolchain@2e4fc08e24c79a982d0b6f4638011718d61c0eee
+      uses: dtolnay/rust-toolchain@55c7845fad90d0ae8b2e83715cb900e5e861e8cb
       with:
         toolchain: ${{ inputs.version }}
         components: ${{ inputs.components }}

--- a/.github/actions/use-pre-commit/action.yml
+++ b/.github/actions/use-pre-commit/action.yml
@@ -25,7 +25,7 @@ runs:
   steps:
     - name: Cache pre-commit install
       id: cache-pre-commit
-      uses: actions/cache@c3f1317a9e7b1ef106c153ac8c0f00fed3ddbc0d # pin v3.0.4
+      uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin v3.0.11
       with:
         key: pre-commit-${{ inputs.version }}-${{ hashFiles(inputs.config-file) }}
         path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     name: ⭐ CI is happy ⭐
     needs:
       - check-quality-assurance
+      - rust-prebuild-matrix
       - test-python-matrix
       - test-rust-matrix
       - test-web-app
@@ -88,7 +89,8 @@ jobs:
         with:
           version: ${{ env.rust-version }}
           components: rustfmt, clippy
-          cache-key: ${{ github.job }}-ubuntu-20.04
+          cache-key: ${{ github.job }}
+          os: ubuntu-20.04
         timeout-minutes: 10
 
       - name: Debug installed tools
@@ -136,10 +138,105 @@ jobs:
         timeout-minutes: 30
 
   ##############################################################################
+  #                            🦀 Rust Pre-build                               #
+  ##############################################################################
+  rust-prebuild-matrix:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: 🐧 Linux
+            # All linux jobs must run the same ubuntu version to avoid Rust caching issues !
+            os: ubuntu-20.04
+          - name: 🍎 macOS
+            os: macos-12
+          - name: 🏁 Windows
+            os: windows-2022
+    name: '${{ matrix.name }}: 🦀 Rust Prebuild 🏗️'
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin v3.1.0
+
+      - uses: ./.github/actions/paths-filter
+        id: changes
+
+      - name: Check modified path that require rust-ci run
+        id: rust-changes
+        if: >-
+          steps.changes.outputs.rust == 'true'
+          || steps.changes.outputs.python == 'true'
+          || steps.changes.outputs.rust-ext == 'true'
+          || github.ref == 'refs/heads/master'
+        run: echo "run=true" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - uses: ./.github/actions/setup-rust
+        id: rust-cache
+        if: steps.rust-changes.outputs.run == 'true'
+        with:
+          version: ${{ env.rust-version }}
+          cache-key: integration
+          os: ${{ matrix.os }}
+        timeout-minutes: 10
+
+      # Pyo3 need additional configuration on MacOS to be manually build
+      # see https://pyo3.rs/v0.17.3/building_and_distribution.html#macos
+      - name: (🍎 macOS) Configure cargo for PyO3
+        if: >-
+          steps.rust-changes.outputs.run == 'true'
+          && steps.rust-cache.outputs.cache-hit != 'true'
+          && startsWith(matrix.os, 'macos-')
+        shell: bash
+        run: |
+          set -eux
+          set -o pipefail
+          mkdir -p .cargo
+          cat << EOF | tee .cargo/config.toml
+          [target.x86_64-apple-darwin]
+          rustflags = [
+            "-C", "link-arg=-undefined",
+            "-C", "link-arg=dynamic_lookup",
+          ]
+          EOF
+
+      - name: Fetch rust dependencies
+        if: >-
+          steps.rust-changes.outputs.run == 'true'
+          && steps.rust-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          find . -name Cargo.toml -not -path './oxidation/libparsec_python/*' -exec cargo fetch --verbose --locked --manifest-path \{\} \;
+        timeout-minutes: 20
+
+      # In this step it may look like we're executing `cargo build` 2 time but
+      # the first one is call with `--all-targets` and not the other one.
+      # Why ?
+      # When I was testing, even tho we specify `--all-targets` (meaning to build everything (tests and libs)),
+      # after that step if I do `cargo build` It still as building/linking to be done.
+      - name: Build rust workspace
+        if: >-
+          steps.rust-changes.outputs.run == 'true'
+          && steps.rust-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -ex
+          cargo build \
+            --locked \
+            --workspace \
+            --profile ${{ env.CARGO_PROFILE }} \
+            --all-targets
+          cargo build \
+            --locked \
+            --workspace \
+            --profile ${{ env.CARGO_PROFILE }}
+        timeout-minutes: 50 # MacOS can be really slow to build our rust lib
+
+  ##############################################################################
   #                            🐍 Python tests                                 #
   ##############################################################################
 
   test-python-matrix:
+    needs: rust-prebuild-matrix
     strategy:
       fail-fast: false
       matrix:
@@ -231,7 +328,8 @@ jobs:
         if: steps.python-changes.outputs.run == 'true'
         with:
           version: ${{ env.rust-version }}
-          cache-key: ${{ github.job }}-${{ matrix.os }}
+          cache-key: integration
+          os: ${{ matrix.os }}
         timeout-minutes: 10
 
       - uses: ./.github/actions/setup-python-poetry
@@ -298,6 +396,7 @@ jobs:
   ##############################################################################
 
   test-rust-matrix:
+    needs: rust-prebuild-matrix
     strategy:
       fail-fast: false
       matrix:
@@ -330,11 +429,12 @@ jobs:
         if: steps.rust-changes.outputs.run == 'true'
         with:
           version: ${{ env.rust-version }}
-          cache-key: ${{ github.job }}-${{ matrix.os }}
+          cache-key: integration
+          os: ${{ matrix.os }}
         timeout-minutes: 10
 
       # Pyo3 need additional configuration on MacOS to be manually build
-      # see https://pyo3.rs/master/building_and_distribution.html#macos
+      # see https://pyo3.rs/v0.17.3/building_and_distribution.html#macos
       - name: (🍎 macOS) Configure cargo for PyO3
         if: >-
           steps.rust-changes.outputs.run == 'true'
@@ -352,24 +452,19 @@ jobs:
           ]
           EOF
 
-      # Pyo3 can't build for test with `multiple-pymethods` feature
-      # see https://github.com/PyO3/pyo3/issues/2623
-      - name: Build rust codebase
+      - name: Build rust test codebase
         if: steps.rust-changes.outputs.run == 'true'
         shell: bash
-        run: |
-          set -ex
-          cargo build --workspace
-          cargo test --workspace --no-run
+        run: cargo test --workspace --profile ${{ env.CARGO_PROFILE }} --no-run
 
       - name: Test rust codebase
         if: steps.rust-changes.outputs.run == 'true'
         shell: bash
         run: |
           set -ex
-          cargo test --package libparsec_crypto --features use-sodiumoxide --no-default-features
-          cargo test --package libparsec_crypto --features use-rustcrypto --no-default-features
-          cargo test --workspace --features mock-time --exclude libparsec_crypto
+          cargo test --profile ${{ env.CARGO_PROFILE }} --package libparsec_crypto --features use-sodiumoxide --no-default-features
+          cargo test --profile ${{ env.CARGO_PROFILE }} --package libparsec_crypto --features use-rustcrypto --no-default-features
+          cargo test --profile ${{ env.CARGO_PROFILE }} --workspace --features mock-time --exclude libparsec_crypto
 
   ##############################################################################
   #                            🐜 Wasm tests                                   #
@@ -420,7 +515,7 @@ jobs:
         with:
           version: ${{ env.rust-version }}
           target: wasm32-unknown-unknown
-          cache-key: wasm32
+          os: wasm32-ubuntu-20.04
 
       - name: Install Wasm-Pack
         if: steps.wasm-pack-changes.outputs.run == 'true'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,5 @@ overflow-checks = true
 debug-assertions = true
 debug = true
 incremental = true
+opt-level = 1
+codegen-units = 256


### PR DESCRIPTION
 the same cache for rust & python jobs
- Build rust code using the same profile for rust & python jobs
- Add job to pre generate rust cache
- Update dependencies on action `actions/cache` to `v3.0.11`