### PR TITLE
Bump npm packages to remove some deprecated one

### DIFF
--- a/oxidation/client/electron/package-lock.json
+++ b/oxidation/client/electron/package-lock.json
@@ -18,9 +18,9 @@
                 "electron-window-state": "~5.0.3"
             },
             "devDependencies": {
+                "@electron/rebuild": "^3.2.10",
                 "electron": "^22.0.0",
                 "electron-builder": "~23.6.0",
-                "electron-rebuild": "^3.2.9",
                 "typescript": "~4.9.3"
             }
         },
@@ -95,6 +95,36 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/@electron/asar": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.2.2.tgz",
+            "integrity": "sha512-32fMU68x8a6zvxtC1IC/BhPDKTh8rQjdmwEplj3CDpnkcwBzZVN9v/8cK0LJqQ0FOQQVZW8BWZ1S6UU53TYR4w==",
+            "dev": true,
+            "dependencies": {
+                "chromium-pickle-js": "^0.2.0",
+                "commander": "^5.0.0",
+                "glob": "^7.1.6",
+                "minimatch": "^3.0.4"
+            },
+            "bin": {
+                "asar": "bin/asar.js"
+            },
+            "engines": {
+                "node": ">=10.12.0"
+            },
+            "optionalDependencies": {
+                "@types/glob": "^7.1.1"
+            }
+        },
+        "node_modules/@electron/asar/node_modules/commander": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/@electron/get": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.2.tgz",
@@ -148,16 +178,92 @@
                 "node": ">= 4.0.0"
             }
         },
-        "node_modules/@electron/universal": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.2.1.tgz",
-            "integrity": "sha512-7323HyMh7KBAl/nPDppdLsC87G6RwRU02dy5FPeGB1eS7rUePh55+WNWiDPLhFQqqVPHzh77M69uhmoT8XnwMQ==",
+        "node_modules/@electron/rebuild": {
+            "version": "3.2.10",
+            "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.2.10.tgz",
+            "integrity": "sha512-SUBM6Mwi3yZaDFQjZzfGKpYTtOp9m60glounwX6tfGeVc/ZOl4jbquktUcyy7gYSLDWFLtKkftkY2xgMJZLQgg==",
             "dev": true,
             "dependencies": {
+                "@malept/cross-spawn-promise": "^2.0.0",
+                "chalk": "^4.0.0",
+                "debug": "^4.1.1",
+                "detect-libc": "^2.0.1",
+                "fs-extra": "^10.0.0",
+                "got": "^11.7.0",
+                "lzma-native": "^8.0.5",
+                "node-abi": "^3.0.0",
+                "node-api-version": "^0.1.4",
+                "node-gyp": "^9.0.0",
+                "ora": "^5.1.0",
+                "semver": "^7.3.5",
+                "tar": "^6.0.5",
+                "yargs": "^17.0.1"
+            },
+            "bin": {
+                "electron-rebuild": "lib/src/cli.js"
+            },
+            "engines": {
+                "node": ">=12.13.0"
+            }
+        },
+        "node_modules/@electron/rebuild/node_modules/@malept/cross-spawn-promise": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+            "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/malept"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+                }
+            ],
+            "dependencies": {
+                "cross-spawn": "^7.0.1"
+            },
+            "engines": {
+                "node": ">= 12.13.0"
+            }
+        },
+        "node_modules/@electron/rebuild/node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@electron/rebuild/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/@electron/universal": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.3.4.tgz",
+            "integrity": "sha512-BdhBgm2ZBnYyYRLRgOjM5VHkyFItsbggJ0MHycOjKWdFGYwK97ZFXH54dTvUWEfha81vfvwr5On6XBjt99uDcg==",
+            "dev": true,
+            "dependencies": {
+                "@electron/asar": "^3.2.1",
                 "@malept/cross-spawn-promise": "^1.1.0",
-                "asar": "^3.1.0",
                 "debug": "^4.3.1",
-                "dir-compare": "^2.4.0",
+                "dir-compare": "^3.0.0",
                 "fs-extra": "^9.0.1",
                 "minimatch": "^3.0.4",
                 "plist": "^3.0.4"
@@ -759,37 +865,6 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
-        "node_modules/asar": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/asar/-/asar-3.2.0.tgz",
-            "integrity": "sha512-COdw2ZQvKdFGFxXwX3oYh2/sOsJWJegrdJCGxnN4MZ7IULgRBp9P6665aqj9z1v9VwP4oP1hRBojRDQ//IGgAg==",
-            "deprecated": "Please use @electron/asar moving forward.  There is no API change, just a package name change",
-            "dev": true,
-            "dependencies": {
-                "chromium-pickle-js": "^0.2.0",
-                "commander": "^5.0.0",
-                "glob": "^7.1.6",
-                "minimatch": "^3.0.4"
-            },
-            "bin": {
-                "asar": "bin/asar.js"
-            },
-            "engines": {
-                "node": ">=10.12.0"
-            },
-            "optionalDependencies": {
-                "@types/glob": "^7.1.1"
-            }
-        },
-        "node_modules/asar/node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/assert-plus": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -990,12 +1065,15 @@
             }
         },
         "node_modules/buffer-equal": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-            "integrity": "sha512-tcBWO2Dl4e7Asr9hTGcpVrCe+F7DubpmqWCTbj4FHLmjqO2hIaC383acQubWtRJhdceqs5uBHs6Es+Sk//RKiQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.1.tgz",
