### PR TITLE
[GUI] Fixed user guide link not clickable after creating an organization

### DIFF
--- a/newsfragments/4367.bugfix.rst
+++ b/newsfragments/4367.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed link to user guide not clickable after creation an organization

--- a/parsec/core/gui/forms/question_widget.ui
+++ b/parsec/core/gui/forms/question_widget.ui
@@ -88,6 +88,9 @@
        <property name="wordWrap">
         <bool>true</bool>
        </property>
+       <property name="openExternalLinks">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
     </layout>


### PR DESCRIPTION
# What has changed ?

<!-- Why this PR exist ? what is its goal ? -->

Simple fix of a link (`<a href="">`) in a text not being clickable.

<!-- If it affect the user there must be a news fragment created for that, and linked to an issue -->
- [X] Does this PR affect the User ?

<!-- If this PR is linked to an issue you can add `closes #<id of the linked pr>` this will close the issue when the PR is merged -->
Closes #4367 
