### PR TITLE
Releaser workflow

### DIFF
--- a/.github/workflows/package-python.yml
+++ b/.github/workflows/package-python.yml
@@ -1,19 +1,24 @@
-name: package-ci
+name: Package python parsec
 
 on:
+  workflow_call:
+    inputs:
+      version:
+        description: The version to use
+        type: string
+        required: true
   workflow_dispatch:
+    inputs:
+      version:
+        description: The version to use (if not provided will generated one from the codespace version)
+        type: string
+        required: false
   pull_request:
     paths:
-      - .github/workflows/package-ci.yml
+      - .github/workflows/package-python.yml
       - packaging
       - build.py
       - pyproject.toml
-  push:
-    branches:
-      - master
-      - "[0-9]+.[0-9]+"
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+*
 
 # We set `concurrency` to prevent having this workflow being run on code that is not up-to-date on a PR (a user make multiple push in a quick manner).
 # But on the main branch, we don't want that behavior.
@@ -21,7 +26,7 @@ on:
 #
 # For that we use `head_ref` that is only defined on `pull-request` and fallback to `run_id` (this is a counter, so it's value is unique between workflow call).
 concurrency:
-  group: package-ci-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: package-python-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 env:
@@ -51,7 +56,7 @@ jobs:
     name: "${{ matrix.name }}: 📦 Packaging (build Wheel)"
     runs-on: ${{ matrix.os }}
     outputs:
-      wheel-version: ${{ steps.wheel-version.outputs.version }}
+      wheel-version: ${{ steps.version.outputs.full }}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin v3.5.2
         timeout-minutes: 5
@@ -63,29 +68,38 @@ jobs:
         timeout-minutes: 10
 
       - name: Get wheel version
-        id: wheel-version
+        id: version
         shell: bash
         run: |
           set -eux
-          # Retrieve Parsec version and customize it if we are not building on a tag
-          # See https://www.python.org/dev/peps/pep-0440/#local-version-identifiers
-          if ([ "${{ github.ref_type }}" == "tag" ])
-          then
-            # Use tag name as version
-            VERSION=`git describe --tag`
-          else
-            # Use `<tag_name>+dev<commit_hash>` as version
-            VERSION=`sed -n 's/^__version__ = "\\(.*\\)"$/\\1/p' parsec/_version.py`
-            COMMIT=`git rev-parse --verify --short HEAD`
-            VERSION="$VERSION.$COMMIT"
-            # Customize version with tag
-            sed -i.back -e "s#^\\(__version__ = \\).*\$#\\1'$VERSION'#" parsec/_version.py
-            test $(grep -E '^version = ' -o pyproject.toml | wc -l) -eq 1  # Sanity check for the next sed
-            sed -i.back -e "s#^\\(version = \\).*\$#\\1'$VERSION'#" pyproject.toml
-          fi
 
-          echo "::warning title=Wheel version::$VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          function parse_version {
+            PYTHONPATH=. python3 misc/releaser.py version "$@"
+          }
+
+          case "${{ github.event_name }}" in
+            workflow_call)
+              parse_version "${{ inputs.version }}" | tee -a $GITHUB_OUTPUT
+              ;;
+            workflow_dispatch)
+              VERSION="${{ inputs.version }}"
+              # No version provided, fallback to the version in the repository
+              if [ -z "$VERSION" ]; then
+                VERSION=$(parse_version --uniq-dev)
+              fi
+              parse_version "VERSION" | tee -a $GITHUB_OUTPUT
+              ;;
+            pull_request)
+              parse_version --uniq-dev | tee -a $GITHUB_OUTPUT
+              ;;
+            *)
+              echo 'Unsupported event type ${{ github.event_name }}' >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Set parsec version ${{ steps.version.outputs.full }}
+        run: python3 misc/version_updater.py --tool parsec --version ${{ steps.version.outputs.full }}
 
       - name: Build wheel
         uses: pypa/cibuildwheel@51f5c7fe68ff24694d5a6ac0eb3ad476ddd062a8  # pin v2.13.0
@@ -94,7 +108,7 @@ jobs:
         timeout-minutes: 50
 
       - name: Set file for wheel version
-        run: echo ${{ steps.wheel-version.outputs.version }} > dist/version
+        run: echo v${{ steps.version.outputs.full }} > dist/version
 
       - name: Hack the wheel macos version
         if: startsWith(matrix.os, 'macos-')
