### PR TITLE
Fix human handle

### DIFF
--- a/newsfragments/3749.bugfix.rst
+++ b/newsfragments/3749.bugfix.rst
@@ -1,0 +1,1 @@
+Accept parenthesis in HumanHandle's label

--- a/oxidation/libparsec/crates/types/src/id.rs
+++ b/oxidation/libparsec/crates/types/src/id.rs
@@ -332,7 +332,7 @@ impl HumanHandle {
             || label.chars().any(|c| {
                 matches!(
                     c,
-                    '(' | ')' | '<' | '>' | '@' | ',' | ':' | ';' | '\\' | '"' | '[' | ']'
+                    '<' | '>' | '@' | ',' | ':' | ';' | '\\' | '"' | '[' | ']'
                 )
             })
         {
@@ -408,6 +408,7 @@ pub struct FileDescriptor(pub u32);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     fn test_from_str() {
@@ -422,5 +423,15 @@ mod tests {
         assert!("dummy".parse::<DeviceID>().is_err());
         assert!(format!("alice@{}", too_long).parse::<DeviceID>().is_err());
         assert!("alice@pc1".parse::<DeviceID>().is_ok());
+    }
+
+    #[rstest]
+    #[case::invalid_email("test", "test", false)]
+    #[case::invalid_email("a@b..c", "test", false)]
+    #[case::invalid_email("@b.c", "test", false)]
+    #[case::parenthesis_allowed("a@b.c", "()", true)]
+    #[case::invalid_name_with_backslash("a@b", "hell\\o", false)]
+    fn test_human_handle(#[case] email: &str, #[case] label: &str, #[case] is_ok: bool) {
+        assert_eq!(HumanHandle::new(email, label).is_ok(), is_ok)
     }
 }


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
Fix: Accept parenthesis in HumanHandle's label

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [x] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
closes #3749
