### PR TITLE
Change `yamllint` configuration to only allow for double-quote style in yaml files

### DIFF
--- a/.cspell/cspell.config.yml
+++ b/.cspell/cspell.config.yml
@@ -114,16 +114,16 @@ cache:
 useGitignore: true
 allowCompoundWords: true
 ignorePaths:
-  - '**/parsec/core/resources/default_*.ignore'
-  - '**/*.svg'
-  - '**/docs/figures/*.svg'
-  - '**/windows-icon-handler/**/*.vcxproj'
-  - '**/windows-icon-handler/**/*.vcxproj.filters'
-  - '**/gradle.lockfile'
-  - '**/buildscript-gradle.lockfile'
-  - '**/gradle/verification-metadata.xml'
-  - '**/*.icns'
-  - '**/.git'
+  - "**/parsec/core/resources/default_*.ignore"
+  - "**/*.svg"
+  - "**/docs/figures/*.svg"
+  - "**/windows-icon-handler/**/*.vcxproj"
+  - "**/windows-icon-handler/**/*.vcxproj.filters"
+  - "**/gradle.lockfile"
+  - "**/buildscript-gradle.lockfile"
+  - "**/gradle/verification-metadata.xml"
+  - "**/*.icns"
+  - "**/.git"
 import:
   - "@cspell/dict-fr-fr/cspell-ext.json"
   - "@cspell/dict-fr-reforme/cspell-ext.json"

--- a/.github/actions/use-pre-commit/action.yml
+++ b/.github/actions/use-pre-commit/action.yml
@@ -5,11 +5,11 @@ inputs:
   extra-args:
     description: options to pass to pre-commit run-precommit
     required: false
-    default: ''
+    default: ""
   changed-files:
     description: List of changed files to run `pre-commit` on, if empty will run on all files
     required: false
-    default: ''
+    default: ""
   config-file:
     description: where is located the pre-commit config file
     required: false
@@ -21,7 +21,7 @@ inputs:
   install-only:
     description: Only install pre-commit without running it.
     required: false
-    default: 'false'
+    default: "false"
   install-dir:
     description: Path where to install pre-commit.
     required: false

--- a/.github/filters/ci.yml
+++ b/.github/filters/ci.yml
@@ -25,8 +25,8 @@ rust-python-binding: &rust-python-binding src/**
 rust-web-binding: &rust-web-binding oxidation/bindings/web/**
 
 any-python:
-  - '*.py'
-  - '*.pyi'
+  - "*.py"
+  - "*.pyi"
 
 python: &python
   - parsec/**

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -36,7 +36,7 @@ jobs:
           - name: 🏁 Windows
             os: windows-2022
             winfsp-version: 1.11.22176
-    name: '${{ matrix.name }}: 🐍 Python tests'
+    name: "${{ matrix.name }}: 🐍 Python tests"
     # Just a fail-safe timeout, see the fine grain per-task timeout instead
     timeout-minutes: 60
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -28,7 +28,7 @@ jobs:
             os: macos-12
           - name: 🏁 Windows
             os: windows-2022
-    name: '${{ matrix.name }}: 🦀 Rust tests'
+    name: "${{ matrix.name }}: 🦀 Rust tests"
     # Just a fail-safe timeout, see the fine grain per-task timeout instead
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -37,7 +37,7 @@ jobs:
             os: macos-12
           - name: 🏁 Windows
             os: windows-2022
-    name: '${{ matrix.name }}: 📦 Packaging (build Wheel)'
+    name: "${{ matrix.name }}: 📦 Packaging (build Wheel)"
     runs-on: ${{ matrix.os }}
     outputs:
       wheel-version: ${{ steps.wheel-version.outputs.version }}
@@ -122,7 +122,7 @@ jobs:
         timeout-minutes: 5
 
   package-linux-build-snap:
-    name: '🐧 Linux: 📦 Packaging (build Snap)'
+    name: "🐧 Linux: 📦 Packaging (build Snap)"
     needs: package-wheel
     runs-on: ubuntu-20.04
     env:
@@ -174,7 +174,7 @@ jobs:
           if-no-files-found: error
 
   package-linux-test-snap:
-    name: '🐧 Linux: 📦 Packaging (test Snap on ${{ matrix.os }})'
+    name: "🐧 Linux: 📦 Packaging (test Snap on ${{ matrix.os }})"
     needs: package-linux-build-snap
     runs-on: ${{ matrix.os }}
     strategy:
@@ -203,7 +203,7 @@ jobs:
           xvfb-run parsec --diagnose
 
   package-linux-release-snap:
-    name: '🐧 Linux: 📦 Packaging (release Snap)'
+    name: "🐧 Linux: 📦 Packaging (release Snap)"
     needs: [ package-linux-build-snap, package-linux-test-snap ]
     runs-on: ubuntu-20.04
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
@@ -222,7 +222,7 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_CREDENTIALS }}
 
   package-linux-release-pypi:
-    name: '🐧 Linux: 📦 Packaging (release Pypi)'
+    name: "🐧 Linux: 📦 Packaging (release Pypi)"
     needs: [ package-wheel, package-linux-test-snap ]
     runs-on: ubuntu-20.04
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
@@ -242,7 +242,7 @@ jobs:
           password: ${{ secrets.PYPI_CREDENTIALS }}
 
   package-windows-build-installer-content:
-    name: '🏁 Windows: 📦 Packaging (build installer content)'
+    name: "🏁 Windows: 📦 Packaging (build installer content)"
     needs: package-wheel
     runs-on: windows-2022
     steps:
@@ -303,7 +303,7 @@ jobs:
 
   package-macos-build-app:
     runs-on: macos-12
-    name: '🍎 macOS: 📦 Packaging (build installer content)'
+    name: "🍎 macOS: 📦 Packaging (build installer content)"
     needs: package-wheel
     env:
       WHEEL_VERSION: ${{ needs.package-wheel.outputs.wheel-version }}
@@ -346,7 +346,7 @@ jobs:
 
   package-macos-test-app:
     runs-on: macos-${{ matrix.macos-version }}
-    name: '🍎 macOS: 📦 Packaging (test app on macOS-${{ matrix.macos-version }})'
+    name: "🍎 macOS: 📦 Packaging (test app on macOS-${{ matrix.macos-version }})"
     needs: [ package-wheel, package-macos-build-app ]
     env:
       WHEEL_VERSION: ${{ needs.package-wheel.outputs.wheel-version }}
@@ -393,7 +393,7 @@ jobs:
             paths: |
               oxidation/client/electron/dist/parsec-*.dmg
               oxidation/client/electron/dist/parsec-*.dmg.blockmap
-    name: '${{matrix.name }}: ⚡ Package electron'
+    name: "${{matrix.name }}: ⚡ Package electron"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -75,7 +75,7 @@ rules:
     forbid-explicit-octal: false
 
   quoted-strings:
-    quote-type: any # I would prefer "double" style
+    quote-type: double
     required: only-when-needed
     extra-allowed:
       - \d{2,2}:\d{2,2}


### PR DESCRIPTION
This will ensure a consistent style across our yaml files. 
I choose double-quote since it's the same style enforced in the python files (but remain open to discussion).
