### PR TITLE
Disable pdfs generation on read the docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,21 +9,12 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.9"
-  # Must be the same list as defined in `docs/Dockerfile`.
-  # (You can exclude `make`, `python3{,-pip}` & `latexmk` since they're already present)
-  apt_packages:
-    - fonts-roboto
-    - fonts-firacode
-    - imagemagick
-    - librsvg2-bin
-    - texlive-luatex
-    - texlive-latex-base
-    - texlive-latex-recommended
-    - texlive-latex-extra
 
+# Note: Read the docs does not support multiple pdfs generation
+# See https://github.com/readthedocs/readthedocs.org/issues/2045
 # Build our docs in additional formats such as PDF
-formats:
-  - pdf
+# formats:
+#   - pdf
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
Read the docs doesn't support multiple pdfs generation for the moment. See <https://github.com/readthedocs/readthedocs.org/issues/2045>.
