### PR TITLE
[parsec] Improve typing

### DIFF
--- a/parsec/core/fs/remote_loader.py
+++ b/parsec/core/fs/remote_loader.py
@@ -9,6 +9,7 @@ import trio
 from trio import MemoryReceiveChannel, MemorySendChannel, open_memory_channel
 
 from parsec._parsec import (
+    BlockAccess,
     BlockCreateRepAlreadyExists,
     BlockCreateRepInMaintenance,
     BlockCreateRepNotAllowed,
@@ -18,12 +19,20 @@ from parsec._parsec import (
     BlockReadRepNotAllowed,
     BlockReadRepNotFound,
     BlockReadRepOk,
+    ChunkID,
     CoreEvent,
     DateTime,
+    DeviceID,
+    EntryID,
+    LocalDevice,
     RealmCreateRepAlreadyExists,
     RealmCreateRepOk,
     RealmGetRoleCertificatesRepNotAllowed,
     RealmGetRoleCertificatesRepOk,
+    RealmID,
+    RealmRole,
+    SequesterServiceID,
+    UserID,
     VlobCreateRepAlreadyExists,
     VlobCreateRepBadEncryptionRevision,
     VlobCreateRepInMaintenance,
@@ -33,6 +42,7 @@ from parsec._parsec import (
     VlobCreateRepRequireGreaterTimestamp,
     VlobCreateRepSequesterInconsistency,
     VlobCreateRepTimeout,
+    VlobID,
     VlobListVersionsRepInMaintenance,
     VlobListVersionsRepNotAllowed,
     VlobListVersionsRepNotFound,
@@ -53,10 +63,10 @@ from parsec._parsec import (
     VlobUpdateRepRequireGreaterTimestamp,
     VlobUpdateRepSequesterInconsistency,
     VlobUpdateRepTimeout,
+    WorkspaceEntry,
 )
 from parsec.api.data import (
     AnyRemoteManifest,
-    BlockAccess,
     DataError,
     DeviceCertificate,
     RealmRoleCertificate,
@@ -66,7 +76,6 @@ from parsec.api.data import (
     UserCertificate,
 )
 from parsec.api.data.manifest import manifest_decrypt_verify_and_load
-from parsec.api.protocol import DeviceID, RealmID, RealmRole, SequesterServiceID, UserID, VlobID
 from parsec.core.backend_connection import BackendConnectionError, BackendNotAvailable
 from parsec.core.fs.exceptions import (
     FSBackendOfflineError,
@@ -87,7 +96,7 @@ from parsec.core.fs.exceptions import (
     FSWorkspaceNoReadAccess,
     FSWorkspaceNoWriteAccess,
 )
-from parsec.core.fs.storage import BaseWorkspaceStorage
+from parsec.core.fs.storage.workspace_storage import AnyWorkspaceStorage
 from parsec.core.remote_devices_manager import (
     RemoteDevicesManager,
     RemoteDevicesManagerBackendOfflineError,
@@ -96,7 +105,6 @@ from parsec.core.remote_devices_manager import (
     RemoteDevicesManagerInvalidTrustchainError,
     RemoteDevicesManagerUserNotFoundError,
 )
-from parsec.core.types import ChunkID, EntryID, LocalDevice, WorkspaceEntry
 from parsec.crypto import CryptoError, HashDigest, VerifyKey
 from parsec.event_bus import EventBus
 from parsec.utils import open_service_nursery
@@ -437,7 +445,7 @@ class RemoteLoader(UserRemoteLoader):
         get_previous_workspace_entry: Callable[[], Awaitable[WorkspaceEntry | None]],
         backend_cmds: BackendAuthenticatedCmds,
         remote_devices_manager: RemoteDevicesManager,
-        local_storage: BaseWorkspaceStorage,
+        local_storage: AnyWorkspaceStorage,
         event_bus: EventBus,
     ):
         super().__init__(

--- a/parsec/core/fs/storage/__init__.py
+++ b/parsec/core/fs/storage/__init__.py
@@ -6,7 +6,7 @@ from parsec.core.fs.storage.local_database import LocalDatabase
 from parsec.core.fs.storage.manifest_storage import ManifestStorage
 from parsec.core.fs.storage.user_storage import UserStorage, user_storage_non_speculative_init
 from parsec.core.fs.storage.workspace_storage import (
-    BaseWorkspaceStorage,
+    AnyWorkspaceStorage,
     WorkspaceStorage,
     WorkspaceStorageTimestamped,
     workspace_storage_non_speculative_init,
@@ -20,7 +20,7 @@ __all__ = (
     "ChunkStorage",
     "BlockStorage",
     "workspace_storage_non_speculative_init",
-    "BaseWorkspaceStorage",
+    "AnyWorkspaceStorage",
     "WorkspaceStorage",
     "WorkspaceStorageTimestamped",
 )

--- a/parsec/core/fs/storage/workspace_storage.py
+++ b/parsec/core/fs/storage/workspace_storage.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections import defaultdict
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncIterator, Dict, List, NoReturn, Set, Tuple, cast
+from typing import TYPE_CHECKING, AsyncIterator, Dict, List, NoReturn, Set, Tuple, Union, cast
 
 import trio
 from structlog import get_logger
@@ -33,18 +33,25 @@ from parsec.core.types.manifest import AnyLocalManifest
 
 logger = get_logger()
 
+
 DEFAULT_CHUNK_VACUUM_THRESHOLD = 512 * 1024 * 1024
 
 FAILSAFE_PATTERN_FILTER = Regex.from_regex_str(
     r"^\b$"
 )  # Matches nothing (https://stackoverflow.com/a/2302992/2846140)
 
+AnyWorkspaceStorage = Union["WorkspaceStorage", "WorkspaceStorageTimestamped"]
+
+__all__ = [
+    "WorkspaceStorage",
+    "AnyWorkspaceStorage",
+]
+
 
 async def workspace_storage_non_speculative_init(
     data_base_dir: Path, device: LocalDevice, workspace_id: EntryID
 ) -> None:
     db_path = get_workspace_data_storage_db_path(data_base_dir, device, workspace_id)
-
     # Local data storage service
     async with LocalDatabase.run(db_path) as data_localdb:
 

--- a/parsec/core/fs/workspacefs/entry_transactions.py
+++ b/parsec/core/fs/workspacefs/entry_transactions.py
@@ -455,7 +455,7 @@ class EntryTransactions(FileTransactions):
             # ~ Atomic change
             await self.local_storage.set_manifest(child.id, child, check_lock_status=False)
             await self.local_storage.set_manifest(parent.id, new_parent)
-            fd = self.local_storage.create_file_descriptor(child) if open else None
+            fd = FileDescriptor(self.local_storage.create_file_descriptor(child)) if open else None
 
         # Send events
         self._send_event(CoreEvent.FS_ENTRY_UPDATED, id=parent.id)
@@ -479,7 +479,7 @@ class EntryTransactions(FileTransactions):
                 raise FSIsADirectoryError(filename=path)
 
             # Return the entry id of the open file and the file descriptor
-            return manifest.id, self.local_storage.create_file_descriptor(manifest)
+            return manifest.id, FileDescriptor(self.local_storage.create_file_descriptor(manifest))
 
     async def file_resize(self, path: FsPath, length: int) -> EntryID:
         # Check write rights

--- a/parsec/core/fs/workspacefs/file_operations.py
+++ b/parsec/core/fs/workspacefs/file_operations.py
@@ -1,7 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) AGPL-3.0 2016-present Scille SAS
 from __future__ import annotations
 
-# Imports
 from parsec._parsec import prepare_read, prepare_reshape, prepare_resize, prepare_write
 
 __all__ = [

--- a/parsec/core/fs/workspacefs/remanence_manager.py
+++ b/parsec/core/fs/workspacefs/remanence_manager.py
@@ -19,7 +19,7 @@ from parsec.core.fs.exceptions import (
     FSRemoteManifestNotFound,
 )
 from parsec.core.fs.remote_loader import RemoteLoader
-from parsec.core.fs.storage import BaseWorkspaceStorage
+from parsec.core.fs.storage import AnyWorkspaceStorage
 from parsec.core.fs.workspacefs.sync_transactions import ChangesAfterSync, SyncTransactions
 from parsec.core.types import (
     BlockID,
@@ -112,7 +112,7 @@ class RemanenceManagerInfo:
 class RemanenceManager:
     def __init__(
         self,
-        local_storage: BaseWorkspaceStorage,
+        local_storage: AnyWorkspaceStorage,
         remote_loader: RemoteLoader,
         transactions: SyncTransactions,
         workspace_id: EntryID,

--- a/parsec/core/fs/workspacefs/workspacefs.py
+++ b/parsec/core/fs/workspacefs/workspacefs.py
@@ -4,16 +4,31 @@ from __future__ import annotations
 from collections import defaultdict
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncIterator, Awaitable, Callable, Dict, List, Tuple, cast
+from typing import TYPE_CHECKING, AsyncIterator, Awaitable, Callable, cast
 
 import attr
 import structlog
 import trio
 
-from parsec._parsec import CoreEvent, DateTime, FileManifest, RealmStatusRepOk, Regex
-from parsec.api.data import AnyRemoteManifest, BlockAccess
-from parsec.api.data import FileManifest as RemoteFileManifest
-from parsec.api.protocol import MaintenanceType, RealmID, UserID
+from parsec._parsec import (
+    BlockAccess,
+    CoreEvent,
+    DateTime,
+    EntryID,
+    EntryName,
+    LocalDevice,
+    LocalFileManifest,
+    LocalFolderManifest,
+    LocalWorkspaceManifest,
+    MaintenanceType,
+    RealmID,
+    RealmStatusRepOk,
+    Regex,
+    UserID,
+    WorkspaceEntry,
+)
+from parsec._parsec import FileManifest as RemoteFileManifest
+from parsec.api.data import AnyRemoteManifest
 from parsec.core.backend_connection import BackendConnectionError, BackendNotAvailable
 from parsec.core.fs import workspacefs  # Needed to break cyclic import with WorkspaceFSTimestamped
 from parsec.core.fs.exceptions import (
@@ -34,7 +49,7 @@ from parsec.core.fs.exceptions import (
 )
 from parsec.core.fs.path import AnyPath, FsPath
 from parsec.core.fs.remote_loader import RemoteLoader
-from parsec.core.fs.storage import BaseWorkspaceStorage, WorkspaceStorage
+from parsec.core.fs.storage.workspace_storage import AnyWorkspaceStorage, WorkspaceStorage
 from parsec.core.fs.workspacefs.entry_transactions import BlockInfo
 from parsec.core.fs.workspacefs.remanence_manager import RemanenceManager, RemanenceManagerInfo
 from parsec.core.fs.workspacefs.sync_transactions import SyncTransactions
@@ -44,16 +59,9 @@ from parsec.core.remote_devices_manager import RemoteDevicesManager
 from parsec.core.types import (
     DEFAULT_BLOCK_SIZE,
     BackendOrganizationFileLinkAddr,
-    EntryID,
-    EntryName,
-    LocalDevice,
-    LocalFileManifest,
-    LocalFolderManifest,
-    LocalWorkspaceManifest,
     RemoteFolderishManifests,
     RemoteFolderManifest,
     RemoteWorkspaceManifest,
-    WorkspaceEntry,
     WorkspaceRole,
 )
 from parsec.crypto import CryptoError
@@ -68,8 +76,8 @@ logger = structlog.get_logger()
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)
 class ReencryptionNeed:
-    user_revoked: Tuple[UserID, ...]
-    role_revoked: Tuple[UserID, ...]
+    user_revoked: tuple[UserID, ...]
+    role_revoked: tuple[UserID, ...]
     reencryption_already_in_progress: bool = False
 
     @property
@@ -84,7 +92,7 @@ class WorkspaceFS:
         get_workspace_entry: Callable[[], WorkspaceEntry],
         get_previous_workspace_entry: Callable[[], Awaitable[WorkspaceEntry | None]],
         device: LocalDevice,
-        local_storage: BaseWorkspaceStorage,
+        local_storage: AnyWorkspaceStorage,
         backend_cmds: BackendAuthenticatedCmds,
         event_bus: EventBus,
         remote_devices_manager: RemoteDevicesManager,
@@ -99,7 +107,7 @@ class WorkspaceFS:
         self.event_bus = event_bus
         self.remote_devices_manager = remote_devices_manager
         self.preferred_language = preferred_language
-        self.sync_locks: Dict[EntryID, trio.Lock] = defaultdict(trio.Lock)
+        self.sync_locks: dict[EntryID, trio.Lock] = defaultdict(trio.Lock)
         self.remote_loader = RemoteLoader(
             self.device,
             self.workspace_id,
@@ -225,7 +233,7 @@ class WorkspaceFS:
         await self.remote_loader.load_block(block)
 
     async def receive_load_blocks(
-        self, blocks: List[BlockAccess], nursery: trio.Nursery
+        self, blocks: list[BlockAccess], nursery: trio.Nursery
     ) -> "trio.MemoryReceiveChannel[BlockAccess]":
         """
         Raises:
@@ -252,7 +260,7 @@ class WorkspaceFS:
     def is_revoked(self) -> bool:
         return self.get_workspace_entry().role is None
 
-    async def path_info(self, path: AnyPath) -> Dict[str, object]:
+    async def path_info(self, path: AnyPath) -> dict[str, object]:
         """
         Raises:
             FSError
@@ -267,7 +275,7 @@ class WorkspaceFS:
         info = await self.transactions.entry_info(FsPath(path))
         return cast(EntryID, info["id"])
 
-    async def get_user_roles(self) -> Dict[UserID, WorkspaceRole]:
+    async def get_user_roles(self) -> dict[UserID, WorkspaceRole]:
         """
         Raises:
             FSError
@@ -415,10 +423,10 @@ class WorkspaceFS:
         info = await self.transactions.entry_info(path)
         if "children" not in info:
             raise FSNotADirectoryError(filename=str(path))
-        for child in cast(Dict[EntryName, EntryID], info["children"]):
+        for child in cast(dict[EntryName, EntryID], info["children"]):
             yield path / child
 
-    async def listdir(self, path: AnyPath) -> List[FsPath]:
+    async def listdir(self, path: AnyPath) -> list[FsPath]:
         """
         Raises:
             FSError
@@ -677,15 +685,15 @@ class WorkspaceFS:
 
     async def entry_id_to_path(
         self, needle_entry_id: EntryID
-    ) -> Tuple[FsPath, Dict[str, object]] | None:
+    ) -> tuple[FsPath, dict[str, object]] | None:
         async def _recursive_search(
             path: FsPath,
-        ) -> Tuple[FsPath, Dict[str, object]] | None:
+        ) -> tuple[FsPath, dict[str, object]] | None:
             entry_info = await self.path_info(path=path)
             if entry_info["id"] == needle_entry_id:
                 return path, entry_info
             if entry_info["type"] == "folder":
-                children = cast(List[str], entry_info["children"])
+                children = cast(list[str], entry_info["children"])
                 for child_name in children:
                     result = await _recursive_search(path=path / child_name)
                     if result:
@@ -796,7 +804,7 @@ class WorkspaceFS:
                     # busy loop trying to sync the this entry again and again.
                     # On top of that, if the entry is further modified (or if the workspacefs is restarted) the sync
                     # monitor will try again to do the sync.
-                    if isinstance(exc.manifest, (FileManifest, LocalFileManifest)):
+                    if isinstance(exc.manifest, (RemoteFileManifest, LocalFileManifest)):
                         path_info = await self.entry_id_to_path(exc.id)
                         if path_info is None:
                             path = FsPath("/")
@@ -895,9 +903,9 @@ class WorkspaceFS:
 
     # Debugging helper
 
-    async def dump(self) -> Dict[str, object]:
-        async def rec(entry_id: EntryID) -> Dict[str, object]:
-            result: Dict[str, object] = {"id": entry_id}
+    async def dump(self) -> dict[str, object]:
+        async def rec(entry_id: EntryID) -> dict[str, object]:
+            result: dict[str, object] = {"id": entry_id}
             try:
                 manifest = await self.local_storage.get_manifest(entry_id)
             except FSLocalMissError:
@@ -908,7 +916,7 @@ class WorkspaceFS:
             if not isinstance(manifest, (LocalFolderManifest, LocalWorkspaceManifest)):
                 return result
 
-            children: Dict[EntryName, Dict[str, object]] = {}
+            children: dict[EntryName, dict[str, object]] = {}
             for key, value in manifest.children.items():
                 children[key] = await rec(value)
             result["children"] = children

--- a/parsec/core/gui/create_org_widget.py
+++ b/parsec/core/gui/create_org_widget.py
@@ -23,7 +23,7 @@ from parsec.core.backend_connection import (
     BackendOutOfBallparkError,
 )
 from parsec.core.config import CoreConfig
-from parsec.core.fs.storage.user_storage import user_storage_non_speculative_init
+from parsec.core.fs.storage import user_storage_non_speculative_init
 from parsec.core.gui import validators
 from parsec.core.gui.authentication_choice_widget import AuthenticationChoiceWidget
 from parsec.core.gui.custom_dialogs import GreyedDialog, show_error

--- a/parsec/core/sync_monitor.py
+++ b/parsec/core/sync_monitor.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 
 import math
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Union, cast
+from typing import TYPE_CHECKING, Any, Iterable, cast
 
 import trio
 from structlog import get_logger
 
 from parsec._parsec import (
     CoreEvent,
+    EntryID,
     VlobPollChangesRepInMaintenance,
     VlobPollChangesRepNotAllowed,
     VlobPollChangesRepNotFound,
@@ -32,8 +33,8 @@ from parsec.core.fs import (
     UserFS,
 )
 from parsec.core.fs.exceptions import FSServerUploadTemporarilyUnavailableError
-from parsec.core.fs.storage import UserStorage, WorkspaceStorage
-from parsec.core.types import EntryID, WorkspaceRole
+from parsec.core.fs.storage import AnyWorkspaceStorage, UserStorage, WorkspaceStorage
+from parsec.core.types import WorkspaceRole
 from parsec.event_bus import EventBus, EventCallback
 
 if TYPE_CHECKING:
@@ -100,7 +101,7 @@ class SyncContext:
     def _get_backend_cmds(self) -> BackendAuthenticatedCmds:
         raise NotImplementedError
 
-    def _get_local_storage(self) -> Union[UserStorage, WorkspaceStorage]:
+    def _get_local_storage(self) -> UserStorage | AnyWorkspaceStorage:
         raise NotImplementedError
 
     def __repr__(self) -> str:
@@ -339,7 +340,7 @@ class SyncContextStore:
 
     def __init__(self, user_fs: UserFS) -> None:
         self.user_fs = user_fs
-        self._ctxs: Dict[EntryID, SyncContext] = {}
+        self._ctxs: dict[EntryID, SyncContext] = {}
 
     def iter(self) -> Iterable[SyncContext]:
         return self._ctxs.copy().values()


### PR DESCRIPTION
- Replace `BaseWorkspaceStorage` with `AnyWorkspaceStorage`
    > This change will make more sense when we merge #2903 
- Replace `Tuple` by `tuple`, `Dict` by `dict`, etc
- Move import mostly to `parsec._parsec`