### PR TITLE
Fix available device key file path type

### DIFF
--- a/src/binding_utils.rs
+++ b/src/binding_utils.rs
@@ -1,13 +1,35 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 (eventually AGPL-3.0) 2016-present Scille SAS
 
 use pyo3::{
-    exceptions::PyNotImplementedError, pyclass::CompareOp, types::PyByteArray, types::PyBytes,
-    types::PyFrozenSet, FromPyObject, PyAny, PyResult,
+    exceptions::PyNotImplementedError,
+    pyclass::CompareOp,
+    types::{PyByteArray, PyBytes, PyFrozenSet, PyTuple},
+    FromPyObject, IntoPy, PyAny, PyObject, PyResult,
 };
 use std::{
     collections::{hash_map::DefaultHasher, HashSet},
     hash::{Hash, Hasher},
 };
+
+#[derive(FromPyObject)]
+pub(crate) struct PathWrapper(pub std::path::PathBuf);
+
+impl IntoPy<PyObject> for PathWrapper {
+    fn into_py(self, py: pyo3::Python<'_>) -> pyo3::PyObject {
+        // Pathlib is part of the standard library
+        let pathlib_module = py
+            .import("pathlib")
+            .expect("import `pathlib` module failed.");
+        let path_ctor = pathlib_module
+            .getattr("Path")
+            .expect("can't get `Path` from `pathlib`.");
+
+        path_ctor
+            .call1(PyTuple::new(py, [self.0]))
+            .expect("call to `Path` constructor failed.")
+            .into_py(py)
+    }
+}
 
 #[derive(FromPyObject)]
 pub enum BytesWrapper<'py> {

--- a/src/local_device.rs
+++ b/src/local_device.rs
@@ -13,6 +13,7 @@ use libparsec::platform_device_loader;
 use crate::{
     addrs::BackendOrganizationAddr,
     api_crypto::{PrivateKey, PublicKey, SecretKey, SigningKey, VerifyKey},
+    binding_utils::PathWrapper,
     enumerate::{DeviceFileType, UserProfile},
     ids::{DeviceID, DeviceLabel, DeviceName, EntryID, HumanHandle, OrganizationID, UserID},
     local_device::client_types::StrPath,
@@ -520,8 +521,8 @@ impl AvailableDevice {
     }
 
     #[getter]
-    fn key_file_path(&self) -> PathBuf {
-        self.0.key_file_path.to_path_buf()
+    fn key_file_path(&self) -> PathWrapper {
+        PathWrapper(self.0.key_file_path.to_path_buf())
     }
 
     #[getter]

--- a/tests/core/test_local_device.py
+++ b/tests/core/test_local_device.py
@@ -317,6 +317,12 @@ def test_supports_legacy_is_admin_field(alice):
     }
 
 
+def test_key_file_path_are_proper_paths(config_dir):
+    devices = list_available_devices(config_dir)
+    for device in devices:
+        assert isinstance(device.key_file_path, pathlib.Path)
+
+
 def test_list_devices_support_legacy_file_with_meaningful_name(config_dir):
     # Legacy path might exceed the 256 characters limit in some cases (see issue #1356)
     # So we use the `\\?\` workaround: https://stackoverflow.com/a/57502760/2846140


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
This closes #3942 . When we return a `PathBuf` with `pyo3` the default conversion gives a python string. We want this conversion to yield a `pathlib.Path` because it makes path manipulation easier in python.

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
