### PR TITLE
Replace `string error` with an enum in `libparsec_types::addr`

### DIFF
--- a/src/addrs.rs
+++ b/src/addrs.rs
@@ -75,11 +75,11 @@ impl BackendAddr {
         match allow_http_redirection {
             true => match libparsec::types::BackendAddr::from_any(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
-                Err(err) => Err(PyValueError::new_err(err)),
+                Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
             false => match libparsec::types::BackendAddr::from_str(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
-                Err(err) => Err(PyValueError::new_err(err)),
+                Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
         }
     }
@@ -187,11 +187,11 @@ impl BackendOrganizationAddr {
         match allow_http_redirection {
             true => match libparsec::types::BackendOrganizationAddr::from_any(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
-                Err(err) => Err(PyValueError::new_err(err)),
+                Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
             false => match libparsec::types::BackendOrganizationAddr::from_str(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
-                Err(err) => Err(PyValueError::new_err(err)),
+                Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
         }
     }
@@ -242,7 +242,7 @@ impl BackendActionAddr {
                         Ok(BackendPkiEnrollmentAddr(v).into_py(py).to_object(py))
                     }
                 },
-                Err(err) => Err(PyValueError::new_err(err)),
+                Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
             false => match url.parse::<libparsec::types::BackendActionAddr>() {
                 Ok(ba) => match ba {
@@ -261,7 +261,7 @@ impl BackendActionAddr {
                         Ok(BackendPkiEnrollmentAddr(v).into_py(py).to_object(py))
                     }
                 },
-                Err(err) => Err(PyValueError::new_err(err)),
+                Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
         }
     }
@@ -386,11 +386,11 @@ impl BackendOrganizationBootstrapAddr {
         match allow_http_redirection {
             true => match libparsec::types::BackendOrganizationBootstrapAddr::from_any(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
-                Err(err) => Err(PyValueError::new_err(err)),
+                Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
             false => match libparsec::types::BackendOrganizationBootstrapAddr::from_str(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
-                Err(err) => Err(PyValueError::new_err(err)),
+                Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
         }
     }
@@ -535,11 +535,11 @@ impl BackendOrganizationFileLinkAddr {
         match allow_http_redirection {
             true => match libparsec::types::BackendOrganizationFileLinkAddr::from_any(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
-                Err(err) => Err(PyValueError::new_err(err)),
+                Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
             false => match libparsec::types::BackendOrganizationFileLinkAddr::from_str(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
-                Err(err) => Err(PyValueError::new_err(err)),
+                Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
         }
     }
@@ -678,11 +678,11 @@ impl BackendInvitationAddr {
         match allow_http_redirection {
             true => match libparsec::types::BackendInvitationAddr::from_any(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
-                Err(err) => Err(PyValueError::new_err(err)),
+                Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
             false => match libparsec::types::BackendInvitationAddr::from_str(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
-                Err(err) => Err(PyValueError::new_err(err)),
+                Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
         }
     }
@@ -806,11 +806,11 @@ impl BackendPkiEnrollmentAddr {
         match allow_http_redirection {
             true => match libparsec::types::BackendPkiEnrollmentAddr::from_any(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
-                Err(err) => Err(PyValueError::new_err(err)),
+                Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
             false => match libparsec::types::BackendPkiEnrollmentAddr::from_str(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
-                Err(err) => Err(PyValueError::new_err(err)),
+                Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
         }
     }

--- a/tests/core/test_backend_address.py
+++ b/tests/core/test_backend_address.py
@@ -151,7 +151,7 @@ def test_addr_with_bad_port(addr_testbed, bad_port):
 
 
 @pytest.mark.parametrize("with_port", [False, True])
-def test_addr_with_no_hostname(addr_testbed, with_port):
+def test_addr_with_no_hostname(addr_testbed, with_port: bool):
     if with_port:
         domain = ":4242"
     else:
@@ -159,7 +159,10 @@ def test_addr_with_no_hostname(addr_testbed, with_port):
     url = addr_testbed.generate_url(DOMAIN=domain)
     with pytest.raises(ValueError) as exc:
         addr_testbed.cls.from_url(url)
-    assert str(exc.value) in ["Missing mandatory hostname", "Invalid URL"]
+    if with_port:
+        assert f"Cannot parse raw url `{url}`: empty host" == str(exc.value)
+    else:
+        assert f"No hostname on url `{url}`" == str(exc.value)
 
 
 def test_good_addr_with_unknown_field(addr_testbed):


### PR DESCRIPTION
Using an enum instead of string errors:

- Reduce the amount of duplicate string found in the codebase.
- Reduce the amount of place where we could have typo.

closes #4230
