### PR TITLE
Remove `remote_devices_manager` field from `WorkspaceFS` & `WorkspaceFSTimestamped`

### DIFF
--- a/parsec/core/fs/workspacefs/workspacefs.py
+++ b/parsec/core/fs/workspacefs/workspacefs.py
@@ -110,7 +110,6 @@ class WorkspaceFS:
         self.local_storage = local_storage
         self.backend_cmds = backend_cmds
         self.event_bus = event_bus
-        self.remote_devices_manager = remote_devices_manager
         self.preferred_language = preferred_language
         self.sync_locks: dict[EntryID, trio.Lock] = defaultdict(trio.Lock)
         self.remote_loader = RemoteLoader(
@@ -119,7 +118,7 @@ class WorkspaceFS:
             self.get_workspace_entry,
             self.get_previous_workspace_entry,
             self.backend_cmds,
-            self.remote_devices_manager,
+            remote_devices_manager,
             self.local_storage,
             self.event_bus,
         )

--- a/parsec/core/fs/workspacefs/workspacefs_timestamped.py
+++ b/parsec/core/fs/workspacefs/workspacefs_timestamped.py
@@ -21,7 +21,6 @@ class WorkspaceFSTimestamped(WorkspaceFS):
         self.local_storage = workspacefs.local_storage.to_timestamped(timestamp)
         self.backend_cmds = workspacefs.backend_cmds
         self.event_bus = workspacefs.event_bus
-        self.remote_devices_manager = workspacefs.remote_devices_manager
         self.preferred_language = workspacefs.preferred_language
 
         self.timestamp = timestamp


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
