### PR TITLE
Remove outdated comment

### DIFF
--- a/oxidation/libparsec/crates/crypto/src/rustcrypto/secret.rs
+++ b/oxidation/libparsec/crates/crypto/src/rustcrypto/secret.rs
@@ -78,9 +78,6 @@ impl SecretKey {
         if digest_size != 5 {
             panic!("Not implemented for this digest size");
         }
-        // TODO investigate why new() is not working
-        // let mut hasher = Blake2bMac40::new(&self.0);
-        // &self.0 always provide the correct key size
         let mut hasher = <Blake2bMac40 as KeyInit>::new_from_slice(self.0.as_ref())
             .unwrap_or_else(|_| unreachable!());
         hasher.update(data);


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
The comment seems to be outdated, because we use `new`

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
