### PR TITLE
Fix CI saving `libparsec-python` during the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,7 @@ jobs:
         if: >-
           steps.should-run-python-jobs.outputs.run == 'true'
           && steps.cache-libparsec.outputs.cache-hit != 'true'
-          && contains(github.ref, 'gh-readonly-queue') != 'true'
+          && !contains(github.ref, 'gh-readonly-queue')
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # pin v3.3.1
         with:
           key: ${{ steps.cache-key.outputs.key }}


### PR DESCRIPTION
During the merge queue, the python jobs where saving the `libparsec-python` artifact but this is a waste of resources given the merge queue branch isn't reused.

The problem was `contains` directly return a boolean and not a boolean string (`'true'` or `'false'`) The previous expression was checking `true != 'true'` which result in `true`

The fix was to remove the `string` comparaison and directly inverting (using the not `!` operator) the result of `contains(..)`

Closes #4304
