### PR TITLE
Support `--version` flag almost everywhere

### DIFF
--- a/newsfragments/4363.feature.rst
+++ b/newsfragments/4363.feature.rst
@@ -1,0 +1,2 @@
+Handle the CLI flag ``--version`` on parsec sub-command.
+You can now type ``parsec --version`` to get the current version of parsec in a terminal.

--- a/parsec/backend/cli/__init__.py
+++ b/parsec/backend/cli/__init__.py
@@ -15,11 +15,13 @@ from parsec.backend.cli.sequester import (
     list_services,
     update_service,
 )
+from parsec.cli_utils import version_option
 
 __all__ = ("backend_cmd_group",)
 
 
 @click.group(short_help="Handle sequestered organization")
+@version_option
 def backend_sequester_cmd() -> None:
     pass
 
@@ -34,6 +36,7 @@ backend_sequester_cmd.add_command(import_service_certificate, "import_service_ce
 
 
 @click.group()
+@version_option
 def backend_cmd_group() -> None:
     pass
 

--- a/parsec/cli_utils.py
+++ b/parsec/cli_utils.py
@@ -25,6 +25,7 @@ import trio
 from typing_extensions import Concatenate, ParamSpec
 
 from parsec._parsec import DateTime
+from parsec._version import __version__
 from parsec.logging import configure_logging, configure_sentry_logging
 from parsec.utils import open_service_nursery
 
@@ -284,17 +285,23 @@ def sentry_config_options(
     return _sentry_config_options
 
 
+def version_option(fn: Callable[P, R]) -> Callable[P, R]:
+    return click.version_option(version=__version__, prog_name="parsec")(fn)
+
+
 def debug_config_options(fn: Callable[P, R]) -> Callable[Concatenate[bool, P], R]:
-    decorator = cast(
-        Callable[[Callable[P, R]], Callable[Concatenate[bool, P], R]],
+    for decorator in (
         click.option(
             "--debug",
             is_flag=True,
             # Don't prefix with `PARSEC_` given devs are lazy
             envvar="DEBUG",
         ),
-    )
-    return decorator(fn)
+        version_option,
+    ):
+        fn = decorator(fn)  # type: ignore[operator]
+
+    return cast(Callable[Concatenate[bool, P], R], fn)
 
 
 class ParsecDateTimeClickType(click.ParamType):

--- a/parsec/core/cli/__init__.py
+++ b/parsec/core/cli/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import click
 
+from parsec.cli_utils import version_option
 from parsec.core.cli import (
     bootstrap_organization,
     create_organization,
@@ -24,6 +25,7 @@ __all__ = ("core_cmd_group",)
 
 
 @click.group()
+@version_option
 def core_cmd_group() -> None:
     pass
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,9 +67,30 @@ def cli_workspace_role(request):
     return request.param, expected_role
 
 
-def test_version():
+@pytest.mark.parametrize(
+    "args",
+    (
+        ["--version"],
+        ["core", "--version"],
+        ["core", "gui", "--version"],
+        ["backend", "--version"],
+        ["backend", "run", "--version"],
+        ["backend", "sequester", "--version"],
+        ["backend", "sequester", "list_services", "--version"],
+    ),
+    ids=[
+        "root",
+        "core",
+        "core_gui",
+        "backend",
+        "backend_run",
+        "backend_sequester",
+        "backend_sequester_list_services",
+    ],
+)
+def test_version(args: list[str]):
     runner = CliRunner()
-    result = runner.invoke(cli, ["--version"])
+    result = runner.invoke(cli, args)
     assert result.exit_code == 0
     assert f"parsec, version {parsec_version}\n" in result.output
 


### PR DESCRIPTION
Currently, the `--version` is only handled on the root CLI

```
python -m parsec.cli --version
```

But the installed `parsec` app is aliased like that

```
python -m parsec.cli core gui
```

So previously when adding the flag `--version` result in the error described in #4363.

To fix that, I've added `click.version` in the function `debug_config_options` So everywhere this function is used to add the `--debug` flag, we also get the `--version` flag.

I've added more case for the test `test_version` to show it's working with sub-command

Closes #4363
