### PR TITLE
Remove `dependabot` from ignored branch for the news fragment check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,7 @@ jobs:
         if: |
           startsWith(github.ref, 'refs/pull/')
           && !(
-            startsWith(github.head_ref, 'dependabot')
-            || startsWith(github.head_ref, 'yolo')
+            startsWith(github.head_ref, 'yolo')
             || startsWith(github.head_ref, 'release')
             || startsWith(github.head_ref, 'revert')
             )


### PR DESCRIPTION
The news fragments check is now only run when:

- The folder `newsfragments` or it's content was modified.
- The branch don't start with `yolo`, `revert` and `release`.

Ignoring branch starting with `dependabot` don't make sense here because `dependabot` **MUST NOT** edit that folder or it's content.
