### PR TITLE
Update maturin & patchelf

### DIFF
--- a/build.py
+++ b/build.py
@@ -33,6 +33,8 @@ def run(cmd: str, **kwargs) -> subprocess.CompletedProcess:
 def build():
     run(f"{PYTHON_EXECUTABLE_PATH} --version")
     run(f"{PYTHON_EXECUTABLE_PATH} misc/generate_pyqt.py")
+    if sys.platform == "linux":
+        run("patchelf --version")
 
     if sys.platform == "win32":
         libparsec_path = "parsec/_parsec.cp39-win_amd64.pyd"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1304,25 +1304,25 @@ files = [
 
 [[package]]
 name = "maturin"
-version = "0.14.4"
+version = "0.14.10"
 description = "Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "maturin-0.14.4-py3-none-linux_armv6l.whl", hash = "sha256:0a0fec756c119fc4add8efed1e026e56892542dcad344383de7db1dae5d80373"},
-    {file = "maturin-0.14.4-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:50e4e34b7d1f9b06eebccee1d6fdf53f90cca1511d69b3c0cd16ad156cd2021c"},
-    {file = "maturin-0.14.4-py3-none-macosx_10_9_x86_64.macosx_10_9_arm64.macosx_10_9_universal2.whl", hash = "sha256:4c4a2d0c6fe4cfd79709a2cf8e8ec38deee6058bf2258bfa7fd183ae4291c95d"},
-    {file = "maturin-0.14.4-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:0b01d6457f9a2eb3c5f8c45858996445cc2428caf62ca2d60d7e0fa0e0c096ce"},
-    {file = "maturin-0.14.4-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:dbbcb56b2e38a03b76b5c8923bd25421fa2cc4512eb676613cb20e4941115945"},
-    {file = "maturin-0.14.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:a84d8b14e276c3f762333723cf11e1f35733e61fc4fe018161524d0305c8f5e8"},
-    {file = "maturin-0.14.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:e6a64d50c9c927b55e6287815afe08ede8ee25230a932735d04b7489f55cbb28"},
-    {file = "maturin-0.14.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:4865bce1fdf6d11db15a933e8dad585b55b649ec5fd1d375affb2bf65a48ebba"},
-    {file = "maturin-0.14.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:af39527f107984c0588cea36a6c0e27c98d482e7066f138f11921a0e478c90cd"},
-    {file = "maturin-0.14.4-py3-none-win32.whl", hash = "sha256:c83f23ce52c11591ff6d28c9fc6396eb83dd99fbf38376053e55637565075719"},
-    {file = "maturin-0.14.4-py3-none-win_amd64.whl", hash = "sha256:aee59d35a5ae58fddafc68f93b4c41950db3a2d7b67199693edc037defa990fd"},
-    {file = "maturin-0.14.4-py3-none-win_arm64.whl", hash = "sha256:af450b1785c31d4d8ac6d3d0072f87a13ea5d77e71b35f4268bc67f30f46da5a"},
-    {file = "maturin-0.14.4.tar.gz", hash = "sha256:4f881de93bf68b313d9020ff731c2a075a847b43492d2f10151b0a6f5f4ee8af"},
+    {file = "maturin-0.14.10-py3-none-linux_armv6l.whl", hash = "sha256:ec8269c02cc435893308dfd50f57f14fb1be3554e4e61c5bf49b97363b289775"},
+    {file = "maturin-0.14.10-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:e9c19dc0a28109280f7d091ca7b78e25f3fc340fcfac92801829a21198fa20eb"},
+    {file = "maturin-0.14.10-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:cf950ebfe449a97617b91d75e09766509e21a389ce3f7b6ef15130ad8a95430a"},
+    {file = "maturin-0.14.10-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:c0d25e82cb6e5de9f1c028fcf069784be4165b083e79412371edce05010b68f3"},
+    {file = "maturin-0.14.10-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:9da98bee0a548ecaaa924cc8cb94e49075d5e71511c62a1633a6962c7831a29b"},
+    {file = "maturin-0.14.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:2f097a63f3bed20a7da56fc7ce4d44ef8376ee9870604da16b685f2d02c87c79"},
+    {file = "maturin-0.14.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:4946ad7545ba5fc0ad08bc98bc8e9f6ffabb6ded71db9ed282ad4596b998d42a"},
+    {file = "maturin-0.14.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:98bfed21c3498857b3381efeb041d77e004a93b22261bf9690fe2b9fbb4c210f"},
+    {file = "maturin-0.14.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b157e2e8a0216d02df1d0451201fcb977baf0dcd223890abfbfbfd01e0b44630"},
+    {file = "maturin-0.14.10-py3-none-win32.whl", hash = "sha256:5abf311d4618b673efa30cacdac5ae2d462e49da58db9a5bf0d8bde16d9c16be"},
+    {file = "maturin-0.14.10-py3-none-win_amd64.whl", hash = "sha256:11b8550ceba5b81465a18d06f0d3a4cfc1cd6cbf68eda117c253bbf3324b1264"},
+    {file = "maturin-0.14.10-py3-none-win_arm64.whl", hash = "sha256:6cc9afb89f28bd591b62f8f3c29736c81c322cffe88f9ab8eb1749377bbc3521"},
+    {file = "maturin-0.14.10.tar.gz", hash = "sha256:895c48cbe56ae994c2a1eeeef19475ca4819aa4c6412af727a63a772e8ef2d87"},
 ]
 
 [package.dependencies]
