### PR TITLE
Improve `freeze_time` mock

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -53,6 +53,9 @@ ignore_missing_imports = True
 [mypy-tests.*]
 ignore_errors = True
 
+[mypy-tests.common.freeze_time]
+ignore_errors = False
+
 [mypy-oxidation.*]
 ignore_errors = True
 

--- a/tests/common/binder.py
+++ b/tests/common/binder.py
@@ -114,7 +114,7 @@ def initialize_local_user_manifest(initial_user_manifest_state):
         assert initial_user_manifest in ("non_speculative_v0", "speculative_v0", "v1")
         # Create a storage just for this operation (the underlying database
         # will be reused by the core's storage thanks to `persistent_mockup`)
-        with freeze_time("2000-01-01", device=device) as timestamp:
+        with freeze_time("2000-01-01", devices=[device]) as timestamp:
             async with UserStorage.run(data_base_dir, device) as storage:
                 assert storage.get_user_manifest().base_version == 0
 

--- a/tests/common/freeze_time.py
+++ b/tests/common/freeze_time.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from typing import Iterator, Optional
 
 import trio
 
@@ -9,79 +10,70 @@ from parsec._parsec import DateTime, mock_time
 from parsec.api.protocol import DeviceID
 from parsec.core.types import LocalDevice
 
-__freeze_time_dict: dict[DeviceID, DateTime] = {}
+FreezeContext = dict[DeviceID, tuple[Optional[trio.lowlevel.Task], Optional[DateTime]]]
+__freeze_time_dict: FreezeContext = {}
 
 
-def _timestamp_mockup(device: LocalDevice) -> DateTime:
-    _, time = __freeze_time_dict.get(device.device_id, (None, None))
-    return time or device.time_provider.now()
+def _freeze_devices(
+    devices: list[LocalDevice], current_task: trio.lowlevel.Task | None, time: DateTime
+) -> FreezeContext:
+    restore_context: FreezeContext = dict()
 
+    for device in devices:
+        # Get device id
+        dev_id = device.device_id
 
-@contextmanager
-def freeze_device_time(device: LocalDevice | DeviceID, current_time: DateTime | str):
-    # Parse time
-    if isinstance(current_time, str):
-        [y, m, d] = current_time.split("-")
-        current_time = DateTime(int(y), int(m), int(d))
+        # Freeze time with mockup (idempotent) & timeprovider
+        print(f"[_freeze_devices] device_id={dev_id}, update time provider config")
+        # Mypy doesn't like that we assign a function to a method type
+        device.time_provider.mock_time(freeze=time)
 
-    # Get device id
-    if isinstance(device, LocalDevice):
-        device_id = device.device_id
-    elif isinstance(device, DeviceID):
-        device_id = device
-    else:
-        assert False, device
+        # Save previous context
+        previous_task, previous_time = __freeze_time_dict.get(dev_id, (None, None))
 
-    # Apply mockup (idempotent)
-    type(device).timestamp = _timestamp_mockup
+        # Ensure time has not been frozen from another coroutine
+        assert previous_task in (None, current_task)
 
-    # Save previous context
-    previous_task, previous_time = __freeze_time_dict.get(device_id, (None, None))
-
-    # Get current trio task
-    try:
-        current_task = trio.lowlevel.current_task()
-    except RuntimeError:
-        current_task = None
-
-    # Ensure time has not been frozen from another coroutine
-    assert previous_task in (None, current_task)
-
-    try:
         # Set new context
-        __freeze_time_dict[device_id] = (current_task, current_time)
-        yield current_time
-    finally:
-        # Restore previous context
-        __freeze_time_dict[device_id] = (previous_task, previous_time)
+        __freeze_time_dict[dev_id] = (current_task, time)
+
+        restore_context[dev_id] = (previous_task, previous_time)
+
+    return restore_context
 
 
-__freeze_time_task = None
+def _unfreeze_devices(devices: list[LocalDevice], previous_context: FreezeContext) -> None:
+    for device in devices:
+        dev_id = device.device_id
+        previous_task, previous_time = previous_context[dev_id]
+        __freeze_time_dict[dev_id] = (previous_task, previous_time)
+
+        if previous_time is not None:
+            device.time_provider.mock_time(freeze=previous_time)
+        else:
+            device.time_provider.mock_time(realtime=True)
+
+
+# Global ID that is used to save previous task & time when freezing datetime.
+__global_freeze_time_id = DeviceID.new()
 
 
 @contextmanager
