### PR TITLE
Fix flakiness in tests/core/test_messages_monitor.py when alice_core'…

### DIFF
--- a/tests/core/test_messages_monitor.py
+++ b/tests/core/test_messages_monitor.py
@@ -10,7 +10,7 @@ from parsec._parsec import CoreEvent, DateTime
 from parsec.api.data import EntryName, PingMessageContent
 from parsec.api.protocol import UserID
 from parsec.core.backend_connection import BackendConnStatus
-from parsec.core.logged_core import LoggedCore
+from parsec.core.logged_core import LoggedCore, UserFS
 from parsec.core.types import WorkspaceEntry, WorkspaceRole
 from parsec.crypto import SecretKey
 from tests.common import create_shared_workspace, freeze_time
@@ -88,22 +88,22 @@ async def test_process_while_offline(
 
 @pytest.mark.trio
 async def test_new_sharing_trigger_event(
-    alice_core: LoggedCore,
+    alice_user_fs: UserFS,
     bob_core: LoggedCore,
     running_backend,
 ):
     KEY = SecretKey.generate()
     # First, create a folder and sync it on backend
-    with freeze_time("2000-01-01", devices=[alice_core.device], freeze_datetime=True):
-        wid = await alice_core.user_fs.workspace_create(EntryName("foo"))
-    workspace = alice_core.user_fs.get_workspace(wid)
-    with freeze_time("2000-01-02", devices=[alice_core.device], freeze_datetime=True):
+    with freeze_time("2000-01-01", devices=[alice_user_fs.device], freeze_datetime=True):
+        wid = await alice_user_fs.workspace_create(EntryName("foo"))
+    workspace = alice_user_fs.get_workspace(wid)
+    with freeze_time("2000-01-02", devices=[alice_user_fs.device], freeze_datetime=True):
         await workspace.sync()
 
     # Now we can share this workspace with Bob
     with bob_core.event_bus.listen() as spy:
-        with freeze_time("2000-01-03", devices=[alice_core.device], freeze_datetime=True):
-            await alice_core.user_fs.workspace_share(
+        with freeze_time("2000-01-03", devices=[alice_user_fs.device], freeze_datetime=True):
+            await alice_user_fs.workspace_share(
                 wid, recipient=UserID("bob"), role=WorkspaceRole.MANAGER
             )
 
@@ -134,7 +134,9 @@ async def test_new_sharing_trigger_event(
 
 
 @pytest.mark.trio
-async def test_revoke_sharing_trigger_event(alice_core, bob_core, running_backend):
+async def test_revoke_sharing_trigger_event(
+    alice_user_fs: UserFS, bob_core: LoggedCore, running_backend
+):
     KEY = SecretKey.generate()
 
     def _update_event(event):
@@ -148,11 +150,11 @@ async def test_revoke_sharing_trigger_event(alice_core, bob_core, running_backen
         return event
 
     with freeze_time("2000-01-02"):
-        wid = await create_shared_workspace(EntryName("w"), alice_core, bob_core)
+        wid = await create_shared_workspace(EntryName("w"), alice_user_fs, bob_core)
 
     with bob_core.event_bus.listen() as spy:
         with freeze_time("2000-01-03"):
-            await alice_core.user_fs.workspace_share(wid, recipient=UserID("bob"), role=None)
+            await alice_user_fs.workspace_share(wid, recipient=UserID("bob"), role=None)
 
         # Each workspace participant should get the message
         await spy.wait_with_timeout(


### PR DESCRIPTION
…s sync_monitor decides to sync in the background right between two freeze_time calls

fix #4178  🤘

# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
