### PR TITLE
Tweak CI to save cache only during master build

### DIFF
--- a/.cspell/cspell.config.yml
+++ b/.cspell/cspell.config.yml
@@ -47,6 +47,7 @@ words:
   - schemafile
   - intlify
   - htmlcov
+  - Swatinem
 ignoreWords:
   - ApiV
   - ABCDEFGHJKLMNPQRSTUVWXYZ

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,21 @@ jobs:
         if: >-
           steps.python-changes.outputs.run == 'true'
           && steps.cache-libparsec.outputs.cache-hit != 'true'
+        with:
+          # We setup the cache by hand, see below
+          cache: false
+
+      - name: Retreive Rust cache
+        uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # pin v2.2.0
+        if: >-
+          steps.python-changes.outputs.run == 'true'
+          && steps.cache-libparsec.outputs.cache-hit != 'true'
+        with:
+          # Cache is limited to 10Go (and cache is ~700mo per platform !). On top of that.
+          # cache is only shared between master and the PRs (and not accross PRs).
+          # So we only save the cache on master build given it's the ones that are the
+          # most likely to be reused.
+          save-if: github.ref == 'refs/heads/master'
 
       - name: Install python deps
         if: steps.python-changes.outputs.run == 'true'
@@ -337,6 +352,19 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@685abf830623a8456904376fce2de24302d98a7f # pin v1.3.4
         if: steps.rust-changes.outputs.run == 'true'
+        with:
+          # We setup the cache by hand, see below
+          cache: false
+
+      - name: Retreive Rust cache
+        uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # pin v2.2.0
+        if: steps.rust-changes.outputs.run == 'true'
+        with:
+          # Cache is limited to 10Go (and cache is ~700mo per platform !). On top of that.
+          # cache is only shared between master and the PRs (and not accross PRs).
+          # So we only save the cache on master build given it's the ones that are the
+          # most likely to be reused.
+          save-if: github.ref == 'refs/heads/master'
 
       - name: Test rust codebase
         if: steps.rust-changes.outputs.run == 'true'


### PR DESCRIPTION
# What has changed ?

Each CI run end up with roughly 6 x 700mo of cache, this is too huge for the 10Go cache :(

A stopgap is to only save the cache of the build on master: PRs cannot share they cache so only master's cache is shared accross PRs
On top of that it brings an incentive to rebase the PRs: you get the cache working if you use a recent enough master base !

Aaaaand last but not least it seems saving cache [takes quiet some time](https://github.com/Scille/parsec-cloud/actions/runs/3735400246/jobs/6338596940): I saw a 2mn30s time to upload 677mo of cache on Windows (~50s on macOS and ~30s on Linux)