### PR TITLE
Correct MacOS timeout on the step `build python wheel`

### DIFF
--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -75,7 +75,7 @@ jobs:
         uses: pypa/cibuildwheel@a808017c3962f4d678fe685239668aad8c150932  # pin v2.12.0
         with:
           output-dir: dist
-        timeout-minutes: 30
+        timeout-minutes: 50
 
       - name: Set file for wheel version
         run: echo ${{ steps.wheel-version.outputs.version }} > dist/version


### PR DESCRIPTION
Macos timeout on that step, see <https://github.com/Scille/parsec-cloud/actions/runs/4254198641/jobs/7400109887>

So i've increase the timeout by 20 minutes.

Closes #4088
