### PR TITLE
Use Protocol V3 on python binding

### DIFF
--- a/oxidation/libparsec/crates/core/src/trustchain.rs
+++ b/oxidation/libparsec/crates/core/src/trustchain.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 use crate::{build_signature_path, TrustchainError, TrustchainResult};
 use libparsec_crypto::VerifyKey;
-use libparsec_protocol::authenticated_cmds::v2::user_get::Trustchain;
+use libparsec_protocol::authenticated_cmds::v3::user_get::Trustchain;
 use libparsec_types::{
     CertificateSignerOwned, CertificateSignerRef, DateTime, DeviceCertificate, DeviceID,
     RevokedUserCertificate, TimeProvider, UserCertificate, UserID, UserProfile,

--- a/oxidation/libparsec/crates/core/tests/test_trustchain.rs
+++ b/oxidation/libparsec/crates/core/tests/test_trustchain.rs
@@ -4,7 +4,7 @@ use chrono::{TimeZone, Utc};
 use rstest::rstest;
 
 use libparsec_core::{TrustchainContext, TrustchainError};
-use libparsec_protocol::authenticated_cmds::v2::user_get::Trustchain;
+use libparsec_protocol::authenticated_cmds::v3::user_get::Trustchain;
 use libparsec_types::{
     CertificateSignerOwned, DateTime, DeviceCertificate, DeviceID, RevokedUserCertificate,
     UserCertificate, UserProfile,

--- a/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/realm_update_roles.json5
+++ b/oxidation/libparsec/crates/protocol/schema/authenticated_cmds/realm_update_roles.json5
@@ -2,8 +2,6 @@
     {
         "label": "RealmUpdateRoles",
         "major_versions": [
-            1,
-            2,
             3
         ],
         "req": {
@@ -57,6 +55,90 @@
             },
             "in_maintenance": {},
             "user_revoked": {},
+            "require_greater_timestamp": {
+                "fields": {
+                    "strictly_greater_than": {
+                        "type": "DateTime"
+                    }
+                }
+            },
+            "bad_timestamp": {
+                "fields": {
+                    "reason": {
+                        "type": "NonRequiredOption<String>"
+                    },
+                    "ballpark_client_early_offset": {
+                        "type": "Float"
+                    },
+                    "ballpark_client_late_offset": {
+                        "type": "Float"
+                    },
+                    "backend_timestamp": {
+                        "type": "DateTime"
+                    },
+                    "client_timestamp": {
+                        "type": "DateTime"
+                    }
+                }
+            }
+        }
+    },
+    {
+        "label": "RealmUpdateRoles",
+        "major_versions": [
+            1,
+            2
+        ],
+        "req": {
+            "cmd": "realm_update_roles",
+            "fields": {
+                "role_certificate": {
+                    "type": "Bytes"
+                },
+                "recipient_message": {
+                    "type": "RequiredOption<Bytes>"
+                }
+            }
+        },
+        "reps": {
+            "ok": {},
+            "not_allowed": {
+                "fields": {
+                    "reason": {
+                        "type": "NonRequiredOption<String>"
+                    }
+                }
+            },
+            "invalid_certification": {
+                "fields": {
+                    "reason": {
+                        "type": "NonRequiredOption<String>"
+                    }
+                }
+            },
+            "invalid_data": {
+                "fields": {
+                    "reason": {
+                        "type": "NonRequiredOption<String>"
+                    }
+                }
+            },
+            "already_granted": {},
+            "incompatible_profile": {
+                "fields": {
+                    "reason": {
+                        "type": "NonRequiredOption<String>"
+                    }
+                }
+            },
+            "not_found": {
+                "fields": {
+                    "reason": {
+                        "type": "NonRequiredOption<String>"
+                    }
+                }
+            },
+            "in_maintenance": {},
             "require_greater_timestamp": {
                 "fields": {
                     "strictly_greater_than": {

--- a/oxidation/libparsec/crates/protocol/tests/test_realm.rs
+++ b/oxidation/libparsec/crates/protocol/tests/test_realm.rs
@@ -611,16 +611,17 @@ fn serde_realm_update_roles_req(#[case] raw_expected: (&[u8], authenticated_cmds
         authenticated_cmds::realm_update_roles::Rep::InMaintenance
     )
 )]
-#[case::user_revoked(
-    (
-        // Generated from Python implementation (Parsec v2.11.1+dev)
-        // Content:
-        //   status: "user_revoked"
-        //
-        &hex!("81a6737461747573ac757365725f7265766f6b6564")[..],
-        authenticated_cmds::realm_update_roles::Rep::UserRevoked
-    )
-)]
+// TODO: Test me on API-v3
+// #[case::user_revoked(
+//     (
+//         // Generated from Python implementation (Parsec v2.11.1+dev)
+//         // Content:
+//         //   status: "user_revoked"
+//         //
+//         &hex!("81a6737461747573ac757365725f7265766f6b6564")[..],
+//         authenticated_cmds::realm_update_roles::Rep::UserRevoked
+//     )
+// )]
 #[case::require_greater_timestamp(
     (
         // Generated from Python implementation (Parsec v2.11.1+dev)

--- a/parsec/_parsec_pyi/protocol/realm.pyi
+++ b/parsec/_parsec_pyi/protocol/realm.pyi
@@ -41,10 +41,10 @@ class RealmCreateRepBadTimestamp(RealmCreateRep):
     def __init__(
         self,
         reason: str | None,
-        ballpark_client_early_offset: float | None,
-        ballpark_client_late_offset: float | None,
-        backend_timestamp: DateTime | None,
-        client_timestamp: DateTime | None,
+        ballpark_client_early_offset: float,
+        ballpark_client_late_offset: float,
+        backend_timestamp: DateTime,
+        client_timestamp: DateTime,
     ) -> None: ...
     @property
     def reason(self) -> str | None: ...

--- a/src/enumerate.rs
+++ b/src/enumerate.rs
@@ -6,7 +6,7 @@ use pyo3::{
 };
 
 use libparsec::client_types;
-use libparsec::protocol::authenticated_cmds::v2::{invite_delete, invite_new};
+use libparsec::protocol::authenticated_cmds::v3::{invite_delete, invite_new};
 
 #[pyclass]
 #[derive(Clone)]

--- a/src/protocol/block.rs
+++ b/src/protocol/block.rs
@@ -9,7 +9,7 @@ use crate::{
         gen_rep,
     },
 };
-use libparsec::protocol::authenticated_cmds::v2::{block_create, block_read};
+use libparsec::protocol::authenticated_cmds::v3::{block_create, block_read};
 
 #[pyclass]
 #[derive(Clone)]

--- a/src/protocol/cmds.rs
+++ b/src/protocol/cmds.rs
@@ -6,8 +6,8 @@ use pyo3::{
 };
 
 use libparsec::protocol::{
-    anonymous_cmds::v2 as anonymous_cmds, authenticated_cmds::v2 as authenticated_cmds,
-    invited_cmds::v2 as invited_cmds,
+    anonymous_cmds::v3 as anonymous_cmds, authenticated_cmds::v3 as authenticated_cmds,
+    invited_cmds::v3 as invited_cmds,
 };
 
 use crate::protocol::*;

--- a/src/protocol/events.rs
+++ b/src/protocol/events.rs
@@ -6,7 +6,7 @@ use crate::{
         Reason,
     },
 };
-use libparsec::protocol::authenticated_cmds::v2::{
+use libparsec::protocol::authenticated_cmds::v3::{
     events_listen::{self, APIEvent},
     events_subscribe,
 };

--- a/src/protocol/invite.rs
+++ b/src/protocol/invite.rs
@@ -6,12 +6,12 @@ use pyo3::{
     types::{PyBytes, PyType},
 };
 
-use libparsec::protocol::authenticated_cmds::v2::{
+use libparsec::protocol::authenticated_cmds::v3::{
     invite_1_greeter_wait_peer, invite_2a_greeter_get_hashed_nonce, invite_2b_greeter_send_nonce,
     invite_3a_greeter_wait_peer_trust, invite_3b_greeter_signify_trust,
     invite_4_greeter_communicate, invite_delete, invite_list, invite_new,
 };
-use libparsec::protocol::invited_cmds::v2::{
+use libparsec::protocol::invited_cmds::v3::{
     invite_1_claimer_wait_peer, invite_2a_claimer_send_hashed_nonce, invite_2b_claimer_send_nonce,
     invite_3a_claimer_signify_trust, invite_3b_claimer_wait_peer_trust,
     invite_4_claimer_communicate, invite_info,
@@ -232,7 +232,7 @@ impl InviteNewRepOk {
             Self,
             InviteNewRep(invite_new::Rep::Ok {
                 token,
-                email_sent: libparsec::types::Maybe::Present(email_sent.0),
+                email_sent: email_sent.0,
             }),
         ))
     }
@@ -248,10 +248,9 @@ impl InviteNewRepOk {
     #[getter]
     fn email_sent(_self: PyRef<'_, Self>) -> PyResult<InvitationEmailSentStatus> {
         match &_self.as_ref().0 {
-            invite_new::Rep::Ok { email_sent, .. } => match email_sent {
-                libparsec::types::Maybe::Present(p) => Ok(InvitationEmailSentStatus(p.clone())),
-                libparsec::types::Maybe::Absent => Err(PyAttributeError::new_err("")),
-            },
+            invite_new::Rep::Ok { email_sent, .. } => {
+                Ok(InvitationEmailSentStatus(email_sent.clone()))
+            }
             _ => Err(PyAttributeError::new_err("")),
         }
     }

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -6,7 +6,7 @@ use pyo3::{
     types::{PyBytes, PyTuple},
 };
 
-use libparsec::protocol::authenticated_cmds::v2::message_get;
+use libparsec::protocol::authenticated_cmds::v3::message_get;
 
 use crate::ids::DeviceID;
 use crate::protocol::{

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -31,8 +31,6 @@ use pyo3::{types::PyModule, PyResult, Python};
 pub(crate) type Reason = Option<String>;
 pub(crate) type Bytes = Vec<u8>;
 pub(crate) type ListOfBytes = Vec<Vec<u8>>;
-pub(crate) type OptionalFloat = Option<f64>;
-pub(crate) type OptionalDateTime = Option<crate::time::DateTime>;
 
 macro_rules! rs_to_py {
     ($v: ident, Reason, $py: ident) => {
@@ -53,18 +51,6 @@ macro_rules! rs_to_py {
     };
     ($v: ident, SequesterServiceID, $py: ident) => {
         SequesterServiceID(*$v)
-    };
-    ($v: ident, OptionalDateTime, $py: ident) => {
-        match *$v {
-            libparsec::types::Maybe::Present(v) => Some(DateTime(v)),
-            libparsec::types::Maybe::Absent => None,
-        }
-    };
-    ($v: ident, OptionalFloat, $py: ident) => {
-        match *$v {
-            libparsec::types::Maybe::Present(v) => Some(v),
-            libparsec::types::Maybe::Absent => None,
-        }
     };
     ($v: ident, $ty: ty, $py: ident) => {
         *$v

--- a/src/protocol/organization.rs
+++ b/src/protocol/organization.rs
@@ -6,7 +6,7 @@ use pyo3::{
     types::{PyBytes, PyTuple},
 };
 
-use libparsec::protocol::authenticated_cmds::v2::{organization_config, organization_stats};
+use libparsec::protocol::authenticated_cmds::v3::{organization_config, organization_stats};
 
 use crate::{
     enumerate::UserProfile,
@@ -226,12 +226,8 @@ impl OrganizationConfigRepOk {
             OrganizationConfigRep(organization_config::Rep::Ok {
                 user_profile_outsider_allowed,
                 active_users_limit,
-                sequester_authority_certificate: libparsec::types::Maybe::Present(
-                    sequester_authority_certificate,
-                ),
-                sequester_services_certificates: libparsec::types::Maybe::Present(
-                    sequester_services_certificates,
-                ),
+                sequester_authority_certificate,
+                sequester_services_certificates,
             }),
         ))
     }
@@ -266,10 +262,9 @@ impl OrganizationConfigRepOk {
             organization_config::Rep::Ok {
                 sequester_authority_certificate,
                 ..
-            } => match sequester_authority_certificate {
-                libparsec::types::Maybe::Present(x) => x.as_ref().map(|x| PyBytes::new(py, x)),
-                _ => None,
-            },
+            } => sequester_authority_certificate
+                .as_ref()
+                .map(|x| PyBytes::new(py, x)),
             _ => return Err(PyNotImplementedError::new_err("")),
         })
     }
@@ -283,12 +278,9 @@ impl OrganizationConfigRepOk {
             organization_config::Rep::Ok {
                 sequester_services_certificates,
                 ..
-            } => match sequester_services_certificates {
-                libparsec::types::Maybe::Present(x) => x
-                    .as_ref()
-                    .map(|x| PyTuple::new(py, x.iter().map(|x| PyBytes::new(py, x)))),
-                _ => None,
-            },
+            } => sequester_services_certificates
+                .as_ref()
+                .map(|x| PyTuple::new(py, x.iter().map(|x| PyBytes::new(py, x)))),
             _ => return Err(PyNotImplementedError::new_err("")),
         })
     }

--- a/src/protocol/ping.rs
+++ b/src/protocol/ping.rs
@@ -7,7 +7,7 @@ use pyo3::{
 };
 
 use libparsec::protocol::{
-    authenticated_cmds::v2 as authenticated_cmds, invited_cmds::v2 as invited_cmds,
+    authenticated_cmds::v3 as authenticated_cmds, invited_cmds::v3 as invited_cmds,
 };
 
 use crate::protocol::{

--- a/src/protocol/pki.rs
+++ b/src/protocol/pki.rs
@@ -1,9 +1,6 @@
 use libparsec::protocol::{
-    anonymous_cmds::v2::{pki_enrollment_info, pki_enrollment_submit},
-    authenticated_cmds::{
-        v2::pki_enrollment_accept,
-        v2::{pki_enrollment_list, pki_enrollment_reject},
-    },
+    anonymous_cmds::v3::{pki_enrollment_info, pki_enrollment_submit},
+    authenticated_cmds::v3::{pki_enrollment_accept, pki_enrollment_list, pki_enrollment_reject},
 };
 use pyo3::{
     exceptions::PyAttributeError,

--- a/src/protocol/realm.rs
+++ b/src/protocol/realm.rs
@@ -7,7 +7,7 @@ use pyo3::{
 };
 use std::collections::HashMap;
 
-use libparsec::protocol::authenticated_cmds::v2::{
+use libparsec::protocol::authenticated_cmds::v3::{
     realm_create, realm_finish_reencryption_maintenance, realm_get_role_certificates,
     realm_start_reencryption_maintenance, realm_stats, realm_status, realm_update_roles,
 };
@@ -16,7 +16,7 @@ use crate::{
     ids::{DeviceID, RealmID, UserID},
     protocol::{
         error::{ProtocolError, ProtocolErrorFields, ProtocolResult},
-        gen_rep, OptionalDateTime, OptionalFloat, Reason,
+        gen_rep, Reason,
     },
     time::DateTime,
 };
@@ -93,10 +93,10 @@ gen_rep!(
     [
         BadTimestamp,
         reason: Reason,
-        ballpark_client_early_offset: OptionalFloat,
-        ballpark_client_late_offset: OptionalFloat,
-        backend_timestamp: OptionalDateTime,
-        client_timestamp: OptionalDateTime,
+        ballpark_client_early_offset: f64,
+        ballpark_client_late_offset: f64,
+        backend_timestamp: DateTime,
+        client_timestamp: DateTime,
     ],
 );
 
@@ -419,10 +419,10 @@ gen_rep!(
     [
         BadTimestamp,
         reason: Reason,
-        ballpark_client_early_offset: OptionalFloat,
-        ballpark_client_late_offset: OptionalFloat,
-        backend_timestamp: OptionalDateTime,
-        client_timestamp: OptionalDateTime,
+        ballpark_client_early_offset: f64,
+        ballpark_client_late_offset: f64,
+        backend_timestamp: DateTime,
+        client_timestamp: DateTime,
     ],
 );
 
@@ -521,10 +521,10 @@ gen_rep!(
     [
         BadTimestamp,
         reason: Reason,
-        ballpark_client_early_offset: OptionalFloat,
-        ballpark_client_late_offset: OptionalFloat,
-        backend_timestamp: OptionalDateTime,
-        client_timestamp: OptionalDateTime,
+        ballpark_client_early_offset: f64,
+        ballpark_client_late_offset: f64,
+        backend_timestamp: DateTime,
+        client_timestamp: DateTime,
     ],
 );
 

--- a/src/protocol/user.rs
+++ b/src/protocol/user.rs
@@ -9,7 +9,7 @@ use pyo3::{
 use std::num::NonZeroU64;
 
 use libparsec::protocol::{
-    authenticated_cmds::v2::{device_create, human_find, user_create, user_get, user_revoke},
+    authenticated_cmds::v3::{device_create, human_find, user_create, user_get, user_revoke},
     IntegerBetween1And100,
 };
 

--- a/src/protocol/vlob.rs
+++ b/src/protocol/vlob.rs
@@ -8,7 +8,7 @@ use pyo3::{
     types::{PyBytes, PyTuple},
 };
 
-use libparsec::protocol::authenticated_cmds::v2::{
+use libparsec::protocol::authenticated_cmds::v3::{
     vlob_create, vlob_list_versions, vlob_maintenance_get_reencryption_batch,
     vlob_maintenance_save_reencryption_batch, vlob_poll_changes, vlob_read, vlob_update,
 };
@@ -17,7 +17,7 @@ use crate::{
     ids::{DeviceID, RealmID, SequesterServiceID, VlobID},
     protocol::{
         error::{ProtocolError, ProtocolErrorFields, ProtocolResult},
-        gen_rep, Bytes, ListOfBytes, OptionalDateTime, OptionalFloat, Reason,
+        gen_rep, Bytes, ListOfBytes, Reason,
     },
     time::DateTime,
 };
@@ -154,10 +154,10 @@ gen_rep!(
     [
         BadTimestamp,
         reason: Reason,
-        ballpark_client_early_offset: OptionalFloat,
-        ballpark_client_late_offset: OptionalFloat,
-        backend_timestamp: OptionalDateTime,
-        client_timestamp: OptionalDateTime,
+        ballpark_client_early_offset: f64,
+        ballpark_client_late_offset: f64,
+        backend_timestamp: DateTime,
+        client_timestamp: DateTime,
     ],
     [NotASequesteredOrganization],
     [
@@ -274,9 +274,7 @@ impl VlobReadRepOk {
                 blob,
                 author: author.0,
                 timestamp: timestamp.0,
-                author_last_role_granted_on: libparsec::types::Maybe::Present(
-                    author_last_role_granted_on.0,
-                ),
+                author_last_role_granted_on: author_last_role_granted_on.0,
             }),
         ))
     }
@@ -319,10 +317,7 @@ impl VlobReadRepOk {
             vlob_read::Rep::Ok {
                 author_last_role_granted_on,
                 ..
-            } => match author_last_role_granted_on {
-                libparsec::types::Maybe::Present(x) => Some(DateTime(*x)),
-                _ => None,
-            },
+            } => Some(DateTime(*author_last_role_granted_on)),
             _ => return Err(PyNotImplementedError::new_err("")),
         })
     }
@@ -425,10 +420,10 @@ gen_rep!(
     [
         BadTimestamp,
         reason: Reason,
-        ballpark_client_early_offset: OptionalFloat,
-        ballpark_client_late_offset: OptionalFloat,
-        backend_timestamp: OptionalDateTime,
-        client_timestamp: OptionalDateTime,
+        ballpark_client_early_offset: f64,
+        ballpark_client_late_offset: f64,
+        backend_timestamp: DateTime,
+        client_timestamp: DateTime,
     ],
     [NotASequesteredOrganization],
     [

--- a/tests/backend/test_compatibility.py
+++ b/tests/backend/test_compatibility.py
@@ -30,15 +30,6 @@ def test_timestamp_out_of_ballpark_rep_schema_compatibility():
         client_timestamp=client_timestamp,
     )
 
-    # Backend API < 2.4 with newer clients
-    RealmCreateRepBadTimestamp(
-        reason=None,
-        ballpark_client_early_offset=None,
-        ballpark_client_late_offset=None,
-        backend_timestamp=None,
-        client_timestamp=None,
-    )
-
 
 def test_handshake_challenge_schema_compatibility():
 


### PR DESCRIPTION
- Correct definition of `RealmUpdateRoles` for the introduced reply `user_revoked` in `3.1`.

## TODOS

- [ ] How the backend can handle v2 & v3 ?
- [ ] Does the client need to handle v2 & v3 ? 