### PR TITLE
Improve electron template for string convertion

### DIFF
--- a/oxidation/bindings/electron/src/meths.rs
+++ b/oxidation/bindings/electron/src/meths.rs
@@ -19,27 +19,30 @@ fn struct_availabledevice_js_to_rs<'a>(
         {
             let custom_from_rs_string =
                 |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-            match custom_from_rs_string(js_val.value(cx)) {
+            let value: Result<std::path::PathBuf, _> = custom_from_rs_string(js_val.value(cx));
+            match value {
                 Ok(val) => val,
-                Err(err) => return cx.throw_type_error(err),
+                Err(err) => return cx.throw_type_error(err.to_string()),
             }
         }
     };
     let organization_id = {
         let js_val: Handle<JsString> = obj.get(cx, "organizationId")?;
         {
-            match js_val.value(cx).parse() {
+            let value: Result<libparsec::types::OrganizationID, _> = js_val.value(cx).parse();
+            match value {
                 Ok(val) => val,
-                Err(err) => return cx.throw_type_error(err),
+                Err(err) => return cx.throw_type_error(err.to_string()),
             }
         }
     };
     let device_id = {
         let js_val: Handle<JsString> = obj.get(cx, "deviceId")?;
         {
-            match js_val.value(cx).parse() {
+            let value: Result<libparsec::types::DeviceID, _> = js_val.value(cx).parse();
+            match value {
                 Ok(val) => val,
-                Err(err) => return cx.throw_type_error(err),
+                Err(err) => return cx.throw_type_error(err.to_string()),
             }
         }
     };
@@ -51,9 +54,10 @@ fn struct_availabledevice_js_to_rs<'a>(
             } else {
                 let js_val = js_val.downcast_or_throw::<JsString, _>(cx)?;
                 Some({
-                    match js_val.value(cx).parse() {
+                    let value: Result<libparsec::HumanHandle, _> = js_val.value(cx).parse();
+                    match value {
                         Ok(val) => val,
-                        Err(err) => return cx.throw_type_error(err),
+                        Err(err) => return cx.throw_type_error(err.to_string()),
                     }
                 })
             }
@@ -67,9 +71,10 @@ fn struct_availabledevice_js_to_rs<'a>(
             } else {
                 let js_val = js_val.downcast_or_throw::<JsString, _>(cx)?;
                 Some({
-                    match js_val.value(cx).parse() {
+                    let value: Result<libparsec::DeviceLabel, _> = js_val.value(cx).parse();
+                    match value {
                         Ok(val) => val,
-                        Err(err) => return cx.throw_type_error(err),
+                        Err(err) => return cx.throw_type_error(err.to_string()),
                     }
                 })
             }
@@ -108,7 +113,7 @@ fn struct_availabledevice_rs_to_js<'a>(
         };
         match custom_to_rs_string(rs_obj.key_file_path) {
             Ok(ok) => ok,
-            Err(err) => return cx.throw_type_error(err),
+            Err(err) => return cx.throw_type_error(err.to_string()),
         }
     })
     .or_throw(cx)?;
@@ -146,9 +151,10 @@ fn struct_clientconfig_js_to_rs<'a>(
         {
             let custom_from_rs_string =
                 |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-            match custom_from_rs_string(js_val.value(cx)) {
+            let value: Result<std::path::PathBuf, _> = custom_from_rs_string(js_val.value(cx));
+            match value {
                 Ok(val) => val,
-                Err(err) => return cx.throw_type_error(err),
+                Err(err) => return cx.throw_type_error(err.to_string()),
             }
         }
     };
@@ -157,9 +163,10 @@ fn struct_clientconfig_js_to_rs<'a>(
         {
             let custom_from_rs_string =
                 |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-            match custom_from_rs_string(js_val.value(cx)) {
+            let value: Result<std::path::PathBuf, _> = custom_from_rs_string(js_val.value(cx));
+            match value {
                 Ok(val) => val,
-                Err(err) => return cx.throw_type_error(err),
+                Err(err) => return cx.throw_type_error(err.to_string()),
             }
         }
     };
