### PR TITLE
Correct fake command group when the module `backend` was missing in the packaging

### DIFF
--- a/parsec/backend/cli/__init__.py
+++ b/parsec/backend/cli/__init__.py
@@ -17,7 +17,7 @@ from parsec.backend.cli.sequester import (
 )
 
 
-__all__ = ("backend_cmd",)
+__all__ = ("backend_cmd_group",)
 
 
 @click.group(short_help="Handle sequestered organization")
@@ -35,11 +35,11 @@ backend_sequester_cmd.add_command(import_service_certificate, "import_service_ce
 
 
 @click.group()
-def backend_cmd() -> None:
+def backend_cmd_group() -> None:
     pass
 
 
-backend_cmd.add_command(run_cmd, "run")
-backend_cmd.add_command(migrate, "migrate")
-backend_cmd.add_command(human_accesses, "human_accesses")
-backend_cmd.add_command(backend_sequester_cmd, "sequester")
+backend_cmd_group.add_command(run_cmd, "run")
+backend_cmd_group.add_command(migrate, "migrate")
+backend_cmd_group.add_command(human_accesses, "human_accesses")
+backend_cmd_group.add_command(backend_sequester_cmd, "sequester")

--- a/parsec/backend/cli/__main__.py
+++ b/parsec/backend/cli/__main__.py
@@ -1,7 +1,7 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 (eventually AGPL-3.0) 2016-present Scille SAS
 from __future__ import annotations
 
-from parsec.backend.cli import backend_cmd
+from parsec.backend.cli import backend_cmd_group
 
 
-backend_cmd()
+backend_cmd_group()

--- a/parsec/cli.py
+++ b/parsec/cli.py
@@ -8,19 +8,19 @@ import os
 from typing import Sequence, Any
 
 from parsec._version import __version__
-from parsec.cli_utils import generate_not_available_cmd
+from parsec.cli_utils import generate_not_available_cmd_group
 
 
 try:
-    from parsec.core.cli import core_cmd
+    from parsec.core.cli import core_cmd_group
 except ImportError as exc:
-    core_cmd = generate_not_available_cmd(exc)
+    core_cmd_group = generate_not_available_cmd_group(exc)
 
 
 try:
-    from parsec.backend.cli import backend_cmd
+    from parsec.backend.cli import backend_cmd_group
 except ImportError as exc:
-    backend_cmd = generate_not_available_cmd(exc)
+    backend_cmd_group = generate_not_available_cmd_group(exc)
 
 
 @click.group()
@@ -29,8 +29,8 @@ def cli() -> None:
     pass
 
 
-cli.add_command(core_cmd, "core")
-cli.add_command(backend_cmd, "backend")
+cli.add_command(core_cmd_group, "core")
+cli.add_command(backend_cmd_group, "backend")
 
 # Add support for PARSEC_CMD_ARGS env var
 

--- a/parsec/cli_utils.py
+++ b/parsec/cli_utils.py
@@ -143,14 +143,16 @@ def generate_not_available_cmd_group(exc: BaseException, hint: str | None = None
         ]
     )
 