@@ -170,10 +184,10 @@ jobs:
       - name: Set snap build version
         run: |
           # Sed with a range specifier to only match on line 2 (where the version value is expected to be).
-          sed -i.back '2,/^version:/{s/^version: .*$/version: ${{ env.WHEEL_VERSION }}/}' ${{ runner.temp }}/snap/snapcraft.yaml
+          sed -i.back '2,/^version:/{s/^version: .*$/version: v${{ env.WHEEL_VERSION }}/}' ${{ runner.temp }}/snap/snapcraft.yaml
           diff -u ${{ runner.temp }}/snap/snapcraft.yaml{.back,} || true
           # Use grep as sanity check to ensure that we have the expected version value.
-          grep --line-number --fixed-string 'version: ${{ env.WHEEL_VERSION }}' ${{ runner.temp }}/snap/snapcraft.yaml
+          grep --line-number --fixed-string 'version: v${{ env.WHEEL_VERSION }}' ${{ runner.temp }}/snap/snapcraft.yaml
 
       - name: Run snapcraft
         working-directory: ${{ runner.temp }}
@@ -257,6 +271,8 @@ jobs:
     name: "🏁 Windows: 📦 Packaging (build installer content)"
     needs: package-wheel
     runs-on: windows-2022
+    env:
+      WHEEL_VERSION: ${{ needs.package-wheel.outputs.wheel-version }}
     steps:
       - uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0  # pin v4.6.1
         with:
@@ -297,20 +313,29 @@ jobs:
 
       # Cannot do the NSIS installer part in CI given it requires to sign `parsec.exe`
 
+      - name: Artifact name
+        id: names
+        shell: bash
+        run: echo "archive=parsec-unsigned-v${{ env.WHEEL_VERSION }}-raw-windows-installer.zip" >> $GITHUB_OUTPUT
+
+      # The 7z man can be found here <https://linux.die.net/man/1/7z>
       - name: Prepare artifact
         run: |
           md dist
