### PR TITLE
[GUI] Maximize window by default

### DIFF
--- a/newsfragments/3946.bugfix.rst
+++ b/newsfragments/3946.bugfix.rst
@@ -1,0 +1,1 @@
+The window now takes the whole screen by default

--- a/parsec/core/gui/main_window.py
+++ b/parsec/core/gui/main_window.py
@@ -581,7 +581,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
     def show_window(self, skip_dialogs: bool = False) -> None:
         try:
-            if self.config.gui_geometry:
+            if self.config.gui_geometry is not None:
                 self.restoreGeometry(self.config.gui_geometry)
             else:
                 self.showMaximized()

--- a/parsec/core/gui/main_window.py
+++ b/parsec/core/gui/main_window.py
@@ -581,9 +581,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
     def show_window(self, skip_dialogs: bool = False) -> None:
         try:
-            if self.config.gui_geometry is not None and not self.restoreGeometry(
-                self.config.gui_geometry
-            ):
+            if self.config.gui_geometry:
+                self.restoreGeometry(self.config.gui_geometry)
+            else:
                 self.showMaximized()
         except TypeError:
             self.showMaximized()


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
When opening the GUI for the first time, the window should take all the available space.

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [X] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
Closes #3946 
