### PR TITLE
Don't save python lib `libparsec` when on Github merge queue

### DIFF
--- a/.github/filters/ci.yml
+++ b/.github/filters/ci.yml
@@ -26,12 +26,6 @@ rust-python-binding: &rust-python-binding src
 
 rust-web-binding: &rust-web-binding oxidation/bindings/web
 
-python: &python
-  - parsec
-  - tests
-  - make.py
-  - build.py
-
 python-dependencies-project: &python-dependencies-project
   - pyproject.toml
   - poetry.lock
@@ -50,6 +44,18 @@ web: &web
   - oxidation/client/*.js
   - oxidation/client/*.ts
 
+python-changes: &python-changes
+  - *python-dependencies-project
+  - parsec
+  - tests
+  - make.py
+  - build.py
+
+rust-changes: &rust-changes
+  - *rust-dependencies-workspace
+  - *rust-libparsec
+  - *rust-toolchain
+
 # The python jobs need to be run when:
 # - The ci workflow has changed
 # - The action `setup-python-poetry` has changed
@@ -62,12 +68,10 @@ web: &web
 python-jobs:
   - *ci-workflow
   - .github/actions/setup-python-poetry
-  - *rust-dependencies-workspace
-  - *rust-libparsec
-  - *rust-toolchain
+  - *python-changes
+  - *rust-changes
   - *rust-python-binding
-  - *python
-  - *python-dependencies-project
+
 
 # The rust jobs need to watch for:
 # - The change on the rust code.
@@ -78,9 +82,8 @@ python-jobs:
 # We don't include the rust code on the binding because they're tested on different jobs.
 rust-jobs:
   - *ci-workflow
-  - *rust-dependencies-workspace
-  - *rust-libparsec
-  - *rust-toolchain
+  - *rust-changes
+
 
 # The web jobs need to be run when:
 # - The ci workflow has changed
@@ -92,9 +95,7 @@ rust-jobs:
 # - The web dependencies has changed
 web-jobs:
   - *ci-workflow
-  - *rust-dependencies-workspace
-  - *rust-libparsec
-  - *rust-toolchain
+  - *rust-changes
   - *rust-web-binding
   - *new-client-dependencies-project
   - *web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,12 +280,10 @@ jobs:
       # libparsec is slow to compile, so we save it in cache and skip the
       # compilation entirely if the Rust code hasn't changed !
 
-      - name: Use cached libparsec if Rust hasn't been modified
+      - name: Restore libparsec if Rust hasn't been modified
         id: cache-libparsec
-        if: >-
-          steps.python-changes.outputs.run == 'true'
-          && steps.rust-changes.outputs.run != 'true'
-        uses: actions/cache@v3
+        if: steps.python-changes.outputs.run == 'true'
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # pin v3.3.1
         with:
           # Key cache contains a hash of all the files that are used to produce _parsec.so
           # Hence if we have a cache hit we know that there is no need for a rebuild !
@@ -326,6 +324,26 @@ jobs:
           if ${{ steps.cache-libparsec.outputs.cache-hit == 'true' }}; then export POETRY_LIBPARSEC_BUILD_STRATEGY=no_build; fi
           python make.py python-ci-install
         timeout-minutes: 20
+
+      # We only save the libparsec lib when:
+      # - We are not in a github queue branch (they're a one time use so caching won't help)
+      # - The rust code isn't modifed.
+      # - We haven't add a cache it.
+      - name: Save cached libparsec to be reused on later call
+        if: >-
+          steps.python-changes.outputs.run == 'true'
+          && steps.changes.outputs.rust-changes != 'true'
+          && steps.cache-libparsec.outputs.cache-hit != 'true'
+          && contains(github.ref, 'gh-readonly-queue') != 'true'
+        uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # pin v3.3.1
+        with:
+          # Key cache contains a hash of all the files that are used to produce _parsec.so
+          # Hence if we have a cache hit we know that there is no need for a rebuild !
+          key: ${{ matrix.os }}-${{ hashFiles('src/**', 'oxidation/libparsec/**', 'rust-toolchain.toml', 'Cargo.toml', 'Cargo.lock') }}-libparsec-python
+          path: |
+            parsec/_parsec.*.pyd
+            parsec/_parsec.*.so
+        timeout-minutes: 2
 
       - name: Basic tests
         if: steps.python-changes.outputs.run == 'true'


### PR DESCRIPTION
Saving the python lib `libparsec` generated by the binding is useless on the merge queue

Because each branch are one time use so the cache isn't reused.

To correct that, I split the `cache` system into 2 phase `restore` & `save`:

- `restore` will always tries to restore the cache
- `save` will only save the cache when we aren't on Github merge queue and the rust code isn't modified

depends on #4223
closes #4153

> This is a re-open of the PR #4226 because it depends on the PR #4223
