### PR TITLE
Oxidize device file type enum

### DIFF
--- a/parsec/_parsec.pyi
+++ b/parsec/_parsec.pyi
@@ -43,6 +43,7 @@ from parsec._parsec_pyi.crypto import (
     VerifyKey,
     generate_nonce,
 )
+from parsec._parsec_pyi.device import DeviceFileType
 from parsec._parsec_pyi.enumerate import (
     ClientType,
     InvitationDeletedReason,
@@ -549,6 +550,8 @@ __all__ = [
     "RealmRoleCertificate",
     "SequesterAuthorityCertificate",
     "SequesterServiceCertificate",
+    # Device
+    "DeviceFileType",
     # Crypto
     "SecretKey",
     "HashDigest",

--- a/parsec/_parsec_pyi/device.pyi
+++ b/parsec/_parsec_pyi/device.pyi
@@ -1,0 +1,11 @@
+# Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
+
+from __future__ import annotations
+
+class DeviceFileType:
+    PASSWORD: DeviceFileType
+    SMARTCARD: DeviceFileType
+    RECOVERY: DeviceFileType
+
+    def values(self) -> tuple[DeviceFileType, ...]: ...
+    def str(self) -> str: ...

--- a/src/enumerate.rs
+++ b/src/enumerate.rs
@@ -326,3 +326,21 @@ crate::binding_utils::impl_enum_field!(
 crate::binding_utils::gen_proto!(CoreEvent, __hash__);
 crate::binding_utils::gen_proto!(CoreEvent, __repr__);
 crate::binding_utils::gen_proto!(CoreEvent, __richcmp__, eq);
+
+#[pyclass]
+pub(crate) struct DeviceFileType(client_types::DeviceFileType);
+
+crate::binding_utils::impl_enum_field!(
+    DeviceFileType,
+    ["PASSWORD", password, client_types::DeviceFileType::Password],
+    [
+        "SMARTCARD",
+        smartcard,
+        client_types::DeviceFileType::Smartcard
+    ],
+    ["RECOVERY", recovery, client_types::DeviceFileType::Recovery]
+);
+
+crate::binding_utils::gen_proto!(DeviceFileType, __hash__);
+crate::binding_utils::gen_proto!(DeviceFileType, __repr__);
+crate::binding_utils::gen_proto!(DeviceFileType, __richcmp__, eq);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,13 +44,14 @@ fn entrypoint(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(api_crypto::generate_nonce, m)?)?;
 
     m.add_class::<enumerate::ClientType>()?;
-    m.add_class::<enumerate::InvitationEmailSentStatus>()?;
+    m.add_class::<enumerate::CoreEvent>()?;
+    m.add_class::<enumerate::DeviceFileType>()?;
     m.add_class::<enumerate::InvitationDeletedReason>()?;
+    m.add_class::<enumerate::InvitationEmailSentStatus>()?;
     m.add_class::<enumerate::InvitationStatus>()?;
     m.add_class::<enumerate::InvitationType>()?;
     m.add_class::<enumerate::RealmRole>()?;
     m.add_class::<enumerate::UserProfile>()?;
-    m.add_class::<enumerate::CoreEvent>()?;
 
     m.add_function(wrap_pyfunction!(file_operations::prepare_read, m)?)?;
     m.add_function(wrap_pyfunction!(file_operations::prepare_write, m)?)?;


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
This PR adds a binding for `DeviceFileType` enum. I didn't removed the python version completely because this will be done in the upcoming PRs to oxidize schemas.

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
