### PR TITLE
Replace generic errors in server RPC API by HTTP codes

### DIFF
--- a/parsec/backend/app.py
+++ b/parsec/backend/app.py
@@ -96,4 +96,6 @@ class BackendApp:
             self.block,
             self.pki,
             self.events,
+            # Ping command is only used in tests
+            include_ping=self.config.debug,
         )

--- a/parsec/backend/ping.py
+++ b/parsec/backend/ping.py
@@ -22,6 +22,7 @@ class BasePingComponent:
         "ping",
         client_types=[
             ClientType.AUTHENTICATED,
+            ClientType.ANONYMOUS,
             ClientType.INVITED,
         ],
     )

--- a/parsec/backend/utils.py
+++ b/parsec/backend/utils.py
@@ -88,7 +88,9 @@ def api(
     return wrapper
 
 
-def collect_apis(*components: object) -> Dict[ClientType, Dict[str, Callable[..., Any]]]:
+def collect_apis(
+    *components: object, include_ping: bool
+) -> Dict[ClientType, Dict[str, Callable[..., Any]]]:
     apis: Dict[ClientType, Dict[str, Callable[..., Any]]] = {}
     for component in components:
         for methname in dir(component):
@@ -100,6 +102,11 @@ def collect_apis(*components: object) -> Dict[ClientType, Dict[str, Callable[...
             for client_type in info["client_types"]:
                 if client_type not in apis:
                     apis[client_type] = {}
+
+                # Ping command is only needed for tests, so skip provide a way
+                # to skip in when in production
+                if info["cmd"] == "ping" and not include_ping:
+                    continue
 
                 assert info["cmd"] not in apis[client_type]
                 apis[client_type][info["cmd"]] = meth

--- a/tests/common/backend.py
+++ b/tests/common/backend.py
@@ -136,7 +136,7 @@ def backend_factory(
                 "administration_token": "s3cr3t",
                 "db_min_connections": 1,
                 "db_max_connections": 5,
-                "debug": False,
+                "debug": True,
                 "db_url": backend_store,
                 "sse_keepalive": 30,
                 "blockstore_config": blockstore,


### PR DESCRIPTION
460 for organization expired
461 for user revoked
415 for any bad content

# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
