### PR TITLE
Bump `diesel_derives` to `2.0.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a7ab9d7967e6a1a247ea38aedf88ab808b4ac0c159576bc71866ab8f9f9250"
+checksum = "0ad74fdcf086be3d4fdd142f67937678fe60ed431c3b2f08599e7687269410c4"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",


### PR DESCRIPTION
This will prevent the error tracked in diesel-rs/diesel#3541