-          Copy-Item -Path build\manifest.ini -Destination dist
-          Copy-Item -Path build\install_files.nsh -Destination dist
-          Copy-Item -Path build\uninstall_files.nsh -Destination dist
-          Copy-Item -Recurse -Path build\parsec-* -Destination dist
-          Copy-Item -Path build\winfsp-* -Destination dist
+          cd build
+          # cspell:disable-next-line
+          7z a -tzip ..\dist\${{ steps.names.outputs.archive }} `
+            manifest.ini `
+            install_files.nsh `
+            uninstall_files.nsh `
+            parsec-* `
+            winfsp-*
         working-directory: ${{ runner.temp }}
 
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin v3.1.2
         with:
-          name: ${{ runner.os }}-${{ runner.arch }}-installer-content
-          path: ${{ runner.temp }}/dist/
+          name: ${{ runner.os }}-${{ runner.arch }}-installer
+          path: ${{ runner.temp }}/dist/${{ steps.names.outputs.archive }}
           if-no-files-found: error
 
   package-macos-build-app:
@@ -346,14 +371,14 @@ jobs:
       - name: Generate Parsec.app
         run: >
           tar --verbose --create --bzip2
-          --file parsec-${{ env.WHEEL_VERSION }}-macos-amd64.tar.bz2
+          --file parsec-unsigned-v${{ env.WHEEL_VERSION }}-macos-amd64.tar.bz2
           --directory build/pyinstaller_dist parsec.app
         working-directory: ${{ runner.temp }}
 
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin v3.1.2
         with:
           name: ${{ runner.os }}-${{ runner.arch }}-installer
-          path: ${{ runner.temp }}/parsec-${{ env.WHEEL_VERSION }}-macos-amd64.tar.bz2
+          path: ${{ runner.temp }}/parsec-unsigned-v${{ env.WHEEL_VERSION }}-macos-amd64.tar.bz2
           if-no-files-found: error
 
   package-macos-test-app:
@@ -378,7 +403,7 @@ jobs:
       - name: Test open app
         run: |
           set -eux
-          tar -xzvf dist/parsec-${{ env.WHEEL_VERSION }}-macos-amd64.tar.bz2 # cspell:disable-line
+          tar -xzvf dist/parsec-unsigned-v${{ env.WHEEL_VERSION }}-macos-amd64.tar.bz2 # cspell:disable-line
           /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f parsec.app
           open parsec.app --args --diagnose
 

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,0 +1,183 @@
+# When a tag is push on the repo, this workflow will run to create a release and add some artifact to it.
+name: Releaser
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/package-python.yml
+      - .github/workflows/releaser.yml
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+*
+
+permissions:
+  contents: write
+
+# We set `concurrency` to prevent having this workflow being more than once for the same tag.
+concurrency:
+  group: releaser-${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  version:
+    runs-on: ubuntu-22.04
+    outputs:
+      full: ${{ steps.version.outputs.full }}
+      pep440: ${{ steps.version.outputs.pep440 }}
+      major: ${{ steps.version.outputs.major }}
+      minor: ${{ steps.version.outputs.minor }}
+      patch: ${{ steps.version.outputs.patch }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
+      dev: ${{ steps.version.outputs.dev }}
+      local: ${{ steps.version.outputs.local }}
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin v3.5.2
+        timeout-minutes: 5
+
+      - name: Parse version for event ${{ github.event_name }}
+        id: version
+        run: |
+          set -o pipefail
+
+          function parse_version {
+            PYTHONPATH=. python3 misc/releaser.py version "$@"
+          }
+
+          case "${{ github.event_name }}" in
+            push)
+              echo "Triggered by a Push"
+              parse_version "${{ github.ref_name }}" | tee -a $GITHUB_OUTPUT
+            ;;
+
+            workflow_dispatch)
+              # If workflow dispatch trigger from a tag, we use the tag as a version else we behave like pull_request
+              TAG="${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}"
+              # If TAG isn't empty use it.
+              if [ -n $TAG ]; then
+                parse_version $TAG | tee -a $GITHUB_OUTPUT
+              else
+                parse_version --uniq-dev | tee -a $GITHUB_OUTPUT
+              fi
+            ;;
+
+            pull_request)
+              echo "Triggered by a Pull-Request"
+              parse_version --uniq-dev | tee -a $GITHUB_OUTPUT
+            ;;
+
+            *)
+              echo "Unsupported event type ${{ github.event_name }}" >&2
+              exit 1
+            ;;
+          esac
+
+  package-parsec-desktop:
+    needs:
+      - version
+    uses: ./.github/workflows/package-python.yml
+    with:
+      version: ${{ needs.version.outputs.full }}
+
+  releaser:
+    needs:
+      - version
+      - package-parsec-desktop
+    name: 🚛 Releaser
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download every artifact generated (and uploaded)
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin v3.0.2
+        with:
+          path: artifacts
+        timeout-minutes: 5
+
+      - name: List downloaded artifacts
+        run: tree artifacts
+
+      - name: Create the folder that will contain the release files
+        run: mkdir release-files
+
+      - name: Copy python wheels
+        run: |
+          set -ex
+          cp -v artifacts/Linux-X64-wheel/parsec_cloud-${{ needs.version.outputs.pep440 }}-*.whl release-files
+          cp -v artifacts/macOS-X64-wheel/parsec_cloud-${{ needs.version.outputs.pep440 }}-*.whl release-files
+          cp -v artifacts/Windows-X64-wheel/parsec_cloud-${{ needs.version.outputs.pep440 }}-*.whl release-files
+        env:
+          BASH_XTRACEFD: 1
+
+      - name: Copy apps for different OSes
+        run: |
+          set -ex
+          cp -v artifacts/Linux-X64-snap/parsec_v${{ needs.version.outputs.full }}_*.snap release-files
+          cp -v artifacts/macOS-X64-installer/parsec-unsigned-v${{ needs.version.outputs.full }}-macos-*.tar.bz2 release-files
+          cp -v artifacts/Windows-X64-installer/parsec-unsigned-v${{ needs.version.outputs.full }}-raw-windows-installer.zip release-files
+        env:
+          BASH_XTRACEFD: 1
+
+      - name: Generate version file
+        run:
+          (
+            echo "full=${{ needs.version.outputs.full }}";
+            echo "pep440=${{ needs.version.outputs.pep440 }}";
+            echo "major=${{ needs.version.outputs.major }}";
+            echo "minor=${{ needs.version.outputs.minor }}";
+            echo "patch=${{ needs.version.outputs.patch }}";
+            echo "prerelease=${{ needs.version.outputs.prerelease }}";
+            echo "dev=${{ needs.version.outputs.dev }}";
+            echo "local=${{ needs.version.outputs.local }}";
+          ) | tee release-files/version
+
+      - name: Generate checksums file released files
+        run: sha256sum release-files/* | sed 's;release-files/;;' | tee checksums.sha256
+
+      - name: Extract checksum for each file
+        run: |
+          set -x
+          # Every files that don't end with '.sha256'
+          for file in $(find release-files -not -name '*.sha256'); do
+            grep $(basename $file) checksums.sha256 | cut -d ' ' -f 1 > "$file".sha256
+          done
+
+      - name: List files in 'release-files'.
+        run: tree release-files
+
+      - name: Generate summary
+        run: |
+          (
+            set -e
+            echo '# Parsec ${{ needs.version.outputs.full }}'
+            echo
+            echo 'You can find all assets checksums below, or use `<asset name>.sha256`'
+            echo
+            echo '```txt'
+            cat checksums.sha256
+            echo '```'
+            echo
+            echo 'Generated by <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>'
+          ) | tee release-summary.md
+
+      - name: Create release
+        if: github.event_name == 'push'
+        uses: softprops/action-gh-release@c9b46fe7aad9f02afd89b12450b780f52dacfb2d
+        with:
+          draft: true
+          body_path: release-summary.md
+          prerelease: ${{ needs.version.outputs.prerelease != '' || needs.version.outputs.dev != '' || needs.version.outputs.local != '' }}
+          name: Release v${{ needs.version.outputs.full }}
+          tag_name: v${{ needs.version.outputs.full }}
+          files: |
+            release-files/parsec_cloud-${{ needs.version.outputs.full }}-*.whl
+            release-files/parsec_cloud-${{ needs.version.outputs.full }}-*.whl.sha256
+            release-files/parsec_v${{ needs.version.outputs.full }}_*.snap
+            release-files/parsec_v${{ needs.version.outputs.full }}_*.snap.sha256
+            release-files/parsec-unsigned-v${{ needs.version.outputs.full }}-raw-windows-installer.zip
+            release-files/parsec-unsigned-v${{ needs.version.outputs.full }}-raw-windows-installer.zip.sha256
+            release-files/parsec-unsigned-v${{ needs.version.outputs.full }}-macos-*.tar.bz2
+            release-files/parsec-unsigned-v${{ needs.version.outputs.full }}-macos-*.tar.bz2.sha256
+            release-files/version
+            release-files/version.sha256
+          fail_on_unmatched_files: true
+          generate_release_notes: false
+        timeout-minutes: 5

