### PR TITLE
Add client version in logs

### DIFF
--- a/parsec/_parsec_pyi/addrs.pyi
+++ b/parsec/_parsec_pyi/addrs.pyi
@@ -113,7 +113,7 @@ class BackendOrganizationBootstrapAddr(BackendAddr):
         cls,
         backend_addr: BackendAddr,
         organization_id: OrganizationID,
-        token: str | None,
+        token: str | None = None,
     ) -> BackendOrganizationBootstrapAddr: ...
 
 class BackendOrganizationFileLinkAddr(BackendAddr):

--- a/parsec/backend/asgi/rpc.py
+++ b/parsec/backend/asgi/rpc.py
@@ -222,6 +222,9 @@ async def anonymous_api(raw_organization_id: str) -> Response:
 
     # Retrieve command
     client_ctx = AnonymousClientContext(organization_id)
+    client_ctx.logger.info(
+        f"Anonymous client successfully connected (client version: {api_version})"
+    )
     if not isinstance(cmd, str):
         return _rpc_msgpack_rep({"status": "unknown_command"}, api_version)
 
@@ -275,6 +278,9 @@ async def authenticated_api(raw_organization_id: str) -> Response:
         profile=user.profile,
         public_key=user.public_key,
         verify_key=device.verify_key,
+    )
+    client_ctx.logger.info(
+        f"Authenticated client successfully connected (client version: {api_version})"
     )
 
     cmd_rep = await cmd_func(client_ctx, msg)

--- a/parsec/backend/asgi/ws.py
+++ b/parsec/backend/asgi/ws.py
@@ -63,7 +63,7 @@ async def handle_ws() -> None:
         return
 
     selected_logger = client_ctx.logger
-    selected_logger.info("Connection established")
+    selected_logger.info(f"Connection established (client version: {client_ctx.api_version})")
 
     # 2) Setup events listener according to client type
 

--- a/tests/backend/test_rpc_handshake.py
+++ b/tests/backend/test_rpc_handshake.py
@@ -1,6 +1,7 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
 from __future__ import annotations
 
+import logging
 from base64 import b64encode
 from typing import Union
 from unittest.mock import patch
@@ -218,3 +219,17 @@ async def test_handshake(
     await _test_handshake_body_not_msgpack(anonymous_rpc, alice)
 
     await _test_authenticated_handshake_author_not_found(alice_rpc)
+
+
+@pytest.mark.trio
+async def test_client_version_in_logs(
+    alice_rpc: AuthenticatedRpcApiClient, anonymous_rpc: AuthenticatedRpcApiClient, caplog
+):
+    with caplog.at_level(logging.INFO):
+        # Authenticated
+        await _test_good_handshake(alice_rpc)
+        assert f"Authenticated client successfully connected (client version: {API_VERSION})"
+
+        # Anonymous
+        await _test_good_handshake(anonymous_rpc)
+        assert f"Anonymous client successfully connected (client version: {API_VERSION})"


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
This PR allows to show what version a client is using in logs. This closes #3615 

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
