### PR TITLE
Don't skip task on the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,7 @@ jobs:
         id: python-changes
         if: >-
           steps.changes.outputs.python-jobs == 'true'
+          || contains(github.ref, 'gh-readonly-queue')
           || github.ref == 'refs/heads/master'
         run: echo "run=true" >> $GITHUB_OUTPUT
         shell: bash
@@ -412,6 +413,7 @@ jobs:
         id: rust-changes
         if: >-
           steps.changes.outputs.rust-jobs == 'true'
+          || contains(github.ref, 'gh-readonly-queue')
           || github.ref == 'refs/heads/master'
         run: echo "run=true" >> $GITHUB_OUTPUT
         shell: bash
@@ -485,6 +487,7 @@ jobs:
         id: web-change
         if: >-
           steps.changes.outputs.web-jobs == 'true'
+          || contains(github.ref, 'gh-readonly-queue')
           || github.ref == 'refs/heads/master'
         run: echo "run=true" >> $GITHUB_OUTPUT
         shell: bash


### PR DESCRIPTION
When the CI run on the merge queue, we don't want it to skip some tasks.

If it's a behavior we want to keep, said it.

closes #4165