@@ -1476,6 +1476,25 @@ files = [
     {file = "packaging-22.0-py3-none-any.whl", hash = "sha256:957e2148ba0e1a3b282772e791ef1d8083648bc131c8ab0c1feba110ce1146c3"},
     {file = "packaging-22.0.tar.gz", hash = "sha256:2198ec20bd4c017b8f9717e00f0c8714076fc2fd93816750ab48e2c41de2cfd3"},
 ]
+
+[[package]]
+name = "patchelf"
+version = "0.17.2.0"
+description = "A small utility to modify the dynamic linker and RPATH of ELF executables."
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "patchelf-0.17.2.0-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:b8d86f32e1414d6964d5d166ddd2cf829d156fba0d28d32a3bd0192f987f4529"},
+    {file = "patchelf-0.17.2.0-py2.py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:9233a0f2fc73820c5bd468f27507bdf0c9ac543f07c7f9888bb7cf910b1be22f"},
+    {file = "patchelf-0.17.2.0-py2.py3-none-manylinux_2_17_s390x.manylinux2014_s390x.musllinux_1_1_s390x.whl", hash = "sha256:6601d7d831508bcdd3d8ebfa6435c2379bf11e41af2409ae7b88de572926841c"},
+    {file = "patchelf-0.17.2.0-py2.py3-none-manylinux_2_5_i686.manylinux1_i686.musllinux_1_1_i686.whl", hash = "sha256:c62a34f0c25e6c2d6ae44389f819a00ccdf3f292ad1b814fbe1cc23cb27023ce"},
+    {file = "patchelf-0.17.2.0-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:1b9fd14f300341dc020ae05c49274dd1fa6727eabb4e61dd7fb6fb3600acd26e"},
+    {file = "patchelf-0.17.2.0.tar.gz", hash = "sha256:dedf987a83d7f6d6f5512269e57f5feeec36719bd59567173b6d9beabe019efe"},
+]
+
+[package.extras]
+test = ["importlib-metadata", "pytest"]
 
 [[package]]
 name = "pathspec"
@@ -1682,7 +1701,7 @@ files = [
 cffi = ">=1.4.1"
 
 [package.extras]
-docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
+docs = ["sphinx (>=1.6.5)", "sphinx_rtd_theme"]
 tests = ["hypothesis (>=3.27.0)", "pytest (>=3.2.1,!=3.3.0)"]
 
 [[package]]
@@ -2693,4 +2712,4 @@ core = ["packaging", "PyQt5", "pyqt5-sip", "qtrio", "qrcode", "fusepy", "winfspy
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.9.0"
-content-hash = "0b4ad48f61cbad5f83f1a63b3b0c197a2e5fe4fa6e3a6d9fe9e9e2128d012dcd"
+content-hash = "1a6dc25652f3ec20b70702b00401c80162151a32fbeeb20d29e7bdb9b84d4ac5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,10 @@ black = "^22.6.0"
 mypy = "^0.982"
 
 setuptools = "^63.1.0"
-maturin = "~=0.14"
+
+maturin = "^0.14.10"
+patchelf = { version = "^0.17.2.0", markers = "platform_system=='Linux'" }
+
 cibuildwheel = "2.10.0"
 editorconfig-checker = "2.4.0"
 types-requests = "^2.28"
@@ -208,7 +211,9 @@ known-first-party = ["parsec"]
 requires = [
     "poetry-core>=1.0.0",
     "setuptools",
-    "maturin~=0.13",
+    "maturin~=0.14",
+    "maturin[patchelf]~=0.14; platform_system=='Linux'",
+    "patchelf~=0.17.2.0; platform_system=='Linux'",
     "PyQt5~=5.15",
     "Babel~=2.10",
     "docutils~=0.17",


### PR DESCRIPTION
- Update `maturin` used in build system to 0.14 (from 0.13)
- Install `patchelf` on Linux platform
- Install extra for `maturin` to use `patchelf`
