### PR TITLE
Simpler web electron error convertion

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -196,11 +196,13 @@ jobs:
         working-directory: oxidation/client
 
       - name: Autobuild for typescript
+        if: steps.js-changes.outputs.run == 'true'
         uses: github/codeql-action/autobuild@168b99b3c22180941ae7dbdd5f5c9678ede476ba # pin v2.2.7
         with:
           working-directory: oxidation/client
 
       - name: Perform CodeQL Analysis
+        if: steps.js-changes.outputs.run == 'true'
         uses: github/codeql-action/analyze@168b99b3c22180941ae7dbdd5f5c9678ede476ba # pin v2.2.7
         with:
           category: /language:typescript

--- a/oxidation/bindings/electron/src/meths.rs
+++ b/oxidation/bindings/electron/src/meths.rs
@@ -177,8 +177,9 @@ fn struct_clientconfig_js_to_rs<'a>(
     let preferred_org_creation_backend_addr = {
         let js_val: Handle<JsString> = obj.get(cx, "preferredOrgCreationBackendAddr")?;
         {
-            let custom_from_rs_string =
-                |s: String| -> Result<_, _> { libparsec::BackendAddr::from_any(&s) };
+            let custom_from_rs_string = |s: String| -> Result<_, String> {
+                libparsec::BackendAddr::from_any(&s).map_err(|e| e.to_string())
+            };
             match custom_from_rs_string(js_val.value(cx)) {
                 Ok(val) => val,
                 Err(err) => return cx.throw_type_error(err),
@@ -791,8 +792,9 @@ fn test_new_testbed(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let test_server = match cx.argument_opt(1) {
         Some(v) => match v.downcast::<JsString, _>(&mut cx) {
             Ok(js_val) => Some({
-                let custom_from_rs_string =
-                    |s: String| -> Result<_, _> { libparsec::BackendAddr::from_any(&s) };
+                let custom_from_rs_string = |s: String| -> Result<_, String> {
+                    libparsec::BackendAddr::from_any(&s).map_err(|e| e.to_string())
+                };
                 match custom_from_rs_string(js_val.value(&mut cx)) {
                     Ok(val) => val,
                     Err(err) => return cx.throw_type_error(err),

--- a/oxidation/bindings/generator/api/common.py
+++ b/oxidation/bindings/generator/api/common.py
@@ -65,12 +65,8 @@ class HumanHandle(StrBasedType):
     pass
 
 
-class Path(StrBasedType):
-    pass
-
-
 class BackendAddr(StrBasedType):
-    custom_from_rs_string = "|s: String| -> Result<_, _> { libparsec::BackendAddr::from_any(&s) }"
+    custom_from_rs_string = "|s: String| -> Result<_, String> { libparsec::BackendAddr::from_any(&s).map_err(|e| e.to_string()) }"
     custom_to_rs_string = "|addr: libparsec::BackendAddr| -> Result<String, &'static str> { Ok(addr.to_url().into()) }"
 
 

--- a/oxidation/bindings/generator/templates/binding_electron_index.d.ts.j2
+++ b/oxidation/bindings/generator/templates/binding_electron_index.d.ts.j2
@@ -80,7 +80,7 @@ export type {{ variant.name }} =
 {% for meth in api.meths %}
 export function {{ meth.name | snake2camel }}(
 {% for arg_name, arg_type in meth.params.items() %}
-    {{ arg_name }}: {{ render_type(arg_type) }}{{ ", " if not loop.last else "" }}
+    {{ arg_name }}: {{ render_type(arg_type) }}{{ "," if not loop.last else "" }}
 {% endfor %}
 ): Promise<{{ render_type(meth.return_type) if meth.return_type else "null" }}>;
 {% endfor %}

--- a/oxidation/bindings/generator/templates/binding_electron_meths.rs.j2
+++ b/oxidation/bindings/generator/templates/binding_electron_meths.rs.j2
@@ -101,15 +101,18 @@ JsFunction
 {%- elif type.kind == "str" -%}
 {{ js_val }}.value({{ mut_cx_ref }})
 {%- elif type.kind == "str_based" -%}
-{% if type.custom_from_rs_string -%}
-{let custom_from_rs_string = {{ type.custom_from_rs_string }};
-match custom_from_rs_string({{ js_val }}.value({{ mut_cx_ref }}))
-{%- else -%}
-{match {{ js_val }}.value({{ mut_cx_ref }}).parse()
-{%- endif %} {
-    Ok(val) => val,
-    Err(err) => return cx.throw_type_error(err),
-}}
+{
+    {% if type.custom_from_rs_string -%}
+    let custom_from_rs_string = {{ type.custom_from_rs_string }};
+    match custom_from_rs_string({{ js_val }}.value({{ mut_cx_ref }}))
+    {%- else -%}
+    match {{ js_val }}.value({{ mut_cx_ref }}).parse()
+    {%- endif %}
+    {
+        Ok(val) => val,
+        Err(err) => return cx.throw_type_error(err),
+    }
+}
 {%- elif type.kind == "bytes" -%}
 {{ js_val }}.as_slice({{ mut_cx_ref }}).to_vec()
 {%- elif type.kind == "struct" -%}

--- a/oxidation/bindings/generator/templates/binding_web_meths.rs.j2
+++ b/oxidation/bindings/generator/templates/binding_web_meths.rs.j2
@@ -58,7 +58,7 @@ let {{ param_name }} =
 {
     let custom_from_rs_string = {{ type.custom_from_rs_string }};
     custom_from_rs_string({{ param_name }})
-        .map_err(|e| TypeError::new(&e.to_string()))
+        .map_err(|e| TypeError::new(e.as_ref()))
 }?;
 {%- else -%}
 {{ param_name }}.parse().map_err(|_| {
@@ -137,7 +137,7 @@ js_val.dyn_into::<JsString>().ok().and_then(|s| s.as_string()).ok_or_else(|| Typ
 .and_then(|x| {
     let custom_from_rs_string = {{ type.custom_from_rs_string }};
     custom_from_rs_string(x)
-.map_err(|e| TypeError::new(&e.to_string())) })
+.map_err(|e| TypeError::new(e.as_ref())) })
 {%- else -%}
 ?.parse()
 {%- endif %}
@@ -181,7 +181,7 @@ JsValue::from_str({%- if type.custom_to_rs_string -%}
     let custom_to_rs_string = {{ type.custom_to_rs_string }};
     match custom_to_rs_string({{ rs_value }}) {
         Ok(ok) => ok,
-        Err(err) => return Err(JsValue::from(TypeError::new(err))),
+        Err(err) => return Err(JsValue::from(TypeError::new(err.as_ref()))),
     }.as_ref()
 }
 {%- else -%}

--- a/oxidation/bindings/generator/templates/client_plugin_definitions.d.ts.j2
+++ b/oxidation/bindings/generator/templates/client_plugin_definitions.d.ts.j2
@@ -91,7 +91,7 @@ export interface LibParsecPlugin {
 {% for meth in api.meths %}
     {{ meth.name | snake2camel }}(
 {% for arg_name, arg_type in meth.params.items() %}
-        {{ arg_name }}: {{ render_type(arg_type) }}{{ ", " if not loop.last else "" }}
+        {{ arg_name }}: {{ render_type(arg_type) }}{{ "," if not loop.last else "" }}
 {% endfor %}
     ): Promise<{{ render_type(meth.return_type) if meth.return_type else "null" }}>;
 {% endfor %}

--- a/oxidation/bindings/web/src/meths.rs
+++ b/oxidation/bindings/web/src/meths.rs
@@ -26,7 +26,7 @@ fn struct_availabledevice_js_to_rs(obj: JsValue) -> Result<libparsec::AvailableD
             .and_then(|x| {
                 let custom_from_rs_string =
                     |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-                custom_from_rs_string(x).map_err(|e| TypeError::new(&e.to_string()))
+                custom_from_rs_string(x).map_err(|e| TypeError::new(e.as_ref()))
             })
             .map_err(|_| TypeError::new("Not a valid Path"))?
     };
@@ -116,7 +116,7 @@ fn struct_availabledevice_rs_to_js(rs_obj: libparsec::AvailableDevice) -> Result
         };
         match custom_to_rs_string(rs_obj.key_file_path) {
             Ok(ok) => ok,
-            Err(err) => return Err(JsValue::from(TypeError::new(err))),
+            Err(err) => return Err(JsValue::from(TypeError::new(err.as_ref()))),
         }
         .as_ref()
     });
@@ -156,7 +156,7 @@ fn struct_clientconfig_js_to_rs(obj: JsValue) -> Result<libparsec::ClientConfig,
             .and_then(|x| {
                 let custom_from_rs_string =
                     |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-                custom_from_rs_string(x).map_err(|e| TypeError::new(&e.to_string()))
+                custom_from_rs_string(x).map_err(|e| TypeError::new(e.as_ref()))
             })
             .map_err(|_| TypeError::new("Not a valid Path"))?
     };
@@ -170,7 +170,7 @@ fn struct_clientconfig_js_to_rs(obj: JsValue) -> Result<libparsec::ClientConfig,
             .and_then(|x| {
                 let custom_from_rs_string =
                     |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-                custom_from_rs_string(x).map_err(|e| TypeError::new(&e.to_string()))
+                custom_from_rs_string(x).map_err(|e| TypeError::new(e.as_ref()))
             })
             .map_err(|_| TypeError::new("Not a valid Path"))?
     };
@@ -184,7 +184,7 @@ fn struct_clientconfig_js_to_rs(obj: JsValue) -> Result<libparsec::ClientConfig,
             .and_then(|x| {
                 let custom_from_rs_string =
                     |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-                custom_from_rs_string(x).map_err(|e| TypeError::new(&e.to_string()))
+                custom_from_rs_string(x).map_err(|e| TypeError::new(e.as_ref()))
             })
             .map_err(|_| TypeError::new("Not a valid Path"))?
     };
@@ -196,9 +196,10 @@ fn struct_clientconfig_js_to_rs(obj: JsValue) -> Result<libparsec::ClientConfig,
             .and_then(|s| s.as_string())
             .ok_or_else(|| TypeError::new("Not a string"))
             .and_then(|x| {
-                let custom_from_rs_string =
-                    |s: String| -> Result<_, _> { libparsec::BackendAddr::from_any(&s) };
-                custom_from_rs_string(x).map_err(|e| TypeError::new(&e.to_string()))
+                let custom_from_rs_string = |s: String| -> Result<_, String> {
+                    libparsec::BackendAddr::from_any(&s).map_err(|e| e.to_string())
+                };
+                custom_from_rs_string(x).map_err(|e| TypeError::new(e.as_ref()))
             })
             .map_err(|_| TypeError::new("Not a valid BackendAddr"))?
     };
@@ -226,7 +227,7 @@ fn struct_clientconfig_rs_to_js(rs_obj: libparsec::ClientConfig) -> Result<JsVal
         };
         match custom_to_rs_string(rs_obj.config_dir) {
             Ok(ok) => ok,
-            Err(err) => return Err(JsValue::from(TypeError::new(err))),
+            Err(err) => return Err(JsValue::from(TypeError::new(err.as_ref()))),
         }
         .as_ref()
     });
@@ -239,7 +240,7 @@ fn struct_clientconfig_rs_to_js(rs_obj: libparsec::ClientConfig) -> Result<JsVal
         };
         match custom_to_rs_string(rs_obj.data_base_dir) {
             Ok(ok) => ok,
-            Err(err) => return Err(JsValue::from(TypeError::new(err))),
+            Err(err) => return Err(JsValue::from(TypeError::new(err.as_ref()))),
         }
         .as_ref()
     });
