### PR TITLE
Set proper typing on pyQtSignal receivers

### DIFF
--- a/parsec/core/gui/claim_device_widget.py
+++ b/parsec/core/gui/claim_device_widget.py
@@ -1,6 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
 from __future__ import annotations
-from typing import Any, Awaitable, Callable
+from typing import Any, Awaitable, Callable, Optional
 
 import trio
 from enum import IntEnum
@@ -613,7 +613,7 @@ class ClaimDeviceWidget(QWidget, Ui_ClaimDeviceWidget):
         assert self.dialog is not None
         self.dialog.reject()
 
-    def _on_page_failed(self, job: QtToTrioJob[None]) -> None:
+    def _on_page_failed(self, job: Optional[QtToTrioJob[None]]) -> None:
         # The dialog has already been rejected
         if not self.isVisible():
             return

--- a/parsec/core/gui/claim_device_widget.py
+++ b/parsec/core/gui/claim_device_widget.py
@@ -1,6 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
 from __future__ import annotations
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable
 
 import trio
 from enum import IntEnum
@@ -613,7 +613,7 @@ class ClaimDeviceWidget(QWidget, Ui_ClaimDeviceWidget):
         assert self.dialog is not None
         self.dialog.reject()
 
-    def _on_page_failed(self, job: Optional[QtToTrioJob[None]]) -> None:
+    def _on_page_failed(self, job: QtToTrioJob[None] | None) -> None:
         # The dialog has already been rejected
         if not self.isVisible():
             return

--- a/parsec/core/gui/claim_user_widget.py
+++ b/parsec/core/gui/claim_user_widget.py
@@ -1,6 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
 from __future__ import annotations
-from typing import Any, Awaitable, Callable, Tuple, cast
+from typing import Any, Awaitable, Callable, Tuple, Optional, cast
 
 import trio
 from enum import IntEnum
@@ -710,7 +710,7 @@ class ClaimUserWidget(QWidget, Ui_ClaimUserWidget):
         if self.dialog:
             self.dialog.reject()
 
-    def _on_page_failed_force_reject(self, job: QtToTrioJob[None]) -> None:
+    def _on_page_failed_force_reject(self, job: Optional[QtToTrioJob[None]]) -> None:
         # The dialog has already been rejected
         if not self.isVisible():
             return
@@ -718,7 +718,7 @@ class ClaimUserWidget(QWidget, Ui_ClaimUserWidget):
         assert self.dialog is not None
         self.dialog.reject()
 
-    def _on_page_failed(self, job: QtToTrioJob[None]) -> None:
+    def _on_page_failed(self, job: Optional[QtToTrioJob[None]]) -> None:
         # The dialog has already been rejected
         if not self.isVisible():
             return

--- a/parsec/core/gui/claim_user_widget.py
+++ b/parsec/core/gui/claim_user_widget.py
@@ -1,6 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
 from __future__ import annotations
-from typing import Any, Awaitable, Callable, Tuple, Optional, cast
+from typing import Any, Awaitable, Callable, Tuple, cast
 
 import trio
 from enum import IntEnum
@@ -710,7 +710,7 @@ class ClaimUserWidget(QWidget, Ui_ClaimUserWidget):
         if self.dialog:
             self.dialog.reject()
 
-    def _on_page_failed_force_reject(self, job: Optional[QtToTrioJob[None]]) -> None:
+    def _on_page_failed_force_reject(self, job: QtToTrioJob[None] | None) -> None:
         # The dialog has already been rejected
         if not self.isVisible():
             return
@@ -718,7 +718,7 @@ class ClaimUserWidget(QWidget, Ui_ClaimUserWidget):
         assert self.dialog is not None
         self.dialog.reject()
 
-    def _on_page_failed(self, job: Optional[QtToTrioJob[None]]) -> None:
+    def _on_page_failed(self, job: QtToTrioJob[None] | None) -> None:
         # The dialog has already been rejected
         if not self.isVisible():
             return

--- a/parsec/core/gui/greet_device_widget.py
+++ b/parsec/core/gui/greet_device_widget.py
@@ -1,6 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
 from __future__ import annotations
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 import trio
 from enum import IntEnum
@@ -533,7 +533,7 @@ class GreetDeviceWidget(QWidget, Ui_GreetDeviceWidget):
         self.greeter = Greeter()
         self._run_greeter()
 
-    def _on_page_failed(self, job: Optional[QtToTrioJob[None]]) -> None:
+    def _on_page_failed(self, job: QtToTrioJob[None] | None) -> None:
         # The dialog has already been rejected
         if not self.isVisible():
             return

--- a/parsec/core/gui/greet_device_widget.py
+++ b/parsec/core/gui/greet_device_widget.py
@@ -1,6 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
 from __future__ import annotations
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 import trio
 from enum import IntEnum
@@ -533,7 +533,7 @@ class GreetDeviceWidget(QWidget, Ui_GreetDeviceWidget):
         self.greeter = Greeter()
         self._run_greeter()
 
-    def _on_page_failed(self, job: QtToTrioJob[None]) -> None:
+    def _on_page_failed(self, job: Optional[QtToTrioJob[None]]) -> None:
         # The dialog has already been rejected
         if not self.isVisible():
             return

--- a/parsec/core/gui/greet_user_widget.py
+++ b/parsec/core/gui/greet_user_widget.py
@@ -1,6 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
 from __future__ import annotations
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 import trio
 from enum import IntEnum
@@ -636,7 +636,7 @@ class GreetUserWidget(QWidget, Ui_GreetUserWidget):
         self.greeter = Greeter()
         self._run_greeter()
 
-    def _on_page_failed(self, job: QtToTrioJob[None]) -> None:
+    def _on_page_failed(self, job: Optional[QtToTrioJob[None]]) -> None:
         # The dialog has already been rejected
         if not self.isVisible():
             return

--- a/parsec/core/gui/greet_user_widget.py
+++ b/parsec/core/gui/greet_user_widget.py
@@ -1,6 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
 from __future__ import annotations
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 import trio
 from enum import IntEnum
@@ -636,7 +636,7 @@ class GreetUserWidget(QWidget, Ui_GreetUserWidget):
         self.greeter = Greeter()
         self._run_greeter()
 
-    def _on_page_failed(self, job: Optional[QtToTrioJob[None]]) -> None:
+    def _on_page_failed(self, job: QtToTrioJob[None] | None) -> None:
         # The dialog has already been rejected
         if not self.isVisible():
             return


### PR DESCRIPTION
# What has changed ?
Closes #3614 by handling an Optional QtToTrioJob in signal receivers.

<!-- Why this PR exist ? what is its goal ? -->

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
