### PR TITLE
Harden `upload-artifact` to fail if no file is found

### DIFF
--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -111,6 +111,7 @@ jobs:
         with:
           name: ${{ runner.os }}-${{ runner.arch }}-wheel
           path: dist/
+          if-no-file-found: error
         timeout-minutes: 5
 
   package-linux-build-snap:
@@ -162,6 +163,7 @@ jobs:
         with:
           name: ${{ runner.os }}-${{ runner.arch }}-snap
           path: ${{ runner.temp }}/parsec*.snap
+          if-no-file-found: error
 
   package-linux-test-snap:
     name: '🐧 Linux: 📦 Packaging (test Snap on ${{ matrix.os }})'
@@ -288,6 +290,7 @@ jobs:
         with:
           name: ${{ runner.os }}-${{ runner.arch }}-installer-content
           path: ${{ runner.temp }}/dist/
+          if-no-file-found: error
 
   package-macos-build-app:
     runs-on: macos-12
@@ -329,6 +332,7 @@ jobs:
         with:
           name: ${{ runner.os }}-${{ runner.arch }}-installer
           path: ${{ runner.temp }}/parsec-${{ env.WHEEL_VERSION }}-macos-amd64.tar.bz2
+          if-no-file-found: error
 
   package-macos-test-app:
     runs-on: macos-${{ matrix.macos-version }}
@@ -440,6 +444,7 @@ jobs:
           path: |
             oxidation/client/android/app/build/outputs/apk/release/app-release-unsigned.apk
             oxidation/client/android/app/build/outputs/apk/release/output-metadata.json
+          if-no-file-found: error
 
   package-web-app:
     runs-on: ubuntu-22.04
@@ -459,3 +464,4 @@ jobs:
         with:
           name: webapp
           path: oxidation/client/dist/
+          if-no-file-found: error


### PR DESCRIPTION
Settings `if-no-file-found=error` will make the github action `upload-artifact` to fail if it found no file.

depends on #4090 
