### PR TITLE
Added GUI test to check invitation where the greeter has no human handle

### DIFF
--- a/tests/core/gui/users_widget/test_greet.py
+++ b/tests/core/gui/users_widget/test_greet.py
@@ -325,18 +325,13 @@ def GreetUserTestBed(
                 )
 
                 user_widget = None
-                # Order can change a little bit depending on whether the user has a human handle
+                # Order can change a little bit depending on whether the user has a human handle or not
                 for i in range(u_w.layout_users.count()):
                     user_widget = u_w.layout_users.itemAt(i).widget()
                     if (
                         isinstance(user_widget, UserButton)
                         and user_widget.user_info.human_handle is not None
                     ):
-                        print(
-                            user_widget.user_info.human_handle,
-                            self.granted_email,
-                            self.granted_label,
-                        )
                         if (
                             user_widget.user_info.human_handle.email == self.granted_email
                             and user_widget.user_info.human_handle.label == self.granted_label

--- a/tests/core/gui/users_widget/test_greet.py
+++ b/tests/core/gui/users_widget/test_greet.py
@@ -9,14 +9,13 @@ from functools import partial
 
 from parsec.utils import start_task
 from parsec.core.gui.lang import translate
-from parsec._parsec import DateTime, InvitationType
+from parsec._parsec import DateTime
 from parsec.api.protocol import (
     DeviceLabel,
     InvitationDeletedReason,
     HumanHandle,
     UserProfile,
 )
-from parsec.core.types import BackendInvitationAddr
 from parsec.core.backend_connection import backend_invited_cmds_factory
 from parsec.core.invite import claimer_retrieve_info
 from parsec.core.gui.users_widget import UserInvitationButton, UserButton
@@ -42,7 +41,13 @@ def catch_greet_user_widget(widget_catcher_factory):
 
 @pytest.fixture
 def GreetUserTestBed(
-    aqtbot, catch_greet_user_widget, autoclose_dialog, backend, running_backend, logged_gui
+    aqtbot,
+    catch_greet_user_widget,
+    autoclose_dialog,
+    backend,
+    running_backend,
+    logged_gui,
+    monkeypatch,
 ):
     class _GreetUserTestBed:
         def __init__(self):
@@ -90,29 +95,27 @@ def GreetUserTestBed(
             author = logged_gui.test_get_central_widget().core.device
             claimer_email = self.requested_email
 
-            # Create new invitation
-
-            invitation = await backend.invite.new_for_user(
-                organization_id=author.organization_id,
-                greeter_user_id=author.user_id,
-                claimer_email=claimer_email,
-            )
-            invitation_addr = BackendInvitationAddr.build(
-                backend_addr=author.organization_addr.get_backend_addr(),
-                organization_id=author.organization_id,
-                invitation_type=InvitationType.USER,
-                token=invitation.token,
-            )
-
-            # Switch to users page
-
             users_widget = await logged_gui.test_switch_to_users_widget()
 
-            assert users_widget.layout_users.count() == 4
+            monkeypatch.setattr(
+                "parsec.core.gui.users_widget.get_text_input",
+                lambda *args, **kwargs: claimer_email,
+            )
+
+            # Create new invitation
+            aqtbot.mouse_click(users_widget.button_add_user, QtCore.Qt.LeftButton)
+
+            def _invitation_shown():
+                assert users_widget.layout_users.count() == 4
+                invitation_widget = users_widget.layout_users.itemAt(0).widget()
+                assert isinstance(invitation_widget, UserInvitationButton)
+
+            await aqtbot.wait_until(_invitation_shown)
 
             invitation_widget = users_widget.layout_users.itemAt(0).widget()
-            assert isinstance(invitation_widget, UserInvitationButton)
             assert invitation_widget.email == claimer_email
+
+            invitation_addr = invitation_widget.addr
 
             # Click on the invitation button
 
@@ -315,7 +318,31 @@ def GreetUserTestBed(
                 ]
                 # User list should be updated
                 assert u_w.layout_users.count() == 4
-                user_widget = u_w.layout_users.itemAt(3).widget()
+                # Should all be users, no invitation
+                assert all(
+                    isinstance(u_w.layout_users.itemAt(i).widget(), UserButton)
+                    for i in range(u_w.layout_users.count())
+                )
+
+                user_widget = None
+                # Order can change a little bit depending on whether the user has a human handle
+                for i in range(u_w.layout_users.count()):
+                    user_widget = u_w.layout_users.itemAt(i).widget()
+                    if (
+                        isinstance(user_widget, UserButton)
+                        and user_widget.user_info.human_handle is not None
+                    ):
+                        print(
+                            user_widget.user_info.human_handle,
+                            self.granted_email,
+                            self.granted_label,
+                        )
+                        if (
+                            user_widget.user_info.human_handle.email == self.granted_email
+                            and user_widget.user_info.human_handle.label == self.granted_label
+                        ):
+                            break
+
                 assert isinstance(user_widget, UserButton)
                 assert user_widget.user_info.human_handle.email == self.granted_email
                 assert user_widget.user_info.human_handle.label == self.granted_label
@@ -330,7 +357,16 @@ def GreetUserTestBed(
 @pytest.mark.gui
 @pytest.mark.trio
 @customize_fixtures(logged_gui_as_admin=True)
-async def test_greet_user(GreetUserTestBed):
+@customize_fixtures(alice_has_human_handle=True)
+async def test_greet_user_greeter_has_human_handle(GreetUserTestBed):
+    await GreetUserTestBed().run()
+
+
+@pytest.mark.gui
+@pytest.mark.trio
+@customize_fixtures(logged_gui_as_admin=True)
+@customize_fixtures(alice_has_human_handle=False)
+async def test_greet_user_greeter_does_not_have_human_handle(GreetUserTestBed):
     await GreetUserTestBed().run()
 
 

--- a/tests/core/gui/users_widget/test_invite.py
+++ b/tests/core/gui/users_widget/test_invite.py
@@ -18,11 +18,7 @@ def str_len_limiter(monkeypatch):
     )
 
 
-@pytest.mark.gui
-@pytest.mark.trio
-@pytest.mark.parametrize("online", (True, False))
-@customize_fixtures(logged_gui_as_admin=True)
-async def test_invite_user(
+async def _invite_user(
     aqtbot,
     logged_gui,
     bob,
@@ -103,6 +99,64 @@ async def test_invite_user(
 
             await aqtbot.wait_until(_email_send_failed)
             assert not email_letterbox.emails
+
+
+@pytest.mark.gui
+@pytest.mark.trio
+@pytest.mark.parametrize("online", (True, False))
+@customize_fixtures(logged_gui_as_admin=True)
+@customize_fixtures(alice_has_human_handle=True)
+async def test_invite_user_greeter_has_human_handle(
+    aqtbot,
+    logged_gui,
+    bob,
+    running_backend,
+    monkeypatch,
+    autoclose_dialog,
+    email_letterbox,
+    online,
+    snackbar_catcher,
+):
+    await _invite_user(
+        aqtbot,
+        logged_gui,
+        bob,
+        running_backend,
+        monkeypatch,
+        autoclose_dialog,
+        email_letterbox,
+        online,
+        snackbar_catcher,
+    )
+
+
+@pytest.mark.gui
+@pytest.mark.trio
+@pytest.mark.parametrize("online", (True, False))
+@customize_fixtures(logged_gui_as_admin=True)
+@customize_fixtures(alice_has_human_handle=False)
+async def test_invite_user_greeter_does_not_have_human_handle(
+    aqtbot,
+    logged_gui,
+    bob,
+    running_backend,
+    monkeypatch,
+    autoclose_dialog,
+    email_letterbox,
+    online,
+    snackbar_catcher,
+):
+    await _invite_user(
+        aqtbot,
+        logged_gui,
+        bob,
+        running_backend,
+        monkeypatch,
+        autoclose_dialog,
+        email_letterbox,
+        online,
+        snackbar_catcher,
+    )
 
 
 @pytest.mark.gui


### PR DESCRIPTION
# What has changed ?

Added GUI tests for user invitation, making sure that it works when the greeter has no human handle. The test fails without #3509 and succeeds with it, as expected.

<!-- Why this PR exist ? what is its goal ? -->

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [x] Does this PR affect the User ?

Closes #3505 
<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