-    @click.group(
-        context_settings=dict(ignore_unknown_options=True),
+    class NotAvailableGroup(click.Group):
+        def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+            raise SystemExit(error_msg)
+
+        def list_commands(self, ctx: click.Context) -> list[str]:
+            raise SystemExit(error_msg)
+
+    return NotAvailableGroup(
         help=f"Not available{' (' + hint + ')' if hint else ''}",
     )
-    def bad_cmd(args: Any) -> NoReturn:
-        raise SystemExit(error_msg)
-
-    return bad_cmd
 
 
 def generate_not_available_cmd(exc: BaseException, hint: str | None = None) -> click.Command:

--- a/parsec/cli_utils.py
+++ b/parsec/cli_utils.py
@@ -133,7 +133,7 @@ def cli_exception_handler(debug: bool) -> Iterator[bool]:
             raise SystemExit(1)
 
 
-def generate_not_available_cmd(exc: BaseException, hint: str | None = None) -> click.Group:
+def generate_not_available_cmd_group(exc: BaseException, hint: str | None = None) -> click.Group:
     error_msg = "".join(
         [
             click.style("Not available: ", fg="red"),
@@ -143,7 +143,26 @@ def generate_not_available_cmd(exc: BaseException, hint: str | None = None) -> c
         ]
     )
 
-    @click.group
+    @click.group(
+        context_settings=dict(ignore_unknown_options=True),
+        help=f"Not available{' (' + hint + ')' if hint else ''}",
+    )
+    def bad_cmd(args: Any) -> NoReturn:
+        raise SystemExit(error_msg)
+
+    return bad_cmd
+
+
+def generate_not_available_cmd(exc: BaseException, hint: str | None = None) -> click.Command:
+    error_msg = "".join(
+        [
+            click.style("Not available: ", fg="red"),
+            "Importing this module has failed with error:\n\n",
+            *traceback.format_exception(type(exc), exc, exc.__traceback__),
+            f"\n\n{hint}\n" if hint else "",
+        ]
+    )
+
     @click.command(
         context_settings=dict(ignore_unknown_options=True),
         help=f"Not available{' (' + hint + ')' if hint else ''}",

--- a/parsec/core/cli/__init__.py
+++ b/parsec/core/cli/__init__.py
@@ -19,39 +19,39 @@ from parsec.core.cli import run
 from parsec.core.cli import pki
 
 
-__all__ = ("core_cmd",)
+__all__ = ("core_cmd_group",)
 
 
 @click.group()
-def core_cmd() -> None:
+def core_cmd_group() -> None:
     pass
 
 
-core_cmd.add_command(run.run_gui, "gui")
-core_cmd.add_command(run.run_mountpoint, "run")
-core_cmd.add_command(rsync.run_rsync, "rsync")
-core_cmd.add_command(create_workspace.create_workspace, "create_workspace")
-core_cmd.add_command(share_workspace.share_workspace, "share_workspace")
-core_cmd.add_command(reencrypt_workspace.reencrypt_workspace, "reencrypt_workspace")
-core_cmd.add_command(list_devices.list_devices, "list_devices")
-core_cmd.add_command(list_devices.remove_device, "remove_device")
-core_cmd.add_command(recovery.export_recovery_device, "export_recovery_device")
-core_cmd.add_command(recovery.import_recovery_device, "import_recovery_device")
-core_cmd.add_command(human_find.human_find, "human_find")
+core_cmd_group.add_command(run.run_gui, "gui")
+core_cmd_group.add_command(run.run_mountpoint, "run")
+core_cmd_group.add_command(rsync.run_rsync, "rsync")
+core_cmd_group.add_command(create_workspace.create_workspace, "create_workspace")
+core_cmd_group.add_command(share_workspace.share_workspace, "share_workspace")
+core_cmd_group.add_command(reencrypt_workspace.reencrypt_workspace, "reencrypt_workspace")
+core_cmd_group.add_command(list_devices.list_devices, "list_devices")
+core_cmd_group.add_command(list_devices.remove_device, "remove_device")
+core_cmd_group.add_command(recovery.export_recovery_device, "export_recovery_device")
+core_cmd_group.add_command(recovery.import_recovery_device, "import_recovery_device")
+core_cmd_group.add_command(human_find.human_find, "human_find")
 
-core_cmd.add_command(invitation.invite_user, "invite_user")
-core_cmd.add_command(invitation.invite_device, "invite_device")
-core_cmd.add_command(invitation.list_invitations, "list_invitations")
-core_cmd.add_command(invitation.greet_invitation, "greet_invitation")
-core_cmd.add_command(invitation.claim_invitation, "claim_invitation")
-core_cmd.add_command(invitation.cancel_invitation, "cancel_invitation")
+core_cmd_group.add_command(invitation.invite_user, "invite_user")
+core_cmd_group.add_command(invitation.invite_device, "invite_device")
+core_cmd_group.add_command(invitation.list_invitations, "list_invitations")
+core_cmd_group.add_command(invitation.greet_invitation, "greet_invitation")
+core_cmd_group.add_command(invitation.claim_invitation, "claim_invitation")
+core_cmd_group.add_command(invitation.cancel_invitation, "cancel_invitation")
 
-core_cmd.add_command(create_organization.create_organization, "create_organization")
-core_cmd.add_command(stats_organization.stats_organization, "stats_organization")
-core_cmd.add_command(status_organization.status_organization, "status_organization")
-core_cmd.add_command(stats_organization.stats_server, "stats_server")
-core_cmd.add_command(bootstrap_organization.bootstrap_organization, "bootstrap_organization")
+core_cmd_group.add_command(create_organization.create_organization, "create_organization")
+core_cmd_group.add_command(stats_organization.stats_organization, "stats_organization")
+core_cmd_group.add_command(status_organization.status_organization, "status_organization")
+core_cmd_group.add_command(stats_organization.stats_server, "stats_server")
+core_cmd_group.add_command(bootstrap_organization.bootstrap_organization, "bootstrap_organization")
 
-core_cmd.add_command(pki.pki_enrollment_submit, "pki_enrollment_submit")
-core_cmd.add_command(pki.pki_enrollment_poll, "pki_enrollment_poll")
-core_cmd.add_command(pki.pki_enrollment_review_pendings, "pki_enrollment_review_pendings")
+core_cmd_group.add_command(pki.pki_enrollment_submit, "pki_enrollment_submit")
+core_cmd_group.add_command(pki.pki_enrollment_poll, "pki_enrollment_poll")
+core_cmd_group.add_command(pki.pki_enrollment_review_pendings, "pki_enrollment_review_pendings")

--- a/parsec/core/cli/__main__.py
+++ b/parsec/core/cli/__main__.py
@@ -1,7 +1,7 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
 from __future__ import annotations
 
-from parsec.core.cli import core_cmd
+from parsec.core.cli import core_cmd_group
 
 
-core_cmd()
+core_cmd_group()

--- a/parsec/core/cli/run.py
+++ b/parsec/core/cli/run.py
@@ -24,7 +24,7 @@ try:
     from parsec.core.gui import run_gui as _run_gui
 
 except ImportError as exc:
-    _run_gui = generate_not_available_cmd(exc)
+    run_gui = generate_not_available_cmd(exc)
 
 else:
 


### PR DESCRIPTION
When building a pre-release wheel of `parsec` `cibuildwheel` was failing in the test phase of the wheel.
The cause was a problem with a bad use of the decorator `click.group` alongside `click.command`, both seems to be exclusive.

Alongside the fix, We also choose
 
- To rename `backend_cmd` => `backend_cmd_group`
- To rename `core_cmd` => `core_cmd_group`
- Correct the definition of the fake cmd `run_gui` in `core.cli.run`

Co-Authored: @vxgmichel 