### PR TITLE
Update `Read the docs` configuration files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -206,3 +206,9 @@ repos:
 
       - id: check-metaschema
         files: ^json_schema/
+
+      - id: check-jsonschema
+        name: Validate Read the doc configuration files
+        alias: check-readthedoc
+        files: .readthedocs.yml
+        args: [ --schemafile, https://raw.githubusercontent.com/readthedocs/readthedocs.org/main/readthedocs/rtd_tests/fixtures/spec/v2/schema.json ]

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,13 @@ version: 2
 
 # The Docker image used for building the docs.
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
+# Build our docs in additional formats such as PDF
+formats:
+  - pdf
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
- Validate `Read the doc` configuration file 
- Change `image` to `os` since it's deprecated.
- Fix os version to `ubuntu-22.04`.
- Specify python version `3.9`.
- Config RTD to generate `pdf` alongside the website.

Closes #4517