### PR TITLE
Configure a mirror list for ubuntu APT repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,21 @@ jobs:
         run: echo "run=true" >> $GITHUB_OUTPUT
         shell: bash
 
+      - name: (🐧 Linux) Set apt mirror
+        # GitHub Actions apt proxy is super unstable
+        # see https://github.com/actions/runner-images/issues/7048
+        if: >-
+          steps.python-changes.outputs.run == 'true'
+          && startsWith(matrix.os, 'ubuntu-')
+        run: |
+          set -e -o pipefail
+          (
+            # make sure there is a `\t` between URL and `priority:*` attributes
+            printf 'http://azure.archive.ubuntu.com/ubuntu	priority:1\n';
+            curl http://mirrors.ubuntu.com/mirrors.txt | grep https
+          ) | sudo tee /etc/apt/mirrors.txt
+          sudo sed -i 's/http:\/\/azure.archive.ubuntu.com\/ubuntu\//mirror+file:\/etc\/apt\/mirrors.txt/' /etc/apt/sources.list
+
       - name: (🐧 Linux) Configure PostgreSQL APT repository
         if: >-
           steps.python-changes.outputs.run == 'true'


### PR DESCRIPTION
Sometime the default configured APT proxy in the ubuntu runner image have connection failure. Since this Repo is a cache-proxy meaning it redirect to the official Canonical repo on cache miss, We can have failure if the link between the Cache-proxy and the ubuntu repo fail for whatever reason.

To mitigate that I've applied the suggestion in https://github.com/actions/runner-images/issues/7048#issuecomment-1419426054 We basically make `apt` use a mirror list of APT repos with the Cache-proxy has the top priority one.