### PR TITLE
mypy: Add mypy typing to `service_nursery`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -116,8 +116,6 @@ allow_incomplete_defs = True
 ignore_errors = True
 [mypy-parsec.sequester_crypto]
 ignore_errors = True
-[mypy-parsec.service_nursery]
-ignore_errors = True
 [mypy-parsec.win32]
 ignore_errors = True
 [mypy-parsec.types]


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
This PR adds support to module `add-mypy-service-nursery`. This closes #3530 .

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
