### PR TITLE
mypy: Add mypy typing to `crypto`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -115,8 +115,6 @@ allow_incomplete_defs = True
 ignore_errors = True
 [mypy-parsec.types]
 ignore_errors = True
-[mypy-parsec.crypto]
-ignore_errors = True
 
 # Untyped modules in parsec.core.*
 [mypy-parsec.core.messages_monitor]


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
This PR adds mypy typing for `crypto` module. This closes #3528 

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
