### PR TITLE
mypy: Add mypy typing to `messages_monitor`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -111,8 +111,3 @@ ignore_errors = True
 ignore_errors = True
 [mypy-parsec.types]
 ignore_errors = True
-
-# Untyped modules in parsec.core.*
-[mypy-parsec.core.messages_monitor]
-allow_untyped_defs = True
-allow_incomplete_defs = True

--- a/parsec/core/messages_monitor.py
+++ b/parsec/core/messages_monitor.py
@@ -2,17 +2,19 @@
 from __future__ import annotations
 
 import trio
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from parsec.core.core_events import CoreEvent
 from parsec.core.fs import FSBackendOfflineError
 from parsec.core.backend_connection import BackendNotAvailable
+from parsec.core.fs.userfs import UserFS
+from parsec.event_bus import EventBus, EventCallback
 
 if TYPE_CHECKING:
     from parsec.core.backend_connection.authenticated import MonitorTaskStatus
 
 
-async def freeze_messages_monitor_mockpoint():
+async def freeze_messages_monitor_mockpoint() -> None:
     """
     Noop function that could be mocked during tests to be able to freeze the
     monitor coroutine running in background
@@ -20,10 +22,12 @@ async def freeze_messages_monitor_mockpoint():
     pass
 
 
-async def monitor_messages(user_fs, event_bus, task_status: MonitorTaskStatus):
+async def monitor_messages(
+    user_fs: UserFS, event_bus: EventBus, task_status: MonitorTaskStatus
+) -> None:
     wakeup = trio.Event()
 
-    def _on_message_received(event, index):
+    def _on_message_received(event: CoreEvent, index: int) -> None:
         nonlocal wakeup
         wakeup.set()
         # Don't wait for the *actual* awakening to change the status to
@@ -31,7 +35,9 @@ async def monitor_messages(user_fs, event_bus, task_status: MonitorTaskStatus):
         # not yet notified to task_status
         task_status.awake()
 
-    with event_bus.connect_in_context((CoreEvent.BACKEND_MESSAGE_RECEIVED, _on_message_received)):
+    with event_bus.connect_in_context(
+        (CoreEvent.BACKEND_MESSAGE_RECEIVED, cast(EventCallback, _on_message_received))
+    ):
         try:
             await user_fs.process_last_messages()
             task_status.started()


### PR DESCRIPTION


# What has changed ?

Mypy is now activated on every modules of `parsec.core`. This PR adds mypy typing to `parsec.core.messages_monitor` which is the last module of `core` without proper typing. This closes #3566 

<!-- Why this PR exist ? what is its goal ? -->

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