@@ -168,9 +175,10 @@ fn struct_clientconfig_js_to_rs<'a>(
         {
             let custom_from_rs_string =
                 |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-            match custom_from_rs_string(js_val.value(cx)) {
+            let value: Result<std::path::PathBuf, _> = custom_from_rs_string(js_val.value(cx));
+            match value {
                 Ok(val) => val,
-                Err(err) => return cx.throw_type_error(err),
+                Err(err) => return cx.throw_type_error(err.to_string()),
             }
         }
     };
@@ -179,9 +187,10 @@ fn struct_clientconfig_js_to_rs<'a>(
         {
             let custom_from_rs_string =
                 |s: String| -> Result<_, _> { libparsec::BackendAddr::from_any(&s) };
-            match custom_from_rs_string(js_val.value(cx)) {
+            let value: Result<libparsec::BackendAddr, _> = custom_from_rs_string(js_val.value(cx));
+            match value {
                 Ok(val) => val,
-                Err(err) => return cx.throw_type_error(err),
+                Err(err) => return cx.throw_type_error(err.to_string()),
             }
         }
     };
@@ -212,7 +221,7 @@ fn struct_clientconfig_rs_to_js<'a>(
         };
         match custom_to_rs_string(rs_obj.config_dir) {
             Ok(ok) => ok,
-            Err(err) => return cx.throw_type_error(err),
+            Err(err) => return cx.throw_type_error(err.to_string()),
         }
     })
     .or_throw(cx)?;
@@ -225,7 +234,7 @@ fn struct_clientconfig_rs_to_js<'a>(
         };
         match custom_to_rs_string(rs_obj.data_base_dir) {
             Ok(ok) => ok,
-            Err(err) => return cx.throw_type_error(err),
+            Err(err) => return cx.throw_type_error(err.to_string()),
         }
     })
     .or_throw(cx)?;
@@ -238,7 +247,7 @@ fn struct_clientconfig_rs_to_js<'a>(
         };
         match custom_to_rs_string(rs_obj.mountpoint_base_dir) {
             Ok(ok) => ok,
-            Err(err) => return cx.throw_type_error(err),
+            Err(err) => return cx.throw_type_error(err.to_string()),
         }
     })
     .or_throw(cx)?;
@@ -249,7 +258,7 @@ fn struct_clientconfig_rs_to_js<'a>(
         };
         match custom_to_rs_string(rs_obj.preferred_org_creation_backend_addr) {
             Ok(ok) => ok,
-            Err(err) => return cx.throw_type_error(err),
+            Err(err) => return cx.throw_type_error(err.to_string()),
         }
     })
     .or_throw(cx)?;
@@ -430,9 +439,11 @@ fn variant_deviceaccessparams_js_to_rs<'a>(
                 {
                     let custom_from_rs_string =
                         |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-                    match custom_from_rs_string(js_val.value(cx)) {
+                    let value: Result<std::path::PathBuf, _> =
+                        custom_from_rs_string(js_val.value(cx));
+                    match value {
                         Ok(val) => val,
-                        Err(err) => return cx.throw_type_error(err),
+                        Err(err) => return cx.throw_type_error(err.to_string()),
                     }
                 }
             };
@@ -448,9 +459,11 @@ fn variant_deviceaccessparams_js_to_rs<'a>(
                 {
                     let custom_from_rs_string =
                         |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-                    match custom_from_rs_string(js_val.value(cx)) {
+                    let value: Result<std::path::PathBuf, _> =
+                        custom_from_rs_string(js_val.value(cx));
+                    match value {
                         Ok(val) => val,
-                        Err(err) => return cx.throw_type_error(err),
+                        Err(err) => return cx.throw_type_error(err.to_string()),
                     }
                 }
             };
@@ -478,7 +491,7 @@ fn variant_deviceaccessparams_rs_to_js<'a>(
                 };
                 match custom_to_rs_string(path) {
                     Ok(ok) => ok,
-                    Err(err) => return cx.throw_type_error(err),
+                    Err(err) => return cx.throw_type_error(err.to_string()),
                 }
             })
             .or_throw(cx)?;
