### PR TITLE
Add a crate to manage http proxy configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,6 +1237,7 @@ dependencies = [
  "hyper",
  "libparsec_crypto",
  "libparsec_miniprotocol",
+ "libparsec_platform_http_proxy",
  "libparsec_protocol",
  "libparsec_testbed",
  "libparsec_tests_fixtures",
@@ -1375,6 +1376,13 @@ dependencies = [
  "serde_json",
  "tokio",
  "web-sys",
+]
+
+[[package]]
+name = "libparsec_platform_http_proxy"
+version = "0.0.0"
+dependencies = [
+ "reqwest",
 ]
 
 [[package]]

--- a/oxidation/libparsec/crates/client_connection/Cargo.toml
+++ b/oxidation/libparsec/crates/client_connection/Cargo.toml
@@ -22,6 +22,7 @@ libparsec_types = { path = "../types" }
 libparsec_miniprotocol = { path = "../miniprotocol" }
 libparsec_protocol = { path = "../protocol" }
 libparsec_testbed = { path = "../testbed", optional = true }
+libparsec_platform_http_proxy = { path = "../platform_http_proxy" }
 
 # Used to send HTTP request to the server.
 reqwest = { version = "0.11.16", features = ["native-tls-vendored"] }

--- a/oxidation/libparsec/crates/client_connection/src/anonymous_cmds.rs
+++ b/oxidation/libparsec/crates/client_connection/src/anonymous_cmds.rs
@@ -22,10 +22,10 @@ pub struct AnonymousCmds {
 
 impl AnonymousCmds {
     /// Create a new `AnonymousCmds`
-    pub fn new(client: Client, addr: BackendAnonymousAddr) -> Result<Self, url::ParseError> {
+    pub fn new(client: Client, addr: BackendAnonymousAddr) -> Self {
         let url = addr.to_anonymous_http_url();
 
-        Ok(Self { client, addr, url })
+        Self { client, addr, url }
     }
 
     pub fn addr(&self) -> &BackendAnonymousAddr {

--- a/oxidation/libparsec/crates/client_connection/src/authenticated_cmds.rs
+++ b/oxidation/libparsec/crates/client_connection/src/authenticated_cmds.rs
@@ -65,18 +65,18 @@ impl AuthenticatedCmds {
         addr: BackendOrganizationAddr,
         device_id: DeviceID,
         signing_key: SigningKey,
-    ) -> Result<Self, url::ParseError> {
+    ) -> Self {
         let url = addr.to_authenticated_http_url();
 
         let device_id = BASE64_STANDARD.encode(device_id.to_string().as_bytes());
 
-        Ok(Self {
+        Self {
             client,
             addr,
             url,
             device_id,
             signing_key,
-        })
+        }
     }
 
     pub fn addr(&self) -> &BackendOrganizationAddr {

--- a/oxidation/libparsec/crates/client_connection/src/invited_cmds.rs
+++ b/oxidation/libparsec/crates/client_connection/src/invited_cmds.rs
@@ -25,10 +25,10 @@ pub struct InvitedCmds {
 
 impl InvitedCmds {
     /// Create a new `InvitedCmds`
-    pub fn new(client: Client, addr: BackendInvitationAddr) -> Result<Self, url::ParseError> {
+    pub fn new(client: Client, addr: BackendInvitationAddr) -> Self {
         let url = addr.to_invited_url();
 
-        Ok(Self { client, addr, url })
+        Self { client, addr, url }
     }
 
     pub fn addr(&self) -> &BackendInvitationAddr {

--- a/oxidation/libparsec/crates/client_connection/src/lib.rs
+++ b/oxidation/libparsec/crates/client_connection/src/lib.rs
@@ -14,6 +14,8 @@ pub use client::{
 pub use error::{CommandError, CommandResult};
 pub use invited_cmds::InvitedCmds;
 
+pub use libparsec_platform_http_proxy::ProxyConfig;
+
 /// We send the HTTP request with the body encoded in `msgpack` format.
 /// This is the corresponding mime type to convey that info.
 pub const PARSEC_CONTENT_TYPE: &str = "application/msgpack";

--- a/oxidation/libparsec/crates/platform_http_proxy/Cargo.toml
+++ b/oxidation/libparsec/crates/platform_http_proxy/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "libparsec_platform_http_proxy"
+version = "0.0.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+reqwest = { version = "0.11.16", default-features = false }

--- a/oxidation/libparsec/crates/platform_http_proxy/src/lib.rs
+++ b/oxidation/libparsec/crates/platform_http_proxy/src/lib.rs
@@ -1,0 +1,128 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 (eventually AGPL-3.0) 2016-present Scille SAS
+
+#[cfg(test)]
+#[path = "../tests/unit/tests.rs"]
+mod tests;
+
+#[cfg(not(test))]
+const HTTP_PROXY: &str = "HTTP_PROXY";
+#[cfg(test)]
+const HTTP_PROXY: &str = "TEST_HTTP_PROXY";
+#[cfg(not(test))]
+const HTTPS_PROXY: &str = "HTTPS_PROXY";
+#[cfg(test)]
+const HTTPS_PROXY: &str = "TEST_HTTPS_PROXY";
+
+#[derive(Default)]
+pub struct ProxyConfig {
+    http_proxy: Option<String>,
+    https_proxy: Option<String>,
+}
+
+impl ProxyConfig {
+    /// Create a new proxy config with value which is initialized using the env see [ProxyConfig::with_env].
+    /// It's an alias over `ProxyConfig::default().with_env()`.
+    pub fn new_from_env() -> Self {
+        Self::default().with_env()
+    }
+
+    /// Will configure the proxy using the environment variables:
+    ///
+    /// - `HTTP_PROXY` env var. will be used to configure the http proxy.
+    /// - `HTTPS_PROXY` env var. will be used to configure the https proxy.
+    ///
+    /// On `wasm32` this function will do nothing has we cant have access to the env variables since we will be run in a web navigator context.
+    pub fn with_env(self) -> Self {
+        self.with_env_internal()
+    }
+
+    /// Set the http proxy to use, will overwrite the previous configuration.
+    fn with_http_proxy<S: AsRef<str>>(mut self, proxy: S) -> Self {
+        self.http_proxy.replace(proxy.as_ref().to_string());
+        self
+    }
+
+    /// Set the https proxy to use, will overwrite the previous configuration.
+    fn with_https_proxy<S: AsRef<str>>(mut self, proxy: S) -> Self {
+        self.https_proxy.replace(proxy.as_ref().to_string());
+        self
+    }
+}
+
+impl ProxyConfig {
+    /// Configure the http client builder with the proxy configuration,
+    ///
+    /// On `wasm32` this will do nothing has `wasm32` `reqwest` don't expose `Proxy`
+    /// And we likely prefer use the web navigator to handle the proxy configuration.
+    // TODO: In the future we would like to provide an `url` alongside the build to handle the proxy pac.
+    pub fn configure_http_client(
+        &self,
+        builder: reqwest::ClientBuilder,
+    ) -> reqwest::Result<reqwest::ClientBuilder> {
+        self.configure_http_client_internal(builder)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod not_wasm32 {
+    use std::{iter::Chain, option::IntoIter};
+
+    use reqwest::Proxy;
+
+    use super::ProxyConfig;
+
+    impl ProxyConfig {
+        pub(crate) fn with_env_internal(self) -> Self {
+            let cls = if let Ok(proxy) = std::env::var(crate::HTTP_PROXY) {
+                self.with_http_proxy(proxy)
+            } else {
+                self
+            };
+
+            if let Ok(proxy) = std::env::var(crate::HTTPS_PROXY) {
+                cls.with_https_proxy(proxy)
+            } else {
+                cls
+            }
+        }
+
+        pub(crate) fn configure_http_client_internal(
+            &self,
+            mut builder: reqwest::ClientBuilder,
+        ) -> reqwest::Result<reqwest::ClientBuilder> {
+            for proxy in self.get_proxies() {
+                builder = builder.proxy(proxy?);
+            }
+
+            Ok(builder)
+        }
+
+        pub(crate) fn get_proxies(
+            &self,
+        ) -> Chain<IntoIter<reqwest::Result<Proxy>>, IntoIter<reqwest::Result<Proxy>>> {
+            self.http_proxy
+                .as_ref()
+                .map(Proxy::http)
+                .into_iter()
+                .chain(self.https_proxy.as_ref().map(Proxy::https).into_iter())
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm32 {
+    use super::ProxyConfig;
+
+    impl ProxyConfig {
+        pub(crate) fn with_env_internal(self) -> Self {
+            self
+        }
+
+        pub(crate) fn configure_http_client_internal(
+            &self,
+            builder: reqwest::ClientBuilder,
+        ) -> reqwest::Result<reqwest::ClientBuilder> {
+            Ok(builder)
+        }
+    }
+}

--- a/oxidation/libparsec/crates/platform_http_proxy/tests/unit/tests.rs
+++ b/oxidation/libparsec/crates/platform_http_proxy/tests/unit/tests.rs
@@ -1,0 +1,157 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 (eventually AGPL-3.0) 2016-present Scille SAS
+
+//! [reqwest::Proxy] don't implement `PartialEq` so we can't compare that easily.
+//! I'm reduce to perform string comparaison for now.
+
+use crate::ProxyConfig;
+use std::env;
+
+#[test]
+fn test_default() {
+    let config = ProxyConfig::default();
+
+    assert!(config.http_proxy.is_none());
+    assert!(config.https_proxy.is_none());
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn test_with_http_proxy() {
+    let config = ProxyConfig::default().with_http_proxy("https://127.0.0.1:1337");
+
+    let proxies = config
+        .get_proxies()
+        .collect::<reqwest::Result<Vec<_>>>()
+        .expect("The provided proxy value should be OK");
+
+    // We should only have 1 proxy configured.
+    assert!(proxies.len() == 1);
+
+    assert_eq!(
+        format!("{:?}", proxies[0]),
+        format!(
+            "{:?}",
+            reqwest::Proxy::http("https://127.0.0.1:1337").unwrap()
+        )
+    )
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn test_with_https_proxy() {
+    let config = ProxyConfig::default().with_https_proxy("https://127.0.0.1:1337");
+
+    let proxies = config
+        .get_proxies()
+        .collect::<reqwest::Result<Vec<_>>>()
+        .expect("The provided proxy value should be OK");
+
+    // We should only have 1 proxy configured.
+    assert_eq!(proxies.len(), 1, "proxies={:?}", proxies);
+
+    assert_eq!(
+        format!("{:?}", proxies[0]),
+        format!(
+            "{:?}",
+            reqwest::Proxy::https("https://127.0.0.1:1337").unwrap()
+        )
+    )
+}
+
+// This test test every possible combination.
+// It can't be split because that would cause a `TOC/TOU` (Time to Check Time to use) error
+// Where other tests are modifying the env variables `HTTP_PROXY` & `HTTPS_PROXY`.
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn test_with_env() {
+    assert_eq!(env::var(crate::HTTPS_PROXY), Err(env::VarError::NotPresent), "HTTPS_PROXY is already configured. Meaning it could be in use elsewhere, this will likely conflict with this test");
+    assert_eq!(env::var(crate::HTTP_PROXY), Err(env::VarError::NotPresent), "HTTPS_PROXY is already configured. Meaning it could be in use elsewhere, this will likely conflict with this test");
+
+    let config = ProxyConfig::default().with_env();
+
+    let proxies = config
+        .get_proxies()
+        .collect::<reqwest::Result<Vec<_>>>()
+        .expect("We should not have parsed a proxy url");
+
+    assert!(proxies.is_empty());
+
+    env::remove_var(crate::HTTPS_PROXY);
+    env::set_var(crate::HTTP_PROXY, "https://only.http.proxy:1337");
+
+    let config = ProxyConfig::default().with_env();
+
+    let proxies = config
+        .get_proxies()
+        .collect::<reqwest::Result<Vec<_>>>()
+        .expect("The provided proxy value should be OK");
+
+    // We should only have 1 proxy configured.
+    assert!(proxies.len() == 1);
+
+    assert_eq!(
+        format!("{:?}", proxies[0]),
+        format!(
+            "{:?}",
+            reqwest::Proxy::http("https://only.http.proxy:1337").unwrap()
+        )
+    );
+
+    env::remove_var(crate::HTTP_PROXY);
+    env::set_var(crate::HTTPS_PROXY, "https://only.https.proxy:1337");
+
+    let config = ProxyConfig::default().with_env();
+
+    let proxies = config
+        .get_proxies()
+        .collect::<reqwest::Result<Vec<_>>>()
+        .expect("The provided proxy value should be OK");
+
+    // We should only have 1 proxy configured.
+    assert!(proxies.len() == 1);
+
+    assert_eq!(
+        format!("{:?}", proxies[0]),
+        format!(
+            "{:?}",
+            reqwest::Proxy::https("https://only.https.proxy:1337").unwrap()
+        )
+    );
+
+    env::set_var(crate::HTTP_PROXY, "https://both.http.proxy:1337");
+    env::set_var(crate::HTTPS_PROXY, "https://both.https.proxy:1337");
+
+    let config = ProxyConfig::default().with_env();
+
+    let proxies = config
+        .get_proxies()
+        .collect::<reqwest::Result<Vec<_>>>()
+        .expect("The provided proxy value should be OK");
+
+    // We should only have 2 proxies configured.
+    assert_eq!(
+        proxies.len(),
+        2,
+        "Invalid number of parsed proxies: {:?}",
+        proxies
+    );
+
+    let proxies_list = format!("{:?}", proxies);
+
+    // We remove the http proxy from the string
+    let repr_http_proxy = format!(
+        "{:?}",
+        reqwest::Proxy::http("https://both.http.proxy:1337").unwrap()
+    );
+    let proxies_list_without_https_proxy = proxies_list.replacen(&repr_http_proxy, "", 1);
+
+    // We remove the https proxy from the string
+    let repr_https_proxy = format!(
+        "{:?}",
+        reqwest::Proxy::https("https://both.https.proxy:1337").unwrap()
+    );
+    let proxies_list_without_any_proxy =
+        proxies_list_without_https_proxy.replacen(&repr_https_proxy, "", 1);
+
+    assert_eq!(proxies_list_without_any_proxy, "[, ]")
+}

--- a/src/backend_connection/anonymous_cmds.rs
+++ b/src/backend_connection/anonymous_cmds.rs
@@ -31,8 +31,13 @@ impl AnonymousCmds {
             return Err(PyValueError::new_err("Invalid addr provided: accepted addr are BackendOrganizationAddr or BackendPkiEnrollmentAddr"));
         };
 
-        let anonymous_cmds = client_connection::generate_anonymous_client(addr);
-        Ok(Self(Arc::new(anonymous_cmds)))
+        let client_config = client_connection::ProxyConfig::new_from_env();
+
+        client_connection::generate_anonymous_client(addr, client_config)
+            .map_err(|e| {
+                PyValueError::new_err(format!("Failed to generate an anonymous client: {e}"))
+            })
+            .map(|client| Self(Arc::new(client)))
     }
 
     #[getter]

--- a/src/backend_connection/authenticated_cmds.rs
+++ b/src/backend_connection/authenticated_cmds.rs
@@ -1,6 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 (eventually AGPL-3.0) 2016-present Scille SAS
 
-use pyo3::{pyclass, pymethods, PyResult};
+use pyo3::{exceptions::PyValueError, pyclass, pymethods, PyResult};
 use std::{collections::HashMap, num::NonZeroU64, sync::Arc};
 
 use libparsec::{
@@ -34,9 +34,18 @@ impl AuthenticatedCmds {
         device_id: DeviceID,
         signing_key: SigningKey,
     ) -> PyResult<Self> {
-        let auth_cmds =
-            client_connection::generate_authenticated_client(signing_key.0, device_id.0, addr.0);
-        Ok(Self(Arc::new(auth_cmds)))
+        let client_config = client_connection::ProxyConfig::new_from_env();
+
+        client_connection::generate_authenticated_client(
+            signing_key.0,
+            device_id.0,
+            addr.0,
+            client_config,
+        )
+        .map_err(|e| {
+            PyValueError::new_err(format!("Fail to generate an authenticated client: {e}"))
+        })
+        .map(|client| Self(Arc::new(client)))
     }
 
     #[getter]


### PR DESCRIPTION
I've added a new crate `platform_http_proxy` with the only goal to return the list of proxies to apply to an http client from `reqwest`.

For now it only handle the configuration from the env variables `HTTP_PROXY` & `HTTPS_PROXY` + manual configuration.

Note that proxy configuration isn't possible on `wasm`.
`Reqwest` does not expose `Proxy` when compile on `wasm`

Closes #3873