### PR TITLE
Increase Retrieve Rust cache timeout (MacOS timeout sometimes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,7 @@ jobs:
           # So we only save the cache on master build given it's the ones that are the
           # most likely to be reused.
           save-if: ${{ github.ref == 'refs/heads/master' }}
-        timeout-minutes: 2
+        timeout-minutes: 5
 
       - name: Install python deps
         if: steps.should-run-python-jobs.outputs.run == 'true'


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->
Why 5 minutes ? Because it's 5 minutes in Rust tests

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [ ] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
