### PR TITLE
Remove uneccessary line in `protocol/pki`

### DIFF
--- a/parsec/api/protocol/pki.py
+++ b/parsec/api/protocol/pki.py
@@ -17,7 +17,6 @@ from parsec._parsec import (
 from parsec.api.protocol.base import ApiCommandSerializer
 from parsec.serde import fields
 
-
 EnrollmentIDField = fields.uuid_based_field_factory(EnrollmentID)
 
 # pki_enrollment_submit


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
Last CI run on master failed because of format error that wasn't caught before merge. This PR remove this problematic line (https://github.com/Scille/parsec-cloud/actions/runs/3658771748/jobs/6183964861).

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
