### PR TITLE
Protect _net_send against LocalProtocolError

### DIFF
--- a/newsfragments/3595.bugfix.rst
+++ b/newsfragments/3595.bugfix.rst
@@ -1,0 +1,1 @@
+Fix an issue that prevented proper reconnection of the client in some specific cases

--- a/parsec/api/transport.py
+++ b/parsec/api/transport.py
@@ -94,6 +94,9 @@ class Transport:
         except RemoteProtocolError as exc:
             raise TransportError(*exc.args) from exc
 
+        except LocalProtocolError as exc:
+            raise TransportError(*exc.args) from exc
+
     @classmethod
     async def init_for_client(
         cls: Type["Transport"],

--- a/parsec/core/backend_connection/transport.py
+++ b/parsec/core/backend_connection/transport.py
@@ -120,6 +120,8 @@ async def _connect(
         stream = _upgrade_stream_to_ssl(stream, hostname)
 
     try:
+        # TODO: explain why keepalive is not passed as a parameter
+        # It may be a good reason, but I'm not entirely sure
         transport = await Transport.init_for_client(stream, host=hostname)
         transport.keepalive = keepalive
 


### PR DESCRIPTION
Fix #3595 

# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [x] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
