### PR TITLE
mypy: Remove unused error ignore for `monitoring`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -107,10 +107,6 @@ ignore_errors = True
 # Untyped parsec modules (yet)
 
 # Untyped modules in parsec.*
-[mypy-parsec.monitoring]
-allow_untyped_defs = True
-allow_incomplete_defs = True
-
 [mypy-parsec.win32]
 ignore_errors = True
 [mypy-parsec.types]


### PR DESCRIPTION
# What has changed ?
Type checking for `parsec.monitoring` has been accidentally disabled by commit `c404347b94` despite this module has been properly typed by #3515.

<!-- Why this PR exist ? what is its goal ? -->

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
