### PR TITLE
[GUI] Show unmounted workspace by default and save the state

### DIFF
--- a/newsfragments/3969.bugfix.rst
+++ b/newsfragments/3969.bugfix.rst
@@ -1,0 +1,1 @@
+Unmounted workspaces are no longer hidden by default and the state is saved when the application exits

--- a/parsec/core/config.py
+++ b/parsec/core/config.py
@@ -81,6 +81,7 @@ class CoreConfig:
     gui_allow_multiple_instances: bool = False
     gui_show_confined: bool = False
     gui_geometry: bytes | None = None
+    gui_hide_unmounted: bool = False
 
     ipc_win32_mutex_name: str = "parsec-cloud"
 
@@ -119,6 +120,7 @@ def config_factory(
     preferred_org_creation_backend_addr: BackendAddr | None = None,
     gui_show_confined: bool = False,
     gui_geometry: bytes | None = None,
+    gui_hide_unmounted: bool = False,
     ipc_win32_mutex_name: str = "parsec-cloud",
     environ: Mapping[str, str] = {},
     **_: object,
@@ -165,6 +167,7 @@ def config_factory(
         preferred_org_creation_backend_addr=preferred_org_creation_backend_addr,
         gui_show_confined=gui_show_confined,
         gui_geometry=gui_geometry,
+        gui_hide_unmounted=gui_hide_unmounted,
         ipc_win32_mutex_name=ipc_win32_mutex_name,
     )
 
@@ -275,6 +278,7 @@ def save_config(config: CoreConfig) -> None:
                 "gui_geometry": base64.b64encode(config.gui_geometry).decode("ascii")
                 if config.gui_geometry
                 else None,
+                "gui_hide_unmounted": config.gui_hide_unmounted,
                 "ipc_win32_mutex_name": config.ipc_win32_mutex_name,
             },
             indent=True,

--- a/parsec/core/gui/forms/workspaces_widget.ui
+++ b/parsec/core/gui/forms/workspaces_widget.ui
@@ -178,7 +178,7 @@
           <string>TEXT_WORKSPACES_HIDE_UNMOUNTED</string>
          </property>
          <property name="checked">
-          <bool>true</bool>
+          <bool>false</bool>
          </property>
         </widget>
        </item>

--- a/parsec/core/gui/workspaces_widget.py
+++ b/parsec/core/gui/workspaces_widget.py
@@ -175,7 +175,8 @@ class WorkspacesWidget(QWidget, Ui_WorkspacesWidget):
         self.unmount_error.connect(self.on_unmount_error)
         self.file_open_success.connect(self._on_file_open_success)
         self.file_open_error.connect(self._on_file_open_error)
-        self.check_hide_unmounted.stateChanged.connect(self._on_hide_unmounted_changed)
+        self.check_hide_unmounted.setChecked(self.core.config.gui_hide_unmounted)
+        self.check_hide_unmounted.toggled.connect(self._on_hide_unmounted_changed)
 
         self.workspace_reencryption_success.connect(self._on_workspace_reencryption_success)
         self.workspace_reencryption_error.connect(self._on_workspace_reencryption_error)
@@ -256,7 +257,8 @@ class WorkspacesWidget(QWidget, Ui_WorkspacesWidget):
             self.layout_workspaces.itemAt(0).widget(), WorkspaceButton
         )
 
-    def _on_hide_unmounted_changed(self, state: object) -> None:
+    def _on_hide_unmounted_changed(self, checked: bool) -> None:
+        self.event_bus.send(CoreEvent.GUI_CONFIG_CHANGED, gui_hide_unmounted=checked)
         self.refresh_workspace_layout()
 
     def goto_file_clicked(self) -> None:
@@ -408,7 +410,7 @@ class WorkspacesWidget(QWidget, Ui_WorkspacesWidget):
         # Get info for both filters
         name_filter = self.line_edit_search.text().lower() or None
         user_filter = self.filter_user_info and self.filter_user_info.user_id
-        hide_unmounted_filter = self.check_hide_unmounted.checkState() == Qt.Checked
+        hide_unmounted_filter = self.check_hide_unmounted.isChecked()
 
         # Remove all widgets and add them back in order to make sure the order is always correct
         self.layout_workspaces.pop_all()

--- a/tests/core/gui/conftest.py
+++ b/tests/core/gui/conftest.py
@@ -16,6 +16,8 @@ from parsec._parsec import DeviceFileType, LocalDevice, save_device_with_passwor
 from parsec.api.data import EntryName
 from parsec.core.config import CoreConfig
 from parsec.core.gui.central_widget import CentralWidget
