### PR TITLE
Better distinction between file and folder in GUI

### DIFF
--- a/newsfragments/3855.misc.rst
+++ b/newsfragments/3855.misc.rst
@@ -1,0 +1,1 @@
+Added better distinction between file and folder actions in contextual menus.

--- a/parsec/core/gui/file_table.py
+++ b/parsec/core/gui/file_table.py
@@ -294,13 +294,14 @@ class FileTable(QTableWidget):
 
             # Show the option to create a timestamped share link to the user is
             # useless here because it has the same effect as creating a regular file link
+            filetype = "FILE" if selected[0].type == FileType.File else "FOLDER"
             if not self.is_timestamped_workspace:
-                action = menu.addAction(_("ACTION_FILE_MENU_GET_FILE_LINK"))
+                action = menu.addAction(_(f"ACTION_FILE_MENU_GET_{filetype}_LINK"))
                 action.triggered.connect(self.file_path_clicked.emit)
-                action = menu.addAction(_("ACTION_FILE_MENU_GET_FILE_LINK_TIMESTAMP"))
+                action = menu.addAction(_(f"ACTION_FILE_MENU_GET_{filetype}_LINK_TIMESTAMP"))
                 action.triggered.connect(self.file_path_timestamp_clicked.emit)
             else:
-                action = menu.addAction(_("ACTION_FILE_MENU_GET_FILE_LINK"))
+                action = menu.addAction(_(f"ACTION_FILE_MENU_GET_{filetype}_LINK"))
                 action.triggered.connect(self.file_path_clicked.emit)
 
         menu.exec_(global_pos)

--- a/parsec/core/gui/files_widget.py
+++ b/parsec/core/gui/files_widget.py
@@ -462,7 +462,8 @@ class FilesWidget(QWidget, Ui_FilesWidget):
         path = self.current_directory / files[0].name
         addr = self.workspace_fs.generate_file_link(path)
         desktop.copy_to_clipboard(addr.to_url())
-        SnackbarManager.inform(T("TEXT_FILE_LINK_COPIED_TO_CLIPBOARD"))
+        filetype = "FILE" if files[0].type == FileType.File else "FOLDER"
+        SnackbarManager.inform(T(f"TEXT_{filetype}_LINK_COPIED_TO_CLIPBOARD"))
 
     def on_get_file_path_timestamp_clicked(self) -> None:
         assert self.workspace_fs is not None
@@ -472,7 +473,8 @@ class FilesWidget(QWidget, Ui_FilesWidget):
         path = self.current_directory / files[0].name
         ts_addr = self.workspace_fs.generate_file_link(path, timestamp=DateTime.now())
         desktop.copy_to_clipboard(ts_addr.to_url())
-        SnackbarManager.inform(T("TEXT_FILE_LINK_COPIED_TO_CLIPBOARD"))
+        filetype = "FILE" if files[0].type == FileType.File else "FOLDER"
+        SnackbarManager.inform(T(f"TEXT_{filetype}_LINK_COPIED_TO_CLIPBOARD"))
 
     def on_copy_clicked(self) -> None:
         files = self.table_files.selected_files()
@@ -624,14 +626,15 @@ class FilesWidget(QWidget, Ui_FilesWidget):
 
         if len(files) == 1:
             selection_end = files[0].name.find(".")