@@ -252,7 +253,7 @@ fn struct_clientconfig_rs_to_js(rs_obj: libparsec::ClientConfig) -> Result<JsVal
         };
         match custom_to_rs_string(rs_obj.mountpoint_base_dir) {
             Ok(ok) => ok,
-            Err(err) => return Err(JsValue::from(TypeError::new(err))),
+            Err(err) => return Err(JsValue::from(TypeError::new(err.as_ref()))),
         }
         .as_ref()
     });
@@ -267,7 +268,7 @@ fn struct_clientconfig_rs_to_js(rs_obj: libparsec::ClientConfig) -> Result<JsVal
         };
         match custom_to_rs_string(rs_obj.preferred_org_creation_backend_addr) {
             Ok(ok) => ok,
-            Err(err) => return Err(JsValue::from(TypeError::new(err))),
+            Err(err) => return Err(JsValue::from(TypeError::new(err.as_ref()))),
         }
         .as_ref()
     });
@@ -454,7 +455,7 @@ fn variant_deviceaccessparams_js_to_rs(
                         let custom_from_rs_string = |s: String| -> Result<_, &'static str> {
                             Ok(std::path::PathBuf::from(s))
                         };
-                        custom_from_rs_string(x).map_err(|e| TypeError::new(&e.to_string()))
+                        custom_from_rs_string(x).map_err(|e| TypeError::new(e.as_ref()))
                     })
                     .map_err(|_| TypeError::new("Not a valid Path"))?
             };
