### PR TITLE
Fix special character handling in Reply-To email header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ env:
     --exclude=libparsec_bindings_web
     --exclude=libparsec_bindings_electron
     --exclude=libparsec_bindings_common
+  # Temporary fix for macos tests:
+  # See: https://github.com/python-poetry/poetry/issues/7161
+  SYSTEM_VERSION_COMPAT: "0"
 
 jobs:
 
@@ -251,8 +254,8 @@ jobs:
             # All linux jobs must run the same ubuntu version to avoid Rust caching issues !
             # 20.04 is required to install PostgreSQL 12
             os: ubuntu-20.04
-          # - name: 🍎 macOS
-          #   os: macos-12
+          - name: 🍎 macOS
+            os: macos-12
           - name: 🏁 Windows
             os: windows-2022
             winfsp-version: 1.11.22176

--- a/newsfragments/3752.bugfix.rst
+++ b/newsfragments/3752.bugfix.rst
@@ -1,0 +1,1 @@
+Fix user invitation email sending error when the greeter's name contains special characters

--- a/tests/backend/invite/test_manage_invitations.py
+++ b/tests/backend/invite/test_manage_invitations.py
@@ -175,7 +175,7 @@ async def test_invite_with_send_mail(alice, alice_ws, email_letterbox):
     assert "Subject: [Parsec] Alicey McAliceFace invited you to CoolOrg" in body
     assert "From: Parsec <no-reply@parsec.com>" in body
     assert "To: zack@example.com" in body
-    assert "Reply-To: Alicey McAliceFace <alice@example.com>" in body
+    assert "Reply-To: =?utf-8?q?Alicey_McAliceFace?= <alice@example.com>" in body
     assert token.hex in body
     assert (
         "You have received an invitation from Alicey McAliceFace to join the CoolOrg organization on Parsec."


### PR DESCRIPTION
Fix #3752

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [x] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
