### PR TITLE
Remove pki enrollment status field

### DIFF
--- a/parsec/api/protocol/__init__.py
+++ b/parsec/api/protocol/__init__.py
@@ -123,7 +123,6 @@ from parsec.api.protocol.vlob import (
 )
 from parsec.api.protocol.pki import (
     PkiEnrollmentStatus,
-    PkiEnrollmentStatusField,
     pki_enrollment_submit_serializer,
     pki_enrollment_info_serializer,
     pki_enrollment_list_serializer,
@@ -262,7 +261,6 @@ __all__ = (
     "BlockCreateRep",
     # PKI enrollment
     "PkiEnrollmentStatus",
-    "PkiEnrollmentStatusField",
     "pki_enrollment_submit_serializer",
     "pki_enrollment_info_serializer",
     "pki_enrollment_list_serializer",

--- a/parsec/api/protocol/pki.py
+++ b/parsec/api/protocol/pki.py
@@ -15,9 +15,6 @@ class PkiEnrollmentStatus(Enum):
     CANCELLED = "CANCELLED"
 
 
-PkiEnrollmentStatusField = fields.enum_field_factory(PkiEnrollmentStatus)
-
-
 # pki_enrollment_submit
 
 


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
`PkiEnrollmentStatus` is unused

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
closes #3575
