### PR TITLE
Correct `sphinx` warning

### DIFF
--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -12,3 +12,4 @@ Hack on Parsec
 
     quickstart
     release
+    functional_architecture

--- a/docs/development/quickstart.rst
+++ b/docs/development/quickstart.rst
@@ -105,7 +105,7 @@ On linux:
 
 On Windows:
 
-.. code-block:: cmd
+.. code-block:: bat
 
     .\tests\scripts\run_testenv.bat
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,7 +47,6 @@ The main documentation for the site is organized into the following sections:
     :caption: Development
     :name: sec-devel
 
-    development
     history
 
 .. Indices and tables

--- a/docs/userguide/index.rst
+++ b/docs/userguide/index.rst
@@ -17,4 +17,4 @@ User Guide
     share_data
     revoke_user
 
-You can also use the simplified `Parsec User Guide [French]<https://parsec.cloud/wp-content/uploads/2022/04/GU-a-jour-Android-new-1.pdf>`_
+You can also use the simplified `Parsec User Guide [French] <https://parsec.cloud/wp-content/uploads/2022/04/GU-a-jour-Android-new-1.pdf>`_


### PR DESCRIPTION
`sphinx` during the `make gettext` complain with the following warning:

- Missing document `development`

    ```txt
    /parsec-cloud/docs/index.rst:45: WARNING: toctree contains reference to nonexisting document 'development'
    ```

    Resolved by removing `development` (we don't want those documents on the website).

- Document `functional_architecture` isn't included

    ```txt
    /parsec-cloud/docs/development/functional_architecture.rst: WARNING: document isn't included in any toctree
    ```

    Resolved by including it in the TOC

- Unknown target name in `userguide/index` ```txt /parsec-cloud/docs/userguide/index.rst:20: ERROR: Unknown target name: "parsec user guide [french]<https://parsec.cloud/wp-content/uploads/2022/04/gu-a-jour-android-new-1.pdf>". ```

    Resolved by adding a ` ` between `[French]` and `<...URL...>`

- Unknown lexer `cmd` ```txt /parsec-cloud/docs/development/quickstart.rst:108: WARNING: Pygments lexer name 'cmd' is not known ```

    `Pygments` don't define the lexer `cmd` but define the lexer `bat`
