### PR TITLE
Prevent BackendApp's repr from hurting readability by dumping it whole content

### DIFF
--- a/parsec/backend/app.py
+++ b/parsec/backend/app.py
@@ -63,7 +63,7 @@ async def backend_app_factory(
         )
 
 
-@attr.s(slots=True, auto_attribs=True, kw_only=True, eq=False)
+@attr.s(slots=True, auto_attribs=True, kw_only=True, eq=False, repr=False)
 class BackendApp:
     config: BackendConfig
     event_bus: EventBus


### PR DESCRIPTION
With this fix:
```
(Pdb) backend_asgi_app.backend
<parsec.backend.app.BackendApp object at 0x7f4268081880>
```

vs current:
```
(Pdb) backend_asgi_app.backend
BackendApp(config=BackendConfig(administration_token='s3cr3t', db_url='MOCKED', db_min_connections=1, db_max_connections=5, blockstore_config=MockedBlockStoreConfig(), email_config=MockedEmailConfig(sender='Parsec <no-reply@parsec.com>', tmpdir='/tmp/tmp-email-folder-z5dmpkzb'), forward_proto_enforce_https=None, backend_addr=BackendAddr { url: "parsec://127.0.0.1:51197?no_ssl=true" }, debug=False, organization_bootstrap_webhook_url=None, organization_spontaneous_bootstrap=False, organization_initial_active_users_limit=None, organization_initial_user_profile_outsider_allowed=True), event_bus=<tests.common.event_bus_spy.SpiedEventBus object at 0x7f36d977cbb0>, webhooks=<parsec.backend.webhooks.WebhooksComponent object at 0x7f36d9790820>, user=<parsec.backend.memory.user.MemoryUserComponent object at 0x7f36d97909d0>, invite=<parsec.backend.memory.invite.MemoryInviteComponent object at 0x7f36d9790a30>, organization=<parsec.backend.memory.organization.MemoryOrganizationComponent object at 0x7f36d97909a0>, message=<parsec.backend.memory.message.MemoryMessageComponent object at 0x7f36d9790a90>, realm=<parsec.backend.memory.realm.MemoryRealmComponent object at 0x7f36d9790af0>, vlob=<parsec.backend.memory.vlob.MemoryVlobComponent object at 0x7f36d9790b20>, ping=<parsec.backend.memory.ping.MemoryPingComponent object at 0x7f36d9790b50>, blockstore=<parsec.backend.memory.block.MemoryBlockStoreComponent object at 0x7f36d9790d00>, block=<parsec.backend.memory.block.MemoryBlockComponent object at 0x7f36d9790c70>, pki=<parsec.backend.memory.pki.MemoryPkiEnrollmentComponent object at 0x7f36d9790bb0>, sequester=<parsec.backend.memory.sequester.MemorySequesterComponent object at 0x7f36d9790c10>, events=<parsec.backend.events.EventsComponent object at 0x7f36d9790cd0>, apis={Authenticated: {'device_create': <bound method BaseUserComponent.api_device_create of <parsec.backend.memory.user.MemoryUserComponent object at 0x7f36d97909d0>>, 'human_find': <bound method BaseUserComponent.api_human_find of <parsec.backend.memory.user.MemoryUserComponent object at 0x7f36d97909d0>>, 'user_create': <bound method BaseUserComponent.api_user_create of <parsec.backend.memory.user.MemoryUserComponent object at 0x7f36d97909d0>>, 'user_get': <bound method BaseUserComponent.api_user_get of <parsec.backend.memory.user.MemoryUserComponent object at 0x7f36d97909d0>>, 'user_revoke': <bound method BaseUserComponent.api_user_revoke of <parsec.backend.memory.user.MemoryUserComponent object at 0x7f36d97909d0>>, 'invite_1_greeter_wait_peer': <bound method BaseInviteComponent.api_invite_1_greeter_wait_peer of <parsec.backend.memory.invite.MemoryInviteComponent object at 0x7f36d9790a30>>, 'invite_2a_greeter_get_hashed_nonce': <bound method BaseInviteComponent.api_invite_2a_greeter_get_hashed_nonce of <parsec.backend.memory.invite.MemoryInviteComponent object at 0x7f36d9790a30>>, 'invite_2b_greeter_send_nonce': <bound method BaseInviteComponent.api_invite_2b_greeter_send_nonce of <parsec.backend.memory.invite.MemoryInviteComponent object at 0x7f36d9790a30>>, 'invite_3a_greeter_wait_peer_trust': <bound method BaseInviteComponent.api_invite_3a_greeter_wait_peer_trust of <parsec.backend.memory.invite.MemoryInviteComponent object at 0x7f36d9790a30>>, 'invite_3b_greeter_signify_trust': <bound method BaseInviteComponent.api_invite_3b_greeter_signify_trust of <parsec.backend.memory.invite.MemoryInviteComponent object at 0x7f36d9790a30>>, 'invite_4_greeter_communicate': <bound method BaseInviteComponent.api_invite_4_greeter_communicate of <parsec.backend.memory.invite.MemoryInviteComponent object at 0x7f36d9790a30>>, 'invite_delete': <bound method BaseInviteComponent.api_invite_delete of <parsec.backend.memory.invite.MemoryInviteComponent object at 0x7f36d9790a30>>, 'invite_list': <bound method BaseInviteComponent.api_invite_list of <parsec.backend.memory.invite.MemoryInviteComponent object at 0x7f36d9790a30>>, 'invite_new': <bound method BaseInviteComponent.api_invite_new of <parsec.backend.memory.invite.MemoryInviteComponent object at 0x7f36d9790a30>>, 'organization_config': <bound method BaseOrganizationComponent.api_authenticated_organization_config of <parsec.backend.memory.organization.MemoryOrganizationComponent object at 0x7f36d97909a0>>, 'organization_stats': <bound method BaseOrganizationComponent.api_authenticated_organization_stats of <parsec.backend.memory.organization.MemoryOrganizationComponent object at 0x7f36d97909a0>>, 'message_get': <bound method BaseMessageComponent.api_message_get of <parsec.backend.memory.message.MemoryMessageComponent object at 0x7f36d9790a90>>, 'realm_create': <bound method BaseRealmComponent.api_realm_create of <parsec.backend.memory.realm.MemoryRealmComponent object at 0x7f36d9790af0>>, 'realm_finish_reencryption_maintenance': <bound method BaseRealmComponent.api_realm_finish_reencryption_maintenance of <parsec.backend.memory.realm.MemoryRealmComponent object at 0x7f36d9790af0>>, 'realm_get_role_certificates': <bound method BaseRealmComponent.api_realm_get_role_certificates of <parsec.backend.memory.realm.MemoryRealmComponent object at 0x7f36d9790af0>>, 'realm_start_reencryption_maintenance': <bound method BaseRealmComponent.api_realm_start_reencryption_maintenance of <parsec.backend.memory.realm.MemoryRealmComponent object at 0x7f36d9790af0>>, 'realm_stats': <bound method BaseRealmComponent.api_realm_stats of <parsec.backend.memory.realm.MemoryRealmComponent object at 0x7f36d9790af0>>, 'realm_status': <bound method BaseRealmComponent.api_realm_status of <parsec.backend.memory.realm.MemoryRealmComponent object at 0x7f36d9790af0>>, 'realm_update_roles': <bound method BaseRealmComponent.api_realm_update_roles of <parsec.backend.memory.realm.MemoryRealmComponent object at 0x7f36d9790af0>>, 'vlob_create': <bound method BaseVlobComponent.api_vlob_create of <parsec.backend.memory.vlob.MemoryVlobComponent object at 0x7f36d9790b20>>, 'vlob_list_versions': <bound method BaseVlobComponent.api_vlob_list_versions of <parsec.backend.memory.vlob.MemoryVlobComponent object at 0x7f36d9790b20>>, 'vlob_maintenance_get_reencryption_batch': <bound method BaseVlobComponent.api_vlob_maintenance_get_reencryption_batch of <parsec.backend.memory.vlob.MemoryVlobComponent object at 0x7f36d9790b20>>, 'vlob_maintenance_save_reencryption_batch': <bound method BaseVlobComponent.api_vlob_maintenance_save_reencryption_batch of <parsec.backend.memory.vlob.MemoryVlobComponent object at 0x7f36d9790b20>>, 'vlob_poll_changes': <bound method BaseVlobComponent.api_vlob_poll_changes of <parsec.backend.memory.vlob.MemoryVlobComponent object at 0x7f36d9790b20>>, 'vlob_read': <bound method BaseVlobComponent.api_vlob_read of <parsec.backend.memory.vlob.MemoryVlobComponent object at 0x7f36d9790b20>>, 'vlob_update': <bound method BaseVlobComponent.api_vlob_update of <parsec.backend.memory.vlob.MemoryVlobComponent object at 0x7f36d9790b20>>, 'ping': <bound method BasePingComponent.api_ping of <parsec.backend.memory.ping.MemoryPingComponent object at 0x7f36d9790b50>>, 'block_create': <bound method BaseBlockComponent.api_block_create of <parsec.backend.memory.block.MemoryBlockComponent object at 0x7f36d9790c70>>, 'block_read': <bound method BaseBlockComponent.api_block_read of <parsec.backend.memory.block.MemoryBlockComponent object at 0x7f36d9790c70>>, 'pki_enrollment_accept': <bound method BasePkiEnrollmentComponent.api_pki_enrollment_accept of <parsec.backend.memory.pki.MemoryPkiEnrollmentComponent object at 0x7f36d9790bb0>>, 'pki_enrollment_list': <bound method BasePkiEnrollmentComponent.api_pki_enrollment_list of <parsec.backend.memory.pki.MemoryPkiEnrollmentComponent object at 0x7f36d9790bb0>>, 'pki_enrollment_reject': <bound method BasePkiEnrollmentComponent.api_pki_enrollment_reject of <parsec.backend.memory.pki.MemoryPkiEnrollmentComponent object at 0x7f36d9790bb0>>, 'events_listen': <bound method EventsComponent.api_events_listen of <parsec.backend.events.EventsComponent object at 0x7f36d9790cd0>>, 'events_subscribe': <bound method EventsComponent.api_events_subscribe of <parsec.backend.events.EventsComponent object at 0x7f36d9790cd0>>}, Invited: {'invite_1_claimer_wait_peer': <bound method BaseInviteComponent.api_invite_1_claimer_wait_peer of <parsec.backend.memory.invite.MemoryInviteComponent object at 0x7f36d9790a30>>, 'invite_2a_claimer_send_hashed_nonce': <bound method BaseInviteComponent.api_invite_2a_claimer_send_hash_nonce of <parsec.backend.memory.invite.MemoryInviteComponent object at 0x7f36d9790a30>>, 'invite_2b_claimer_send_nonce': <bound method BaseInviteComponent.api_invite_2b_claimer_send_nonce of <parsec.backend.memory.invite.MemoryInviteComponent object at 0x7f36d9790a30>>, 'invite_3a_claimer_signify_trust': <bound method BaseInviteComponent.api_invite_3a_claimer_signify_trust of <parsec.backend.memory.invite.MemoryInviteComponent object at 0x7f36d9790a30>>, 'invite_3b_claimer_wait_peer_trust': <bound method BaseInviteComponent.api_invite_3b_claimer_wait_peer_trust of <parsec.backend.memory.invite.MemoryInviteComponent object at 0x7f36d9790a30>>, 'invite_4_claimer_communicate': <bound method BaseInviteComponent.api_invite_4_claimer_communicate of <parsec.backend.memory.invite.MemoryInviteComponent object at 0x7f36d9790a30>>, 'invite_info': <bound method BaseInviteComponent.api_invite_info of <parsec.backend.memory.invite.MemoryInviteComponent object at 0x7f36d9790a30>>, 'ping': <bound method BasePingComponent.api_ping of <parsec.backend.memory.ping.MemoryPingComponent object at 0x7f36d9790b50>>}, Apiv1Anonymous: {'organization_bootstrap': <bound method BaseOrganizationComponent.api_organization_bootstrap of <parsec.backend.memory.organization.MemoryOrganizationComponent object at 0x7f36d97909a0>>, 'ping': <bound method BasePingComponent.api_ping of <parsec.backend.memory.ping.MemoryPingComponent object at 0x7f36d9790b50>>}, Anonymous: {'organization_bootstrap': <bound method BaseOrganizationComponent.api_organization_bootstrap of <parsec.backend.memory.organization.MemoryOrganizationComponent object at 0x7f36d97909a0>>, 'pki_enrollment_info': <bound method BasePkiEnrollmentComponent.api_pki_enrollment_info of <parsec.backend.memory.pki.MemoryPkiEnrollmentComponent object at 0x7f36d9790bb0>>, 'pki_enrollment_submit': <bound method BasePkiEnrollmentComponent.api_pki_enrollment_submit of <parsec.backend.memory.pki.MemoryPkiEnrollmentComponent object at 0x7f36d9790bb0>>}})
```