### PR TITLE
Configure `pre-commit` to run `cspell` hook on manual trigger

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,8 @@ repos:
     rev: v6.30.1
     hooks:
       - id: cspell
+        stages:
+          - manual
         args:
           - --config=./.cspell/cspell.config.yml
           - --no-progress


### PR DESCRIPTION
Documentation about [`stages`](https://pre-commit.com/#config-stages)
