### PR TITLE
Rework `Q&A` to not require `rust` install.

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -99,4 +99,12 @@ jobs:
           steps.should-run-rust-jobs.outputs.run == 'true'
           && startsWith(matrix.os, 'ubuntu-')
         with:
-          extra-args: clippy --all-files --verbose
+          extra-args: clippy --verbose
+        timeout-minutes: 5
+
+      - name: Check rust code format
+        if: >-
+          steps.should-run-rust-jobs.outputs.run == 'true'
+          && startsWith(matrix.os, 'ubuntu-')
+        run: cargo fmt --check
+        timeout-minutes: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,13 +88,6 @@ jobs:
             newsfragments:
               - newsfragments/**
 
-      - name: Install Cargo fmt
-        run: |
-          set -ex
-          rustup component add rustfmt
-          cargo fmt --version
-        timeout-minutes: 2
-
       - uses: ./.github/actions/setup-python-poetry
         with:
           python-version: ${{ env.python-version }}
@@ -155,7 +148,7 @@ jobs:
             }}
           config-file: ${{ steps.patched-pre-commit-config.outputs.path }}
         env:
-          SKIP: clippy,cspell
+          SKIP: clippy,fmt,cspell
         timeout-minutes: 30
 
   test-python-matrix:


### PR DESCRIPTION
This is possible to skipping the `fmt` step that required `rust` (`cargo fmt`). Now the `cargo fmt` step is perform in `ci-rust`.