+            "integrity": "sha512-QoV3ptgEaQpvVwbXdSO39iqPQTCxSF7A5U99AxbHYqUdCizL/lH2Z0A2y6nbZucxMEOtNyZfG2s6gsVugGpKkg==",
             "dev": true,
             "engines": {
-                "node": ">=0.4.0"
+                "node": ">=0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/buffer-fill": {
@@ -1375,15 +1453,6 @@
                 "color-support": "bin.js"
             }
         },
-        "node_modules/colors": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-            "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.1.90"
-            }
-        },
         "node_modules/combined-stream": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1573,42 +1642,13 @@
             "optional": true
         },
         "node_modules/dir-compare": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-2.4.0.tgz",
-            "integrity": "sha512-l9hmu8x/rjVC9Z2zmGzkhOEowZvW7pmYws5CWHutg8u1JgvsKWMx7Q/UODeu4djLZ4FgW5besw5yvMQnBHzuCA==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-3.3.0.tgz",
+            "integrity": "sha512-J7/et3WlGUCxjdnD3HAAzQ6nsnc0WL6DD7WcwJb7c39iH1+AWfg+9OqzJNaI6PkBwBvm1mhZNL9iY/nRiZXlPg==",
             "dev": true,
             "dependencies": {
-                "buffer-equal": "1.0.0",
-                "colors": "1.0.3",
-                "commander": "2.9.0",
-                "minimatch": "3.0.4"
-            },
-            "bin": {
-                "dircompare": "src/cli/dircompare.js"
-            }
-        },
-        "node_modules/dir-compare/node_modules/commander": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-            "integrity": "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==",
-            "dev": true,
-            "dependencies": {
-                "graceful-readlink": ">= 1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.6.x"
-            }
-        },
-        "node_modules/dir-compare/node_modules/minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
+                "buffer-equal": "^1.0.0",
+                "minimatch": "^3.0.4"
             }
         },
         "node_modules/dmg-builder": {
@@ -1868,83 +1908,6 @@
             }
         },
         "node_modules/electron-publish/node_modules/jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dev": true,
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/electron-rebuild": {
-            "version": "3.2.9",
-            "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-3.2.9.tgz",
-            "integrity": "sha512-FkEZNFViUem3P0RLYbZkUjC8LUFIK+wKq09GHoOITSJjfDAVQv964hwaNseTTWt58sITQX3/5fHNYcTefqaCWw==",
-            "deprecated": "Please use @electron/rebuild moving forward.  There is no API change, just a package name change",
-            "dev": true,
-            "dependencies": {
-                "@malept/cross-spawn-promise": "^2.0.0",
-                "chalk": "^4.0.0",
-                "debug": "^4.1.1",
-                "detect-libc": "^2.0.1",
-                "fs-extra": "^10.0.0",
-                "got": "^11.7.0",
-                "lzma-native": "^8.0.5",
-                "node-abi": "^3.0.0",
-                "node-api-version": "^0.1.4",
-                "node-gyp": "^9.0.0",
-                "ora": "^5.1.0",
-                "semver": "^7.3.5",
-                "tar": "^6.0.5",
-                "yargs": "^17.0.1"
-            },
-            "bin": {
-                "electron-rebuild": "lib/src/cli.js"
-            },
-            "engines": {
-                "node": ">=12.13.0"
-            }
-        },
-        "node_modules/electron-rebuild/node_modules/@malept/cross-spawn-promise": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
-            "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/malept"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
-                }
-            ],
-            "dependencies": {
-                "cross-spawn": "^7.0.1"
-            },
-            "engines": {
-                "node": ">= 12.13.0"
-            }
-        },
-        "node_modules/electron-rebuild/node_modules/fs-extra": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-            "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/electron-rebuild/node_modules/jsonfile": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
             "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
