### PR TITLE
Prevent using node > 18.13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,9 @@ on:
 env:
   python-version: "3.9"
   rust-version: 1.66.1
-  node-version: 18.13.0
+  # We use the version 18.12 because the version >= 18.13 have some breaking changes on how they format the date.
+  # That would break our unit test if we don't update them.
+  node-version: 18.12.0
   poetry-version: 1.2.2
   # TODO: We stick to PostgreSQL 12 for the moment given later versions are
   # much slower (postgresql tests runs in ~9mn on 12 vs ~36mn on 14 !)
@@ -428,6 +430,9 @@ jobs:
         run: echo "run=true" >> $GITHUB_OUTPUT
         shell: bash
 
+      - uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516  # pin v3.5.1
+        with:
+          node-version: ${{ env.node-version }}
       # TODO: cache libparsec and reuse it if Rust code hasn't changed !
 
       - name: Install dependencies

--- a/oxidation/client/package.json
+++ b/oxidation/client/package.json
@@ -79,7 +79,9 @@
         "wasm-pack": "^0.10.3"
     },
     "engines": {
-        "node": ">=16.13.0 <19.0.0"
+        "//": "We don't want to use node >= 18.13 because they've made some breaking changes on the Date formating.",
+        "//": "And that break our unit test. We better correct them when we bump the version of node that is compatible on all platform (web included)",
+        "node": ">=16.13.0 <18.13.0"
     },
     "description": "An Ionic project"
 }


### PR DESCRIPTION
Currently our unit test started to fail because of a change introduced in node-18.13.0 (nodejs/node#46123).
So using a version before that change would correct the test that fail in #4071.

Changes
-------

- Change node-version in `ci.yml` to `18.12.0`
- Use github action `actions/setup-node` in `Web tests`