@@ -497,7 +510,7 @@ fn variant_deviceaccessparams_rs_to_js<'a>(
                 };
                 match custom_to_rs_string(path) {
                     Ok(ok) => ok,
-                    Err(err) => return cx.throw_type_error(err),
+                    Err(err) => return cx.throw_type_error(err.to_string()),
                 }
             })
             .or_throw(cx)?;
@@ -606,9 +619,10 @@ fn client_list_available_devices(mut cx: FunctionContext) -> JsResult<JsPromise>
         {
             let custom_from_rs_string =
                 |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-            match custom_from_rs_string(js_val.value(&mut cx)) {
+            let value: Result<std::path::PathBuf, _> = custom_from_rs_string(js_val.value(&mut cx));
+            match value {
                 Ok(val) => val,
-                Err(err) => return cx.throw_type_error(err),
+                Err(err) => return cx.throw_type_error(err.to_string()),
             }
         }
     };
@@ -793,9 +807,11 @@ fn test_new_testbed(mut cx: FunctionContext) -> JsResult<JsPromise> {
             Ok(js_val) => Some({
                 let custom_from_rs_string =
                     |s: String| -> Result<_, _> { libparsec::BackendAddr::from_any(&s) };
-                match custom_from_rs_string(js_val.value(&mut cx)) {
+                let value: Result<libparsec::BackendAddr, _> =
+                    custom_from_rs_string(js_val.value(&mut cx));
+                match value {
                     Ok(val) => val,
-                    Err(err) => return cx.throw_type_error(err),
+                    Err(err) => return cx.throw_type_error(err.to_string()),
                 }
             }),
             Err(_) => None,
@@ -821,7 +837,7 @@ fn test_new_testbed(mut cx: FunctionContext) -> JsResult<JsPromise> {
                     };
                     match custom_to_rs_string(ret) {
                         Ok(ok) => ok,
-                        Err(err) => return cx.throw_type_error(err),
+                        Err(err) => return cx.throw_type_error(err.to_string()),
                     }
                 })
                 .or_throw(&mut cx)?;
