### PR TITLE
Updated bindings generator to use camelCase for TypeScript

### DIFF
--- a/oxidation/bindings/electron/src/index.d.ts
+++ b/oxidation/bindings/electron/src/index.d.ts
@@ -11,11 +11,11 @@ export type Result<T, E = Error> =
 
 
 export interface AvailableDevice {
-    key_file_path: string;
-    organization_id: string;
-    device_id: string;
-    human_handle: string | null;
-    device_label: string | null;
+    keyFilePath: string;
+    organizationId: string;
+    deviceId: string;
+    humanHandle: string | null;
+    deviceLabel: string | null;
     slug: string;
     ty: DeviceFileType;
 }

--- a/oxidation/bindings/electron/src/meths.rs
+++ b/oxidation/bindings/electron/src/meths.rs
@@ -15,28 +15,28 @@ fn struct_availabledevice_js_to_rs<'a>(
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::AvailableDevice> {
     let key_file_path = {
-        let js_val: Handle<JsString> = obj.get(cx, "key_file_path")?;
+        let js_val: Handle<JsString> = obj.get(cx, "keyFilePath")?;
         match js_val.value(cx).parse() {
             Ok(val) => val,
             Err(err) => return cx.throw_type_error(err),
         }
     };
     let organization_id = {
-        let js_val: Handle<JsString> = obj.get(cx, "organization_id")?;
+        let js_val: Handle<JsString> = obj.get(cx, "organizationId")?;
         match js_val.value(cx).parse() {
             Ok(val) => val,
             Err(err) => return cx.throw_type_error(err),
         }
     };
     let device_id = {
-        let js_val: Handle<JsString> = obj.get(cx, "device_id")?;
+        let js_val: Handle<JsString> = obj.get(cx, "deviceId")?;
         match js_val.value(cx).parse() {
             Ok(val) => val,
             Err(err) => return cx.throw_type_error(err),
         }
     };
     let human_handle = {
-        let js_val: Handle<JsValue> = obj.get(cx, "human_handle")?;
+        let js_val: Handle<JsValue> = obj.get(cx, "humanHandle")?;
         {
             if js_val.is_a::<JsNull, _>(cx) {
                 None
@@ -50,7 +50,7 @@ fn struct_availabledevice_js_to_rs<'a>(
         }
     };
     let device_label = {
-        let js_val: Handle<JsValue> = obj.get(cx, "device_label")?;
+        let js_val: Handle<JsValue> = obj.get(cx, "deviceLabel")?;
         {
             if js_val.is_a::<JsNull, _>(cx) {
                 None
@@ -89,21 +89,21 @@ fn struct_availabledevice_rs_to_js<'a>(
 ) -> NeonResult<Handle<'a, JsObject>> {
     let js_obj = cx.empty_object();
     let js_key_file_path = JsString::try_new(cx, rs_obj.key_file_path).or_throw(cx)?;
-    js_obj.set(cx, "key_file_path", js_key_file_path)?;
+    js_obj.set(cx, "keyFilePath", js_key_file_path)?;
     let js_organization_id = JsString::try_new(cx, rs_obj.organization_id).or_throw(cx)?;
-    js_obj.set(cx, "organization_id", js_organization_id)?;
+    js_obj.set(cx, "organizationId", js_organization_id)?;
     let js_device_id = JsString::try_new(cx, rs_obj.device_id).or_throw(cx)?;
-    js_obj.set(cx, "device_id", js_device_id)?;
+    js_obj.set(cx, "deviceId", js_device_id)?;
     let js_human_handle = match rs_obj.human_handle {
         Some(elem) => JsString::try_new(cx, elem).or_throw(cx)?.as_value(cx),
         None => JsNull::new(cx).as_value(cx),
     };
-    js_obj.set(cx, "human_handle", js_human_handle)?;
+    js_obj.set(cx, "humanHandle", js_human_handle)?;
     let js_device_label = match rs_obj.device_label {
         Some(elem) => JsString::try_new(cx, elem).or_throw(cx)?.as_value(cx),
         None => JsNull::new(cx).as_value(cx),
     };
-    js_obj.set(cx, "device_label", js_device_label)?;
+    js_obj.set(cx, "deviceLabel", js_device_label)?;
     let js_slug = JsString::try_new(cx, rs_obj.slug).or_throw(cx)?;
     js_obj.set(cx, "slug", js_slug)?;
     let js_ty = variant_devicefiletype_rs_to_js(cx, rs_obj.ty)?;

--- a/oxidation/bindings/generator/generate.py
+++ b/oxidation/bindings/generator/generate.py
@@ -4,6 +4,7 @@ from types import ModuleType
 from typing import Union, Dict, List, OrderedDict, Type, Optional
 from importlib import import_module
 import argparse
+import inspect
 from dataclasses import dataclass
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from pathlib import Path
@@ -31,6 +32,24 @@ env = Environment(
     undefined=StrictUndefined,
     keep_trailing_newline=True,
 )
+
+
+def snake_case_to_camel_case(s: str) -> str:
+    camel = ""
+    next_is_uppercase = False
+    for c in s:
+        if c == "_":
+            next_is_uppercase = True
+            continue
+        if next_is_uppercase:
+            camel += c.upper()
+            next_is_uppercase = False
+        else:
+            camel += c
+    return camel
+
+
+env.filters["snake2camel"] = snake_case_to_camel_case
 
 
 def _raise_helper(msg):
@@ -136,21 +155,6 @@ class MethSpec:
     params: OrderedDict[str, BaseTypeInUse]
     return_type: Optional[BaseTypeInUse]
     is_async: bool
-
-    @property
-    def pascalName(self):
-        camel = ""
-        next_is_uppercase = False
-        for c in self.name:
-            if c == "_":
-                next_is_uppercase = True
-                continue
-            if next_is_uppercase:
-                camel += c.upper()
-                next_is_uppercase = False
-            else:
-                camel += c
-        return camel
 
 
 @dataclass

--- a/oxidation/bindings/generator/templates/binding_electron_index.d.ts.j2
+++ b/oxidation/bindings/generator/templates/binding_electron_index.d.ts.j2
@@ -45,9 +45,9 @@ export type Result<T, E = Error> =
 export interface {{ struct.name }} {
 {% for attr_name, attr_type in struct.attributes.items() %}
 {% if attr_type.kind == "optional" %}
-    {{ attr_name }}: {{ render_type(attr_type) }};
+    {{ attr_name | snake2camel }}: {{ render_type(attr_type) }};
 {% else %}
-    {{ attr_name }}: {{ render_type(attr_type) }};
+    {{ attr_name | snake2camel }}: {{ render_type(attr_type) }};
 {% endif %}
 {% endfor %}
 }
@@ -78,7 +78,7 @@ export type {{ variant.name }} =
 
 {# Methods #}
 {% for meth in api.meths %}
-export function {{ meth.pascalName }}(
+export function {{ meth.name | snake2camel }}(
 {%- for arg_name, arg_type in meth.params.items() -%}
     {{ arg_name }}: {{ render_type(arg_type) }}{{ ", " if not loop.last else "" }}
 {%- endfor -%}

--- a/oxidation/bindings/generator/templates/binding_electron_meths.rs.j2
+++ b/oxidation/bindings/generator/templates/binding_electron_meths.rs.j2
@@ -187,7 +187,7 @@ fn {{ struct_js_to_rs_function_name(struct) }}<'a>(
 ) -> NeonResult<libparsec::{{ struct.name }}> {
 {% for attr_name, attr_type in struct.attributes.items() %}
     let {{ attr_name }} = {
-        let js_val: Handle<{{ ts_type(attr_type) }}> = obj.get(cx, "{{ attr_name }}")?;
+        let js_val: Handle<{{ ts_type(attr_type) }}> = obj.get(cx, "{{ attr_name | snake2camel }}")?;
         {{ render_downcasted_js_to_rs("js_val", attr_type, mut_cx_ref="cx") | indent(8) }}
     };
 {% endfor %}
@@ -209,7 +209,7 @@ fn {{ struct_rs_to_js_function_name(struct) }}<'a>(
     let js_obj = cx.empty_object();
 {% for attr_name, attr_type in struct.attributes.items() %}
     let js_{{ attr_name }} = {{ render_rs_to_js("rs_obj.%s" % attr_name, attr_type, mut_cx_ref="cx") | indent }};
-    js_obj.set(cx, "{{ attr_name }}", js_{{ attr_name }})?;
+    js_obj.set(cx, "{{ attr_name | snake2camel }}", js_{{ attr_name }})?;
 {% endfor %}
     Ok(js_obj)
 }
@@ -432,7 +432,7 @@ use neon::{prelude::*, types::buffer::TypedArray};
 
 pub fn register_meths(cx: &mut ModuleContext) -> NeonResult<()> {
 {% for meth in api.meths %}
-    cx.export_function("{{ meth.pascalName }}", {{ meth.name }})?;
+    cx.export_function("{{ meth.name | snake2camel }}", {{ meth.name }})?;
 {% endfor %}
     Ok(())
 }

--- a/oxidation/bindings/generator/templates/binding_web_meths.rs.j2
+++ b/oxidation/bindings/generator/templates/binding_web_meths.rs.j2
@@ -185,7 +185,7 @@ match {{ rs_value }} {
 fn {{ struct_js_to_rs_function_name(struct) }}(obj: JsValue) -> Result<libparsec::{{ struct.name }}, JsValue> {
 {% for attr_name, attr_type in struct.attributes.items() %}
     let {{ attr_name }} = {
-        let js_val = Reflect::get(&obj, &"{{ attr_name }}".into())?;
+        let js_val = Reflect::get(&obj, &"{{ attr_name | snake2camel }}".into())?;
         {{ render_js_value_to_rs("js_val", attr_type) | indent(8) }}
     };
 {% endfor %}
@@ -204,7 +204,7 @@ fn {{ struct_rs_to_js_function_name(struct) }}(rs_obj: libparsec::{{ struct.name
     let js_obj = Object::new().into();
 {% for attr_name, attr_type in struct.attributes.items() %}
     let js_{{ attr_name }} = {{ render_rs_to_js_value("rs_obj.%s" % attr_name, attr_type) | indent }};
-    Reflect::set(&js_obj, &"{{ attr_name }}".into(), &js_{{ attr_name }})?;
+    Reflect::set(&js_obj, &"{{ attr_name | snake2camel }}".into(), &js_{{ attr_name }})?;
 {% endfor %}
     Ok(js_obj)
 }
@@ -276,7 +276,7 @@ fn {{ variant_rs_to_js_function_name(variant) }}(rs_obj: libparsec::{{ variant.n
 {%- macro render_async_function(meth) %}
 #[allow(non_snake_case)]
 #[wasm_bindgen]
-pub fn {{ meth.pascalName }}(
+pub fn {{ meth.name | snake2camel }}(
 {%- for param_name, param_type in meth.params.items() -%}
 {{ param_name }}: {{ function_param_type(param_type) }}{{ "" if loop.last else ", " }}
 {%- endfor -%}
@@ -310,7 +310,7 @@ pub fn {{ meth.pascalName }}(
 {%- macro render_sync_function(meth) %}
 #[allow(non_snake_case)]
 #[wasm_bindgen]
-pub fn {{ meth.pascalName }}(
+pub fn {{ meth.name | snake2camel }}(
 {%- for param_name, param_type in meth.params.items() -%}
 {{ param_name }}: {{ function_param_type(param_type) }}{{ "" if loop.last else ", " }}
 {%- endfor -%}

--- a/oxidation/bindings/generator/templates/client_plugin_definitions.d.ts.j2
+++ b/oxidation/bindings/generator/templates/client_plugin_definitions.d.ts.j2
@@ -43,9 +43,9 @@ export type Result<T, E = Error> =
 export interface {{ struct.name }} {
 {% for attr_name, attr_type in struct.attributes.items() %}
 {% if attr_type.kind == "optional" %}
-    {{ attr_name }}: {{ render_type(attr_type) }};
+    {{ attr_name | snake2camel }}: {{ render_type(attr_type) }};
 {% else %}
-    {{ attr_name }}: {{ render_type(attr_type) }};
+    {{ attr_name | snake2camel }}: {{ render_type(attr_type) }};
 {% endif %}
 {% endfor %}
 }
@@ -59,9 +59,9 @@ export interface {{ variant.name }}{{ variant_value.name }} {
     tag: '{{ variant_value.name }}'
 {% for attr_name, attr_type in variant_value.attributes.items() %}
 {% if attr_type.kind == "optional" %}
-    {{ attr_name }}: {{ render_type(attr_type) }};
+    {{ attr_name | snake2camel }}: {{ render_type(attr_type) }};
 {% else %}
-    {{ attr_name }}: {{ render_type(attr_type) }};
+    {{ attr_name | snake2camel }}: {{ render_type(attr_type) }};
 {% endif %}
 {% endfor %}
 }
@@ -75,7 +75,7 @@ export type {{ variant.name }} =
 {# Methods #}
 export interface LibParsecPlugin {
 {% for meth in api.meths %}
-    {{ meth.pascalName }}(
+    {{ meth.name | snake2camel }}(
 {%- for arg_name, arg_type in meth.params.items() -%}
         {{ arg_name }}: {{ render_type(arg_type) }}{{ ", " if not loop.last else "" }}
 {%- endfor -%}

--- a/oxidation/bindings/web/src/meths.rs
+++ b/oxidation/bindings/web/src/meths.rs
@@ -17,7 +17,7 @@ use wasm_bindgen_futures::*;
 #[allow(dead_code)]
 fn struct_availabledevice_js_to_rs(obj: JsValue) -> Result<libparsec::AvailableDevice, JsValue> {
     let key_file_path = {
-        let js_val = Reflect::get(&obj, &"key_file_path".into())?;
+        let js_val = Reflect::get(&obj, &"keyFilePath".into())?;
         js_val
             .dyn_into::<JsString>()
             .ok()
@@ -27,7 +27,7 @@ fn struct_availabledevice_js_to_rs(obj: JsValue) -> Result<libparsec::AvailableD
             .map_err(|_| TypeError::new("Not a valid StrPath"))?
     };
     let organization_id = {
-        let js_val = Reflect::get(&obj, &"organization_id".into())?;
+        let js_val = Reflect::get(&obj, &"organizationId".into())?;
         js_val
             .dyn_into::<JsString>()
             .ok()
@@ -37,7 +37,7 @@ fn struct_availabledevice_js_to_rs(obj: JsValue) -> Result<libparsec::AvailableD
             .map_err(|_| TypeError::new("Not a valid OrganizationID"))?
     };
     let device_id = {
-        let js_val = Reflect::get(&obj, &"device_id".into())?;
+        let js_val = Reflect::get(&obj, &"deviceId".into())?;
         js_val
             .dyn_into::<JsString>()
             .ok()
@@ -47,7 +47,7 @@ fn struct_availabledevice_js_to_rs(obj: JsValue) -> Result<libparsec::AvailableD
             .map_err(|_| TypeError::new("Not a valid DeviceID"))?
     };
     let human_handle = {
-        let js_val = Reflect::get(&obj, &"human_handle".into())?;
+        let js_val = Reflect::get(&obj, &"humanHandle".into())?;
         if js_val.is_null() {
             None
         } else {
@@ -63,7 +63,7 @@ fn struct_availabledevice_js_to_rs(obj: JsValue) -> Result<libparsec::AvailableD
         }
     };
     let device_label = {
-        let js_val = Reflect::get(&obj, &"device_label".into())?;
+        let js_val = Reflect::get(&obj, &"deviceLabel".into())?;
         if js_val.is_null() {
             None
         } else {
@@ -105,21 +105,21 @@ fn struct_availabledevice_js_to_rs(obj: JsValue) -> Result<libparsec::AvailableD
 fn struct_availabledevice_rs_to_js(rs_obj: libparsec::AvailableDevice) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
     let js_key_file_path = JsValue::from_str(rs_obj.key_file_path.as_ref());
-    Reflect::set(&js_obj, &"key_file_path".into(), &js_key_file_path)?;
+    Reflect::set(&js_obj, &"keyFilePath".into(), &js_key_file_path)?;
     let js_organization_id = JsValue::from_str(rs_obj.organization_id.as_ref());
-    Reflect::set(&js_obj, &"organization_id".into(), &js_organization_id)?;
+    Reflect::set(&js_obj, &"organizationId".into(), &js_organization_id)?;
     let js_device_id = JsValue::from_str(rs_obj.device_id.as_ref());
-    Reflect::set(&js_obj, &"device_id".into(), &js_device_id)?;
+    Reflect::set(&js_obj, &"deviceId".into(), &js_device_id)?;
     let js_human_handle = match rs_obj.human_handle {
         Some(val) => JsValue::from_str(val.as_ref()),
         None => JsValue::NULL,
     };
-    Reflect::set(&js_obj, &"human_handle".into(), &js_human_handle)?;
+    Reflect::set(&js_obj, &"humanHandle".into(), &js_human_handle)?;
     let js_device_label = match rs_obj.device_label {
         Some(val) => JsValue::from_str(val.as_ref()),
         None => JsValue::NULL,
     };
-    Reflect::set(&js_obj, &"device_label".into(), &js_device_label)?;
+    Reflect::set(&js_obj, &"deviceLabel".into(), &js_device_label)?;
     let js_slug = rs_obj.slug.into();
     Reflect::set(&js_obj, &"slug".into(), &js_slug)?;
     let js_ty = variant_devicefiletype_rs_to_js(rs_obj.ty)?;

--- a/oxidation/client/src/plugins/libparsec/definitions.d.ts
+++ b/oxidation/client/src/plugins/libparsec/definitions.d.ts
@@ -9,11 +9,11 @@ export type Result<T, E = Error> =
   | { ok: false; error: E };
 
 export interface AvailableDevice {
-    key_file_path: string;
-    organization_id: string;
-    device_id: string;
-    human_handle: string | null;
-    device_label: string | null;
+    keyFilePath: string;
+    organizationId: string;
+    deviceId: string;
+    humanHandle: string | null;
+    deviceLabel: string | null;
     slug: string;
     ty: DeviceFileType;
 }


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
Use camelCase for auto-generated TypeScript bindings. Not sure if I got every cases.

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
Closes #3886 
