### PR TITLE
Break cyclic dependencies in `libparsec_protocol`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,6 +1181,7 @@ dependencies = [
  "libparsec_core",
  "libparsec_core_fs",
  "libparsec_crypto",
+ "libparsec_miniprotocol",
  "libparsec_platform_async",
  "libparsec_platform_device_loader",
  "libparsec_platform_local_db",
@@ -1235,6 +1236,7 @@ dependencies = [
  "http-body",
  "hyper",
  "libparsec_crypto",
+ "libparsec_miniprotocol",
  "libparsec_protocol",
  "libparsec_testbed",
  "libparsec_tests_fixtures",
@@ -1336,6 +1338,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "libparsec_miniprotocol"
+version = "0.1.0"
+dependencies = [
+ "rmp-serde",
+ "serde",
+]
+
+[[package]]
 name = "libparsec_platform_async"
 version = "0.0.0"
 dependencies = [
@@ -1393,6 +1403,7 @@ dependencies = [
  "glob",
  "hex-literal 0.3.4",
  "libparsec_crypto",
+ "libparsec_miniprotocol",
  "libparsec_serialization_format",
  "libparsec_tests_fixtures",
  "libparsec_types",
@@ -1410,7 +1421,7 @@ name = "libparsec_serialization_format"
 version = "0.0.0"
 dependencies = [
  "itertools",
- "libparsec_protocol",
+ "libparsec_miniprotocol",
  "libparsec_types",
  "miniserde",
  "pretty_assertions",

--- a/oxidation/libparsec/Cargo.toml
+++ b/oxidation/libparsec/Cargo.toml
@@ -32,6 +32,7 @@ libparsec_testbed = { path = "crates/testbed", optional = true }
 # TODO: merge with regular dependencies
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libparsec_protocol = { path = "crates/protocol" }
+libparsec_miniprotocol = { path = "crates/miniprotocol" }
 libparsec_core_fs = { path = "crates/core_fs" }
 libparsec_types = { path = "crates/types" }
 # TODO: should not be an optional

--- a/oxidation/libparsec/crates/client_connection/Cargo.toml
+++ b/oxidation/libparsec/crates/client_connection/Cargo.toml
@@ -19,6 +19,7 @@ libparsec_crypto = { path = "../crypto" }
 # Add primitive type to be used with the protocol
 libparsec_types = { path = "../types" }
 # Provide possible command to send to the server
+libparsec_miniprotocol = { path = "../miniprotocol" }
 libparsec_protocol = { path = "../protocol" }
 libparsec_testbed = { path = "../testbed", optional = true }
 

--- a/oxidation/libparsec/crates/client_connection/src/anonymous_cmds.rs
+++ b/oxidation/libparsec/crates/client_connection/src/anonymous_cmds.rs
@@ -1,6 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 (eventually AGPL-3.0) 2016-present Scille SAS
 
-use libparsec_protocol::Request;
+use libparsec_miniprotocol::Request;
 use libparsec_types::BackendAnonymousAddr;
 use reqwest::{
     header::{HeaderMap, HeaderValue, CONTENT_LENGTH, CONTENT_TYPE},
@@ -54,7 +54,7 @@ impl AnonymousCmds {
     pub async fn send<T>(
         &self,
         request: T,
-    ) -> CommandResult<<T as libparsec_protocol::Request>::Response>
+    ) -> CommandResult<<T as libparsec_miniprotocol::Request>::Response>
     where
         T: Request,
     {

--- a/oxidation/libparsec/crates/client_connection/src/authenticated_cmds.rs
+++ b/oxidation/libparsec/crates/client_connection/src/authenticated_cmds.rs
@@ -32,7 +32,7 @@
 
 use base64::prelude::{Engine, BASE64_STANDARD};
 use libparsec_crypto::SigningKey;
-use libparsec_protocol::Request;
+use libparsec_miniprotocol::Request;
 use libparsec_types::{BackendOrganizationAddr, DeviceID};
 use reqwest::{
     header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE},
@@ -143,7 +143,7 @@ impl AuthenticatedCmds {
     pub async fn send<T>(
         &self,
         request: T,
-    ) -> CommandResult<<T as libparsec_protocol::Request>::Response>
+    ) -> CommandResult<<T as libparsec_miniprotocol::Request>::Response>
     where
         T: Request,
     {

--- a/oxidation/libparsec/crates/client_connection/src/error.rs
+++ b/oxidation/libparsec/crates/client_connection/src/error.rs
@@ -25,7 +25,7 @@ pub enum CommandError {
 
     /// We failed to deserialize the reply.
     #[error("Failed to deserialize the response: {0}")]
-    InvalidResponseContent(libparsec_protocol::DecodeError),
+    InvalidResponseContent(libparsec_miniprotocol::DecodeError),
 
     /// The invitation is already used/deleted
     #[error("Invalid handshake: Invitation already deleted")]
@@ -53,7 +53,7 @@ pub enum CommandError {
 
     /// Failed to serialize the request
     #[error("{0}")]
-    Serialization(libparsec_protocol::EncodeError),
+    Serialization(libparsec_miniprotocol::EncodeError),
 
     /// The version is not supported
     #[error("Unsupported API version: {api_version}, supported versions are: {supported_api_versions:?}")]
@@ -107,8 +107,8 @@ impl PartialEq for CommandError {
 
 impl Eq for CommandError {}
 
-impl From<libparsec_protocol::DecodeError> for CommandError {
-    fn from(e: libparsec_protocol::DecodeError) -> Self {
+impl From<libparsec_miniprotocol::DecodeError> for CommandError {
+    fn from(e: libparsec_miniprotocol::DecodeError) -> Self {
         Self::InvalidResponseContent(e)
     }
 }
@@ -119,8 +119,8 @@ impl From<reqwest::Error> for CommandError {
     }
 }
 
-impl From<libparsec_protocol::EncodeError> for CommandError {
-    fn from(e: libparsec_protocol::EncodeError) -> Self {
+impl From<libparsec_miniprotocol::EncodeError> for CommandError {
+    fn from(e: libparsec_miniprotocol::EncodeError) -> Self {
         Self::Serialization(e)
     }
 }

--- a/oxidation/libparsec/crates/client_connection/src/invited_cmds.rs
+++ b/oxidation/libparsec/crates/client_connection/src/invited_cmds.rs
@@ -1,6 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 (eventually AGPL-3.0) 2016-present Scille SAS
 
-use libparsec_protocol::Request;
+use libparsec_miniprotocol::Request;
 use libparsec_types::{BackendInvitationAddr, InvitationToken};
 use reqwest::{
     header::{HeaderMap, HeaderValue, CONTENT_LENGTH, CONTENT_TYPE},
@@ -66,7 +66,7 @@ impl InvitedCmds {
     pub async fn send<T>(
         &self,
         request: T,
-    ) -> CommandResult<<T as libparsec_protocol::Request>::Response>
+    ) -> CommandResult<<T as libparsec_miniprotocol::Request>::Response>
     where
         T: Request,
     {

--- a/oxidation/libparsec/crates/miniprotocol/Cargo.toml
+++ b/oxidation/libparsec/crates/miniprotocol/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "libparsec_miniprotocol"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rmp-serde = "1.1.1"
+serde = { version = "1.0.147", features = ["derive"], default-features = false }

--- a/oxidation/libparsec/crates/miniprotocol/src/lib.rs
+++ b/oxidation/libparsec/crates/miniprotocol/src/lib.rs
@@ -1,0 +1,37 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 (eventually AGPL-3.0) 2016-present Scille SAS
+
+use std::num::NonZeroU8;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IntegerBetween1And100(NonZeroU8);
+
+impl TryFrom<u64> for IntegerBetween1And100 {
+    type Error = &'static str;
+    fn try_from(data: u64) -> Result<Self, Self::Error> {
+        if data == 0 || data > 100 {
+            return Err("Invalid IntegerBetween1And100 value");
+        }
+
+        Ok(Self(NonZeroU8::new(data as u8).unwrap()))
+    }
+}
+
+impl From<IntegerBetween1And100> for u64 {
+    fn from(data: IntegerBetween1And100) -> Self {
+        u8::from(data.0) as u64
+    }
+}
+
+pub trait Request {
+    type Response: for<'de> Deserialize<'de>;
+
+    fn dump(self) -> Result<Vec<u8>, EncodeError>;
+
+    fn load_response(buf: &[u8]) -> Result<Self::Response, DecodeError>;
+}
+
+/// Error while deserializing data.
+pub type DecodeError = rmp_serde::decode::Error;
+pub type EncodeError = rmp_serde::encode::Error;

--- a/oxidation/libparsec/crates/protocol/Cargo.toml
+++ b/oxidation/libparsec/crates/protocol/Cargo.toml
@@ -15,6 +15,7 @@ path = "tests/mod.rs"
 libparsec_crypto = { path = "../crypto" }
 libparsec_types = { path = "../types" }
 libparsec_serialization_format = { path = "../serialization_format" }
+libparsec_miniprotocol = { path = "../miniprotocol" }
 
 paste = "1.0.12"
 rand = "0.8.5"

--- a/oxidation/libparsec/crates/protocol/src/error.rs
+++ b/oxidation/libparsec/crates/protocol/src/error.rs
@@ -57,7 +57,3 @@ pub struct ChallengeDataReport {
     pub ballpark_client_early_offset: f64,
     pub ballpark_client_late_offset: f64,
 }
-
-/// Error while deserializing data.
-pub type DecodeError = rmp_serde::decode::Error;
-pub type EncodeError = rmp_serde::encode::Error;

--- a/oxidation/libparsec/crates/protocol/src/lib.rs
+++ b/oxidation/libparsec/crates/protocol/src/lib.rs
@@ -3,12 +3,7 @@
 mod error;
 mod handshake;
 
-use serde::{Deserialize, Serialize};
-use std::num::NonZeroU8;
-
 use libparsec_serialization_format::parsec_protocol_cmds_family;
-
-use crate as libparsec_protocol;
 
 pub use error::*;
 pub use handshake::*;
@@ -28,26 +23,6 @@ macro_rules! impl_dump_load {
 }
 pub(crate) use impl_dump_load;
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-pub struct IntegerBetween1And100(NonZeroU8);
-
-impl TryFrom<u64> for IntegerBetween1And100 {
-    type Error = &'static str;
-    fn try_from(data: u64) -> Result<Self, Self::Error> {
-        if data == 0 || data > 100 {
-            return Err("Invalid IntegerBetween1And100 value");
-        }
-
-        Ok(Self(NonZeroU8::new(data as u8).unwrap()))
-    }
-}
-
-impl From<IntegerBetween1And100> for u64 {
-    fn from(data: IntegerBetween1And100) -> Self {
-        u8::from(data.0) as u64
-    }
-}
-
 // This macro implements dump/load methods for client/server side.
 // It checks if both Req and Rep are implemented for a specified command
 // It also provides a way to use commands by specifying status, command and type.
@@ -61,11 +36,3 @@ impl From<IntegerBetween1And100> for u64 {
 parsec_protocol_cmds_family!("schema/invited_cmds");
 parsec_protocol_cmds_family!("schema/authenticated_cmds");
 parsec_protocol_cmds_family!("schema/anonymous_cmds");
-
-pub trait Request {
-    type Response: for<'de> Deserialize<'de>;
-
-    fn dump(self) -> Result<Vec<u8>, rmp_serde::encode::Error>;
-
-    fn load_response(buf: &[u8]) -> Result<Self::Response, ::rmp_serde::decode::Error>;
-}

--- a/oxidation/libparsec/crates/protocol/tests/test_block.rs
+++ b/oxidation/libparsec/crates/protocol/tests/test_block.rs
@@ -2,7 +2,8 @@
 
 use hex_literal::hex;
 
-use libparsec_protocol::{authenticated_cmds::v2 as authenticated_cmds, Request};
+use libparsec_miniprotocol::Request;
+use libparsec_protocol::authenticated_cmds::v2 as authenticated_cmds;
 use libparsec_tests_fixtures::parsec_test;
 use libparsec_types::{BlockID, RealmID};
 

--- a/oxidation/libparsec/crates/protocol/tests/test_events.rs
+++ b/oxidation/libparsec/crates/protocol/tests/test_events.rs
@@ -2,7 +2,8 @@
 
 use hex_literal::hex;
 
-use libparsec_protocol::{authenticated_cmds::v2 as authenticated_cmds, Request};
+use libparsec_miniprotocol::Request;
+use libparsec_protocol::authenticated_cmds::v2 as authenticated_cmds;
 use libparsec_tests_fixtures::parsec_test;
 use libparsec_types::{InvitationStatus, InvitationToken, RealmID, RealmRole, VlobID};
 

--- a/oxidation/libparsec/crates/protocol/tests/test_ping.rs
+++ b/oxidation/libparsec/crates/protocol/tests/test_ping.rs
@@ -2,8 +2,9 @@
 
 use hex_literal::hex;
 
+use libparsec_miniprotocol::Request;
 use libparsec_protocol::{
-    authenticated_cmds::v2 as authenticated_cmds, invited_cmds::v2 as invited_cmds, Request,
+    authenticated_cmds::v2 as authenticated_cmds, invited_cmds::v2 as invited_cmds,
 };
 use libparsec_tests_fixtures::parsec_test;
 

--- a/oxidation/libparsec/crates/protocol/tests/test_user.rs
+++ b/oxidation/libparsec/crates/protocol/tests/test_user.rs
@@ -3,7 +3,8 @@
 use hex_literal::hex;
 use std::num::NonZeroU64;
 
-use libparsec_protocol::{authenticated_cmds::v2 as authenticated_cmds, IntegerBetween1And100};
+use libparsec_miniprotocol::IntegerBetween1And100;
+use libparsec_protocol::authenticated_cmds::v2 as authenticated_cmds;
 use libparsec_tests_fixtures::parsec_test;
 use libparsec_types::HumanHandle;
 

--- a/oxidation/libparsec/crates/serialization_format/Cargo.toml
+++ b/oxidation/libparsec/crates/serialization_format/Cargo.toml
@@ -15,7 +15,7 @@ quote = "1.0.26"
 syn = { version = "2.0.13", features = ["extra-traits"] }
 
 [dev-dependencies]
-libparsec_protocol = { path = "../protocol" }
+libparsec_miniprotocol = { path = "../miniprotocol" }
 libparsec_types = { path = "../types" }
 rstest = "0.17.0"
 pretty_assertions = "1.3.0"

--- a/oxidation/libparsec/crates/serialization_format/src/protocol.rs
+++ b/oxidation/libparsec/crates/serialization_format/src/protocol.rs
@@ -475,9 +475,10 @@ fn quote_cmd(cmd: &GenCmd) -> (TokenStream, TokenStream) {
             quote! {
 
                 pub mod #module_name {
+                    use libparsec_miniprotocol::Request;
+
                     use super::AnyCmdReq;
                     use super::UnknownStatus;
-                    use super::super::super::libparsec_protocol::Request;
 
                     #(#nested_types)*
 

--- a/oxidation/libparsec/crates/serialization_format/src/utils.rs
+++ b/oxidation/libparsec/crates/serialization_format/src/utils.rs
@@ -116,7 +116,7 @@ pub(crate) fn _inspect_type(ty: &Type, types: &HashMap<String, String>) -> Strin
                 "PkiEnrollmentSubmitPayload" => "PkiEnrollmentSubmitPayload",
                 "X509Certificate" => "libparsec_types::X509Certificate",
                 // Used only in protocol
-                "IntegerBetween1And100" => "crate::IntegerBetween1And100",
+                "IntegerBetween1And100" => "libparsec_miniprotocol::IntegerBetween1And100",
                 ident if types.get(ident).is_some() => {
                     types.get(ident).unwrap_or_else(|| unreachable!())
                 }

--- a/oxidation/libparsec/crates/serialization_format/tests/test_protocol.rs
+++ b/oxidation/libparsec/crates/serialization_format/tests/test_protocol.rs
@@ -3,7 +3,7 @@
 use libparsec_types::Maybe;
 use pretty_assertions::assert_eq;
 
-use libparsec_protocol::{self, Request};
+use libparsec_miniprotocol::{self, Request};
 use libparsec_serialization_format::generate_protocol_cmds_family_from_contents;
 
 #[test]

--- a/oxidation/libparsec/src/lib.rs
+++ b/oxidation/libparsec/src/lib.rs
@@ -5,7 +5,10 @@ pub use libparsec_core_fs as core_fs;
 #[cfg(all(not(target_arch = "wasm32"), feature = "test-utils"))]
 pub use libparsec_platform_local_db as local_db;
 #[cfg(not(target_arch = "wasm32"))]
-pub use libparsec_protocol as protocol;
+pub mod protocol {
+    pub use libparsec_miniprotocol::{IntegerBetween1And100, Request};
+    pub use libparsec_protocol::*;
+}
 #[cfg(not(target_arch = "wasm32"))]
 pub use libparsec_types as types;
 


### PR DESCRIPTION
The crate `libparsec_protocol` depends on `libparsec_serialization_format` which it self depends on `libparsec_protocol::Request` (in dev-dependencies for testing purpose).

To resolve that, I've create an intermediate crate `libparsec_miniprotocol` that will be used by the crate `protocol` and `serialization_format`.

The Gain
--------

When compiling `libparsec_protocol[test]` the gain is not obvious:

```
master: 11.1s
this branch: 10.4s
```

But when compiling `libparsec_serialization_format[test]` the gain is clear:

```
master: 12.5s
this branch: 2.7s
```

This gain is caused because `libparsec_protocol` take a lot of time in `code-gen` (=> generating code) and `serialization_format` only required `protocol` for `Request`

> Those result is obtain with
>
> ```bash
> cargo clean -p <crate>
> cargo build -timings -p <crate> --tests
> ```

Others Changes
--------------

- Updated tests to use `libparsec_miniprotocol` when needed.
- Rework how we expose `libparsec::protocol`.
- Update `serialization_format` to use `libparsec_miniprotocol` when generating code.