@@ -840,9 +856,10 @@ fn test_drop_testbed(mut cx: FunctionContext) -> JsResult<JsPromise> {
         {
             let custom_from_rs_string =
                 |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-            match custom_from_rs_string(js_val.value(&mut cx)) {
+            let value: Result<std::path::PathBuf, _> = custom_from_rs_string(js_val.value(&mut cx));
+            match value {
                 Ok(val) => val,
-                Err(err) => return cx.throw_type_error(err),
+                Err(err) => return cx.throw_type_error(err.to_string()),
             }
         }
     };

--- a/oxidation/bindings/generator/api/common.py
+++ b/oxidation/bindings/generator/api/common.py
@@ -54,6 +54,7 @@ class LoggedCoreHandle(I32BasedType):
 
 
 class OrganizationID(StrBasedType):
+    namespace = "libparsec::types"
     pass
 
 
@@ -65,16 +66,13 @@ class HumanHandle(StrBasedType):
     pass
 
 
-class Path(StrBasedType):
-    pass
-
-
 class BackendAddr(StrBasedType):
     custom_from_rs_string = "|s: String| -> Result<_, _> { libparsec::BackendAddr::from_any(&s) }"
     custom_to_rs_string = "|addr: libparsec::BackendAddr| -> Result<String, &'static str> { Ok(addr.to_url().into()) }"
 
 
 class DeviceID(StrBasedType):
+    namespace = "libparsec::types"
     pass
 
 
@@ -83,6 +81,8 @@ class ClientHandle(U32BasedType):
 
 
 class Path(StrBasedType):
+    type = "PathBuf"
+    namespace = "std::path"
     custom_from_rs_string = (
         "|s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) }"
     )

--- a/oxidation/bindings/generator/generate.py
+++ b/oxidation/bindings/generator/generate.py
@@ -77,6 +77,7 @@ env.globals["raise"] = _raise_helper
 class BaseTypeInUse:
     # Name of the type familly (e.g. `bytes`, `struct`, `variant`), to be defined in subclass
     kind: str
+    namespace: str = "libparsec"
 
     @staticmethod
     def parse(param: str) -> "BaseTypeInUse":
@@ -116,6 +117,9 @@ class BaseTypeInUse:
         elif isinstance(param, type) and issubclass(param, StrBasedType):
             return StrBasedTypeInUse(
                 name=param.__name__,
+                type=getattr(param, "type", param.__name__),
+                namespace=getattr(param, "namespace", "libparsec"),
+                from_str_error=getattr(param, "from_str_error", "_"),
                 custom_from_rs_string=getattr(param, "custom_from_rs_string", None),
                 custom_to_rs_string=getattr(param, "custom_to_rs_string", None),
             )
@@ -175,7 +179,11 @@ class RefTypeInUse(BaseTypeInUse):
 class StrBasedTypeInUse(BaseTypeInUse):
     kind = "str_based"
     name: str
+    type: str
+    namespace: str
 
+    # The error returned when trying to parse the value from a string.
+    from_str_error: str
     # If set, custom_from_rs_string/custom_to_rs_string should inlined rust functions
     # `fn (String) -> Result<X, AsRef<str>>`
     custom_from_rs_string: str | None = None

--- a/oxidation/bindings/generator/templates/binding_electron_index.d.ts.j2
+++ b/oxidation/bindings/generator/templates/binding_electron_index.d.ts.j2
@@ -80,7 +80,7 @@ export type {{ variant.name }} =
 {% for meth in api.meths %}
 export function {{ meth.name | snake2camel }}(
 {% for arg_name, arg_type in meth.params.items() %}
-    {{ arg_name }}: {{ render_type(arg_type) }}{{ ", " if not loop.last else "" }}
+    {{ arg_name }}: {{ render_type(arg_type) }}{{ "," if not loop.last else "" }}
 {% endfor %}
 ): Promise<{{ render_type(meth.return_type) if meth.return_type else "null" }}>;
 {% endfor %}

--- a/oxidation/bindings/generator/templates/binding_electron_meths.rs.j2
+++ b/oxidation/bindings/generator/templates/binding_electron_meths.rs.j2
@@ -101,15 +101,18 @@ JsFunction
 {%- elif type.kind == "str" -%}
 {{ js_val }}.value({{ mut_cx_ref }})
 {%- elif type.kind == "str_based" -%}
+{
 {% if type.custom_from_rs_string -%}
-{let custom_from_rs_string = {{ type.custom_from_rs_string }};
-match custom_from_rs_string({{ js_val }}.value({{ mut_cx_ref }}))
+    let custom_from_rs_string = {{ type.custom_from_rs_string }};
+    let value: Result<{{ type.namespace }}::{{ type.type }}, {{ type.from_str_error }}> = custom_from_rs_string({{ js_val }}.value({{ mut_cx_ref }}));
 {%- else -%}
-{match {{ js_val }}.value({{ mut_cx_ref }}).parse()
-{%- endif %} {
-    Ok(val) => val,
-    Err(err) => return cx.throw_type_error(err),
-}}
+    let value: Result<{{ type.namespace }}::{{ type.type }}, {{ type.from_str_error }}> = {{ js_val }}.value({{ mut_cx_ref }}).parse();
+{%- endif %}
+    match value {
+        Ok(val) => val,
+        Err(err) => return cx.throw_type_error(err.to_string()),
+    }
+}
 {%- elif type.kind == "bytes" -%}
 {{ js_val }}.as_slice({{ mut_cx_ref }}).to_vec()
 {%- elif type.kind == "struct" -%}
@@ -221,7 +224,7 @@ JsString::try_new({{ mut_cx_ref }},
     let custom_to_rs_string = {{ type.custom_to_rs_string }};
     match custom_to_rs_string({{ rs_value }}) {
         Ok(ok) => ok,
-        Err(err) => return cx.throw_type_error(err),
+        Err(err) => return cx.throw_type_error(err.to_string()),
     }
 }
 {%- else -%}


### PR DESCRIPTION
Rework the electron template when generating the code that do string conversion in rust. This allow a more configurable code that gives more hints to the rust compiler that need it.

> This also correct the error when converted `AddrError` to `TypeError`