### PR TITLE
Don't build `rust` lib on QA step when installing python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
     name: 📊 Q&A
     # All linux jobs must run the same ubuntu version to avoid Rust caching issues !
     runs-on: ubuntu-20.04
+    env:
+      SKIP_BUILD_RUST_LIB: 'true'
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin v3.1.0
 

--- a/build.py
+++ b/build.py
@@ -8,6 +8,7 @@ import tempfile
 import zipfile
 
 # The default rust build profile to use when compiling the rust extension.
+DEFAULT_SKIP_BUILD_RUST_LIB = "false"
 DEFAULT_CARGO_PROFILE = "release"
 
 
@@ -33,6 +34,12 @@ def run(cmd, **kwargs):
 def build():
     run(f"{PYTHON_EXECUTABLE_PATH} --version")
     run(f"{PYTHON_EXECUTABLE_PATH} misc/generate_pyqt.py")
+
+    if os.environ.get("SKIP_BUILD_RUST_LIB", DEFAULT_SKIP_BUILD_RUST_LIB).lower() in [
+        "true",
+        "1",
+    ]:
+        return
 
     # Maturin provides two commands to compile the Rust code as a Python native module:
     # - `maturin develop` that only compile the native module


### PR DESCRIPTION
Not building the `rust` binding on the QA job save us some time 
because here we do `poetry install` just to have the lint tools like `ruff` or `mypy`.
