### PR TITLE
[GUI] Include user invitation in the query string

### DIFF
--- a/newsfragments/3967.bugfix.rst
+++ b/newsfragments/3967.bugfix.rst
@@ -1,0 +1,1 @@
+No longer hides user invitations if they match the search string

--- a/parsec/core/gui/users_widget.py
+++ b/parsec/core/gui/users_widget.py
@@ -212,18 +212,19 @@ async def _do_list_users_and_invitations(
 ) -> tuple[int, list[UserInfo], list[InviteListItem]]:
     try:
         invitations = [] if omit_invitation else await core.list_invitations()
+        # Filtering invitation using the pattern if present
+        invitations = [
+            inv
+            for inv in invitations
+            if inv.type == InvitationType.USER and (pattern is None or pattern in inv.claimer_email)
+        ]
         users, total = await core.find_humans(
             page=page, per_page=USERS_PER_PAGE, query=pattern, omit_revoked=omit_revoked
         )
         return (
             total,
             users,
-            [
-                inv
-                for inv in invitations
-                if inv.type == InvitationType.USER
-                and (pattern is not None and pattern in inv.claimer_email)
-            ],
+            invitations,
         )
     except BackendNotAvailable as exc:
         raise JobResultError("offline") from exc

--- a/tests/core/gui/users_widget/test_invite.py
+++ b/tests/core/gui/users_widget/test_invite.py
@@ -57,6 +57,18 @@ async def _invite_user(
 
         await aqtbot.wait_until(_new_invitation_displayed)
 
+        # Check if invitation is included by the filter
+        def _filter_shows_invitation():
+            assert u_w.layout_users.count() == 1
+            assert isinstance(u_w.layout_users.itemAt(0).widget(), UserInvitationButton)
+
+        await aqtbot.key_clicks(u_w.line_edit_search, "farn")
+        await aqtbot.wait_until(_filter_shows_invitation)
+
+        # Remove the filter
+        aqtbot.mouse_click(u_w.line_edit_search.button_clear, QtCore.Qt.LeftButton)
+        await aqtbot.wait_until(_new_invitation_displayed)
+
         snackbar_catcher.reset()
 
         # Check if menu to copy addr or email works correctly


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
User invitations were ignored by the query string and not displayed even if the email matched what was searched.

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [X] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
Closes #3967 
