### PR TITLE
Fix `maturin` version to `0.14.15`

### DIFF
--- a/build.py
+++ b/build.py
@@ -32,6 +32,7 @@ def run(cmd: str, **kwargs) -> subprocess.CompletedProcess:
 
 def build():
     run(f"{PYTHON_EXECUTABLE_PATH} --version")
+    run(f"maturin --version")
 
     if os.environ.get("POETRY_PYQT_BUILD_STRATEGY", "") != "no_build":
         run(f"{PYTHON_EXECUTABLE_PATH} misc/generate_pyqt.py")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ mypy = "^0.982"
 
 setuptools = ">=63.1,<68.0"
 
-maturin = "^0.14.10"
+maturin = "0.14.15"
 patchelf = { version = "^0.17.2.0", markers = "platform_system=='Linux'" }
 
 cibuildwheel = "v2.12.3"
@@ -219,8 +219,8 @@ known-first-party = ["parsec"]
 requires = [
     "poetry-core>=1.0.0",
     "setuptools",
-    "maturin~=0.14",
-    "maturin[patchelf]~=0.14; platform_system=='Linux'",
+    "maturin==0.14.15",
+    "maturin[patchelf]==0.14.15; platform_system=='Linux'",
     "patchelf~=0.17.2.0; platform_system=='Linux'",
     "PyQt5~=5.15",
     "Babel~=2.10",


### PR DESCRIPTION
Since `maturin` isn't stable (version > `1.*`) minor change are allowed to be breaking. This actually bites us because the CI now use the version `0.15.1` that contain breaking change.

To correct that, I've fixed the version (using `==` instead of `~=`) and also display the version of maturin in `build.py`.