+            filetype = "FILE" if files[0].type == FileType.File else "FOLDER"
             # If no "." or starts with a ".", we want to select the whole file name
             if selection_end in [-1, 0]:
                 selection_end = len(files[0].name)
             new_name = get_text_input(
                 self,
-                T("TEXT_FILE_RENAME_TITLE"),
-                T("TEXT_FILE_RENAME_INSTRUCTIONS"),
-                placeholder=T("TEXT_FILE_RENAME_PLACEHOLDER"),
+                T(f"TEXT_{filetype}_RENAME_TITLE"),
+                T(f"TEXT_{filetype}_RENAME_INSTRUCTIONS"),
+                placeholder=T(f"TEXT_{filetype}_RENAME_PLACEHOLDER"),
                 default_text=files[0].name,
                 validator=validators.FileNameValidator(),
                 button_text=T("ACTION_FILE_RENAME"),
@@ -684,11 +687,12 @@ class FilesWidget(QWidget, Ui_FilesWidget):
         files = self.table_files.selected_files()
         assert self.workspace_fs is not None
         if len(files) == 1:
+            filetype = "FILE" if files[0].type == FileType.File else "FOLDER"
             result = ask_question(
                 self,
-                T("TEXT_FILE_DELETE_TITLE"),
-                T("TEXT_FILE_DELETE_INSTRUCTIONS_name").format(name=files[0].name),
-                [T("ACTION_FILE_DELETE"), T("ACTION_CANCEL")],
+                T(f"TEXT_{filetype}_DELETE_TITLE"),
+                T(f"TEXT_{filetype}_DELETE_INSTRUCTIONS_name").format(name=files[0].name),
+                [T(f"ACTION_FILE_DELETE"), T("ACTION_CANCEL")],
             )
         else:
             result = ask_question(

--- a/parsec/core/gui/tr/parsec_en.po
+++ b/parsec/core/gui/tr/parsec_en.po
@@ -550,13 +550,13 @@ msgid "TEXT_FILE_HISTORY_TITLE_name"
 msgstr "File history of {name}"
 
 msgid "TEXT_FILE_ITEM_IS_CONFINED_TOOLTIP"
-msgstr "The file will not be synced."
+msgstr "This file will not be synced."
 
 msgid "TEXT_FILE_ITEM_IS_SYNCED_TOOLTIP"
-msgstr "The file is synced."
+msgstr "This file is synced."
 
 msgid "TEXT_FILE_ITEM_IS_NOT_SYNCED_TOOLTIP"
-msgstr "The file is not synced yet."
+msgstr "This file is not synced yet."
 
 msgid "TEXT_FILE_SIZE_B"
 msgstr "B"
@@ -642,8 +642,14 @@ msgstr "Show status"
 msgid "ACTION_FILE_MENU_GET_FILE_LINK"
 msgstr "Get a link to the file"
 
+msgid "ACTION_FILE_MENU_GET_FOLDER_LINK"
+msgstr "Get a link to the folder"
+
 msgid "ACTION_FILE_MENU_GET_FILE_LINK_TIMESTAMP"
 msgstr "Get a link to this version of the file"
+
+msgid "ACTION_FILE_MENU_GET_FOLDER_LINK_TIMESTAMP"
+msgstr "Get a link to this version of the folder"
 
 msgid "TEXT_FILE_TREE_PARENT_FOLDER"
 msgstr "Parent folder"
@@ -663,15 +669,18 @@ msgstr "{count} elements in total"
 msgid "TEXT_FILE_LINK_COPIED_TO_CLIPBOARD"
 msgstr "A link to the file has been copied to your clipboard."
 
+msgid "TEXT_FOLDER_LINK_COPIED_TO_CLIPBOARD"
+msgstr "A link to the folder has been copied to your clipboard."
+
 msgid "TEXT_FILE_FOLDER_MOVED_INTO_ITSELF_ERROR"
 msgstr "Cannot move a folder into itself."
 
 msgid "TEXT_FILE_PASTE_ERROR"
-msgstr "Cannot paste this file here."
+msgstr "Cannot paste this element here."
 
 msgid "TEXT_FILE_HISTORY_MULTIPLE_FILES_SELECTED_ERROR"
 msgstr ""
-"Cannot show the history of multiple files at once. Please select a single"
+"Cannot show the history of multiple elements at once. Please select a single"
 " file."
 
 msgid "TEXT_FILE_STATUS_NO_FILE_SELECTED_ERROR"
@@ -679,8 +688,8 @@ msgstr "No file selected."
 
 msgid "TEXT_FILE_STATUS_MULTIPLE_FILES_SELECTED_ERROR"
 msgstr ""
-"Cannot show the status of multiple files at once. Please select a single "
-"file."
+"Cannot show the status of multiple elements at once. Please select a single "
+"file or folder."
 
 msgid "TEXT_FILE_RENAME_TITLE"
 msgstr "Rename a file"
@@ -691,11 +700,20 @@ msgstr "Enter the new file name."
 msgid "TEXT_FILE_RENAME_PLACEHOLDER"
 msgstr "File name"
 
+msgid "TEXT_FOLDER_RENAME_TITLE"
+msgstr "Rename a folder"
+
+msgid "TEXT_FOLDER_RENAME_INSTRUCTIONS"
+msgstr "Enter the new folder name."
+
+msgid "TEXT_FOLDER_RENAME_PLACEHOLDER"
+msgstr "Folder name"
+
 msgid "ACTION_FILE_RENAME"
 msgstr "Rename"
 
 msgid "TEXT_FILE_RENAME_MULTIPLE_TITLE_count"
-msgstr "Rename {count} files"
+msgstr "Rename {count} elements"
 
 msgid "TEXT_FILE_RENAME_MULTIPLE_INSTRUCTIONS_count"
 msgstr ""
@@ -711,8 +729,14 @@ msgstr "Rename"
 msgid "TEXT_FILE_DELETE_TITLE"
 msgstr "Delete a file"
 
+msgid "TEXT_FOLDER_DELETE_TITLE"
+msgstr "Delete a folder"
+
 msgid "TEXT_FILE_DELETE_INSTRUCTIONS_name"
 msgstr "Are you sure you want to delete the file <b>{name}</b>?"
+
+msgid "TEXT_FOLDER_DELETE_INSTRUCTIONS_name"
+msgstr "Are you sure you want to delete the folder <b>{name}</b>?"
 
 msgid "ACTION_FILE_DELETE"
 msgstr "Delete"
@@ -721,10 +745,10 @@ msgid "ACTION_CANCEL"
 msgstr "Cancel"
 
 msgid "TEXT_FILE_DELETE_MULTIPLE_TITLE_count"
-msgstr "Delete {count} files"
+msgstr "Delete {count} elements"
 
 msgid "TEXT_FILE_DELETE_MULTIPLE_INSTRUCTIONS_count"
-msgstr "Are you sure you want to delete {count} files?"
+msgstr "Are you sure you want to delete {count} elements?"
 
 msgid "ACTION_FILE_DELETE_MULTIPLE"
 msgstr "Delete"
@@ -2408,7 +2432,7 @@ msgid "TEXT_WORKSPACE_FILTERED_user"
 msgstr "Common workspaces with {user}"
 
 msgid "TEXT_WORKSPACE_GOTO_FILE_LINK_TITLE"
-msgstr "Access a file by its link"
+msgstr "Access a file or folder by its link"
 
 msgid "TEXT_WORKSPACE_GOTO_FILE_LINK_INSTRUCTIONS"
 msgstr "Please provide the link to the file."

--- a/parsec/core/gui/tr/parsec_fr.po
+++ b/parsec/core/gui/tr/parsec_fr.po
@@ -573,16 +573,16 @@ msgstr ""
 "fichier."
 
 msgid "TEXT_FILE_HISTORY_TITLE_name"
-msgstr "Historique du fichier {name}"
+msgstr "Historique de l'élément {name}"
 
 msgid "TEXT_FILE_ITEM_IS_CONFINED_TOOLTIP"
-msgstr "Ce fichier ne sera pas synchronisé."
+msgstr "Cet élément ne sera pas synchronisé."
 
 msgid "TEXT_FILE_ITEM_IS_SYNCED_TOOLTIP"
-msgstr "Ce fichier est synchronisé."
+msgstr "Cet élément est synchronisé."
 
 msgid "TEXT_FILE_ITEM_IS_NOT_SYNCED_TOOLTIP"
-msgstr "Ce fichier n'est pas encore synchronisé."
+msgstr "Cet élément n'est pas encore synchronisé."
 
 msgid "TEXT_FILE_SIZE_B"
 msgstr "o"
@@ -668,8 +668,14 @@ msgstr "Détails"
 msgid "ACTION_FILE_MENU_GET_FILE_LINK"
 msgstr "Lien vers ce fichier"
 
+msgid "ACTION_FILE_MENU_GET_FOLDER_LINK"
+msgstr "Lien vers ce dossier"
+
 msgid "ACTION_FILE_MENU_GET_FILE_LINK_TIMESTAMP"
 msgstr "Lien vers ce fichier à cette version"
+
+msgid "ACTION_FILE_MENU_GET_FOLDER_LINK_TIMESTAMP"
+msgstr "Lien vers ce dossier à cette version"
 
 msgid "TEXT_FILE_TREE_PARENT_FOLDER"
 msgstr "Répertoire parent"
@@ -691,24 +697,27 @@ msgstr "{count} éléments au total"
 msgid "TEXT_FILE_LINK_COPIED_TO_CLIPBOARD"
 msgstr "Le lien vers le fichier a été copié dans le presse-papier."
 
+msgid "TEXT_FOLDER_LINK_COPIED_TO_CLIPBOARD"
+msgstr "Le lien vers le dossier a été copié dans le presse-papier."
+
 msgid "TEXT_FILE_FOLDER_MOVED_INTO_ITSELF_ERROR"
 msgstr "Impossible de déplacer un répertoire dans lui-même."
 
 msgid "TEXT_FILE_PASTE_ERROR"
-msgstr "Impossible de coller ce fichier à cet endroit."
+msgstr "Impossible de coller cet élément à cet endroit."
 
 msgid "TEXT_FILE_HISTORY_MULTIPLE_FILES_SELECTED_ERROR"
 msgstr ""
-"Impossible d'afficher l'historique de plusieurs fichiers en une fois. "
-"Veuillez ne sélectionner qu'un fichier."
+"Impossible d'afficher l'historique de plusieurs éléments en une fois. "
+"Veuillez ne sélectionner qu'un élément."
 
 msgid "TEXT_FILE_STATUS_NO_FILE_SELECTED_ERROR"
 msgstr "Aucun fichier sélectionné."
 
 msgid "TEXT_FILE_STATUS_MULTIPLE_FILES_SELECTED_ERROR"
 msgstr ""
-"Impossible d'afficher les détails de plusieurs fichiers en une fois. Veuillez "
-"ne sélectionner qu'un fichier."
+"Impossible d'afficher l'état de plusieurs éléments en une fois. Veuillez "
+"ne sélectionner qu'un fichier ou dossier."
 
 msgid "TEXT_FILE_RENAME_TITLE"
 msgstr "Renommer un fichier"
@@ -719,19 +728,28 @@ msgstr "Entrez le nouveau nom du fichier."
 msgid "TEXT_FILE_RENAME_PLACEHOLDER"
 msgstr "Nom du fichier"
 
+msgid "TEXT_FOLDER_RENAME_TITLE"
+msgstr "Renommer un dossier"
+
+msgid "TEXT_FOLDER_RENAME_INSTRUCTIONS"
+msgstr "Entrez le nouveau nom du dossier."
+
+msgid "TEXT_FOLDER_RENAME_PLACEHOLDER"
+msgstr "Nom du dossier"
+
 msgid "ACTION_FILE_RENAME"
 msgstr "Renommer"
 
 msgid "TEXT_FILE_RENAME_MULTIPLE_TITLE_count"
-msgstr "Renommer {count} fichiers"
+msgstr "Renommer {count} éléments"
 
 msgid "TEXT_FILE_RENAME_MULTIPLE_INSTRUCTIONS_count"
 msgstr ""
-"Entrez le nouveau nom des fichiers. Ils seront renommés selon le format "
+"Entrez le nouveau nom des éléments. Ils seront renommés selon le format "
 "suivant : NOM_NUMERO.EXTENSION."
 
 msgid "TEXT_FILE_RENAME_MULTIPLE_PLACEHOLDER"
-msgstr "Nom des fichiers"
+msgstr "Nom des éléments"
 
 msgid "ACTION_FILE_RENAME_MULTIPLE"
 msgstr "Renommer"
@@ -739,8 +757,14 @@ msgstr "Renommer"
 msgid "TEXT_FILE_DELETE_TITLE"
 msgstr "Supprimer un fichier"
 
+msgid "TEXT_FOLDER_DELETE_TITLE"
+msgstr "Supprimer un dossier"
+
 msgid "TEXT_FILE_DELETE_INSTRUCTIONS_name"
 msgstr "Êtes-vous sûr de vouloir supprimer le fichier <b>{name}</b> ?"
+
+msgid "TEXT_FOLDER_DELETE_INSTRUCTIONS_name"
+msgstr "Êtes-vous sûr de vouloir supprimer le dossier <b>{name}</b> ?"
 
 msgid "ACTION_FILE_DELETE"
 msgstr "Supprimer"
@@ -749,27 +773,27 @@ msgid "ACTION_CANCEL"
 msgstr "Annuler"
 
 msgid "TEXT_FILE_DELETE_MULTIPLE_TITLE_count"
-msgstr "Supprimer plusieurs fichiers"
+msgstr "Supprimer plusieurs éléments"
 
 msgid "TEXT_FILE_DELETE_MULTIPLE_INSTRUCTIONS_count"
-msgstr "Êtes-vous sûr de vouloir supprimer les {count} fichiers ?"
+msgstr "Êtes-vous sûr de vouloir supprimer ces {count} éléments ?"
 
 msgid "ACTION_FILE_DELETE_MULTIPLE"
 msgstr "Supprimer"
 
 msgid "TEXT_FILE_OPEN_MULTIPLE_TITLE_count"
-msgstr "Ouvrir plusieurs fichiers"
+msgstr "Ouvrir plusieurs éléments"
 
 msgid "TEXT_FILE_OPEN_MULTIPLE_INSTRUCTIONS_count"
 msgstr ""
-"Êtes-vous sûr de vouloir ouvrir les {count} fichiers ? Cela peut prendre "
+"Êtes-vous sûr de vouloir ouvrir ces {count} éléments ? Cela peut prendre "
 "du temps."
 
 msgid "ACTION_FILE_OPEN_MULTIPLE"
-msgstr "Ouvrir les fichiers"
+msgstr "Ouvrir les éléments"
 
 msgid "TEXT_FILE_OPEN_MULTIPLE_ERROR"
-msgstr "Certains fichiers n'ont pas pû être ouverts."
+msgstr "Certains éléments n'ont pas pû être ouverts."
 
 msgid "TEXT_FILE_OPEN_ERROR_file"
 msgstr "Le fichier <b>{file}</b> n'a pas pû être ouvert."
@@ -815,7 +839,7 @@ msgstr "Créer un nouveau répertoire"
 
 msgid "TEXT_FILE_RENAME_MULTIPLE_ERROR"
 msgstr ""
-"Un problème est survenu lors du renommage des fichiers. Certains fichiers"
+"Un problème est survenu lors du renommage des éléments. Certains éléments"
 " n'ont peut-être pas été renommés."
 
 msgid "TEXT_FILE_RENAME_ERROR"
@@ -823,8 +847,8 @@ msgstr "Le fichier n'a pas pu être renommé."
 
 msgid "TEXT_FILE_DELETE_MULTIPLE_ERROR"
 msgstr ""
-"Un problème est survenu lors de la suppression des fichiers. Certains "
-"fichiers n'ont peut-être pas été supprimés."
+"Un problème est survenu lors de la suppression des éléments. Certains "
+"éléments n'ont peut-être pas été supprimés."
 
 msgid "TEXT_FILE_DELETE_ERROR"
 msgstr "Ce fichier n'a pas pu être supprimé."
@@ -2476,23 +2500,23 @@ msgid "TEXT_WORKSPACE_FILTERED_user"
 msgstr "Espaces en commun avec {user}"
 
 msgid "TEXT_WORKSPACE_GOTO_FILE_LINK_TITLE"
-msgstr "Accéder à un fichier par son lien"
+msgstr "Accéder à un élément par son lien"
 
 msgid "TEXT_WORKSPACE_GOTO_FILE_LINK_INSTRUCTIONS"
-msgstr "Veuillez fournir un lien vers le fichier."
+msgstr "Veuillez fournir un lien vers l'élément."
 
 msgid "TEXT_WORKSPACE_GOTO_FILE_LINK_PLACEHOLDER"
 msgstr "parsec://parsec.example.com/my_org?action=file_link&workspace_id=xx&path=yy"
 
 msgid "ACTION_GOTO_FILE_LINK"
-msgstr "Accéder au fichier"
+msgstr "Accéder à l'élément"
 
 msgid "TEXT_WORKSPACE_GOTO_FILE_LINK_INVALID_LINK"
 msgstr "Le lien n'est pas valide."
 
 msgid "TEXT_WORKSPACE_GOTO_FILE_LINK_WORKSPACE_NOT_FOUND"
 msgstr ""
-"Impossible de trouver l'espace de travail de ce fichier. Peut-être qu'il "
+"Impossible de trouver l'espace de travail de cet élément. Peut-être qu'il "
 "n'a pas été partagé avec vous."
 
 msgid "TEXT_WORKSPACE_CREATE_NEW_INVALID_NAME"
@@ -3071,7 +3095,7 @@ msgid "TEXT_SETTINGS_INTERFACE_TITLE"
 msgstr "Interface"
 
 msgid "TEXT_SETTINGS_CHECK_SHOW_CONFINED_FILES"
-msgstr "Afficher les fichiers exclus de la synchronisation"
+msgstr "Afficher les éléments exclus de la synchronisation"
 
 msgid "ACTION_SAVE"
 msgstr "Sauvegarder"


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
This PR adds more distinctions between files and folders in contextual menus and titles.
<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [x] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
Closes #3855 

"élément" feels fitting in french, but not quite as much in english. I didn't find another generic term for "file or folder".