### PR TITLE
move pip installation for parsec on documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,12 +69,6 @@ Linux Snap
 ----------
 Available for Linux through Snapcraft at https://snapcraft.io/parsec
 
-Python PIP
-----------
-Parsec is also available directly through PIP for both Linux and Windows with Python > 3.9 with the command:
-``pip install parsec-cloud``
-(or, if you need to specify Python 3 pip version, ``pip3 install parsec-cloud``)
-
 Self-hosted
 -----------
 

--- a/docs/locale/fr/LC_MESSAGES/userguide.po
+++ b/docs/locale/fr/LC_MESSAGES/userguide.po
@@ -79,28 +79,6 @@ msgstr ""
 msgid "You can install the snap from the command line by doing:"
 msgstr "Vous pouvez installer le snap depuis la ligne de commande en faisant :"
 
-#: ../../userguide/installation.rst:37
-msgid "Via pip"
-msgstr "Via pip"
-
-#: ../../userguide/installation.rst:39
-msgid ""
-"Given that Parsec is written in Python, an alternative is to install it through "
-"`pip (the Python package repository) <https://pypi.org/project/parsec-cloud/>`_."
-msgstr ""
-"Parsec étant écrit en Python, une autre façon de l'installer est via `pip "
-"(Python package repository) <https://pypi.org/project/parsec-cloud/>`_."
-
-#: ../../userguide/installation.rst:45
-msgid "Or install it with all its dependencies, for the GUI."
-msgstr ""
-"Ou l'installer avec toutes ses dépendances, pour accéder à l'interface "
-"graphique par exemple."
-
-#: ../../userguide/installation.rst:53
-msgid "Parsec requires Python >= 3.9 to work."
-msgstr "Parsec a besoin de Python >= 3.9 pour fonctionner."
-
 #: ../../userguide/installation.rst:57
 msgid "MacOS"
 msgstr "MacOS"

--- a/docs/userguide/installation.rst
+++ b/docs/userguide/installation.rst
@@ -33,25 +33,6 @@ If you are familiar with Snap, you may notice that Parsec snap is provided in cl
         sudo snap install parsec --classic
 
 
-Via pip
--------
-
-Given that Parsec is written in Python, an alternative is to install it through `pip (the Python package repository) <https://pypi.org/project/parsec-cloud/>`_.
-
-.. code-block:: shell
-
-    pip install parsec-cloud
-
-Or install it with all its dependencies, for the GUI.
-
-.. code-block:: shell
-
-    pip install parsec-cloud[all]
-
-.. note::
-
-    Parsec requires Python >= 3.9 to work.
-
 
 MacOS
 -----


### PR DESCRIPTION
# What has changed ?
Closes #4381
<!--I have removed pip from the documentation for parsec installation since it was useless and not used anymore -->