@@ -2471,12 +2434,6 @@
             "version": "4.2.9",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
             "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
-        },
-        "node_modules/graceful-readlink": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-            "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
-            "dev": true
         },
         "node_modules/has": {
             "version": "1.0.3",
@@ -4412,6 +4369,27 @@
                 "ajv-keywords": "^3.4.1"
             }
         },
+        "@electron/asar": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.2.2.tgz",
+            "integrity": "sha512-32fMU68x8a6zvxtC1IC/BhPDKTh8rQjdmwEplj3CDpnkcwBzZVN9v/8cK0LJqQ0FOQQVZW8BWZ1S6UU53TYR4w==",
+            "dev": true,
+            "requires": {
+                "@types/glob": "^7.1.1",
+                "chromium-pickle-js": "^0.2.0",
+                "commander": "^5.0.0",
+                "glob": "^7.1.6",
+                "minimatch": "^3.0.4"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+                    "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+                    "dev": true
+                }
+            }
+        },
         "@electron/get": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.2.tgz",
@@ -4453,16 +4431,70 @@
                 }
             }
         },
-        "@electron/universal": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.2.1.tgz",
-            "integrity": "sha512-7323HyMh7KBAl/nPDppdLsC87G6RwRU02dy5FPeGB1eS7rUePh55+WNWiDPLhFQqqVPHzh77M69uhmoT8XnwMQ==",
+        "@electron/rebuild": {
+            "version": "3.2.10",
+            "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.2.10.tgz",
+            "integrity": "sha512-SUBM6Mwi3yZaDFQjZzfGKpYTtOp9m60glounwX6tfGeVc/ZOl4jbquktUcyy7gYSLDWFLtKkftkY2xgMJZLQgg==",
             "dev": true,
             "requires": {
+                "@malept/cross-spawn-promise": "^2.0.0",
+                "chalk": "^4.0.0",
+                "debug": "^4.1.1",
+                "detect-libc": "^2.0.1",
+                "fs-extra": "^10.0.0",
+                "got": "^11.7.0",
+                "lzma-native": "^8.0.5",
+                "node-abi": "^3.0.0",
+                "node-api-version": "^0.1.4",
+                "node-gyp": "^9.0.0",
+                "ora": "^5.1.0",
+                "semver": "^7.3.5",
+                "tar": "^6.0.5",
+                "yargs": "^17.0.1"
+            },
+            "dependencies": {
+                "@malept/cross-spawn-promise": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+                    "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^7.0.1"
+                    }
+                },
+                "fs-extra": {
+                    "version": "10.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+                    "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "jsonfile": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+                    "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "@electron/universal": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.3.4.tgz",
+            "integrity": "sha512-BdhBgm2ZBnYyYRLRgOjM5VHkyFItsbggJ0MHycOjKWdFGYwK97ZFXH54dTvUWEfha81vfvwr5On6XBjt99uDcg==",
+            "dev": true,
+            "requires": {
+                "@electron/asar": "^3.2.1",
                 "@malept/cross-spawn-promise": "^1.1.0",
-                "asar": "^3.1.0",
                 "debug": "^4.3.1",
-                "dir-compare": "^2.4.0",
+                "dir-compare": "^3.0.0",
                 "fs-extra": "^9.0.1",
                 "minimatch": "^3.0.4",
                 "plist": "^3.0.4"
@@ -4878,7 +4910,7 @@
             "dev": true,
             "requires": {
                 "@develar/schema-utils": "~2.6.5",
-                "@electron/universal": "1.2.1",
+                "@electron/universal": "~1.3.4",
                 "@malept/flatpak-bundler": "^0.4.0",
                 "7zip-bin": "~5.1.1",
                 "async-exit-hook": "^2.0.1",
@@ -4957,27 +4989,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "asar": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/asar/-/asar-3.2.0.tgz",
-            "integrity": "sha512-COdw2ZQvKdFGFxXwX3oYh2/sOsJWJegrdJCGxnN4MZ7IULgRBp9P6665aqj9z1v9VwP4oP1hRBojRDQ//IGgAg==",
-            "dev": true,
-            "requires": {
-                "@types/glob": "^7.1.1",
-                "chromium-pickle-js": "^0.2.0",
-                "commander": "^5.0.0",
-                "glob": "^7.1.6",
-                "minimatch": "^3.0.4"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-                    "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-                    "dev": true
-                }
-            }
         },
         "assert-plus": {
             "version": "1.0.0",
@@ -5124,9 +5135,9 @@
             "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
         },
         "buffer-equal": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-            "integrity": "sha512-tcBWO2Dl4e7Asr9hTGcpVrCe+F7DubpmqWCTbj4FHLmjqO2hIaC383acQubWtRJhdceqs5uBHs6Es+Sk//RKiQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.1.tgz",
+            "integrity": "sha512-QoV3ptgEaQpvVwbXdSO39iqPQTCxSF7A5U99AxbHYqUdCizL/lH2Z0A2y6nbZucxMEOtNyZfG2s6gsVugGpKkg==",
             "dev": true
         },
         "buffer-fill": {
@@ -5418,12 +5429,6 @@
             "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
             "dev": true
         },
