### PR TITLE
Add the option to rename recovery device at creation

### DIFF
--- a/newsfragments/3537.misc.rst
+++ b/newsfragments/3537.misc.rst
@@ -1,0 +1,1 @@
+Recovery devices can now be renamed when created.

--- a/parsec/core/gui/device_recovery_export_widget.py
+++ b/parsec/core/gui/device_recovery_export_widget.py
@@ -69,7 +69,7 @@ class DeviceRecoveryExportPage2Widget(QWidget, Ui_DeviceRecoveryExportPage2Widge
 
     def _print_recovery_key(self) -> None:
         html = translate("TEXT_RECOVERY_HTML_EXPORT_user-organization-keyname-password").format(
-            organization=self.device.organization_id,
+            organization=self.device.organization_id.str,
             label=self.device.user_display,
             password=self.passphrase,
             keyname=PurePath(self.label_file_path.text()).name,

--- a/parsec/core/gui/device_recovery_export_widget.py
+++ b/parsec/core/gui/device_recovery_export_widget.py
@@ -19,8 +19,8 @@ from parsec.core.local_device import (
     get_recovery_device_file_name,
     save_recovery_device,
     get_available_device,
-    LocalDeviceAlreadyExistsError,
     DeviceFileType,
+    RECOVERY_DEVICE_FILE_SUFFIX,
 )
 from parsec.core.gui.trio_jobs import QtToTrioJob, JobResultError, QtToTrioJobScheduler
 from parsec.core.gui.lang import translate
@@ -93,11 +93,14 @@ class DeviceRecoveryExportPage1Widget(QWidget, Ui_DeviceRecoveryExportPage1Widge
             )
 
     def _on_select_file_clicked(self) -> None:
-        key_dir = QDialogInProcess.getExistingDirectory(
-            self, translate("TEXT_EXPORT_KEY"), str(Path.home())
+        key_file, _ = QDialogInProcess.getSaveFileName(
+            self,
+            translate("TEXT_EXPORT_KEY"),
+            str(Path.home() / get_recovery_device_file_name(self.get_selected_device())),
+            f"*{RECOVERY_DEVICE_FILE_SUFFIX}",
         )
-        if key_dir:
-            self.label_file_path.setText(key_dir)
+        if key_file:
+            self.label_file_path.setText(key_file)
         self._check_infos()
 
     def _check_infos(self) -> None:
@@ -162,19 +165,14 @@ class DeviceRecoveryExportWidget(QWidget, Ui_DeviceRecoveryExportWidget):
     ) -> tuple[LocalDevice, PurePath, str]:
         try:
             recovery_device = await generate_recovery_device(device)
-            file_name = get_recovery_device_file_name(recovery_device)
-            file_path = export_path / file_name
-            passphrase = await save_recovery_device(file_path, recovery_device)
-            return recovery_device, file_path, passphrase
+            passphrase = await save_recovery_device(export_path, recovery_device, force=True)
+            return recovery_device, export_path, passphrase
         except BackendNotAvailable as exc:
             show_error(self, translate("EXPORT_KEY_BACKEND_OFFLINE"), exception=exc)
             raise JobResultError("backend-error") from exc
         except BackendConnectionError as exc:
             show_error(self, translate("EXPORT_KEY_BACKEND_ERROR"), exception=exc)
             raise JobResultError("backend-error") from exc
-        except LocalDeviceAlreadyExistsError as exc:
-            show_error(self, translate("TEXT_RECOVERY_DEVICE_FILE_ALREADY_EXISTS"), exception=exc)
-            raise JobResultError("already-exists") from exc
         except Exception as exc:
             show_error(self, translate("EXPORT_KEY_ERROR"), exception=exc)
             raise JobResultError("error") from exc

--- a/parsec/core/local_device.py
+++ b/parsec/core/local_device.py
@@ -233,7 +233,7 @@ def get_default_key_file(config_dir: Path, device: LocalDevice) -> Path:
     return get_devices_dir(config_dir) / f"{device.slughash}{DEVICE_FILE_SUFFIX}"
 
 
-def get_recovery_device_file_name(recovery_device: LocalDevice) -> str:
+def get_recovery_device_file_name(recovery_device: LocalDevice | AvailableDevice) -> str:
     return f"parsec-recovery-{recovery_device.organization_id.str}-{recovery_device.short_user_display}{RECOVERY_DEVICE_FILE_SUFFIX}"
 
 

--- a/tests/core/gui/test_recovery.py
+++ b/tests/core/gui/test_recovery.py
@@ -40,7 +40,7 @@ def catch_export_recovery_widget(widget_catcher_factory):
 
 @pytest.mark.gui
 @pytest.mark.trio
-@pytest.mark.parametrize("kind", ["ok", "offline", "already_exists"])
+@pytest.mark.parametrize("kind", ["ok", "offline"])
 async def test_export_recovery_device(
     gui,
     aqtbot,
@@ -72,7 +72,7 @@ async def test_export_recovery_device(
     assert exp_w.current_page.combo_devices.count() == 1
     assert exp_w.current_page.combo_devices.currentData() == alice.slug
 
-    exp_w.current_page.label_file_path.setText(str(tmp_path))
+    exp_w.current_page.label_file_path.setText(str(tmp_path / get_recovery_device_file_name(alice)))
 
     exp_w.current_page._check_infos()
 
@@ -109,19 +109,6 @@ async def test_export_recovery_device(
                 ]
 
             await aqtbot.wait_until(_error_shown)
-
-    elif kind == "already_exists":
-        file_name = get_recovery_device_file_name(alice)
-        (tmp_path / file_name).touch()
-
-        aqtbot.mouse_click(exp_w.button_validate, QtCore.Qt.LeftButton)
-
-        def _error_shown():
-            assert autoclose_dialog.dialogs == [
-                ("Error", translate("TEXT_RECOVERY_DEVICE_FILE_ALREADY_EXISTS"))
-            ]
-
-        await aqtbot.wait_until(_error_shown)
 
 
 @pytest.mark.gui


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [x] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