@@ -480,7 +481,7 @@ fn variant_deviceaccessparams_js_to_rs(
                         let custom_from_rs_string = |s: String| -> Result<_, &'static str> {
                             Ok(std::path::PathBuf::from(s))
                         };
-                        custom_from_rs_string(x).map_err(|e| TypeError::new(&e.to_string()))
+                        custom_from_rs_string(x).map_err(|e| TypeError::new(e.as_ref()))
                     })
                     .map_err(|_| TypeError::new("Not a valid Path"))?
             };
@@ -508,7 +509,7 @@ fn variant_deviceaccessparams_rs_to_js(
                 };
                 match custom_to_rs_string(path) {
                     Ok(ok) => ok,
-                    Err(err) => return Err(JsValue::from(TypeError::new(err))),
+                    Err(err) => return Err(JsValue::from(TypeError::new(err.as_ref()))),
                 }
                 .as_ref()
             });
@@ -526,7 +527,7 @@ fn variant_deviceaccessparams_rs_to_js(
                 };
                 match custom_to_rs_string(path) {
                     Ok(ok) => ok,
-                    Err(err) => return Err(JsValue::from(TypeError::new(err))),
+                    Err(err) => return Err(JsValue::from(TypeError::new(err.as_ref()))),
                 }
                 .as_ref()
             });