-        "colors": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-            "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
-            "dev": true
-        },
         "combined-stream": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -5565,35 +5570,13 @@
             "optional": true
         },
         "dir-compare": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-2.4.0.tgz",
-            "integrity": "sha512-l9hmu8x/rjVC9Z2zmGzkhOEowZvW7pmYws5CWHutg8u1JgvsKWMx7Q/UODeu4djLZ4FgW5besw5yvMQnBHzuCA==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-3.3.0.tgz",
+            "integrity": "sha512-J7/et3WlGUCxjdnD3HAAzQ6nsnc0WL6DD7WcwJb7c39iH1+AWfg+9OqzJNaI6PkBwBvm1mhZNL9iY/nRiZXlPg==",
             "dev": true,
             "requires": {
-                "buffer-equal": "1.0.0",
-                "colors": "1.0.3",
-                "commander": "2.9.0",
-                "minimatch": "3.0.4"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.9.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                    "integrity": "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-readlink": ">= 1.0.0"
-                    }
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                }
+                "buffer-equal": "^1.0.0",
+                "minimatch": "^3.0.4"
             }
         },
         "dmg-builder": {
@@ -5790,60 +5773,6 @@
                     "version": "10.1.0",
                     "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
                     "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^6.0.1",
-                        "universalify": "^2.0.0"
-                    }
-                },
-                "jsonfile": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-                    "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.6",
-                        "universalify": "^2.0.0"
-                    }
-                }
-            }
-        },
-        "electron-rebuild": {
-            "version": "3.2.9",
-            "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-3.2.9.tgz",
-            "integrity": "sha512-FkEZNFViUem3P0RLYbZkUjC8LUFIK+wKq09GHoOITSJjfDAVQv964hwaNseTTWt58sITQX3/5fHNYcTefqaCWw==",
-            "dev": true,
-            "requires": {
-                "@malept/cross-spawn-promise": "^2.0.0",
-                "chalk": "^4.0.0",
-                "debug": "^4.1.1",
-                "detect-libc": "^2.0.1",
-                "fs-extra": "^10.0.0",
-                "got": "^11.7.0",
-                "lzma-native": "^8.0.5",
-                "node-abi": "^3.0.0",
-                "node-api-version": "^0.1.4",
-                "node-gyp": "^9.0.0",
-                "ora": "^5.1.0",
-                "semver": "^7.3.5",
-                "tar": "^6.0.5",
-                "yargs": "^17.0.1"
-            },
-            "dependencies": {
-                "@malept/cross-spawn-promise": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
-                    "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
-                    "dev": true,
-                    "requires": {
-                        "cross-spawn": "^7.0.1"
-                    }
-                },
-                "fs-extra": {
-                    "version": "10.0.1",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-                    "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
                     "dev": true,
                     "requires": {
                         "graceful-fs": "^4.2.0",
@@ -6270,12 +6199,6 @@
             "version": "4.2.9",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
             "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
-        },
-        "graceful-readlink": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-            "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
-            "dev": true
         },
         "has": {
             "version": "1.0.3",

--- a/oxidation/client/electron/package.json
+++ b/oxidation/client/electron/package.json
@@ -35,10 +35,13 @@
         "electron-window-state": "~5.0.3"
     },
     "devDependencies": {
+        "@electron/rebuild": "^3.2.10",
         "electron": "^22.0.0",
         "electron-builder": "~23.6.0",
-        "electron-rebuild": "^3.2.9",
         "typescript": "~4.9.3"
+    },
+    "overrides": {
+        "@electron/universal": "~1.3.4"
     },
     "keywords": [
         "capacitor",


### PR DESCRIPTION
# What has changed ?
Override `@electron/universal`'s version to stop using deprecated dependency `asar`
Switch from electron-rebuild to @electron/rebuild (package name change, not breaking).

<!-- Why this PR exist ? what is its goal ? -->

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
fixes #3736 
fixes #3733 
