### PR TITLE
Don't require to install `poetry` & `python` in Q&A.

### DIFF
--- a/.github/actions/use-pre-commit/action.yml
+++ b/.github/actions/use-pre-commit/action.yml
@@ -18,11 +18,22 @@ inputs:
     description: pre-commit version to use
     required: false
     default: 2.21.0
+  install-only:
+    description: Only install pre-commit without running it.
+    required: false
+    default: 'false'
+  install-dir:
+    description: Path where to install pre-commit.
+    required: false
+    default: ~/.cache/pre-commit
 
 outputs:
   cache-hit:
     description: A boolean value to indicate an exact match was found for the key.
     value: ${{ steps.cache-pre-commit.outputs.cache-hit }}
+  install-path:
+    description: A path where pre-commit.pyz is installed
+    value: ${{ inputs.install-dir }}/pre-commit.pyz
 
 runs:
   using: composite
@@ -33,29 +44,34 @@ runs:
       with:
         key: pre-commit-${{ inputs.version }}-${{ hashFiles(inputs.config-file) }}
         path: |
-          ~/.cache/pre-commit
+          ${{ inputs.install-dir }}
 
     # Install pre-commit as a standalone .pyz archive that can be run by Python
     - name: Install pre-commit
+      id: install-precommit
       if: steps.cache-pre-commit.outputs.cache-hit != 'true'
       run: |
-        mkdir -p ~/.cache/pre-commit/
-        curl --proto '=https' --tlsv1.2 -sSL https://github.com/pre-commit/pre-commit/releases/download/v${{ inputs.version }}/pre-commit-${{ inputs.version }}.pyz > ~/.cache/pre-commit/pre-commit.pyz
+        set -eux
+        mkdir -p ${{ inputs.install-dir }}
+        curl --proto '=https' --tlsv1.2 -sSL \
+          https://github.com/pre-commit/pre-commit/releases/download/v${{ inputs.version }}/pre-commit-${{ inputs.version }}.pyz \
+          > ${{ inputs.install-dir }}/pre-commit.pyz
       shell: bash
 
     - name: Debug installed python package
       run: |
         python --version
-        python ~/.cache/pre-commit/pre-commit.pyz --version
+        python ${{ inputs.install-dir }}/pre-commit.pyz --version
       shell: bash
 
 
     - name: Run pre-commit
+      if: inputs.install-only != 'true'
       run: |
         # Run pre-commit
         set -x
         python \
-          ~/.cache/pre-commit/pre-commit.pyz \
+          ${{ inputs.install-dir }}/pre-commit.pyz \
           run \
           --verbose \
           --show-diff-on-failure \

--- a/.github/filters/ci.yml
+++ b/.github/filters/ci.yml
@@ -24,6 +24,10 @@ rust-python-binding: &rust-python-binding src/**
 
 rust-web-binding: &rust-web-binding oxidation/bindings/web/**
 
+any-python:
+  - '*.py'
+  - '*.pyi'
+
 python: &python
   - parsec/**
   - tests/**

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50  # pin v2.11.1
         id: changes
         with:
+          list-files: shell
           filters: .github/filters/ci.yml
 
       - name: Check modified path that require python-ci run
@@ -201,6 +202,36 @@ jobs:
           if ${{ steps.cache-libparsec.outputs.cache-hit == 'true' }}; then export POETRY_LIBPARSEC_BUILD_STRATEGY=no_build; fi
           python make.py python-ci-install
         timeout-minutes: 20
+
+      - name: Install pre-commit
+        if: >-
+          steps.should-run-python-jobs.outputs.run == 'true'
+          && startsWith(matrix.os, 'ubuntu-')
+        id: pre-commit
+        uses: ./.github/actions/use-pre-commit
+        with:
+          install-only: true
+
+      - name: Check python code style
+        if: >-
+          steps.should-run-python-jobs.outputs.run == 'true'
+          && startsWith(matrix.os, 'ubuntu-')
+        run: |
+          set -eux
+          for step in mypy black ruff; do
+            python \
+              ${{ steps.pre-commit.outputs.install-path }} \
+              run \
+              $step \
+              --show-diff-on-failure \
+              --verbose \
+              --color=always \
+              $EXTRA_ARGS
+          done
+        env:
+          EXTRA_ARGS: >-
+            ${{ steps.changes.outputs.any-python_files != '' && format('--files {0}', steps.changes.outputs.any-python_files) || '--all-files' }}
+        timeout-minutes: 10
 
       # We only save the libparsec lib when:
       # - We are not in a github queue branch (they're a one time use so caching won't help)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,12 +82,6 @@ jobs:
             newsfragments:
               - newsfragments/**
 
-      - uses: ./.github/actions/setup-python-poetry
-        with:
-          python-version: ${{ env.python-version }}
-          poetry-version: ${{ env.poetry-version }}
-        timeout-minutes: 5
-
       - name: Check Commit Signature
         run: python .github/scripts/check_commit_signature.py
 
@@ -115,15 +109,6 @@ jobs:
           diff --unified .pre-commit-config.yaml $TEMP_FILE || true
           echo "path=$TEMP_FILE" >> $GITHUB_OUTPUT
 
-      - name: Install project (needed for mypy check)
-        run: |
-          set -ex
-          poetry install -E core -E backend
-        # We skip _parsec.so compilation given Mypy only cares about _parsec.pyi
-        env:
-          POETRY_LIBPARSEC_BUILD_STRATEGY: no_build
-        timeout-minutes: 10
-
       # Clippy basically compile the project, hence it's faster to run it in
       # the test-rust-matrix job where compilation cache is reused !
       - uses: ./.github/actions/use-pre-commit
@@ -137,8 +122,8 @@ jobs:
             }}
           config-file: ${{ steps.patched-pre-commit-config.outputs.path }}
         env:
-          SKIP: clippy,fmt,cspell,eslint
-        timeout-minutes: 30
+          SKIP: clippy,fmt,cspell,ruff,black,mypy,eslint
+        timeout-minutes: 5
 
   test-python-matrix:
     uses: ./.github/workflows/ci-python.yml


### PR DESCRIPTION
Installing `poetry` & `python` in `Q&A` was only required when we change python code.

It's more efficient to do that in `ci-python` since this workflow should be run when actual python code is changed (note, it is also run when we modify `rust` code).

Other Changes
-------------

- Action `use-pre-commit`:
  - Return the install path of `pre-commit` in the outputs variable `install-path`.
  - Skip `Run pre-commit` step when `install-only != true`.
