### PR TITLE
Add an admissibility policy for accepting downsynced manifests when block remanence is enabled

### DIFF
--- a/parsec/core/fs/exceptions.py
+++ b/parsec/core/fs/exceptions.py
@@ -28,6 +28,7 @@ from parsec.core.types import ChunkID, EntryID
 # - `FsOperationError` initialization takes `AnyPath` arguments, defined as `Union[str, FsPath]`
 if TYPE_CHECKING:
     from parsec.core.fs.path import AnyPath
+    from parsec.core.fs.workspacefs.sync_transactions import ChangesAfterSync
 
 # Base classes for all file system errors
 
@@ -146,6 +147,12 @@ class FSFileConflictError(FSInternalError):
 
 class FSReshapingRequiredError(FSInternalError):
     pass
+
+
+class FSChangesNotAdmissibleError(FSInternalError):
+    def __init__(self, changes: ChangesAfterSync):
+        super().__init__(changes)
+        self.changes = changes
 
 
 class FSNoSynchronizationRequired(FSInternalError):

--- a/parsec/core/fs/workspacefs/workspacefs.py
+++ b/parsec/core/fs/workspacefs/workspacefs.py
@@ -18,6 +18,7 @@ from parsec.core.backend_connection import BackendConnectionError, BackendNotAva
 from parsec.core.fs import workspacefs  # Needed to break cyclic import with WorkspaceFSTimestamped
 from parsec.core.fs.exceptions import (
     FSBackendOfflineError,
+    FSChangesNotAdmissibleError,
     FSError,
     FSFileConflictError,
     FSInvalidArgumentError,
@@ -732,6 +733,11 @@ class WorkspaceFS:
                 # The entry first requires reshaping
                 except FSReshapingRequiredError:
                     await self.transactions.file_reshape(entry_id)
+                    continue
+
+                # The entry first requires to download blocks
+                except FSChangesNotAdmissibleError as exc:
+                    await self.transactions.make_changes_admissible(exc.changes)
                     continue
 
             # The manifest doesn't exist locally


### PR DESCRIPTION
Even when offline availability is enabled, a user might still not be able to access a file if the data could not be downloaded in time. This is not a problem for new files and folders but it is in the two following cases:
- A file has been modified and the core went offline right after acknowledging the changes (but the data hasn't been downloaded yet).
- A file has been overwritten (i.e a new entry id has been produced) and the core went offline right after acknowledging the changes in the corresponding folder (but the data hasn't been downloaded yet)

This PR addresses those two cases by implementing an admissibility policy for accepting downsynced manifests. Note that a similar mechanism already exists for synchronizing manifests that require a reshape (in some cases, reshaping require a block that is not available locally). 

One thing to consider with those changes is that some synchronization might take longer to appear than before. For instance, a user (with offline availability enabled) downsync a folder manifest containing a new small file and an overwritten large file. In this case, the large file will have to be entirely downloaded before the small file can become accessible. I think this is an acceptable behavior though.