### PR TITLE
Update gen web rust template to convert rust error to string

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -22,6 +22,7 @@ BlockStore
 Booyakasha
 boto
 botocore
+browserslistrc
 Bsas
 bxsalsa
 cachekey

--- a/.github/filters/ci.yml
+++ b/.github/filters/ci.yml
@@ -1,6 +1,6 @@
 ci-workflow: &ci-workflow .github/workflows/ci.yml
 
-rust-libparsec: &rust-libparsec oxidation/libparsec
+rust-libparsec: &rust-libparsec oxidation/libparsec/**
 
 rust-dependencies-workspace: &rust-dependencies-workspace
   - Cargo.toml
@@ -8,7 +8,7 @@ rust-dependencies-workspace: &rust-dependencies-workspace
 
 rust-toolchain: &rust-toolchain rust-toolchain.toml
 
-rust-python-binding: &rust-python-binding src
+rust-python-binding: &rust-python-binding src/**
 
 # TODO: We currently don't test the electron application
 # So we don't have to watch the electron binding (likewise for the client code related to electron)
@@ -24,11 +24,11 @@ rust-python-binding: &rust-python-binding src
 # So we don't have to watch the client code related to the ios application
 # new-client-ios: &new-client-ios oxidation/client/ios
 
-rust-web-binding: &rust-web-binding oxidation/bindings/web
+rust-web-binding: &rust-web-binding oxidation/bindings/web/**
 
 python: &python
-  - parsec
-  - tests
+  - parsec/**
+  - tests/**
   - make.py
   - build.py
 
@@ -38,17 +38,17 @@ python-dependencies-project: &python-dependencies-project
   - setup.cfg
 
 new-client-dependencies-project: &new-client-dependencies-project
-  - oxidation/client/package.json
-  - oxidation/client/package-lock.json
-  - oxidation/client/tsconfig.json
+  - oxidation/client/*.ts
+  - oxidation/client/*.json
+  - oxidation/client/*.js
+  - oxidation/client/.browserslistrc
+  - oxidation/client/.env
 
 web: &web
-  - oxidation/client/public
-  - oxidation/client/resources
-  - oxidation/client/src
-  - oxidation/client/tests
-  - oxidation/client/*.js
-  - oxidation/client/*.ts
+  - oxidation/client/public/**
+  - oxidation/client/resources/**
+  - oxidation/client/src/**
+  - oxidation/client/tests/**
 
 # The python jobs need to be run when:
 # - The ci workflow has changed
@@ -61,7 +61,7 @@ web: &web
 # - We updated the python dependencies
 python-jobs:
   - *ci-workflow
-  - .github/actions/setup-python-poetry
+  - .github/actions/setup-python-poetry/**
   - *rust-dependencies-workspace
   - *rust-libparsec
   - *rust-toolchain

--- a/oxidation/bindings/generator/templates/binding_web_meths.rs.j2
+++ b/oxidation/bindings/generator/templates/binding_web_meths.rs.j2
@@ -58,7 +58,7 @@ let {{ param_name }} =
 {
     let custom_from_rs_string = {{ type.custom_from_rs_string }};
     custom_from_rs_string({{ param_name }})
-        .map_err(|e| TypeError::new(e))
+        .map_err(|e| TypeError::new(&e.to_string()))
 }?;
 {%- else -%}
 {{ param_name }}.parse().map_err(|_| {
@@ -137,7 +137,7 @@ js_val.dyn_into::<JsString>().ok().and_then(|s| s.as_string()).ok_or_else(|| Typ
 .and_then(|x| {
     let custom_from_rs_string = {{ type.custom_from_rs_string }};
     custom_from_rs_string(x)
-.map_err(|e| TypeError::new(e)) })
+.map_err(|e| TypeError::new(&e.to_string())) })
 {%- else -%}
 ?.parse()
 {%- endif %}

--- a/oxidation/bindings/web/src/meths.rs
+++ b/oxidation/bindings/web/src/meths.rs
@@ -26,7 +26,7 @@ fn struct_availabledevice_js_to_rs(obj: JsValue) -> Result<libparsec::AvailableD
             .and_then(|x| {
                 let custom_from_rs_string =
                     |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-                custom_from_rs_string(x).map_err(|e| TypeError::new(e))
+                custom_from_rs_string(x).map_err(|e| TypeError::new(&e.to_string()))
             })
             .map_err(|_| TypeError::new("Not a valid Path"))?
     };
@@ -156,7 +156,7 @@ fn struct_clientconfig_js_to_rs(obj: JsValue) -> Result<libparsec::ClientConfig,
             .and_then(|x| {
                 let custom_from_rs_string =
                     |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-                custom_from_rs_string(x).map_err(|e| TypeError::new(e))
+                custom_from_rs_string(x).map_err(|e| TypeError::new(&e.to_string()))
             })
             .map_err(|_| TypeError::new("Not a valid Path"))?
     };
@@ -170,7 +170,7 @@ fn struct_clientconfig_js_to_rs(obj: JsValue) -> Result<libparsec::ClientConfig,
             .and_then(|x| {
                 let custom_from_rs_string =
                     |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-                custom_from_rs_string(x).map_err(|e| TypeError::new(e))
+                custom_from_rs_string(x).map_err(|e| TypeError::new(&e.to_string()))
             })
             .map_err(|_| TypeError::new("Not a valid Path"))?
     };
@@ -184,7 +184,7 @@ fn struct_clientconfig_js_to_rs(obj: JsValue) -> Result<libparsec::ClientConfig,
             .and_then(|x| {
                 let custom_from_rs_string =
                     |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-                custom_from_rs_string(x).map_err(|e| TypeError::new(e))
+                custom_from_rs_string(x).map_err(|e| TypeError::new(&e.to_string()))
             })
             .map_err(|_| TypeError::new("Not a valid Path"))?
     };
@@ -198,7 +198,7 @@ fn struct_clientconfig_js_to_rs(obj: JsValue) -> Result<libparsec::ClientConfig,
             .and_then(|x| {
                 let custom_from_rs_string =
                     |s: String| -> Result<_, _> { libparsec::BackendAddr::from_any(&s) };
-                custom_from_rs_string(x).map_err(|e| TypeError::new(e))
+                custom_from_rs_string(x).map_err(|e| TypeError::new(&e.to_string()))
             })
             .map_err(|_| TypeError::new("Not a valid BackendAddr"))?
     };
@@ -454,7 +454,7 @@ fn variant_deviceaccessparams_js_to_rs(
                         let custom_from_rs_string = |s: String| -> Result<_, &'static str> {
                             Ok(std::path::PathBuf::from(s))
                         };
-                        custom_from_rs_string(x).map_err(|e| TypeError::new(e))
+                        custom_from_rs_string(x).map_err(|e| TypeError::new(&e.to_string()))
                     })
                     .map_err(|_| TypeError::new("Not a valid Path"))?
             };
@@ -480,7 +480,7 @@ fn variant_deviceaccessparams_js_to_rs(
                         let custom_from_rs_string = |s: String| -> Result<_, &'static str> {
                             Ok(std::path::PathBuf::from(s))
                         };
-                        custom_from_rs_string(x).map_err(|e| TypeError::new(e))
+                        custom_from_rs_string(x).map_err(|e| TypeError::new(&e.to_string()))
                     })
                     .map_err(|_| TypeError::new("Not a valid Path"))?
             };
@@ -641,7 +641,7 @@ pub fn clientListAvailableDevices(path: String) -> Promise {
         let path = {
             let custom_from_rs_string =
                 |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-            custom_from_rs_string(path).map_err(|e| TypeError::new(e))
+            custom_from_rs_string(path).map_err(|e| TypeError::new(&e.to_string()))
         }?;
 
         let ret = libparsec::client_list_available_devices(&path).await;
@@ -736,7 +736,7 @@ pub fn testNewTestbed(template: String, test_server: Option<String>) -> Promise 
                 let test_server = {
                     let custom_from_rs_string =
                         |s: String| -> Result<_, _> { libparsec::BackendAddr::from_any(&s) };
-                    custom_from_rs_string(test_server).map_err(|e| TypeError::new(e))
+                    custom_from_rs_string(test_server).map_err(|e| TypeError::new(&e.to_string()))
                 }?;
 
                 Some(test_server)
@@ -768,7 +768,7 @@ pub fn testDropTestbed(path: String) -> Promise {
         let path = {
             let custom_from_rs_string =
                 |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-            custom_from_rs_string(path).map_err(|e| TypeError::new(e))
+            custom_from_rs_string(path).map_err(|e| TypeError::new(&e.to_string()))
         }?;
 
         libparsec::test_drop_testbed(&path).await;


### PR DESCRIPTION
This was required by the change made in #4233 where we change the error type for AddrError from a string to an enum. But `TypeError` expect a `string` in the `TypeError::new` (would be nice if it allows `impl Display` instead :thinking:)

Other change
------------

Rework generator script to format generated rust code

> Before exiting the script, the generator will call `cargo-fmt` on the modified packages.