+from parsec.core.gui.devices_widget import DevicesWidget
+from parsec.core.gui.enrollment_widget import EnrollmentWidget
 from parsec.core.gui.files_widget import FilesWidget
 from parsec.core.gui.lang import switch_language
 from parsec.core.gui.login_widget import (
@@ -26,10 +28,13 @@ from parsec.core.gui.login_widget import (
     LoginWidget,
 )
 from parsec.core.gui.main_window import MainWindow
+from parsec.core.gui.mount_widget import MountWidget
 from parsec.core.gui.parsec_application import ParsecApp
 from parsec.core.gui.trio_jobs import QtToTrioJobScheduler
+from parsec.core.gui.users_widget import UsersWidget
 from parsec.core.gui.workspaces_widget import WorkspaceButton, WorkspacesWidget
 from parsec.core.local_device import LocalDeviceAlreadyExistsError
+from parsec.core.logged_core import LoggedCore
 from parsec.event_bus import EventBus
 from tests.common import real_clock_timeout
 
@@ -257,7 +262,7 @@ def gui_factory(
     core_config,
     event_bus_factory,
     running_backend_ready,
-):
+) -> MainWindow:
     windows = []
 
     async def _gui_factory(
@@ -334,7 +339,7 @@ async def logged_gui(
     alice: LocalDevice,
     bob: LocalDevice,
     fixtures_customization,
-):
+) -> MainWindow:
     # Logged as bob (i.e. standard profile) by default
     if fixtures_customization.get("logged_gui_as_admin", False):
         device = alice
@@ -360,49 +365,49 @@ def testing_main_window_cls(aqtbot) -> Type[MainWindow]:
             w = self.tab_center.currentWidget()
             return w
 
-        def test_get_main_widget(self):
+        def test_get_main_widget(self) -> MainWindow:
             tabw = self.test_get_tab()
             item = tabw.layout().itemAt(0)
             return item.widget()
 
-        def test_get_central_widget(self):
+        def test_get_central_widget(self) -> CentralWidget:
             main_widget = self.test_get_main_widget()
             if not isinstance(main_widget, CentralWidget):
                 return None
             return main_widget
 
-        def test_get_login_widget(self):
+        def test_get_login_widget(self) -> LoginWidget:
             main_widget = self.test_get_main_widget()
             if not isinstance(main_widget, LoginWidget):
                 return None
             return main_widget
 
-        def test_get_users_widget(self):
+        def test_get_users_widget(self) -> UsersWidget:
             central_widget = self.test_get_central_widget()
             return central_widget.users_widget
 
-        def test_get_devices_widget(self):
+        def test_get_devices_widget(self) -> DevicesWidget:
             central_widget = self.test_get_central_widget()
             return central_widget.devices_widget
 
-        def test_get_enrollment_widget(self):
+        def test_get_enrollment_widget(self) -> EnrollmentWidget:
             central_widget = self.test_get_central_widget()
             return central_widget.enrollment_widget
 
-        def test_get_mount_widget(self):
+        def test_get_mount_widget(self) -> MountWidget:
             central_widget = self.test_get_central_widget()
             return central_widget.mount_widget
 
-        def test_get_workspaces_widget(self):
+        def test_get_workspaces_widget(self) -> WorkspacesWidget:
             mount_widget = self.test_get_mount_widget()
             mount_widget.workspaces_widget.check_hide_unmounted.setChecked(False)
             return mount_widget.workspaces_widget
 
-        def test_get_files_widget(self):
+        def test_get_files_widget(self) -> FilesWidget:
             mount_widget = self.test_get_mount_widget()
             return mount_widget.files_widget
 
-        def test_get_core(self):
+        def test_get_core(self) -> LoggedCore:
             return self.test_get_central_widget().core
 
         async def test_logout(self):

--- a/tests/core/gui/test_workspaces.py
+++ b/tests/core/gui/test_workspaces.py
@@ -534,7 +534,9 @@ async def test_hide_unmounted_workspaces(logged_gui, aqtbot):
     w_w = logged_gui.test_get_workspaces_widget()
     core = logged_gui.test_get_core()
 
-    w_w.check_hide_unmounted.setChecked(False)
+    # Should be false by default
+    assert core.config.gui_hide_unmounted is False
+    assert w_w.check_hide_unmounted.isChecked() is False
 
     workspace_name = EntryName("wksp1")
 
@@ -567,6 +569,7 @@ async def test_hide_unmounted_workspaces(logged_gui, aqtbot):
 
     # Hide unmounted True, workspace mounted False, workspace should not be visible
     w_w.check_hide_unmounted.setChecked(True)
+
     aqtbot.mouse_click(wk_button.switch_button, QtCore.Qt.LeftButton)
     await aqtbot.wait_until(lambda: _workspace_visible(False))
 


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
No longer hides unmounted workspaces by default, and the state of show/hide unmounted workspaces is saved in config.

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [X] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
Closes #3969 