-def freeze_time(time: DateTime | str = None, device: LocalDevice | DeviceID | None = None):
-    mocks_stack = []
+def freeze_time(
+    time: DateTime | str | None = None,
+    devices: list[LocalDevice] | None = None,
+    freeze_datetime: bool = False,
+) -> Iterator[DateTime]:
+    devices = devices or list()
+    # Will freeze `Datetime` if the caller said so or if no devices where provided
+    freeze_datetime = freeze_datetime or not devices
 
     # Get current time if not provided
     if time is None:
         time = DateTime.now()
-
-    # Freeze a single device
-    if device is not None:
-        with freeze_device_time(device, time) as time:
-            yield time
-        return
-
-    # Parse time
-    global __freeze_time_task
-    if isinstance(time, str):
-        [y, m, d] = time.split("-")
-        time = DateTime(int(y), int(m), int(d))
-
-    # Save previous context
-    previous_task = __freeze_time_task
-    previous_time = mocks_stack.pop() if mocks_stack else None
+    elif isinstance(time, str):
+        y, m, d = map(int, time.split("-"))
+        time = DateTime(y, m, d)
 
     # Get current trio task
     try:
@@ -89,18 +81,28 @@ def freeze_time(time: DateTime | str = None, device: LocalDevice | DeviceID | No
     except RuntimeError:
         current_task = None
 
+    # Freeze a multiple devices
+    restore_context = _freeze_devices(devices, current_task, time)
+
+    # Save previous context
+    global __global_freeze_time_id
+    global __freeze_time_dict
+    previous_task, previous_time = __freeze_time_dict.get(__global_freeze_time_id, (None, None))
+
     # Ensure time has not been frozen from another coroutine
     assert previous_task in (None, current_task)
 
     try:
-        # Set new context
-        __freeze_time_task = current_task
-        mocks_stack.append(time)
-        mock_time(time)
+        # Set freeze datetime
+        if freeze_datetime:
+            __freeze_time_dict[__global_freeze_time_id] = (current_task, time)
+            mock_time(time)
 
         yield time
     finally:
         # Restore previous context
-        __freeze_time_task = previous_task
-        mocks_stack.append(previous_time)
-        mock_time(previous_time)
+        if freeze_datetime:
+            __freeze_time_dict[__global_freeze_time_id] = (previous_task, previous_time)
+            mock_time(previous_time)
+
+        _unfreeze_devices(devices, restore_context)

--- a/tests/core/fs/storage/test_user_storage.py
+++ b/tests/core/fs/storage/test_user_storage.py
@@ -106,7 +106,8 @@ async def test_vacuum(alice_user_storage):
 async def test_storage_file_tree(tmp_path: Path, alice: LocalDevice):
     manifest_sqlite_db = tmp_path / alice.slug / "user_data-v1.sqlite"
 
-    async with UserStorage.run(tmp_path, alice) as aus:
-        assert aus.manifest_storage.path == manifest_sqlite_db
-
-    assert manifest_sqlite_db.is_file()
+    # Pristine start: DB is not created on FS...
+    assert not manifest_sqlite_db.exists()
+    async with UserStorage.run(tmp_path, alice):
+        # ...and now it is !
+        assert manifest_sqlite_db.is_file()

--- a/tests/core/fs/test_bootstrap.py
+++ b/tests/core/fs/test_bootstrap.py
@@ -28,9 +28,9 @@ from tests.core.conftest import UserFsFactory
 async def test_user_manifest_access_while_speculative(
     user_fs_factory: UserFsFactory, alice: LocalDevice
 ):
-    with freeze_time("2000-01-01"):
+    with freeze_time("2000-01-01", devices=[alice]):
         async with user_fs_factory(alice) as user_fs:
-            with freeze_time("2000-01-02"):
+            with freeze_time("2000-01-02", devices=[alice]):
                 user_manifest = user_fs.get_user_manifest()
 
     assert user_manifest.to_stats() == {
@@ -52,7 +52,7 @@ async def test_workspace_manifest_access_while_speculative(
     # when a device gets it local data removed. We use the latter here (even if
     # it is the less likely of the two) given it is simpler to do in the test.
 
-    with freeze_time("2000-01-01"):
+    with freeze_time("2000-01-01", devices=[alice]):
         async with user_fs_factory(alice) as user_fs:
             wksp_id = await user_fs.workspace_create(EntryName("wksp"))
             # Retrieve where the database is stored
@@ -67,7 +67,7 @@ async def test_workspace_manifest_access_while_speculative(
             await manifest_storage.clear_manifest(wksp_id)
 
     # Now re-start the userfs (the same local storage will be used)
-    with freeze_time("2000-01-02"):
+    with freeze_time("2000-01-02", devices=[alice]):
         async with user_fs_factory(alice) as user_fs:
             with freeze_time("2000-01-03"):
                 wksp = user_fs.get_workspace(wksp_id)
@@ -118,13 +118,13 @@ async def test_concurrent_devices_agree_on_user_manifest(
     async with trio.open_nursery() as nursery:
         switch_back_online = await nursery.start(_switch_running_backend_offline)
 
-        with freeze_time("2000-01-01"):
+        with freeze_time("2000-01-01", devices=[alice]):
             if with_speculative != "both":
                 await user_storage_non_speculative_init(data_base_dir=data_base_dir, device=alice)
             async with user_fs_factory(alice, data_base_dir=data_base_dir) as user_fs1:
                 wksp1_id = await user_fs1.workspace_create(EntryName("wksp1"))
 
-                with freeze_time("2000-01-02"):
+                with freeze_time("2000-01-02", devices=[alice, alice2]):
                     if with_speculative not in ("both", "alice2"):
                         await user_storage_non_speculative_init(
                             data_base_dir=data_base_dir, device=alice2
@@ -132,9 +132,13 @@ async def test_concurrent_devices_agree_on_user_manifest(
                     async with user_fs_factory(alice2, data_base_dir=data_base_dir) as user_fs2:
                         wksp2_id = await user_fs2.workspace_create(EntryName("wksp2"))
 
-                        with freeze_time("2000-01-03"):
+                        with freeze_time(
+                            "2000-01-03",
+                            devices=[alice, alice2],
+                            freeze_datetime=True,
+                        ):
                             # Only now the backend appear offline, this is to ensure each
-                            # userfs has created a user manifest in isolation
+                            # UserFS has created a user manifest in isolation
                             await backend_data_binder.bind_organization(
                                 coolorg, alice, initial_user_manifest="not_synced"
                             )
@@ -144,11 +148,11 @@ async def test_concurrent_devices_agree_on_user_manifest(
 
                             # Sync user_fs2 first to ensure created_on field is
                             # kept even if further syncs have an earlier value
-                            with freeze_time("2000-01-04"):
+                            with freeze_time("2000-01-04", devices=[alice2], freeze_datetime=True):
                                 await user_fs2.sync()
-                            with freeze_time("2000-01-05"):
+                            with freeze_time("2000-01-05", devices=[alice], freeze_datetime=True):
                                 await user_fs1.sync()
-                            with freeze_time("2000-01-06"):
+                            with freeze_time("2000-01-06", devices=[alice2], freeze_datetime=True):
                                 await user_fs2.sync()
 
                             # Now, both user fs should have the same view on data
@@ -236,32 +240,32 @@ async def test_concurrent_devices_agree_on_workspace_manifest(
 
     async with user_fs_factory(alice) as alice_user_fs:
         async with user_fs_factory(alice2) as alice2_user_fs:
-            with freeze_time("2000-01-01"):
+            with freeze_time("2000-01-01", devices=[alice]):
                 wksp_id = await alice_user_fs.workspace_create(EntryName("wksp"))
             # Sync user manifest (containing the workspace entry), but
             # not the corresponding workspace manifest !
-            with freeze_time("2000-01-02"):
+            with freeze_time("2000-01-02", devices=[alice], freeze_datetime=True):
                 await alice_user_fs.sync()
 
-            # Retrieve the user manifest but not the workpace manifest, Alice2 hence has a speculative workspace manifest
-            with freeze_time("2000-01-03"):
+            # Retrieve the user manifest but not the workspace manifest, Alice2 hence has a speculative workspace manifest
+            with freeze_time("2000-01-03", devices=[alice2], freeze_datetime=True):
                 await alice2_user_fs.sync()
 
             # Now workspace diverge between devices
             alice_wksp = alice_user_fs.get_workspace(wksp_id)
             alice2_wksp = alice2_user_fs.get_workspace(wksp_id)
-            with freeze_time("2000-01-04"):
+            with freeze_time("2000-01-04", devices=[alice]):
                 await alice_wksp.mkdir("/from_alice")
-            with freeze_time("2000-01-05"):
+            with freeze_time("2000-01-05", devices=[alice2]):
                 await alice2_wksp.mkdir("/from_alice2")
 
             # Sync user_fs2 first to ensure created_on field is
             # kept even if further syncs have an earlier value
-            with freeze_time("2000-01-06"):
+            with freeze_time("2000-01-06", devices=[alice2], freeze_datetime=True):
                 await alice2_wksp.sync()
-            with freeze_time("2000-01-07"):
+            with freeze_time("2000-01-07", devices=[alice], freeze_datetime=True):
                 await alice_wksp.sync()
-            with freeze_time("2000-01-08"):
+            with freeze_time("2000-01-08", devices=[alice2], freeze_datetime=True):
                 await alice2_wksp.sync()
 
             # Now, both user fs should have the same view on workspace
@@ -284,13 +288,13 @@ async def test_concurrent_devices_agree_on_workspace_manifest(
 
 @pytest.mark.trio
 async def test_empty_user_manifest_placeholder_noop_on_resolve_sync(
-    running_backend, user_fs_factory, alice, alice2
+    running_backend, user_fs_factory, alice: LocalDevice, alice2: LocalDevice
 ):
     # Alice creates a workspace and sync it
     async with user_fs_factory(alice) as alice_user_fs:
-        with freeze_time("2000-01-02"):
+        with freeze_time("2000-01-02", devices=[alice]):
             await alice_user_fs.workspace_create(EntryName("wksp1"))
-        with freeze_time("2000-01-03"):
+        with freeze_time("2000-01-03", devices=[alice], freeze_datetime=True):
             await alice_user_fs.sync()
         alice_user_manifest_v1 = alice_user_fs.get_user_manifest()
         assert alice_user_manifest_v1.to_stats() == {
@@ -303,10 +307,10 @@ async def test_empty_user_manifest_placeholder_noop_on_resolve_sync(
             "need_sync": False,
         }
 
-        with freeze_time("2000-01-04"):
+        with freeze_time("2000-01-04", devices=[alice2]):
             # Now Alice2 comes into play with it speculative user manifest
             async with user_fs_factory(alice2) as alice2_user_fs:
-                with freeze_time("2000-01-05"):
+                with freeze_time("2000-01-05", devices=[alice2]):
                     # Access the user manifest to ensure it is created, but do not modify it !
                     alice2_user_manifest_v0 = alice2_user_fs.get_user_manifest()
                     assert alice2_user_manifest_v0.to_stats() == {
@@ -319,7 +323,7 @@ async def test_empty_user_manifest_placeholder_noop_on_resolve_sync(
                     }
 
                     # Finally Alice2 sync, this should not create any remote change
-                    with freeze_time("2000-01-06"):
+                    with freeze_time("2000-01-06", devices=[alice2], freeze_datetime=True):
                         await alice2_user_fs.sync()
 
                     alice2_user_manifest_v1 = alice2_user_fs.get_user_manifest()
@@ -341,23 +345,23 @@ async def test_empty_workspace_manifest_placeholder_noop_on_resolve_sync(
     async with user_fs_factory(alice) as alice_user_fs:
         async with user_fs_factory(alice2) as alice2_user_fs:
             # First Alice creates a workspace, then populates and syncs it
-            with freeze_time("2000-01-01"):
+            with freeze_time("2000-01-01", devices=[alice]):
                 wksp_id = await alice_user_fs.workspace_create(EntryName("wksp"))
             alice_wksp = alice_user_fs.get_workspace(wksp_id)
-            with freeze_time("2000-01-02"):
+            with freeze_time("2000-01-02", devices=[alice]):
                 await alice_wksp.mkdir("/from_alice")
-            with freeze_time("2000-01-03"):
+            with freeze_time("2000-01-03", devices=[alice], freeze_datetime=True):
                 await alice_wksp.sync()
                 await alice_user_fs.sync()
 
             # Alice2 retrieves the user manifest but NOT the workspace manifest
             # hence Alice2 end up with a speculative workspace manifest
-            with freeze_time("2000-01-04"):
+            with freeze_time("2000-01-04", devices=[alice2], freeze_datetime=True):
                 await alice2_user_fs.sync()
             alice2_wksp = alice2_user_fs.get_workspace(wksp_id)
 
             # Access the workspace manifest to ensure it is created, but do not modify it !
-            with freeze_time("2000-01-05"):
+            with freeze_time("2000-01-05", devices=[alice2]):
                 alice2_wksp_stat_v0 = await alice2_wksp.path_info("/")
             assert alice2_wksp_stat_v0 == {
                 "id": wksp_id,
@@ -372,7 +376,7 @@ async def test_empty_workspace_manifest_placeholder_noop_on_resolve_sync(
             }
 
             # Now proceed to sync, this should end up with no remote changes
-            with freeze_time("2000-01-06"):
+            with freeze_time("2000-01-06", devices=[alice2], freeze_datetime=True):
                 await alice2_wksp.sync()
             alice_wksp_stat_v1 = await alice_wksp.path_info("/")
             alice2_wksp_stat_v1 = await alice2_wksp.path_info("/")

--- a/tests/core/fs/test_reencrypt_workspace.py
+++ b/tests/core/fs/test_reencrypt_workspace.py
@@ -21,7 +21,7 @@ from tests.common.backend import RunningBackend
 
 @pytest.fixture
 async def workspace(running_backend, alice_user_fs: UserFS) -> EntryID:
-    with freeze_time("2000-01-02"):
+    with freeze_time("2000-01-02", devices=[alice_user_fs.device], freeze_datetime=True):
         wid = await alice_user_fs.workspace_create(EntryName("w1"))
         # Sync workspace manifest v1
         await alice_user_fs.sync()

--- a/tests/core/fs/userfs/test_sync.py
+++ b/tests/core/fs/userfs/test_sync.py
@@ -43,7 +43,7 @@ async def test_get_manifest(alice_user_fs):
 async def test_create_workspace(
     initial_user_manifest_state: InitialUserManifestState, alice_user_fs: UserFS, alice: LocalDevice
 ):
-    with freeze_time("2000-01-02"):
+    with freeze_time("2000-01-02", devices=[alice]):
         wid = await alice_user_fs.workspace_create(EntryName("w1"))
     um = alice_user_fs.get_user_manifest()
     expected_base_um = initial_user_manifest_state.get_user_manifest_v1_for_backend(alice)

--- a/tests/core/fs/workspacefs_timestamped/conftest.py
+++ b/tests/core/fs/workspacefs_timestamped/conftest.py
@@ -27,60 +27,60 @@ day14 = DateTime(2000, 1, 14)
 @pytest.fixture
 @pytest.mark.trio
 async def alice_workspace(alice_user_fs: UserFS, running_backend):
-    with freeze_time(day0):
+    with freeze_time(day0, devices=[alice_user_fs.device], freeze_datetime=True):
         wid = await alice_user_fs.workspace_create(EntryName("w"))
         workspace = alice_user_fs.get_workspace(wid)
         await workspace.mkdir("/foo")
         # No sync, we want alice_workspace.to_timestamped to fail at day0
         # Still let's create the realm now to avoid restamping
         await alice_user_fs.remote_loader.create_realm(wid)
-    with freeze_time(day1):
+    with freeze_time(day1, devices=[alice_user_fs.device], freeze_datetime=True):
         await workspace.sync()
-    with freeze_time(day2):
+    with freeze_time(day2, devices=[alice_user_fs.device], freeze_datetime=True):
         await workspace.touch("/foo/bar")
         await workspace.sync()
-    with freeze_time(day3):
+    with freeze_time(day3, devices=[alice_user_fs.device], freeze_datetime=True):
         await workspace.touch("/foo/baz")
         await workspace.sync()
 
-    with freeze_time(day4):
+    with freeze_time(day4, devices=[alice_user_fs.device], freeze_datetime=True):
         await workspace.mkdir("/files")
         await workspace.touch("/files/content")
         await workspace.write_bytes("/files/content", b"abcde")
         await workspace.sync()
-    with freeze_time(day5):
+    with freeze_time(day5, devices=[alice_user_fs.device], freeze_datetime=True):
         await workspace.write_bytes("/files/content", b"fghij")
         await workspace.sync()
 
-    with freeze_time(day6):
+    with freeze_time(day6, devices=[alice_user_fs.device], freeze_datetime=True):
         await workspace.rename("/files/content", "/files/renamed")
         await workspace.sync()
-    with freeze_time(day7):
+    with freeze_time(day7, devices=[alice_user_fs.device], freeze_datetime=True):
         await workspace.rename("/files/renamed", "/files/renamed_again")
         await workspace.sync()
-    with freeze_time(day8):
+    with freeze_time(day8, devices=[alice_user_fs.device], freeze_datetime=True):
         await workspace.touch("/files/renamed")
         await workspace.write_bytes("/files/renamed", b"aaaaaa")
         await workspace.sync()
 
-    with freeze_time(day9):
+    with freeze_time(day9, devices=[alice_user_fs.device], freeze_datetime=True):
         await workspace.rename("/files", "/moved")
         await workspace.sync()
-    with freeze_time(day10):
+    with freeze_time(day10, devices=[alice_user_fs.device], freeze_datetime=True):
         await workspace.touch("/moved/content2")
         await workspace.write_bytes("/moved/content2", b"bbbbb")
         await workspace.sync()
-    with freeze_time(day11):
+    with freeze_time(day11, devices=[alice_user_fs.device], freeze_datetime=True):
         await workspace.rename("/moved", "/files")
         await workspace.sync()
 
-    with freeze_time(day12):
+    with freeze_time(day12, devices=[alice_user_fs.device], freeze_datetime=True):
         await workspace.unlink("/files/renamed")
         await workspace.sync()
-    with freeze_time(day13):
+    with freeze_time(day13, devices=[alice_user_fs.device], freeze_datetime=True):
         await workspace.touch("/files/renamed")
         await workspace.sync()
-    with freeze_time(day14):
+    with freeze_time(day14, devices=[alice_user_fs.device], freeze_datetime=True):
         await workspace.touch("/files/renamed")
         await workspace.write_bytes("/files/renamed", b"ccccc")
         await workspace.sync()

--- a/tests/core/test_messages_monitor.py
+++ b/tests/core/test_messages_monitor.py
@@ -92,15 +92,15 @@ async def test_new_sharing_trigger_event(
 ):
     KEY = SecretKey.generate()
     # First, create a folder and sync it on backend
-    with freeze_time("2000-01-01"):
+    with freeze_time("2000-01-01", devices=[alice_core.device], freeze_datetime=True):
         wid = await alice_core.user_fs.workspace_create(EntryName("foo"))
     workspace = alice_core.user_fs.get_workspace(wid)
-    with freeze_time("2000-01-02"):
+    with freeze_time("2000-01-02", devices=[alice_core.device], freeze_datetime=True):
         await workspace.sync()
 
     # Now we can share this workspace with Bob
     with bob_core.event_bus.listen() as spy:
-        with freeze_time("2000-01-03"):
+        with freeze_time("2000-01-03", devices=[alice_core.device], freeze_datetime=True):
             await alice_core.user_fs.workspace_share(
                 wid, recipient=UserID("bob"), role=WorkspaceRole.MANAGER
             )


### PR DESCRIPTION
- Allow to freeze multiple `devices`.
- Use `time_provider` to also freeze time in the rust lib.
- Allow to freeze the global scope alongside some devices.
- Update tests to use the new `freeze_time`
- Also made some change for `test_storage_file_tree`
