### PR TITLE
Remove `libparsec_python` from ignored cpsell ignored paths

### DIFF
--- a/.cspell/cspell.config.yml
+++ b/.cspell/cspell.config.yml
@@ -113,7 +113,6 @@ cache:
 useGitignore: true
 allowCompoundWords: true
 ignorePaths:
-  - ./oxidation/libparsec_python
   - '**/parsec/core/resources/default_*.ignore'
   - '**/*.svg'
   - '**/docs/figures/*.svg'


### PR DESCRIPTION
`libparsec_python` folder was removed in #2898.
So `cpsell` no longer need to watch (or ignore this path).