--- a/misc/version_updater.py
+++ b/misc/version_updater.py
@@ -89,7 +89,7 @@ FILES_WITH_VERSION_INFO: Dict[Path, Dict[Tool, RawRegexes]] = {
         Tool.Poetry: [POETRY_GA_VERSION],
     },
     ROOT_DIR
-    / ".github/workflows/package-ci.yml": {
+    / ".github/workflows/package-python.yml": {
         Tool.Python: [PYTHON_GA_VERSION],
         Tool.Poetry: [POETRY_GA_VERSION],
         Tool.Node: [NODE_GA_VERSION],


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your pull request -->

## Describe your changes

Create a workflow that will automatically create a release when a tag is push.
The release will be create with the generated artifact:

- `Parsec.snap`
- `parsec_cloud.whl`
- `Parsec.app.unsigned`
- `Parsec.nsi.unsigned`

Other Changes
-------------

- Rename `package-ci` to `package-python`
  - `package-macos-build-app`: Rename the generated artifact to be `parsec-unsigned-v1.2.3-macos-amd64.tar.bz2`

    I've added `unsigned` in the artifact name remember that the application isn't signed

  - `package-windows-build-installer`: Create a zip archive containing the generated installation files for the windows installer

    The archive contained the word `unsigned` to remember to sign the file (and also generate the nsis installer).
  - Remove the trigger on push
- `releaser.py`:
  - Allow to overwrite `prerelease` value when parsing the version
  - The pre-release part of the version is now printed in the format `<name>.<id>`
  - Handle `nightly` pre-release

## Checklist

Before you submit this pull request, please make sure to:

- [x] Keep changes in the pull request as small as possible
   <!-- Move unrelated changes to a new pull request -->
- [x] Ensure the commit history is sanitized
   <!-- Commits should have a meaningful title and contain a coherent set of changes
        Squash commits that are only relevant to the branch context -->
- [x] Give a meaningful title to your PR
- [x] Describe your changes
   <!-- Give some context about the changes
        Draw attention to the details that should not be overlooked -->
