### PR TITLE
Simplify pre-commit checks by using a temp file instead of modifying in place the config

### DIFF
--- a/.github/actions/use-pre-commit/action.yml
+++ b/.github/actions/use-pre-commit/action.yml
@@ -64,9 +64,7 @@ runs:
       run: |
         # Build pre-commit args
         if [ '${{ inputs.check-all-files }}' != 'true' ]; then
-          for file in $ALL_FILES; do
-            ARGS="--files=$file $ARGS"
-          done
+          ARGS="--files $ALL_FILES $ARGS"
         else
           ARGS="--all-files $ARGS"
         fi
@@ -81,6 +79,7 @@ runs:
         python
         ~/.cache/pre-commit/pre-commit.pyz
         run
+        --verbose
         --show-diff-on-failure
         --color=always
         ${{ steps.pre-commit-args.outputs.args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,9 +130,12 @@ jobs:
         timeout-minutes: 5
 
       - name: Patch pre-commit for line-ending
+        id: patched-pre-commit-config
         run: |
-          sed -i '/id: mixed-line-ending/a\        args: [ --fix=lf ]' .pre-commit-config.yaml
-          cat .pre-commit-config.yaml
+          TEMP_FILE=$(mktemp)
+          sed '/id: mixed-line-ending/a\        args: [ --fix=lf ]' .pre-commit-config.yaml > $TEMP_FILE
+          diff --unified .pre-commit-config.yaml $TEMP_FILE || true
+          echo "path=$TEMP_FILE" >> $GITHUB_OUTPUT
 
       - name: Install project (needed for mypy check)
         run: |
@@ -152,6 +155,7 @@ jobs:
               github.ref == 'refs/heads/master'
               || contains(github.ref, 'gh-readonly-queue')
             }}
+          extra-args: --config=${{ steps.patched-pre-commit-config.outputs.path }}
         env:
           SKIP: clippy
         timeout-minutes: 30


### PR DESCRIPTION
Before that we were required to generate the CLI arguments with `--files=...` because `pre-commit` was generating an error caused by the patch we've done before in the job

