### PR TITLE
Enable CodeQL to scan typescript / javascript code

### DIFF
--- a/.github/filters/codeql.yml
+++ b/.github/filters/codeql.yml
@@ -30,3 +30,21 @@ java-analyze:
   - *codeql-workflow
   - *rust-android-binding
   - *android
+
+electron: &electron
+  - oxidation/client/electron/**
+
+web: &web
+  - oxidation/client/src/**
+  - oxidation/client/tests/**
+
+ionic-dependencies-project: &ionic-dependencies-project
+  - oxidation/client/*.js
+  - oxidation/client/*.ts
+  - oxidation/client/*.json
+
+js-analyze:
+  - *codeql-workflow
+  - *electron
+  - *web
+  - *ionic-dependencies-project

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -164,3 +164,50 @@ jobs:
         uses: github/codeql-action/analyze@168b99b3c22180941ae7dbdd5f5c9678ede476ba # pin v2.2.7
         with:
           category: /language:java
+
+  javascript-analyze:
+    name: 🌐 Javascript static code Analysis
+    runs-on: ubuntu-20.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin v3.1.0
+
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50  # pin v2.11.1
+        id: changes
+        with:
+          filters: .github/filters/codeql.yml
+
+      - name: Check modified path that require `javascript-analysis` to run
+        id: js-changes
+        if: >-
+          steps.changes.outputs.js-analyze == 'true'
+          || contains(github.ref, 'gh-readonly-queue')
+          || github.ref == 'refs/heads/master'
+        run: echo "run=true" >> $GITHUB_OUTPUT
+        shell: bash
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        if: steps.js-changes.outputs.run == 'true'
+        uses: github/codeql-action/init@168b99b3c22180941ae7dbdd5f5c9678ede476ba # pin v2.2.7
+        with:
+          languages: typescript
+
+      - name: Install dependencies for ionic project
+        if: steps.js-changes.outputs.run == 'true'
+        run: npm clean-install
+        working-directory: oxidation/client
+
+      - name: Autobuild for typescript
+        uses: github/codeql-action/autobuild@168b99b3c22180941ae7dbdd5f5c9678ede476ba # pin v2.2.7
+        with:
+          working-directory: oxidation/client
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@168b99b3c22180941ae7dbdd5f5c9678ede476ba # pin v2.2.7
+        with:
+          category: /language:typescript

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Autobuild android
         if: steps.java-changes.outputs.run == 'true'
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@168b99b3c22180941ae7dbdd5f5c9678ede476ba # pin v2.2.7
         with:
           working-directory: oxidation/client/android
 


### PR DESCRIPTION
I have configured CodeQL to analyse our typescript / javascript codebase that is used to build our new client.

closes #4009
