### PR TITLE
Fix pki enrollment spinner

### DIFF
--- a/newsfragments/3846.bugfix.rst
+++ b/newsfragments/3846.bugfix.rst
@@ -1,0 +1,1 @@
+Hide spinner during an enrollment using PKI

--- a/parsec/core/gui/enrollment_widget.py
+++ b/parsec/core/gui/enrollment_widget.py
@@ -44,7 +44,7 @@ class AcceptCheckInfoWidget(QWidget, Ui_GreetUserCheckInfoWidget):
         self.setupUi(self)
 
         self.dialog: GreyedDialog[AcceptCheckInfoWidget] | None = None
-        self.label_waiting.hide()
+        self.widget_waiting.setVisible(False)
 
         self.line_edit_user_full_name.validity_changed.connect(self.check_infos)
         self.line_edit_user_full_name.set_validator(validators.UserNameValidator())


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->

Hide the spinner during enrollment by PKI.

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [X] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
Closes #3846 