### PR TITLE
UnboundLocalError: local variable `icon_scaled` referenced before assignment

### DIFF
--- a/newsfragments/3769.bugfix.rst
+++ b/newsfragments/3769.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed error when opening the QRCode for device invitation

--- a/parsec/core/gui/custom_widgets.py
+++ b/parsec/core/gui/custom_widgets.py
@@ -329,7 +329,7 @@ class OverlayLabel(ClickableLabel):
             super().setPixmap(self._pix)
             return
 
-        icon = None
+        icon_scaled: QPixmap | None = None
 
         if self.click_mode == OverlayLabel.ClickMode.OpenFullScreen and self.show_icon:
             assert OverlayLabel.OPEN_FULLSCREEN_ICON is not None


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
Fixed a small bug introduced by typing when mouse hovering the QRCode in a device invitation.

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [X] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