@@ -641,7 +642,7 @@ pub fn clientListAvailableDevices(path: String) -> Promise {
         let path = {
             let custom_from_rs_string =
                 |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-            custom_from_rs_string(path).map_err(|e| TypeError::new(&e.to_string()))
+            custom_from_rs_string(path).map_err(|e| TypeError::new(e.as_ref()))
         }?;
 
         let ret = libparsec::client_list_available_devices(&path).await;
@@ -734,9 +735,10 @@ pub fn testNewTestbed(template: String, test_server: Option<String>) -> Promise 
         let test_server = match test_server {
             Some(test_server) => {
                 let test_server = {
-                    let custom_from_rs_string =
-                        |s: String| -> Result<_, _> { libparsec::BackendAddr::from_any(&s) };
-                    custom_from_rs_string(test_server).map_err(|e| TypeError::new(&e.to_string()))
+                    let custom_from_rs_string = |s: String| -> Result<_, String> {
+                        libparsec::BackendAddr::from_any(&s).map_err(|e| e.to_string())
+                    };
+                    custom_from_rs_string(test_server).map_err(|e| TypeError::new(e.as_ref()))
                 }?;
 
                 Some(test_server)
@@ -753,7 +755,7 @@ pub fn testNewTestbed(template: String, test_server: Option<String>) -> Promise 
             };
             match custom_to_rs_string(ret) {
                 Ok(ok) => ok,
-                Err(err) => return Err(JsValue::from(TypeError::new(err))),
+                Err(err) => return Err(JsValue::from(TypeError::new(err.as_ref()))),
             }
             .as_ref()
         }))
@@ -768,7 +770,7 @@ pub fn testDropTestbed(path: String) -> Promise {
         let path = {
             let custom_from_rs_string =
                 |s: String| -> Result<_, &'static str> { Ok(std::path::PathBuf::from(s)) };
-            custom_from_rs_string(path).map_err(|e| TypeError::new(&e.to_string()))
+            custom_from_rs_string(path).map_err(|e| TypeError::new(e.as_ref()))
         }?;
 
         libparsec::test_drop_testbed(&path).await;


### PR DESCRIPTION
- Use `AsRef<str>` to support more error type for `TypeError` and `ctx.throw_type_error`
- Remove extra space added when generating the typescript definition files from the jinja template