### PR TITLE
Add windows to the packaged electron os

### DIFF
--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -363,40 +363,52 @@ jobs:
         include:
           - name: 🐧 Linux
             os: ubuntu-22.04
-            generated-files: |
+            paths: |
               oxidation/client/electron/dist/parsec_*_*.snap
               oxidation/client/electron/dist/parsec-*.AppImage
-    runs-on: ubuntu-22.04
-    name: ⚡ Package electron
+          - name: 🏁 Windows
+            os: windows-2022
+            paths: |
+              oxidation/client/electron/dist/parsec Setup *.exe
+              oxidation/client/electron/dist/parsec Setup *.exe.blockmap
+    name: '${{matrix.name }}: ⚡ Package electron'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin v3.3.0
 
+      - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # pin v4.4.0
+        id: setup-python
+        with:
+          python-version: ${{ env.python-version }}
+        timeout-minutes: 10
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@c758e63728211bd4acda6501cfa2a16c5c751fc4
+        with:
+          toolchain: ${{ env.rust-version }}
+        timeout-minutes: 10
+
       - name: Install dependencies
+        shell: bash
         run: |
           npm clean-install
           (cd electron && npm clean-install)
           (cd ../bindings/electron && npm clean-install)
         working-directory: oxidation/client
+        timeout-minutes: 40
 
       - name: Build Electron App
-        run: |
-          npm run electron:release:sodium
+        run: npm run electron:release:sodium
         working-directory: oxidation/client
-
-      - name: Check that the generated files exist
-        run: |
-          set -e
-          for file in ${{ join(matrix.generated-files.*, ' ') }}; do
-            ls -lh $file
-            test -f $file
-          done
+        timeout-minutes: 40
 
       - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # pin v3.1.1
         with:
           name: ${{ runner.os }}-${{ runner.arch }}-electron-app
-          path: ${{ matrix.generated-files }}
+          path: ${{ matrix.paths }}
           if-no-file-found: error
-
+        timeout-minutes: 10
 
   package-android-app:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
- Also install the correct python version that is used for internal setup script.
- Install the correct rust version.
- Add timeout to the job & tasks.
- Rewrite the artifact upload to accommodate different path depending on the platform we execute the job on.
