### PR TITLE
Fix CI packaging

### DIFF
--- a/.github/actions/paths-filter/filters.yml
+++ b/.github/actions/paths-filter/filters.yml
@@ -9,6 +9,9 @@ rust:
   - Cargo.lock
   - rust-toolchain.toml
 
+rust-platform-web: &rust-platform-web
+  - oxidation/libparsec/crates/platform_*/src/web/**
+
 python:
   - *shared
   - parsec/**
@@ -33,11 +36,12 @@ client-common: &client-common
   - oxidation/client/capacitor.config.ts
   - oxidation/client/babel.config.js
   - oxidation/client/tsconfig.json
-  - oxidation/bindings/common/**
+  - oxidation/bindings/generator/**
 
 client-web:
   - *shared
   - *client-common
+  - *rust-platform-web
   - oxidation/bindings/web/**
   - oxidation/client/tests/**
   - oxidation/client/jest.config.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,13 +373,9 @@ jobs:
         shell: bash
         run: echo OPENSSL_SRC_PERL=C:/Strawberry/perl/bin/perl >> $GITHUB_ENV
 
-      - name: Additional Check
+      - name: Additional Check (for packaging)
         if: startsWith(matrix.os, 'ubuntu')
-        run: |
-          set -ex
-          rustup target add wasm32-unknown-unknown
-          cargo check --no-default-features --features use-sodiumoxide
-          cargo check --target wasm32-unknown-unknown
+        run: cargo check --no-default-features --features use-sodiumoxide
 
       - name: Test rust codebase
         if: steps.rust-changes.outputs.run == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,13 +124,6 @@ jobs:
         env:
           POETRY_LIBPARSEC_BUILD_STRATEGY: no_build
 
-      - name: Additional Check
-        run: |
-          set -ex
-          rustup target add wasm32-unknown-unknown
-          cargo check --no-default-features --features use-sodiumoxide
-          cargo check --target wasm32-unknown-unknown
-
       # Clippy basically compile the project, hence it's faster to run it in
       # the test-rust-matrix job where compilation cache is reused !
       - uses: ./.github/actions/use-pre-commit
@@ -379,6 +372,14 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         shell: bash
         run: echo OPENSSL_SRC_PERL=C:/Strawberry/perl/bin/perl >> $GITHUB_ENV
+
+      - name: Additional Check
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          set -ex
+          rustup target add wasm32-unknown-unknown
+          cargo check --no-default-features --features use-sodiumoxide
+          cargo check --target wasm32-unknown-unknown
 
       - name: Test rust codebase
         if: steps.rust-changes.outputs.run == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,7 @@ jobs:
 
       - name: Additional Check (for packaging)
         if: startsWith(matrix.os, 'ubuntu')
-        run: cargo check --no-default-features --features use-sodiumoxide
+        run: cargo check --profile ci-rust --no-default-features --features use-sodiumoxide
 
       - name: Test rust codebase
         if: steps.rust-changes.outputs.run == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,13 @@ jobs:
         env:
           POETRY_LIBPARSEC_BUILD_STRATEGY: no_build
 
+      - name: Additional Check
+        run: |
+          set -ex
+          rustup target add wasm32-unknown-unknown
+          cargo check --no-default-features --features use-sodiumoxide
+          cargo check --target wasm32-unknown-unknown
+
       # Clippy basically compile the project, hence it's faster to run it in
       # the test-rust-matrix job where compilation cache is reused !
       - uses: ./.github/actions/use-pre-commit
@@ -408,7 +415,6 @@ jobs:
         id: web-change
         if: >-
           steps.changes.outputs.client-web == 'true'
-          || steps.changes.outputs.client-common == 'true'
           || github.ref == 'refs/heads/master'
         run: echo "run=true" >> $GITHUB_OUTPUT
         shell: bash

--- a/build.py
+++ b/build.py
@@ -64,14 +64,11 @@ def build():
     # native module and discard the rest !
 
     maturin_build_profile = "--profile=" + os.environ.get("CARGO_PROFILE", DEFAULT_CARGO_PROFILE)
-    features = (
-        "--no-default-features --features use-sodiumoxide"
-        if maturin_build_profile == "--profile=release"
-        else ""
-    )
+    maturin_build_features = os.environ.get("CARGO_FEATURES", "")
+
     with tempfile.TemporaryDirectory() as distdir:
         run(
-            f"maturin build {maturin_build_profile} --interpreter {PYTHON_EXECUTABLE_PATH} --out {distdir} {features}"
+            f"maturin build {maturin_build_profile} {maturin_build_features} --interpreter {PYTHON_EXECUTABLE_PATH} --out {distdir}"
         )
 
         outputs = list(pathlib.Path(distdir).iterdir())

--- a/build.py
+++ b/build.py
@@ -64,11 +64,11 @@ def build():
     # native module and discard the rest !
 
     maturin_build_profile = "--profile=" + os.environ.get("CARGO_PROFILE", DEFAULT_CARGO_PROFILE)
-    maturin_build_features = os.environ.get("CARGO_EXTRA_ARGS", "")
+    maturin_build_extra_args = os.environ.get("CARGO_EXTRA_ARGS", "")
 
     with tempfile.TemporaryDirectory() as distdir:
         run(
-            f"maturin build {maturin_build_profile} {maturin_build_features} --interpreter {PYTHON_EXECUTABLE_PATH} --out {distdir}"
+            f"maturin build {maturin_build_profile} {maturin_build_extra_args} --interpreter {PYTHON_EXECUTABLE_PATH} --out {distdir}"
         )
 
         outputs = list(pathlib.Path(distdir).iterdir())

--- a/build.py
+++ b/build.py
@@ -64,7 +64,7 @@ def build():
     # native module and discard the rest !
 
     maturin_build_profile = "--profile=" + os.environ.get("CARGO_PROFILE", DEFAULT_CARGO_PROFILE)
-    maturin_build_features = os.environ.get("CARGO_FEATURES", "")
+    maturin_build_features = os.environ.get("CARGO_EXTRA_ARGS", "")
 
     with tempfile.TemporaryDirectory() as distdir:
         run(

--- a/oxidation/libparsec/crates/core/Cargo.toml
+++ b/oxidation/libparsec/crates/core/Cargo.toml
@@ -20,7 +20,7 @@ use-sodiumoxide = ["libparsec_crypto/use-sodiumoxide"]
 libparsec_client_types = { path = "../client_types", default-features = false }
 libparsec_crypto = { path = "../crypto", default-features = false }
 libparsec_platform_async = { path = "../platform_async" }
-libparsec_platform_device_loader = { path = "../platform_device_loader" }
+libparsec_platform_device_loader = { path = "../platform_device_loader", default-features = false }
 libparsec_protocol = { path = "../protocol", default-features = false }
 libparsec_types = { path = "../types", default-features = false }
 

--- a/oxidation/libparsec/crates/platform_device_loader/src/web/local_device.rs
+++ b/oxidation/libparsec/crates/platform_device_loader/src/web/local_device.rs
@@ -15,7 +15,7 @@ pub fn load_device_with_password(slug: &str, password: &str) -> LocalDeviceResul
                     DeviceFile::Password(x) => Some(x),
                     _ => None,
                 })
-                .find(|x| x.slug.as_ref().map(|x| x.as_str()) == Some(slug))
+                .find(|x| x.slug.as_str() == slug)
                 .ok_or_else(|| LocalDeviceError::NotFound { slug: slug.into() })?;
 
             return load_device_with_password_core(password, &device_file);

--- a/oxidation/libparsec/crates/platform_device_loader/src/web/local_device_file.rs
+++ b/oxidation/libparsec/crates/platform_device_loader/src/web/local_device_file.rs
@@ -19,8 +19,7 @@ pub async fn list_available_devices(_config_dir: &Path) -> Vec<AvailableDevice> 
                         device.device_id,
                         device.human_handle,
                         device.device_label,
-                        // There are no legacy device
-                        device.slug.unwrap(),
+                        device.slug,
                     ),
                     DeviceFile::Recovery(device) => (
                         DeviceFileType::Recovery,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,7 @@ test-command = "parsec --version && parsec core list_devices"
 # non-existent and hence $PATH don't know about it (and maturin will fail when calling cargo).
 # For this reason we force $PATH to contain Rust bin dir.
 PATH = "$PATH:$HOME/.cargo/bin"
-CARGO_FEATURES = "--no-default-features --features use-sodiumoxide"
+CARGO_EXTRA_ARGS = "--no-default-features --features use-sodiumoxide"
 
 [tool.maturin]
 features = ["extension-module"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,7 @@ test-command = "parsec --version && parsec core list_devices"
 # non-existent and hence $PATH don't know about it (and maturin will fail when calling cargo).
 # For this reason we force $PATH to contain Rust bin dir.
 PATH = "$PATH:$HOME/.cargo/bin"
+CARGO_FEATURES = "--no-default-features --features use-sodiumoxide"
 
 [tool.maturin]
 features = ["extension-module"]


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
The CI packaging is broken, because the `default-feature` isn't disabled for `libparsec_platform_device_loader` which depends on `libparsec_crypto`

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
