### PR TITLE
Improve DeviceFile & LegacyDeviceFile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,6 +1336,7 @@ dependencies = [
 name = "libparsec_platform_device_loader"
 version = "0.0.0"
 dependencies = [
+ "hex-literal",
  "libparsec_client_types",
  "libparsec_crypto",
  "rstest",

--- a/oxidation/libparsec/crates/client_types/src/local_device_file.rs
+++ b/oxidation/libparsec/crates/client_types/src/local_device_file.rs
@@ -22,8 +22,7 @@ pub struct DeviceFilePassword {
 
     pub device_id: DeviceID,
     pub organization_id: OrganizationID,
-    // Handle legacy device with option
-    pub slug: Option<String>,
+    pub slug: String,
 }
 
 #[serde_as]
@@ -84,7 +83,6 @@ impl DeviceFile {
 
 #[serde_as]
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[cfg_attr(test, derive(Serialize))]
 pub struct LegacyDeviceFilePassword {
     #[serde_as(as = "Bytes")]
     pub salt: Vec<u8>,
@@ -98,7 +96,6 @@ pub struct LegacyDeviceFilePassword {
 /// files used to be serialized with a `type` field set to `password`. In order to
 /// enforce this property serde's `tag` attribute is set to `type` field here.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[cfg_attr(test, derive(Serialize))]
 #[serde(rename_all = "lowercase")]
 #[serde(tag = "type")]
 pub enum LegacyDeviceFile {
@@ -109,13 +106,7 @@ impl LegacyDeviceFile {
     pub fn load(serialized: &[u8]) -> Result<Self, &'static str> {
         rmp_serde::from_slice(serialized).map_err(|_| "Invalid serialization")
     }
-
-    #[cfg(test)]
-    pub fn dump(&self) -> Vec<u8> {
-        rmp_serde::to_vec_named(&self).unwrap_or_else(|_| unreachable!())
-    }
 }
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DeviceFileType {

--- a/oxidation/libparsec/crates/client_types/src/test/test_local_device.rs
+++ b/oxidation/libparsec/crates/client_types/src/test/test_local_device.rs
@@ -137,7 +137,6 @@ fn serde_legacy_device_file(#[case] raw: &[u8], #[case] expected: LegacyDeviceFi
     let device = LegacyDeviceFile::load(raw).unwrap();
     assert_eq!(device, expected);
 
-    // Roundtrip
-    let roundtrip_raw = device.dump();
-    assert_eq!(LegacyDeviceFile::load(&roundtrip_raw).unwrap(), expected);
+    // We don't need to test roundtrip because we will never save this file again !
+    // It will be saved with the good one :)
 }

--- a/oxidation/libparsec/crates/client_types/tests/test_local_device_file.rs
+++ b/oxidation/libparsec/crates/client_types/tests/test_local_device_file.rs
@@ -67,7 +67,7 @@ fn password_protected_device_file(alice: &Device) {
         device_label: alice.device_label.to_owned(),
         device_id: alice.device_id.to_owned(),
         organization_id: alice.organization_id().to_owned(),
-        slug: Some(alice.local_device().slug()),
+        slug: alice.local_device().slug(),
         salt: hex!("2ae6167f0f7472b8565c390df3af4a8b").to_vec(),
     };
 

--- a/oxidation/libparsec/crates/platform_device_loader/Cargo.toml
+++ b/oxidation/libparsec/crates/platform_device_loader/Cargo.toml
@@ -20,6 +20,7 @@ web-sys = { version = "0.3.60", features = ["Window", "Storage"] }
 [dev-dependencies]
 tests_fixtures = { path = "../tests_fixtures" }
 
+hex-literal = "0.3.3"
 tokio = "1.24.1"
 rstest = "0.16.0"
 

--- a/oxidation/libparsec/crates/platform_device_loader/src/native/local_device_file.rs
+++ b/oxidation/libparsec/crates/platform_device_loader/src/native/local_device_file.rs
@@ -136,7 +136,7 @@ fn load_legacy_device_file(key_file: &Path, ciphertext: &[u8]) -> LocalDeviceRes
         device_label: legacy_device.device_label,
         device_id,
         organization_id,
-        slug: Some(slug.to_string()),
+        slug: slug.to_string(),
     }))
 }
 
@@ -151,7 +151,6 @@ pub fn load_device_file(key_file_path: &Path) -> LocalDeviceResult<DeviceFile> {
         .or_else(|_| load_legacy_device_file(key_file_path, &data))
 }
 
-/// For the legacy device files, the slug is contained in the device filename
 pub fn load_available_device(key_file_path: PathBuf) -> LocalDeviceResult<AvailableDevice> {
     let (ty, organization_id, device_id, human_handle, device_label, slug) =
         match load_device_file(&key_file_path)? {
@@ -161,24 +160,7 @@ pub fn load_available_device(key_file_path: PathBuf) -> LocalDeviceResult<Availa
                 device.device_id,
                 device.human_handle,
                 device.device_label,
-                // Handle legacy device
-                match device.slug {
-                    Some(slug) => slug,
-                    None => {
-                        let slug = key_file_path
-                            .file_stem()
-                            .expect("Unreachable because deserialization succeed")
-                            .to_str()
-                            .expect("It may be unreachable")
-                            .to_string();
-
-                        if LocalDevice::load_slug(&slug).is_err() {
-                            return Err(LocalDeviceError::InvalidSlug);
-                        }
-
-                        slug
-                    }
-                },
+                device.slug,
             ),
             DeviceFile::Recovery(device) => (
                 DeviceFileType::Recovery,
@@ -270,7 +252,7 @@ pub fn save_device_with_password(
         device_label: device.device_label.clone(),
         device_id: device.device_id.clone(),
         organization_id: device.organization_id().clone(),
-        slug: Some(device.slug()),
+        slug: device.slug(),
     });
     save_device_file(key_file, &key_file_content)?;
 


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
- Don't serialize anymore legacy device file
- Remove the useless option in `DeviceFilePassword` (we handle `LegacyDeviceFilePassword` somewhere else)

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
