### PR TITLE
Use 'opt-level = 1' for all non libparsec_* dependencies in dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,15 @@ tokio = { version = "1.25", features = ["rt", "rt-multi-thread"] }
 lazy_static = "1.4.0"
 futures = "0.3.21"
 
-# Rust unoptimized code is so slow that we customize dev profile to enable some
-# optimizations, otherwise Python tests take forever.
+# Rust unoptimized code is really slow with crypto algorithm and regex compilation,
+# hence we optimize our 3rd party dependencies.
+[profile.dev.package."*"]
+opt-level = 1
+
 [profile.dev-python]
 inherits = "dev"
-opt-level = 1
+# We don't optimize our own crates here given it comes with a high impact on
+# when doing single change recompilation.
 
 # Custom profiles for the CI. The idea here is to try to save compilation time
 # and artifacts size (to keep cache efficient).


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
