### PR TITLE
mypy: Add typing for `sync_monitor`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -182,8 +182,6 @@ allow_incomplete_defs = True
 # Ignored modules in parsec.core.*
 [mypy-parsec.core.win_registry]
 ignore_errors = True
-[mypy-parsec.core.sync_monitor]
-ignore_errors = True
 [mypy-parsec.core.ipcinterface]
 ignore_errors = True
 [mypy-parsec.core.remote_devices_manager]


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
This PR adds mypy typing to `parsec.core.sync_monitor`. This closes #3508 

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
