### PR TITLE
[GUI] Added user filtering by profile

### DIFF
--- a/newsfragments/4033.feature.rst
+++ b/newsfragments/4033.feature.rst
@@ -1,0 +1,1 @@
+Added user filtering by profile

--- a/parsec/core/gui/custom_widgets.py
+++ b/parsec/core/gui/custom_widgets.py
@@ -385,7 +385,7 @@ class FilterLineEdit(QLineEdit):
     def _move_button(self) -> None:
         r = self.geometry()
         self.button_clear.setGeometry(
-            r.x() + r.width() - self.button_clear.width(), r.y(), r.height(), r.height()
+            r.x() + r.width() - self.button_clear.width(), 0, r.height(), r.height()
         )
 
 

--- a/parsec/core/gui/forms/users_widget.ui
+++ b/parsec/core/gui/forms/users_widget.ui
@@ -67,6 +67,53 @@
       <number>0</number>
      </property>
      <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_4">
+       <item>
+        <widget class="Button" name="button_add_user">
+         <property name="cursor">
+          <cursorShape>PointingHandCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>ACTION_USER_INVITE_USER</string>
+         </property>
+         <property name="icon">
+          <iconset resource="../rc/resources.qrc">
+           <normaloff>:/icons/images/material/person_add.svg</normaloff>:/icons/images/material/person_add.svg</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>24</width>
+           <height>24</height>
+          </size>
+         </property>
+         <property name="flat">
+          <bool>true</bool>
+         </property>
+         <property name="color" stdset="0">
+          <color>
+           <red>0</red>
+           <green>146</green>
+           <blue>255</blue>
+          </color>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_7">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item>
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <property name="spacing">
         <number>10</number>
@@ -99,34 +146,7 @@
         </widget>
        </item>
        <item>
-        <widget class="Button" name="button_add_user">
-         <property name="cursor">
-          <cursorShape>PointingHandCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>ACTION_USER_INVITE_USER</string>
-         </property>
-         <property name="icon">
-          <iconset resource="../rc/resources.qrc">
-           <normaloff>:/icons/images/material/person_add.svg</normaloff>:/icons/images/material/person_add.svg</iconset>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>24</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="flat">
-          <bool>true</bool>
-         </property>
-         <property name="color" stdset="0">
-          <color>
-           <red>0</red>
-           <green>146</green>
-           <blue>255</blue>
-          </color>
-         </property>
-        </widget>
+        <widget class="QComboBox" name="combo_filter_role"/>
        </item>
        <item>
         <spacer name="horizontalSpacer">
@@ -216,7 +236,7 @@
           <x>0</x>
           <y>0</y>
           <width>931</width>
-          <height>539</height>
+          <height>503</height>
          </rect>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/parsec/core/gui/tr/parsec_en.po
+++ b/parsec/core/gui/tr/parsec_en.po
@@ -3156,3 +3156,15 @@ msgstr "Downloading missing data"
 
 msgid "TEXT_WORKSPACE_IS_EMPTY"
 msgstr "This workspace is empty."
+
+msgid "TEXT_FILTER_USERS_ROLE_NONE"
+msgstr "Show all profiles"
+
+msgid "TEXT_FILTER_USERS_ROLE_ADMIN"
+msgstr "Only Administrator profiles"
+
+msgid "TEXT_FILTER_USERS_ROLE_STANDARD"
+msgstr "Only Standard profiles"
+
+msgid "TEXT_FILTER_USERS_ROLE_OUTSIDER"
+msgstr "Only Outsider profiles"

--- a/parsec/core/gui/tr/parsec_fr.po
+++ b/parsec/core/gui/tr/parsec_fr.po
@@ -525,7 +525,7 @@ msgstr ""
 "standard."
 
 msgid "NOT_ALLOWED_OUTSIDER_PROFILE_TOOLTIP"
-msgstr "Votre configuration actuelle n'autorise pas ce type de profil"
+msgstr "La configuration de l'organisation n'autorise pas ce type de profil"
 
 msgid "TEXT_USER_PROFILE_OUTSIDER_TOOLTIP"
 msgstr ""
@@ -3242,3 +3242,15 @@ msgstr "Téléchargement des données manquantes"
 
 msgid "TEXT_WORKSPACE_IS_EMPTY"
 msgstr "Cet espace de travail est vide."
+
+msgid "TEXT_FILTER_USERS_ROLE_NONE"
+msgstr "Voir tous les profils"
+
+msgid "TEXT_FILTER_USERS_ROLE_ADMIN"
+msgstr "Profils Administrateur seulement"
+
+msgid "TEXT_FILTER_USERS_ROLE_STANDARD"
+msgstr "Profils Standard seulement"
+
+msgid "TEXT_FILTER_USERS_ROLE_OUTSIDER"
+msgstr "Profils Externe seulement"

--- a/tests/core/gui/users_widget/test_list.py
+++ b/tests/core/gui/users_widget/test_list.py
@@ -23,14 +23,17 @@ def _assert_all_users_visible(u_w, index=0):
     adam_w = u_w.layout_users.itemAt(index).widget()
     assert adam_w.label_username.text() == "Adamy McAdam..."
     assert adam_w.label_email.text() == "adam@example..."
+    assert adam_w.label_role.text() == translate("TEXT_USER_PROFILE_ADMIN")
 
     alice_w = u_w.layout_users.itemAt(index + 1).widget()
     assert alice_w.label_username.text() == "Alicey McAli..."
     assert alice_w.label_email.text() == "alice@exampl..."  # cspell: disable-line
+    assert alice_w.label_role.text() == translate("TEXT_USER_PROFILE_ADMIN")
 
     bob_w = u_w.layout_users.itemAt(index + 2).widget()
     assert bob_w.label_username.text() == "Boby McBobFa..."
     assert bob_w.label_email.text() == "bob@example...."
+    assert bob_w.label_role.text() == translate("TEXT_USER_PROFILE_STANDARD")
 
     assert alice_w.isVisible() is True
     assert bob_w.isVisible() is True
@@ -147,6 +150,20 @@ async def test_filter_users(aqtbot, running_backend, logged_gui, str_len_limiter
     assert alice_w.label_username.text() == "Alicey McAli..."
     assert alice_w.label_email.text() == "alice@exampl..."  # cspell: disable-line
     assert u_w.layout_users.count() == 2
+
+    async with aqtbot.wait_signal(u_w.list_success):
+        aqtbot.mouse_click(u_w.line_edit_search.button_clear, QtCore.Qt.LeftButton)
+    await aqtbot.wait_until(lambda: _assert_all_users_visible(u_w=u_w))
+
+    # Set to Standard
+    u_w.combo_filter_role.setCurrentIndex(2)
+    await aqtbot.wait_until(lambda: _users_shown(count=1))
+    bob_w = u_w.layout_users.itemAt(0).widget()
+
+    assert bob_w.isVisible() is True
+    assert bob_w.label_username.text() == "Boby McBobFa..."
+    assert bob_w.label_email.text() == "bob@example...."
+    assert u_w.layout_users.count() == 1
 
 
 @pytest.mark.gui


### PR DESCRIPTION
# What has changed ?

Added a combo box to filter users by their profile (show only administrators for example).

Also fixed a small mistake with input's clear button not showing in some cases.

<!-- Why this PR exist ? what is its goal ? -->

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [X] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
Closes #4033 