### PR TITLE
Break Cyclic dependencies in `libparsec_types` (fixture mod)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,6 @@ dependencies = [
  "libparsec_crypto",
  "libparsec_platform_async",
  "libparsec_serialization_format",
- "libparsec_tests_utils",
  "paste",
  "percent-encoding",
  "pretty_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,6 +901,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,7 +1311,7 @@ dependencies = [
  "getrandom 0.1.16",
  "getrandom 0.2.6",
  "hex",
- "hex-literal",
+ "hex-literal 0.3.4",
  "lazy_static",
  "libsodium-sys",
  "openssl",
@@ -1350,7 +1356,7 @@ dependencies = [
 name = "libparsec_platform_device_loader"
 version = "0.0.0"
 dependencies = [
- "hex-literal",
+ "hex-literal 0.3.4",
  "libparsec_crypto",
  "libparsec_testbed",
  "libparsec_tests_fixtures",
@@ -1383,7 +1389,7 @@ version = "0.0.0"
 dependencies = [
  "futures",
  "glob",
- "hex-literal",
+ "hex-literal 0.3.4",
  "libparsec_crypto",
  "libparsec_serialization_format",
  "libparsec_tests_fixtures",
@@ -1420,7 +1426,7 @@ name = "libparsec_testbed"
 version = "0.0.0"
 dependencies = [
  "crc32fast",
- "hex-literal",
+ "hex-literal 0.3.4",
  "lazy_static",
  "libparsec_crypto",
  "libparsec_tests_fixtures",
@@ -1435,9 +1441,8 @@ name = "libparsec_tests_fixtures"
 version = "0.0.0"
 dependencies = [
  "env_logger",
- "hex-literal",
+ "hex-literal 0.3.4",
  "lazy_static",
- "libparsec_crypto",
  "libparsec_platform_device_loader",
  "libparsec_platform_local_db",
  "libparsec_testbed",
@@ -1468,12 +1473,12 @@ dependencies = [
  "flate2",
  "fnmatch-regex",
  "glob",
- "hex-literal",
+ "hex-literal 0.4.1",
  "lazy_static",
  "libparsec_crypto",
  "libparsec_platform_async",
  "libparsec_serialization_format",
- "libparsec_tests_fixtures",
+ "libparsec_tests_utils",
  "paste",
  "percent-encoding",
  "pretty_assertions",

--- a/oxidation/libparsec/crates/tests_fixtures/Cargo.toml
+++ b/oxidation/libparsec/crates/tests_fixtures/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-libparsec_crypto = { path = "../crypto" }
-libparsec_types = { path = "../types" }
+libparsec_types = { path = "../types", features = [ "test-fixtures" ] }
 libparsec_testbed = { path = "../testbed" }
 libparsec_tests_macros = { path = "../tests_macros" }
 # Enable testbed support in crates here
@@ -19,5 +18,4 @@ hex-literal = "0.3.3"
 uuid = { version = "1.2.2", features = ["v4", "fast-rng"] }
 lazy_static = "1.4.0"
 regex = "1.7.3"
-
 # No dev-dependencies: this crate is itself only used in other crates' own dev-dependencies

--- a/oxidation/libparsec/crates/tests_fixtures/src/lib.rs
+++ b/oxidation/libparsec/crates/tests_fixtures/src/lib.rs
@@ -1,4 +1,10 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 (eventually AGPL-3.0) 2016-present Scille SAS
+use std::path::PathBuf;
+
+use rstest::fixture;
+use uuid::Uuid;
+
+pub use libparsec_tests_macros::parsec_test;
 
 mod testbed;
 mod trustchain;
@@ -10,218 +16,13 @@ pub use trustchain::*;
 pub use env_logger;
 pub use rstest;
 
-pub use libparsec_tests_macros::parsec_test;
-
-use hex_literal::hex;
-use rstest::fixture;
-use std::path::PathBuf;
-use uuid::Uuid;
-
-use libparsec_crypto::prelude::*;
-use libparsec_types::*;
-
-pub struct Device {
-    pub organization_addr: BackendOrganizationAddr,
-    pub device_id: DeviceID,
-    pub device_label: Option<DeviceLabel>,
-    pub human_handle: Option<HumanHandle>,
-    pub signing_key: SigningKey,
-    pub private_key: PrivateKey,
-    pub profile: UserProfile,
-    pub user_manifest_id: EntryID,
-    pub user_manifest_key: SecretKey,
-    pub local_symkey: SecretKey,
-    pub time_provider: TimeProvider,
-}
-
-impl Device {
-    pub fn user_id(&self) -> &UserID {
-        self.device_id.user_id()
-    }
-
-    pub fn organization_id(&self) -> &OrganizationID {
-        self.organization_addr.organization_id()
-    }
-
-    pub fn verify_key(&self) -> VerifyKey {
-        self.signing_key.verify_key()
-    }
-
-    pub fn public_key(&self) -> PublicKey {
-        self.private_key.public_key()
-    }
-
-    pub fn root_verify_key(&self) -> &VerifyKey {
-        self.organization_addr.root_verify_key()
-    }
-
-    pub fn local_device(&self) -> LocalDevice {
-        LocalDevice {
-            organization_addr: self.organization_addr.to_owned(),
-            device_id: self.device_id.to_owned(),
-            device_label: self.device_label.to_owned(),
-            human_handle: self.human_handle.to_owned(),
-            signing_key: self.signing_key.to_owned(),
-            private_key: self.private_key.to_owned(),
-            profile: self.profile.to_owned(),
-            user_manifest_id: self.user_manifest_id.to_owned(),
-            user_manifest_key: self.user_manifest_key.to_owned(),
-            local_symkey: self.local_symkey.to_owned(),
-            time_provider: self.time_provider.clone(),
-        }
-    }
-}
-
-pub struct Organization {
-    pub addr: BackendOrganizationAddr,
-    pub signing_key: SigningKey,
-}
-
-impl Organization {
-    /// Convert `parsec://example.com:9999/...` -> `parsec://alice_dev1.example.com:9999/...`
-    /// (useful to filter connections so that some devices end up offline)
-    pub fn addr_with_prefixed_host(&self, prefix: &str) -> BackendOrganizationAddr {
-        let mut url = self.addr.to_url();
-        let custom_host = format!("{}.{}", prefix, url.host().unwrap());
-        url.set_host(Some(&custom_host)).unwrap();
-        url.as_ref().parse().unwrap()
-    }
-}
-
-#[fixture]
-#[once]
-pub fn coolorg() -> Organization {
-    Organization {
-        addr: "parsec://example.com:9999/CoolOrg?no_ssl=true&rvk=XYUXM4ZM5SGKSTXNZ4FK7VATZUKZGY7A7LOJ42CXFR32DYL5TO6Qssss".parse().unwrap(),
-        signing_key: SigningKey::from(hex!("b62e7d2a9ed95187975294a1afb1ba345a79e4beb873389366d6c836d20ec5bc")),
-    }
-}
-
-#[fixture]
-#[once]
-pub fn alice(coolorg: &Organization) -> Device {
-    Device {
-        organization_addr: coolorg.addr_with_prefixed_host("alice_dev1"),
-        device_id: "alice@dev1".parse().unwrap(),
-        device_label: Some("My dev1 machine".parse().unwrap()),
-        human_handle: Some(HumanHandle::new("alice@example.com", "Alicey McAliceFace").unwrap()),
-        signing_key: SigningKey::from(hex!(
-            "d544f66ece9c85d5b80275db9124b5f04bb038081622bed139c1e789c5217400"
-        )),
-        private_key: PrivateKey::from(hex!(
-            "74e860967fd90d063ebd64fb1ba6824c4c010099dd37508b7f2875a5db2ef8c9"
-        )),
-        profile: UserProfile::Admin,
-        user_manifest_id: EntryID::from_hex("a4031e8bcdd84df8ae12bd3d05e6e20f").unwrap(),
-        user_manifest_key: SecretKey::from(hex!(
-            "26bf35a98c1e54e90215e154af92a1af2d1142cdd0dba25b990426b0b30b0f9a"
-        )),
-        local_symkey: SecretKey::from(hex!(
-            "125a78618995e2e0f9a19bc8617083c809c03deb5457d5b82df5bcaec9966cd4"
-        )),
-        time_provider: TimeProvider::default(),
-    }
-}
-
-#[fixture]
-#[once]
-pub fn bob(coolorg: &Organization) -> Device {
-    Device {
-        organization_addr: coolorg.addr_with_prefixed_host("bob_dev1"),
-        device_id: "bob@dev1".parse().unwrap(),
-        device_label: Some("My dev1 machine".parse().unwrap()),
-        human_handle: Some(HumanHandle::new("bob@example.com", "Boby McBobFace").unwrap()),
-        signing_key: SigningKey::from(hex!(
-            "85f47472a2c0f30f01b769617db248f3ec8d96a490602a9262f95e9e43432b30"
-        )),
-        private_key: PrivateKey::from(hex!(
-            "16767ec446f2611f971c36f19c2dc11614d853475ac395d6c1d70ba46d07dd49"
-        )),
-        profile: UserProfile::Standard,
-        user_manifest_id: EntryID::from_hex("71568d41afcb4e2380b3d164ace4fb85").unwrap(),
-        user_manifest_key: SecretKey::from(hex!(
-            "65de53d2c6cd965aa53a1ba5cc7e54b331419e6103466121996fa99a97197a48"
-        )),
-        local_symkey: SecretKey::from(hex!(
-            "93f25b18491016f20b10dcf4eb7986716d914653d6ab4e778701c13435e6bdf0"
-        )),
-        time_provider: TimeProvider::default(),
-    }
-}
-
-#[fixture]
-#[once]
-pub fn mallory(coolorg: &Organization) -> Device {
-    Device {
-        organization_addr: coolorg.addr_with_prefixed_host("mallory_dev1"),
-        device_id: "mallory@dev1".parse().unwrap(),
-        device_label: None,
-        human_handle: Some(
-            HumanHandle::new("mallory@example.com", "Mallory McMalloryFace").unwrap(),
-        ),
-        signing_key: SigningKey::generate(),
-        private_key: PrivateKey::generate(),
-        profile: UserProfile::Standard,
-        user_manifest_id: EntryID::default(),
-        user_manifest_key: SecretKey::generate(),
-        local_symkey: SecretKey::generate(),
-        time_provider: TimeProvider::default(),
-    }
-}
-
-#[fixture]
-#[once]
-pub fn user_certificate(alice: &Device, bob: &Device, timestamp: DateTime) -> Vec<u8> {
-    UserCertificate {
-        author: CertificateSignerOwned::User(alice.device_id.clone()),
-        timestamp,
-        user_id: bob.user_id().clone(),
-        human_handle: bob.human_handle.clone(),
-        public_key: bob.public_key(),
-        profile: UserProfile::Standard,
-    }
-    .dump_and_sign(&alice.signing_key)
-}
-
-#[fixture]
-#[once]
-pub fn redacted_user_certificate(alice: &Device, bob: &Device, timestamp: DateTime) -> Vec<u8> {
-    UserCertificate {
-        author: CertificateSignerOwned::User(alice.device_id.clone()),
-        timestamp,
-        user_id: bob.user_id().clone(),
-        human_handle: None,
-        public_key: bob.public_key(),
-        profile: UserProfile::Standard,
-    }
-    .dump_and_sign(&alice.signing_key)
-}
-
-#[fixture]
-#[once]
-pub fn device_certificate(alice: &Device, bob: &Device, timestamp: DateTime) -> Vec<u8> {
-    DeviceCertificate {
-        author: CertificateSignerOwned::User(alice.device_id.clone()),
-        timestamp,
-        device_id: bob.device_id.clone(),
-        device_label: bob.device_label.clone(),
-        verify_key: bob.verify_key(),
-    }
-    .dump_and_sign(&alice.signing_key)
-}
-
-#[fixture]
-#[once]
-pub fn redacted_device_certificate(alice: &Device, bob: &Device, timestamp: DateTime) -> Vec<u8> {
-    DeviceCertificate {
-        author: CertificateSignerOwned::User(alice.device_id.clone()),
-        timestamp,
-        device_id: bob.device_id.clone(),
-        device_label: None,
-        verify_key: bob.verify_key(),
-    }
-    .dump_and_sign(&alice.signing_key)
-}
+pub use libparsec_types::{
+    fixtures::{
+        alice, bob, coolorg, device_certificate, mallory, redacted_device_certificate,
+        redacted_user_certificate, timestamp, user_certificate, Device, Organization,
+    },
+    DateTime,
+};
 
 /// A temporary path that will be removed on drop.
 pub struct TmpPath(PathBuf);
@@ -274,13 +75,4 @@ pub fn tmp_path() -> TmpPath {
     std::fs::create_dir_all(&path).expect("Cannot create tmp_path dir");
 
     TmpPath(path)
-}
-
-// Most unit tests uses the current time as a shorthand to get a datetime object.
-// This is something that is cumbersome (by design !) in our code given it is
-// achieved by doing `TimeProvider::default().now()`.
-// So instead this fixture should be used when a default `DateTime` object is needed.
-#[fixture]
-pub fn timestamp() -> DateTime {
-    "2020-01-01T00:00:00Z".parse().unwrap()
 }

--- a/oxidation/libparsec/crates/types/Cargo.toml
+++ b/oxidation/libparsec/crates/types/Cargo.toml
@@ -47,8 +47,6 @@ hex-literal = { version = "0.4.1", optional = true }
 rstest = { version = "0.17.0", optional = true }
 
 [dev-dependencies]
-libparsec_tests_utils = { path = "../tests_utils" }
-
 pretty_assertions = "1.3.0"
 serde_test = "1.0.159"
 hex-literal = "0.4.1"

--- a/oxidation/libparsec/crates/types/Cargo.toml
+++ b/oxidation/libparsec/crates/types/Cargo.toml
@@ -6,15 +6,14 @@ license = " BUSL-1.1"
 autotests = false
 
 [[test]]
-name = "integration"
+name = "types_integration"
 path = "tests/mod.rs"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 # TODO: this feature is never referenced, is it useful ?
 js = ["uuid/js"]
 test-mock-time = []
+test-fixtures = ["dep:hex-literal", "dep:rstest"]
 
 [dependencies]
 libparsec_crypto = { path = "../crypto" }
@@ -44,13 +43,15 @@ thiserror = "1.0.37"
 email-address-parser = "2.0.0-rc2"
 fnmatch-regex = "0.2.0"
 sha2 = "0.10.6"
+hex-literal = { version = "0.4.1", optional = true }
+rstest = { version = "0.17.0", optional = true }
 
 [dev-dependencies]
-libparsec_tests_fixtures = { path = "../tests_fixtures" }
+libparsec_tests_utils = { path = "../tests_utils" }
 
 pretty_assertions = "1.3.0"
 serde_test = "1.0.159"
-hex-literal = "0.3.3"
+hex-literal = "0.4.1"
 rstest_reuse = "0.4.0"
 rstest = "0.17.0"
 

--- a/oxidation/libparsec/crates/types/src/error.rs
+++ b/oxidation/libparsec/crates/types/src/error.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use thiserror::Error;
 
-use crate::{DateTime, DeviceFileType, DeviceID, EntryID, RealmID, Regex, UserID};
+use crate::{DateTime, DeviceFileType, DeviceID, EntryID, RealmID, UserID};
 use libparsec_crypto::CryptoError;
 
 #[derive(Error, Debug)]
@@ -19,7 +19,7 @@ pub enum RegexError {
     },
 }
 
-pub type RegexResult = Result<Regex, RegexError>;
+pub type RegexResult<T> = Result<T, RegexError>;
 
 #[derive(Error, Debug)]
 pub enum EntryNameError {

--- a/oxidation/libparsec/crates/types/src/fixtures.rs
+++ b/oxidation/libparsec/crates/types/src/fixtures.rs
@@ -1,0 +1,224 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 (eventually AGPL-3.0) 2016-present Scille SAS
+
+use hex_literal::hex;
+use rstest::fixture;
+
+use libparsec_crypto::{PrivateKey, PublicKey, SecretKey, SigningKey, VerifyKey};
+
+use crate::{
+    BackendOrganizationAddr, CertificateSignerOwned, DateTime, DeviceCertificate, DeviceID,
+    DeviceLabel, EntryID, HumanHandle, LocalDevice, OrganizationID, TimeProvider, UserCertificate,
+    UserID, UserProfile,
+};
+
+pub struct Device {
+    pub organization_addr: BackendOrganizationAddr,
+    pub device_id: DeviceID,
+    pub device_label: Option<DeviceLabel>,
+    pub human_handle: Option<HumanHandle>,
+    pub signing_key: SigningKey,
+    pub private_key: PrivateKey,
+    pub profile: UserProfile,
+    pub user_manifest_id: EntryID,
+    pub user_manifest_key: SecretKey,
+    pub local_symkey: SecretKey,
+    pub time_provider: TimeProvider,
+}
+
+impl Device {
+    pub fn user_id(&self) -> &UserID {
+        self.device_id.user_id()
+    }
+
+    pub fn organization_id(&self) -> &OrganizationID {
+        self.organization_addr.organization_id()
+    }
+
+    pub fn verify_key(&self) -> VerifyKey {
+        self.signing_key.verify_key()
+    }
+
+    pub fn public_key(&self) -> PublicKey {
+        self.private_key.public_key()
+    }
+
+    pub fn root_verify_key(&self) -> &VerifyKey {
+        self.organization_addr.root_verify_key()
+    }
+
+    pub fn local_device(&self) -> LocalDevice {
+        LocalDevice {
+            organization_addr: self.organization_addr.to_owned(),
+            device_id: self.device_id.to_owned(),
+            device_label: self.device_label.to_owned(),
+            human_handle: self.human_handle.to_owned(),
+            signing_key: self.signing_key.to_owned(),
+            private_key: self.private_key.to_owned(),
+            profile: self.profile.to_owned(),
+            user_manifest_id: self.user_manifest_id.to_owned(),
+            user_manifest_key: self.user_manifest_key.to_owned(),
+            local_symkey: self.local_symkey.to_owned(),
+            time_provider: self.time_provider.clone(),
+        }
+    }
+}
+
+pub struct Organization {
+    pub addr: BackendOrganizationAddr,
+    pub signing_key: SigningKey,
+}
+
+impl Organization {
+    /// Convert `parsec://example.com:9999/...` -> `parsec://alice_dev1.example.com:9999/...`
+    /// (useful to filter connections so that some devices end up offline)
+    pub fn addr_with_prefixed_host(&self, prefix: &str) -> BackendOrganizationAddr {
+        let mut url = self.addr.to_url();
+        let custom_host = format!("{}.{}", prefix, url.host().unwrap());
+        url.set_host(Some(&custom_host)).unwrap();
+        url.as_ref().parse().unwrap()
+    }
+}
+
+#[fixture]
+#[once]
+pub fn coolorg() -> Organization {
+    Organization {
+        addr: "parsec://example.com:9999/CoolOrg?no_ssl=true&rvk=XYUXM4ZM5SGKSTXNZ4FK7VATZUKZGY7A7LOJ42CXFR32DYL5TO6Qssss".parse().unwrap(),
+        signing_key: SigningKey::from(hex!("b62e7d2a9ed95187975294a1afb1ba345a79e4beb873389366d6c836d20ec5bc")),
+    }
+}
+
+#[fixture]
+#[once]
+pub fn alice(coolorg: &Organization) -> Device {
+    Device {
+        organization_addr: coolorg.addr_with_prefixed_host("alice_dev1"),
+        device_id: "alice@dev1".parse().unwrap(),
+        device_label: Some("My dev1 machine".parse().unwrap()),
+        human_handle: Some(HumanHandle::new("alice@example.com", "Alicey McAliceFace").unwrap()),
+        signing_key: SigningKey::from(hex!(
+            "d544f66ece9c85d5b80275db9124b5f04bb038081622bed139c1e789c5217400"
+        )),
+        private_key: PrivateKey::from(hex!(
+            "74e860967fd90d063ebd64fb1ba6824c4c010099dd37508b7f2875a5db2ef8c9"
+        )),
+        profile: UserProfile::Admin,
+        user_manifest_id: EntryID::from_hex("a4031e8bcdd84df8ae12bd3d05e6e20f").unwrap(),
+        user_manifest_key: SecretKey::from(hex!(
+            "26bf35a98c1e54e90215e154af92a1af2d1142cdd0dba25b990426b0b30b0f9a"
+        )),
+        local_symkey: SecretKey::from(hex!(
+            "125a78618995e2e0f9a19bc8617083c809c03deb5457d5b82df5bcaec9966cd4"
+        )),
+        time_provider: TimeProvider::default(),
+    }
+}
+
+#[fixture]
+#[once]
+pub fn bob(coolorg: &Organization) -> Device {
+    Device {
+        organization_addr: coolorg.addr_with_prefixed_host("bob_dev1"),
+        device_id: "bob@dev1".parse().unwrap(),
+        device_label: Some("My dev1 machine".parse().unwrap()),
+        human_handle: Some(HumanHandle::new("bob@example.com", "Boby McBobFace").unwrap()),
+        signing_key: SigningKey::from(hex!(
+            "85f47472a2c0f30f01b769617db248f3ec8d96a490602a9262f95e9e43432b30"
+        )),
+        private_key: PrivateKey::from(hex!(
+            "16767ec446f2611f971c36f19c2dc11614d853475ac395d6c1d70ba46d07dd49"
+        )),
+        profile: UserProfile::Standard,
+        user_manifest_id: EntryID::from_hex("71568d41afcb4e2380b3d164ace4fb85").unwrap(),
+        user_manifest_key: SecretKey::from(hex!(
+            "65de53d2c6cd965aa53a1ba5cc7e54b331419e6103466121996fa99a97197a48"
+        )),
+        local_symkey: SecretKey::from(hex!(
+            "93f25b18491016f20b10dcf4eb7986716d914653d6ab4e778701c13435e6bdf0"
+        )),
+        time_provider: TimeProvider::default(),
+    }
+}
+
+#[fixture]
+#[once]
+pub fn mallory(coolorg: &Organization) -> Device {
+    Device {
+        organization_addr: coolorg.addr_with_prefixed_host("mallory_dev1"),
+        device_id: "mallory@dev1".parse().unwrap(),
+        device_label: None,
+        human_handle: Some(
+            HumanHandle::new("mallory@example.com", "Mallory McMalloryFace").unwrap(),
+        ),
+        signing_key: SigningKey::generate(),
+        private_key: PrivateKey::generate(),
+        profile: UserProfile::Standard,
+        user_manifest_id: EntryID::default(),
+        user_manifest_key: SecretKey::generate(),
+        local_symkey: SecretKey::generate(),
+        time_provider: TimeProvider::default(),
+    }
+}
+
+// Most unit tests uses the current time as a shorthand to get a datetime object.
+// This is something that is cumbersome (by design !) in our code given it is
+// achieved by doing `TimeProvider::default().now()`.
+// So instead this fixture should be used when a default `DateTime` object is needed.
+#[fixture]
+pub fn timestamp() -> DateTime {
+    "2020-01-01T00:00:00Z".parse().unwrap()
+}
+
+#[fixture]
+#[once]
+pub fn user_certificate(alice: &Device, bob: &Device, timestamp: DateTime) -> Vec<u8> {
+    UserCertificate {
+        author: CertificateSignerOwned::User(alice.device_id.clone()),
+        timestamp,
+        user_id: bob.user_id().clone(),
+        human_handle: bob.human_handle.clone(),
+        public_key: bob.public_key(),
+        profile: UserProfile::Standard,
+    }
+    .dump_and_sign(&alice.signing_key)
+}
+
+#[fixture]
+#[once]
+pub fn redacted_user_certificate(alice: &Device, bob: &Device, timestamp: DateTime) -> Vec<u8> {
+    UserCertificate {
+        author: CertificateSignerOwned::User(alice.device_id.clone()),
+        timestamp,
+        user_id: bob.user_id().clone(),
+        human_handle: None,
+        public_key: bob.public_key(),
+        profile: UserProfile::Standard,
+    }
+    .dump_and_sign(&alice.signing_key)
+}
+
+#[fixture]
+#[once]
+pub fn device_certificate(alice: &Device, bob: &Device, timestamp: DateTime) -> Vec<u8> {
+    DeviceCertificate {
+        author: CertificateSignerOwned::User(alice.device_id.clone()),
+        timestamp,
+        device_id: bob.device_id.clone(),
+        device_label: bob.device_label.clone(),
+        verify_key: bob.verify_key(),
+    }
+    .dump_and_sign(&alice.signing_key)
+}
+
+#[fixture]
+#[once]
+pub fn redacted_device_certificate(alice: &Device, bob: &Device, timestamp: DateTime) -> Vec<u8> {
+    DeviceCertificate {
+        author: CertificateSignerOwned::User(alice.device_id.clone()),
+        timestamp,
+        device_id: bob.device_id.clone(),
+        device_label: None,
+        verify_key: bob.verify_key(),
+    }
+    .dump_and_sign(&alice.signing_key)
+}

--- a/oxidation/libparsec/crates/types/src/lib.rs
+++ b/oxidation/libparsec/crates/types/src/lib.rs
@@ -3,6 +3,11 @@
 #[macro_use]
 extern crate lazy_static;
 
+#[cfg(any(test, feature = "test-fixtures"))]
+/// We define test fixture in that module.
+/// We defined those fixtures here and not in a different crate to prevent cyclic dependencies.
+pub mod fixtures;
+
 mod addr;
 mod certif;
 pub mod data_macros;

--- a/oxidation/libparsec/crates/types/src/regex.rs
+++ b/oxidation/libparsec/crates/types/src/regex.rs
@@ -94,7 +94,7 @@ mod tests {
     use std::{fs, path::Path};
 
     use crate::regex::Regex;
-    use libparsec_tests_fixtures::{tmp_path, TmpPath};
+    use libparsec_tests_utils::{tmp_path, TmpPath};
     use rstest::rstest;
 
     #[rstest]

--- a/oxidation/libparsec/crates/types/src/regex.rs
+++ b/oxidation/libparsec/crates/types/src/regex.rs
@@ -1,7 +1,14 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 (eventually AGPL-3.0) 2016-present Scille SAS
 
+use std::{
+    collections::HashSet,
+    fmt::Display,
+    fs,
+    io::{BufRead, BufReader, Read},
+    path::Path,
+};
+
 use crate::{RegexError, RegexResult};
-use std::{collections::HashSet, fmt::Display, fs, path::Path};
 
 #[derive(Clone, Debug)]
 pub struct Regex(pub Vec<regex::Regex>);
@@ -15,28 +22,44 @@ fn escape_globing_pattern(string: &str) -> String {
 
 impl Regex {
     /// Returns a regex which is built from a file that contains shell like patterns
-    pub fn from_file(file_path: &Path) -> RegexResult {
-        let file_content =
-            fs::read_to_string(file_path).map_err(|err| RegexError::PatternFileIOError {
+    pub fn from_file(file_path: &Path) -> RegexResult<Self> {
+        let reader = fs::File::open(file_path).map(BufReader::new).map_err(|e| {
+            RegexError::PatternFileIOError {
                 file_path: file_path.to_path_buf(),
-                err,
-            })?;
+                err: e,
+            }
+        })?;
 
-        Ok(Self(
-            file_content
-                .lines()
-                .map(str::trim)
-                .filter(|l| *l != "\n" && !l.starts_with('#'))
-                .map(|l| {
-                    fnmatch_regex::glob_to_regex(&escape_globing_pattern(l))
-                        .map_err(|err| RegexError::GlobPatternError { err })
-                })
-                .collect::<Result<Vec<regex::Regex>, RegexError>>()?,
-        ))
+        Self::from_glob_reader(file_path, reader)
+    }
+
+    pub fn from_glob_reader<P: AsRef<Path>, R: Read>(
+        path: P,
+        reader: BufReader<R>,
+    ) -> RegexResult<Self> {
+        reader
+            .lines()
+            .filter_map(|line| match line {
+                Ok(line) => {
+                    let l = line.trim();
+
+                    if l != "\n" && !l.starts_with('#') {
+                        Some(from_glob_pattern(l))
+                    } else {
+                        None
+                    }
+                }
+                Err(e) => Some(Err(RegexError::PatternFileIOError {
+                    file_path: path.as_ref().to_path_buf(),
+                    err: e,
+                })),
+            })
+            .collect::<RegexResult<Vec<regex::Regex>>>()
+            .map(Self)
     }
 
     /// Returns a regex which is an union of all regexes from `raw_regexes` slice parameter
-    pub fn from_raw_regexes(raw_regexes: &[&str]) -> RegexResult {
+    pub fn from_raw_regexes(raw_regexes: &[&str]) -> RegexResult<Self> {
         Ok(Self(
             raw_regexes
                 .iter()
@@ -46,19 +69,23 @@ impl Regex {
     }
 
     /// Returns a regex from a glob pattern
-    pub fn from_glob_pattern(pattern: &str) -> RegexResult {
-        let escaped_str = escape_globing_pattern(pattern);
-        Ok(Regex(vec![fnmatch_regex::glob_to_regex(&escaped_str)
-            .map_err(|err| RegexError::GlobPatternError { err })?]))
+    pub fn from_glob_pattern(pattern: &str) -> RegexResult<Self> {
+        from_glob_pattern(pattern).map(|re| Self(vec![re]))
     }
 
-    pub fn from_regex_str(regex_str: &str) -> RegexResult {
+    pub fn from_regex_str(regex_str: &str) -> RegexResult<Self> {
         Self::from_raw_regexes(&[regex_str])
     }
 
     pub fn is_match(&self, string: &str) -> bool {
         self.0.iter().any(|r| r.is_match(string))
     }
+}
+
+/// Parse a glob pattern like `*.rs` and convert it to an regex.
+fn from_glob_pattern(pattern: &str) -> RegexResult<regex::Regex> {
+    let escaped_str = escape_globing_pattern(pattern);
+    fnmatch_regex::glob_to_regex(&escaped_str).map_err(|err| RegexError::GlobPatternError { err })
 }
 
 impl PartialEq for Regex {
@@ -91,11 +118,14 @@ impl Display for Regex {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, path::Path};
+    use std::{
+        io::{BufReader, Cursor},
+        path::Path,
+    };
+
+    use rstest::rstest;
 
     use crate::regex::Regex;
-    use libparsec_tests_utils::{tmp_path, TmpPath};
-    use rstest::rstest;
 
     #[rstest]
     #[case::base("*.rs\n*.py", "base.tmp")]
@@ -109,14 +139,10 @@ mod tests {
         "# This contains patterns\n## yes\n   *.rs\n\n  \n\n*.py  ",
         "ignore_comment.tmp"
     )]
-    fn from_pattern_file_content(
-        tmp_path: TmpPath,
-        #[case] file_content: &str,
-        #[case] filename: &str,
-    ) {
-        let filepath = tmp_path.join(filename);
-        fs::write(&filepath, file_content).unwrap();
-        let regex = Regex::from_file(&filepath).expect("Regex should be valid");
+    fn from_pattern_file_content(#[case] file_content: &str, #[case] filename: &str) {
+        let reader = Cursor::new(file_content.to_string());
+        let regex = Regex::from_glob_reader(filename, BufReader::new(reader))
+            .expect("Regex should be valid");
 
         assert!(regex.is_match("file.py"));
         assert!(regex.is_match("file.rs"));

--- a/oxidation/libparsec/crates/types/tests/mod.rs
+++ b/oxidation/libparsec/crates/types/tests/mod.rs
@@ -3,9 +3,14 @@
 // Functions using rstest parametrize ignores `#[warn(clippy::too_many_arguments)]`
 // decorator, so we must do global ignore instead :(
 #![allow(clippy::too_many_arguments)]
-// Needed to expose `rstest_reuse::template` proc macro
-#![allow(clippy::single_component_path_imports)]
+#[allow(clippy::single_component_path_imports)]
+/// Needed to expose `rstest_reuse::template` proc macro
 use rstest_reuse;
+
+use libparsec_types::*;
+
+#[path = "../src/fixtures.rs"]
+mod fixtures;
 
 mod test_addr;
 mod test_certif;

--- a/oxidation/libparsec/crates/types/tests/test_addr.rs
+++ b/oxidation/libparsec/crates/types/tests/test_addr.rs
@@ -1,13 +1,19 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 (eventually AGPL-3.0) 2016-present Scille SAS
 
-use pretty_assertions::assert_eq;
-use rstest::rstest;
-use rstest_reuse::*;
-use serde_test::{assert_tokens, Token};
 use std::str::FromStr;
 
+use pretty_assertions::assert_eq;
+use rstest::rstest;
+use rstest_reuse::{apply, template};
+use serde_test::{assert_tokens, Token};
+
 use libparsec_crypto::SigningKey;
-use libparsec_types::*;
+
+use crate::{
+    AddrError, BackendAddr, BackendInvitationAddr, BackendOrganizationAddr,
+    BackendOrganizationBootstrapAddr, BackendOrganizationFileLinkAddr, InvitationType,
+    OrganizationID,
+};
 
 const ORG: &str = "MyOrg";
 const RVK: &str = "P25GRG3XPSZKBEKXYQFBOLERWQNEDY3AO43MVNZCLPXPKN63JRYQssss";
@@ -164,7 +170,7 @@ fn addr_with_org(testbed: &dyn Testbed) {}
  * Actual tests
  */
 
-#[apply(all_addr)]
+#[rstest_reuse::apply(all_addr)]
 fn test_good_addr(testbed: &dyn Testbed) {
     testbed.assert_addr_ok(&testbed.url());
 }

--- a/oxidation/libparsec/crates/types/tests/test_certif.rs
+++ b/oxidation/libparsec/crates/types/tests/test_certif.rs
@@ -5,8 +5,13 @@ use pretty_assertions::assert_eq;
 use rstest::rstest;
 
 use libparsec_crypto::{SequesterPublicKeyDer, SequesterVerifyKeyDer};
-use libparsec_tests_fixtures::{alice, bob, Device};
-use libparsec_types::*;
+
+use crate::{
+    fixtures::{alice, bob, Device},
+    CertificateSignerOwned, CertificateSignerRef, DeviceCertificate, RealmID, RealmRole,
+    RealmRoleCertificate, RevokedUserCertificate, SequesterAuthorityCertificate,
+    SequesterServiceCertificate, SequesterServiceID, UserCertificate, UserProfile,
+};
 
 // TODO: check serde output to ensure handling of Option<T> depending of
 // default/missing policy

--- a/oxidation/libparsec/crates/types/tests/test_id.rs
+++ b/oxidation/libparsec/crates/types/tests/test_id.rs
@@ -3,7 +3,7 @@
 use rstest::rstest;
 use std::str::FromStr;
 
-use libparsec_types::{DeviceID, DeviceLabel, DeviceName, OrganizationID, UserID};
+use crate::{DeviceID, DeviceLabel, DeviceName, OrganizationID, UserID};
 
 #[rstest]
 #[case("foo42")]

--- a/oxidation/libparsec/crates/types/tests/test_invite.rs
+++ b/oxidation/libparsec/crates/types/tests/test_invite.rs
@@ -3,9 +3,13 @@
 use hex_literal::hex;
 use rstest::rstest;
 
-use libparsec_crypto::*;
-use libparsec_tests_fixtures::{bob, Device};
-use libparsec_types::*;
+use libparsec_crypto::SecretKey;
+
+use crate::{
+    fixtures::{bob, Device},
+    InviteDeviceConfirmation, InviteDeviceData, InviteUserConfirmation, InviteUserData,
+    UserProfile,
+};
 
 #[rstest]
 #[case::normal(

--- a/oxidation/libparsec/crates/types/tests/test_local_device.rs
+++ b/oxidation/libparsec/crates/types/tests/test_local_device.rs
@@ -3,10 +3,12 @@
 use hex_literal::hex;
 use rstest::rstest;
 
-use libparsec_crypto::*;
-use libparsec_types::*;
+use libparsec_crypto::SecretKey;
 
-use libparsec_tests_fixtures::{alice, Device};
+use crate::{
+    fixtures::{alice, Device},
+    LocalDevice, UserProfile,
+};
 
 #[rstest]
 #[case::admin(

--- a/oxidation/libparsec/crates/types/tests/test_local_device_file.rs
+++ b/oxidation/libparsec/crates/types/tests/test_local_device_file.rs
@@ -3,8 +3,8 @@
 use hex_literal::hex;
 use rstest::rstest;
 
-use libparsec_tests_fixtures::{alice, Device};
-use libparsec_types::{
+use crate::{
+    fixtures::{alice, Device},
     AvailableDevice, DeviceFile, DeviceFilePassword, DeviceFileRecovery, DeviceFileSmartcard,
     DeviceFileType, HumanHandle, LegacyDeviceFile, LegacyDeviceFilePassword, OrganizationID,
 };

--- a/oxidation/libparsec/crates/types/tests/test_local_manifest.rs
+++ b/oxidation/libparsec/crates/types/tests/test_local_manifest.rs
@@ -8,9 +8,13 @@ use std::{
 };
 
 use libparsec_crypto::prelude::*;
-use libparsec_types::*;
 
-use libparsec_tests_fixtures::{alice, timestamp, Device};
+use crate::{
+    fixtures::{alice, timestamp, Device},
+    BlockAccess, BlockID, Blocksize, Chunk, ChunkID, DateTime, DeviceID, EntryID, EntryName,
+    FileManifest, FolderManifest, LocalFileManifest, LocalFolderManifest, LocalUserManifest,
+    LocalWorkspaceManifest, RealmRole, Regex, UserManifest, WorkspaceEntry, WorkspaceManifest,
+};
 
 type AliceLocalFileManifest = Box<dyn FnOnce(&Device) -> (&'static [u8], LocalFileManifest)>;
 type AliceLocalFolderManifest = Box<dyn FnOnce(&Device) -> (&'static [u8], LocalFolderManifest)>;

--- a/oxidation/libparsec/crates/types/tests/test_manifest.rs
+++ b/oxidation/libparsec/crates/types/tests/test_manifest.rs
@@ -1,12 +1,17 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 (eventually AGPL-3.0) 2016-present Scille SAS
 
-use hex_literal::hex;
-use rstest::rstest;
 use std::{collections::HashMap, num::NonZeroU64, str::FromStr};
 
+use hex_literal::hex;
+use rstest::rstest;
+
 use libparsec_crypto::*;
-use libparsec_tests_fixtures::{alice, Device};
-use libparsec_types::*;
+
+use crate::{
+    fixtures::{alice, Device},
+    BlockAccess, BlockID, Blocksize, DateTime, DeviceID, DeviceName, EntryID, FileManifest,
+    FolderManifest, Manifest, RealmRole, UserID, UserManifest, WorkspaceEntry, WorkspaceManifest,
+};
 
 #[rstest]
 fn serde_file_manifest(alice: &Device) {

--- a/oxidation/libparsec/crates/types/tests/test_message.rs
+++ b/oxidation/libparsec/crates/types/tests/test_message.rs
@@ -3,9 +3,12 @@
 use hex_literal::hex;
 use rstest::rstest;
 
-use libparsec_crypto::*;
-use libparsec_tests_fixtures::{alice, bob, Device};
-use libparsec_types::*;
+use libparsec_crypto::SecretKey;
+
+use crate::{
+    fixtures::{alice, bob, Device},
+    EntryID, MessageContent,
+};
 
 #[rstest]
 fn serde_sharing_granted_message(alice: &Device, bob: &Device) {

--- a/oxidation/libparsec/crates/types/tests/test_pki.rs
+++ b/oxidation/libparsec/crates/types/tests/test_pki.rs
@@ -5,8 +5,9 @@ use rstest::rstest;
 use std::{collections::HashMap, str::FromStr};
 
 use libparsec_crypto::{PublicKey, VerifyKey};
-use libparsec_tests_fixtures::{alice, Device};
-use libparsec_types::{
+
+use crate::{
+    fixtures::{alice, Device},
     BackendPkiEnrollmentAddr, DeviceID, DeviceLabel, EnrollmentID, LocalPendingEnrollment,
     PkiEnrollmentAnswerPayload, PkiEnrollmentSubmitPayload, UserProfile, X509Certificate,
 };

--- a/oxidation/libparsec/crates/types/tests/test_sas_code.rs
+++ b/oxidation/libparsec/crates/types/tests/test_sas_code.rs
@@ -4,7 +4,8 @@ use hex_literal::hex;
 use rstest::rstest;
 
 use libparsec_crypto::*;
-use libparsec_types::*;
+
+use crate::SASCode;
 
 #[test]
 fn generate_sas_codes() {

--- a/oxidation/libparsec/crates/types/tests/test_time.rs
+++ b/oxidation/libparsec/crates/types/tests/test_time.rs
@@ -1,6 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 (eventually AGPL-3.0) 2016-present Scille SAS
 
-use libparsec_types::{DateTime, Duration};
+use crate::{DateTime, Duration};
 
 type Part = (Box<dyn Fn(DateTime) -> u32>, i64);
 


### PR DESCRIPTION
`libparsec_types` required `libparsec_tests_fixtures` which required `libparsec_types` itself causing an error on rust-analyzer.

To resolve that, I have introduced the module `fixture` that define the fixture that where used during the test of libparsec_types and re-expose them in `libparsec_tests_fixtures`.

rust-analyze fell really more snappy now when working on `libparsec_types`, so I've made some compilation benchmark when building the test for `libparsec_types`

On master: `11.5s`
On this branch: `6.8s`

> Both with `jobs=16 ncpu=16`

This also simplify a lot the dev-dependencies tree.

<details>
  <summary>Cargo tree of `libparsec_types` diff between `master` and this branch</summary>

  ```diff
  --- /tmp/libparsec_types_deps_master	2023-04-05 17:43:08.239169906 +0200
  +++ /tmp/libparsec_types_deps_branch	2023-04-05 17:42:57.490062480 +0200
  @@ -313,15 +313,7 @@
  │   │   ├── futures-task v0.3.28
  │   │   └── futures-util v0.3.28 (*)
  │   └── tokio v1.27.0
  -│       ├── bytes v1.1.0
  -│       ├── libc v0.2.140
  -│       ├── mio v0.8.4
  -│       │   ├── libc v0.2.140
  -│       │   └── log v0.4.17
  -│       │       └── cfg-if v1.0.0
  │       ├── pin-project-lite v0.2.9
  -│       ├── socket2 v0.4.9
  -│       │   └── libc v0.2.140
  │       └── tokio-macros v2.0.0 (proc-macro)
  │           ├── proc-macro2 v1.0.54 (*)
  │           ├── quote v1.0.26 (*)
  @@ -390,183 +382,8 @@
  [build-dependencies]
  └── glob v0.3.1
  [dev-dependencies]
  -├── hex-literal v0.3.4 (proc-macro)
  -├── libparsec_tests_fixtures v0.0.0 (/home/andesite/Documents/parsec-cloud/oxidation/libparsec/crates/tests_fixtures)
  -│   ├── env_logger v0.10.0
  -│   │   ├── humantime v2.1.0
  -│   │   ├── is-terminal v0.4.1
  -│   │   │   ├── io-lifetimes v1.0.3
  -│   │   │   │   └── libc v0.2.140
  -│   │   │   └── rustix v0.36.4
  -│   │   │       ├── bitflags v1.3.2
  -│   │   │       ├── io-lifetimes v1.0.3 (*)
  -│   │   │       ├── libc v0.2.140
  -│   │   │       └── linux-raw-sys v0.1.3
  -│   │   ├── log v0.4.17 (*)
  -│   │   ├── regex v1.7.3 (*)
  -│   │   └── termcolor v1.1.3
  -│   ├── hex-literal v0.3.4 (proc-macro)
  -│   ├── lazy_static v1.4.0 (*)
  -│   ├── libparsec_crypto v0.0.0 (/home/andesite/Documents/parsec-cloud/oxidation/libparsec/crates/crypto) (*)
  -│   ├── libparsec_platform_device_loader v0.0.0 (/home/andesite/Documents/parsec-cloud/oxidation/libparsec/crates/platform_device_loader)
  -│   │   ├── libparsec_crypto v0.0.0 (/home/andesite/Documents/parsec-cloud/oxidation/libparsec/crates/crypto) (*)
  -│   │   ├── libparsec_testbed v0.0.0 (/home/andesite/Documents/parsec-cloud/oxidation/libparsec/crates/testbed)
  -│   │   │   ├── crc32fast v1.3.2 (*)
  -│   │   │   ├── hex-literal v0.3.4 (proc-macro)
  -│   │   │   ├── lazy_static v1.4.0 (*)
  -│   │   │   ├── libparsec_crypto v0.0.0 (/home/andesite/Documents/parsec-cloud/oxidation/libparsec/crates/crypto) (*)
  -│   │   │   ├── libparsec_types v0.0.0 (/home/andesite/Documents/parsec-cloud/oxidation/libparsec/crates/types) (*)
  -│   │   │   ├── reqwest v0.11.16
  -│   │   │   │   ├── base64 v0.21.0
  -│   │   │   │   ├── bytes v1.1.0
  -│   │   │   │   ├── encoding_rs v0.8.31
  -│   │   │   │   │   └── cfg-if v1.0.0
  -│   │   │   │   ├── futures-core v0.3.28
  -│   │   │   │   ├── futures-util v0.3.28 (*)
  -│   │   │   │   ├── h2 v0.3.13
  -│   │   │   │   │   ├── bytes v1.1.0
  -│   │   │   │   │   ├── fnv v1.0.7
  -│   │   │   │   │   ├── futures-core v0.3.28
  -│   │   │   │   │   ├── futures-sink v0.3.28
  -│   │   │   │   │   ├── futures-util v0.3.28 (*)
  -│   │   │   │   │   ├── http v0.2.8
  -│   │   │   │   │   │   ├── bytes v1.1.0
  -│   │   │   │   │   │   ├── fnv v1.0.7
  -│   │   │   │   │   │   └── itoa v1.0.2
  -│   │   │   │   │   ├── indexmap v1.9.1
  -│   │   │   │   │   │   └── hashbrown v0.12.1
  -│   │   │   │   │   │   [build-dependencies]
  -│   │   │   │   │   │   └── autocfg v1.1.0
  -│   │   │   │   │   ├── slab v0.4.6
  -│   │   │   │   │   ├── tokio v1.27.0 (*)
  -│   │   │   │   │   ├── tokio-util v0.7.2
  -│   │   │   │   │   │   ├── bytes v1.1.0
  -│   │   │   │   │   │   ├── futures-core v0.3.28
  -│   │   │   │   │   │   ├── futures-sink v0.3.28
  -│   │   │   │   │   │   ├── pin-project-lite v0.2.9
  -│   │   │   │   │   │   ├── tokio v1.27.0 (*)
  -│   │   │   │   │   │   └── tracing v0.1.34
  -│   │   │   │   │   │       ├── cfg-if v1.0.0
  -│   │   │   │   │   │       ├── pin-project-lite v0.2.9
  -│   │   │   │   │   │       ├── tracing-attributes v0.1.21 (proc-macro)
  -│   │   │   │   │   │       │   ├── proc-macro2 v1.0.54 (*)
  -│   │   │   │   │   │       │   ├── quote v1.0.26 (*)
  -│   │   │   │   │   │       │   └── syn v1.0.109 (*)
  -│   │   │   │   │   │       └── tracing-core v0.1.26
  -│   │   │   │   │   │           └── lazy_static v1.4.0 (*)
  -│   │   │   │   │   └── tracing v0.1.34 (*)
  -│   │   │   │   ├── http v0.2.8 (*)
  -│   │   │   │   ├── http-body v0.4.5
  -│   │   │   │   │   ├── bytes v1.1.0
  -│   │   │   │   │   ├── http v0.2.8 (*)
  -│   │   │   │   │   └── pin-project-lite v0.2.9
  -│   │   │   │   ├── hyper v0.14.22
  -│   │   │   │   │   ├── bytes v1.1.0
  -│   │   │   │   │   ├── futures-channel v0.3.28 (*)
  -│   │   │   │   │   ├── futures-core v0.3.28
  -│   │   │   │   │   ├── futures-util v0.3.28 (*)
  -│   │   │   │   │   ├── h2 v0.3.13 (*)
  -│   │   │   │   │   ├── http v0.2.8 (*)
  -│   │   │   │   │   ├── http-body v0.4.5 (*)
  -│   │   │   │   │   ├── httparse v1.8.0
  -│   │   │   │   │   ├── httpdate v1.0.2
  -│   │   │   │   │   ├── itoa v1.0.2
  -│   │   │   │   │   ├── pin-project-lite v0.2.9
  -│   │   │   │   │   ├── socket2 v0.4.9 (*)
  -│   │   │   │   │   ├── tokio v1.27.0 (*)
  -│   │   │   │   │   ├── tower-service v0.3.1
  -│   │   │   │   │   ├── tracing v0.1.34 (*)
  -│   │   │   │   │   └── want v0.3.0
  -│   │   │   │   │       ├── log v0.4.17 (*)
  -│   │   │   │   │       └── try-lock v0.2.3
  -│   │   │   │   ├── hyper-tls v0.5.0
  -│   │   │   │   │   ├── bytes v1.1.0
  -│   │   │   │   │   ├── hyper v0.14.22 (*)
  -│   │   │   │   │   ├── native-tls v0.2.10
  -│   │   │   │   │   │   ├── log v0.4.17 (*)
  -│   │   │   │   │   │   ├── openssl v0.10.48
  -│   │   │   │   │   │   │   ├── bitflags v1.3.2
  -│   │   │   │   │   │   │   ├── cfg-if v1.0.0
  -│   │   │   │   │   │   │   ├── foreign-types v0.3.2
  -│   │   │   │   │   │   │   │   └── foreign-types-shared v0.1.1
  -│   │   │   │   │   │   │   ├── libc v0.2.140
  -│   │   │   │   │   │   │   ├── once_cell v1.17.1
  -│   │   │   │   │   │   │   ├── openssl-macros v0.1.0 (proc-macro)
  -│   │   │   │   │   │   │   │   ├── proc-macro2 v1.0.54 (*)
  -│   │   │   │   │   │   │   │   ├── quote v1.0.26 (*)
  -│   │   │   │   │   │   │   │   └── syn v1.0.109 (*)
  -│   │   │   │   │   │   │   └── openssl-sys v0.9.83
  -│   │   │   │   │   │   │       └── libc v0.2.140
  -│   │   │   │   │   │   │       [build-dependencies]
  -│   │   │   │   │   │   │       ├── autocfg v1.1.0
  -│   │   │   │   │   │   │       ├── cc v1.0.73
  -│   │   │   │   │   │   │       └── pkg-config v0.3.25
  -│   │   │   │   │   │   ├── openssl-probe v0.1.5
  -│   │   │   │   │   │   └── openssl-sys v0.9.83 (*)
  -│   │   │   │   │   ├── tokio v1.27.0 (*)
  -│   │   │   │   │   └── tokio-native-tls v0.3.0
  -│   │   │   │   │       ├── native-tls v0.2.10 (*)
  -│   │   │   │   │       └── tokio v1.27.0 (*)
  -│   │   │   │   ├── ipnet v2.5.0
  -│   │   │   │   ├── log v0.4.17 (*)
  -│   │   │   │   ├── mime v0.3.16
  -│   │   │   │   ├── native-tls v0.2.10 (*)
  -│   │   │   │   ├── once_cell v1.17.1
  -│   │   │   │   ├── percent-encoding v2.2.0
  -│   │   │   │   ├── pin-project-lite v0.2.9
  -│   │   │   │   ├── serde v1.0.147 (*)
  -│   │   │   │   ├── serde_urlencoded v0.7.1
  -│   │   │   │   │   ├── form_urlencoded v1.1.0 (*)
  -│   │   │   │   │   ├── itoa v1.0.2
  -│   │   │   │   │   ├── ryu v1.0.10
  -│   │   │   │   │   └── serde v1.0.147 (*)
  -│   │   │   │   ├── tokio v1.27.0 (*)
  -│   │   │   │   ├── tokio-native-tls v0.3.0 (*)
  -│   │   │   │   ├── tower-service v0.3.1
  -│   │   │   │   └── url v2.3.1 (*)
  -│   │   │   ├── rmp-serde v1.1.1 (*)
  -│   │   │   └── serde v1.0.147 (*)
  -│   │   └── libparsec_types v0.0.0 (/home/andesite/Documents/parsec-cloud/oxidation/libparsec/crates/types) (*)
  -│   ├── libparsec_platform_local_db v0.0.0 (/home/andesite/Documents/parsec-cloud/oxidation/libparsec/crates/platform_local_db)
  -│   │   ├── async-trait v0.1.64 (proc-macro)
  -│   │   │   ├── proc-macro2 v1.0.54 (*)
  -│   │   │   ├── quote v1.0.26 (*)
  -│   │   │   └── syn v1.0.109 (*)
  -│   │   ├── diesel v2.0.3
  -│   │   │   ├── diesel_derives v2.0.2 (proc-macro)
  -│   │   │   │   ├── proc-macro-error v1.0.4
  -│   │   │   │   │   ├── proc-macro-error-attr v1.0.4 (proc-macro)
  -│   │   │   │   │   │   ├── proc-macro2 v1.0.54 (*)
  -│   │   │   │   │   │   └── quote v1.0.26 (*)
  -│   │   │   │   │   │   [build-dependencies]
  -│   │   │   │   │   │   └── version_check v0.9.4
  -│   │   │   │   │   ├── proc-macro2 v1.0.54 (*)
  -│   │   │   │   │   ├── quote v1.0.26 (*)
  -│   │   │   │   │   └── syn v1.0.109 (*)
  -│   │   │   │   │   [build-dependencies]
  -│   │   │   │   │   └── version_check v0.9.4
  -│   │   │   │   ├── proc-macro2 v1.0.54 (*)
  -│   │   │   │   ├── quote v1.0.26 (*)
  -│   │   │   │   └── syn v1.0.109 (*)
  -│   │   │   └── libsqlite3-sys v0.25.2
  -│   │   │       [build-dependencies]
  -│   │   │       ├── cc v1.0.73
  -│   │   │       ├── pkg-config v0.3.25
  -│   │   │       └── vcpkg v0.2.15
  -│   │   ├── libparsec_platform_async v0.0.0 (/home/andesite/Documents/parsec-cloud/oxidation/libparsec/crates/platform_async) (*)
  -│   │   ├── libparsec_testbed v0.0.0 (/home/andesite/Documents/parsec-cloud/oxidation/libparsec/crates/testbed) (*)
  -│   │   ├── libsqlite3-sys v0.25.2 (*)
  -│   │   ├── log v0.4.17 (*)
  -│   │   ├── thiserror v1.0.38 (*)
  -│   │   └── tokio v1.27.0 (*)
  -│   ├── libparsec_testbed v0.0.0 (/home/andesite/Documents/parsec-cloud/oxidation/libparsec/crates/testbed) (*)
  -│   ├── libparsec_tests_macros v0.0.0 (proc-macro) (/home/andesite/Documents/parsec-cloud/oxidation/libparsec/crates/tests_macros)
  -│   │   ├── proc-macro2 v1.0.54 (*)
  -│   │   ├── quote v1.0.26 (*)
  -│   │   └── syn v1.0.109 (*)
  -│   ├── libparsec_types v0.0.0 (/home/andesite/Documents/parsec-cloud/oxidation/libparsec/crates/types) (*)
  -│   ├── log v0.4.17 (*)
  -│   ├── regex v1.7.3 (*)
  +├── hex-literal v0.4.1
  +├── libparsec_tests_utils v0.1.0 (/home/andesite/Documents/parsec-cloud/oxidation/libparsec/crates/tests_utils)
  │   ├── rstest v0.17.0
  │   │   ├── futures v0.3.28 (*)
  │   │   ├── futures-timer v3.0.2
  ```
</details>

See #4385
