### PR TITLE
Fix `backend sequester list_services` CLI output when error is returned

### DIFF
--- a/newsfragments/4368.bugfix.rst
+++ b/newsfragments/4368.bugfix.rst
@@ -1,0 +1,1 @@
+Fix `parsec backend sequester list_services` CLI output when an error is returned

--- a/parsec/backend/cli/sequester.py
+++ b/parsec/backend/cli/sequester.py
@@ -466,11 +466,18 @@ def create_service(
 @click.command(short_help="List available sequester services")
 @click.option("--organization", type=OrganizationID, help="Organization ID", required=True)
 @db_backend_options
+# Add --debug
+@debug_config_options
 def list_services(
-    organization: OrganizationID, db: str, db_max_connections: int, db_min_connections: int
+    organization: OrganizationID,
+    db: str,
+    db_max_connections: int,
+    db_min_connections: int,
+    debug: bool,
 ) -> None:
-    db_config = _get_config(db, db_min_connections, db_max_connections)
-    trio_run(_list_services, db_config, organization, use_asyncio=True)
+    with cli_exception_handler(debug):
+        db_config = _get_config(db, db_min_connections, db_max_connections)
+        trio_run(_list_services, db_config, organization, use_asyncio=True)
 
 
 @click.command(short_help="Disable/re-enable a sequester service")


### PR DESCRIPTION
fix #4368 

# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [X] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
