### PR TITLE
[GUI] Fixed user display on workspace button

### DIFF
--- a/parsec/core/gui/workspace_button.py
+++ b/parsec/core/gui/workspace_button.py
@@ -353,7 +353,9 @@ class WorkspaceButton(QWidget, Ui_WorkspaceButton):
                 if self.get_owner():
                     owner = self.get_owner()
                     if owner:
-                        shared_message = _("TEXT_WORKSPACE_IS_OWNED_BY_user").format(user=owner)
+                        shared_message = _("TEXT_WORKSPACE_IS_OWNED_BY_user").format(
+                            user=owner.short_user_display
+                        )
                 # We don't know the owner's name, just display that the workspace is shared
                 else:
                     shared_message = _("TEXT_WORKSPACE_IS_SHARED")


### PR DESCRIPTION
# What has changed ?

See #3548.
<!-- Why this PR exist ? what is its goal ? -->

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
Closes #3548 
