### PR TITLE
Configure CI workflows to use cargo sparse checkout when updating its index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ env:
     --exclude=libparsec_bindings_android
     --exclude=libparsec_bindings_web
     --exclude=libparsec_bindings_electron
+  # Cargo will be faster with this configuration.
+  # It will only update it's index for the dependencies that we use.
+  # https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html#cargos-sparse-protocol
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
 

--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -20,6 +20,10 @@ env:
   node-version: 18.13.0
   python-version: 3.9
   poetry-version: 1.3.2
+  # Cargo will be faster with this configuration.
+  # It will only update it's index for the dependencies that we use.
+  # https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html#cargos-sparse-protocol
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
   package-wheel:

--- a/oxidation/bindings/README.md
+++ b/oxidation/bindings/README.md
@@ -45,7 +45,7 @@ You can either install `Android Studio` or `Android tools`
 3. In `File > Settings > Appearance & Behavior > System Settings > Android SDK > SDK Platform > Show Package Details` :
 
     - Install Android SDK `30.0.3`
-    - Install Android NDK `22.1.7171670`
+    - Install Android NDK `23.2.8568313` (see [variable.gradle](../client/android/variables.gradle) for the up to date version to use)
     - Android SDK Command-line Tools
 
 4. Python command should be available in PATH environment variable (used by `rust-android-gradle` plugin)
@@ -107,7 +107,7 @@ You can either install `Android Studio` or `Android tools`
    > Note: the path is `latest/bin` because we install `cmdline-tools` a the tag `latest`.
    > For `9.0`, it will be `9.0/bin` for example.
 
-8. Install Android `SDK-30.0.3` and `NDK-22.1.7171670` by running
+8. Install Android `SDK-30.0.3` and `NDK-23.2.8568313` (see [variable.gradle](../client/android/variables.gradle) for the up to date version to use) by running
 
     ```shell
     sdkmanager --install "ndk;<ndk version>" "build-tools;<build tool version>"


### PR DESCRIPTION
Configuring cargo to use the sparse checkout will allow for faster updates of the cargo index (The index cache will also be smaller).

For reference: <https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html#cargos-sparse-protocol>

Depends on #4250 

