### PR TITLE
Sequester export filter date

### DIFF
--- a/parsec/sequester_export_reader.py
+++ b/parsec/sequester_export_reader.py
@@ -180,6 +180,7 @@ class WorkspaceExport:
     filter_on_date: DateTime
 
     def load_manifest(self, manifest_id: EntryID) -> AnyRemoteManifest:
+        # Convert datetime to integer timestamp with us precision (format used in sqlite dump).
         filter_timestamp = int(self.filter_on_date.timestamp() * 1000000)
         row = self.db.con.execute(
             "SELECT version, blob, author, timestamp FROM vlob_atom WHERE vlob_id = ? and timestamp <= ? ORDER BY version DESC LIMIT 1",

--- a/parsec/sequester_export_reader.py
+++ b/parsec/sequester_export_reader.py
@@ -177,11 +177,13 @@ class WorkspaceExport:
     db: RealmExportDb
     decryption_key: PrivateKey
     devices_form_internal_id: Dict[int, Tuple[DeviceID, VerifyKey]]
+    filter_on_date: DateTime
 
     def load_manifest(self, manifest_id: EntryID) -> AnyRemoteManifest:
+        filter_timestamp = int(self.filter_on_date.timestamp() * 1000000)
         row = self.db.con.execute(
-            "SELECT version, blob, author, timestamp FROM vlob_atom WHERE vlob_id = ? ORDER BY version DESC LIMIT 1",
-            (manifest_id.bytes,),
+            "SELECT version, blob, author, timestamp FROM vlob_atom WHERE vlob_id = ? and timestamp <= ? ORDER BY version DESC LIMIT 1",
+            (manifest_id.bytes, filter_timestamp),
         ).fetchone()
         if not row:
             raise InconsistentWorkspaceError(
@@ -371,7 +373,7 @@ class WorkspaceExport:
 
 
 def extract_workspace(
-    output: Path, export_db: Path, decryption_key: PrivateKey
+    output: Path, export_db: Path, decryption_key: PrivateKey, filter_on_date: DateTime
 ) -> Iterator[Tuple[PurePath | None, RealmExportProgress, str]]:
     with RealmExportDb.open(export_db) as db:
         out_certificates: list[Tuple[int, DeviceCertificate]] = []
@@ -380,6 +382,9 @@ def extract_workspace(
             id: (certif.device_id, certif.verify_key) for id, certif in out_certificates
         }
         wksp = WorkspaceExport(
-            db=db, decryption_key=decryption_key, devices_form_internal_id=devices_form_internal_id
+            db=db,
+            decryption_key=decryption_key,
+            devices_form_internal_id=devices_form_internal_id,
+            filter_on_date=filter_on_date,
         )
         yield from wksp.extract_workspace(output=output)

--- a/tests/backend/sequester/test_export.py
+++ b/tests/backend/sequester/test_export.py
@@ -817,7 +817,10 @@ async def test_export_reader_full_run(tmp_path, coolorg: OrganizationFullData, a
     dump_path = tmp_path / "extract_dump"
     list(
         extract_workspace(
-            output=dump_path, export_db=output_db_path, decryption_key=service_decryption_key
+            output=dump_path,
+            export_db=output_db_path,
+            decryption_key=service_decryption_key,
+            filter_on_date=DateTime.now(),
         )
     )
 
@@ -828,3 +831,19 @@ async def test_export_reader_full_run(tmp_path, coolorg: OrganizationFullData, a
     assert {x.name for x in (dump_path / "folder2").iterdir()} == {"file2", "folder3"}
     assert (dump_path / "folder2/file2").read_bytes() == b"a" * 10 + b"b" * 10
     assert {x.name for x in (dump_path / "folder2/folder3").iterdir()} == set()
+
+    # Extract dump at 2000-03-14, where folder2 was empty
+    dump_path_ts = tmp_path / "extract_dump_ts"
+    list(
+        extract_workspace(
+            output=dump_path_ts,
+            export_db=output_db_path,
+            decryption_key=service_decryption_key,
+            filter_on_date=DateTime(2000, 3, 14),
+        )
+    )
+    # Check the result
+    assert {x.name for x in dump_path_ts.iterdir()} == {"file1", "folder1", "folder2"}
+    assert (dump_path_ts / "file1").read_bytes() == b""
+    assert {x.name for x in (dump_path_ts / "folder1").iterdir()} == set()
+    assert {x.name for x in (dump_path_ts / "folder2").iterdir()} == set()


### PR DESCRIPTION
# What has changed ?
Add sequester timestamp cli parameter when building exported data

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
