### PR TITLE
Rework how we determine if a workflow should be run

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -62,20 +62,10 @@ jobs:
           list-files: shell
           filters: .github/filters/ci.yml
 
-      - name: Check modified path that require python-ci run
-        id: should-run-python-jobs
-        if: >-
-          steps.changes.outputs.python-jobs == 'true'
-          || github.ref == 'refs/heads/master'
-        run: echo "run=true" >> $GITHUB_OUTPUT
-        shell: bash
-
+      # GitHub Actions apt proxy is super unstable
+      # see https://github.com/actions/runner-images/issues/7048
       - name: (🐧 Linux) Set apt mirror
-        # GitHub Actions apt proxy is super unstable
-        # see https://github.com/actions/runner-images/issues/7048
-        if: >-
-          steps.should-run-python-jobs.outputs.run == 'true'
-          && startsWith(matrix.os, 'ubuntu-')
+        if: startsWith(matrix.os, 'ubuntu-')
         run: |
           set -e -o pipefail
           (
@@ -86,9 +76,7 @@ jobs:
           sudo sed -i 's/http:\/\/azure.archive.ubuntu.com\/ubuntu\//mirror+file:\/etc\/apt\/mirrors.txt/' /etc/apt/sources.list
 
       - name: (🐧 Linux) Configure PostgreSQL APT repository
-        if: >-
-          steps.should-run-python-jobs.outputs.run == 'true'
-          && startsWith(matrix.os, 'ubuntu-')
+        if: startsWith(matrix.os, 'ubuntu-')
         env:
           POSTGRE_APT_KEY_SHA_512: df557805862cd279f40819834af14e1723b18044df9dc22bea710b6980c98cc8ed39e75ed5c9adaa1932992710f1180f0491dc9437bfd485b4aa2b75776407d4  /usr/share/keyrings/postgre-sql-keyring.gpg
         run: |
@@ -111,9 +99,7 @@ jobs:
         # - A specific version of postgresql is used for PostgreSQL's tests.
         # - dependencies for Qt testing. See: https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions.
       - name: (🐧 Linux) Install packages fuse2, PostgreSQL-${{ env.postgresql-version }}
-        if: >-
-          steps.should-run-python-jobs.outputs.run == 'true'
-          && startsWith(matrix.os, 'ubuntu-')
+        if: startsWith(matrix.os, 'ubuntu-')
         run: |
           # Retry the command until it succeed.
           # We retry because sometime the APT repo configured
@@ -133,16 +119,12 @@ jobs:
         timeout-minutes: 5
 
       - name: (🍎 macOS) Install macfuse
-        if: >-
-          steps.should-run-python-jobs.outputs.run == 'true'
-          && startsWith(matrix.os, 'macos-')
+        if: startsWith(matrix.os, 'macos-')
         run: brew install --cask macfuse
         timeout-minutes: 5
 
       - name: (🏁 Windows) Install WinFSP
-        if: >-
-          steps.should-run-python-jobs.outputs.run == 'true'
-          && startsWith(matrix.os, 'windows-')
+        if: startsWith(matrix.os, 'windows-')
         shell: bash
         run: |
           choco install -y --limit-output winfsp --version=${{ matrix.winfsp-version }}
@@ -154,7 +136,6 @@ jobs:
         timeout-minutes: 5
 
       - uses: ./.github/actions/setup-python-poetry
-        if: steps.should-run-python-jobs.outputs.run == 'true'
         id: setup-python
         with:
           python-version: ${{ env.python-version }}
@@ -167,14 +148,12 @@ jobs:
       # Key cache contains a hash of all the files that are used to produce _parsec.so
       # Hence if we have a cache hit we know that there is no need for a rebuild !
       - name: Setup cache-key
-        if: steps.should-run-python-jobs.outputs.run == 'true'
         id: cache-key
         run: echo "key=${{ matrix.os }}-${{ hashFiles('src/**', 'oxidation/libparsec/**', 'rust-toolchain.toml', 'Cargo.toml', 'Cargo.lock') }}-libparsec-python-${{ env.python-version }}" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Restore libparsec if Rust hasn't been modified
         id: cache-libparsec
-        if: steps.should-run-python-jobs.outputs.run == 'true'
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # pin v3.3.1
         with:
           key: ${{ steps.cache-key.outputs.key }}
@@ -185,9 +164,7 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@ac6bb38f317802fab2f463811237b0d9cba8cc80 # pin v1.4.4
-        if: >-
-          steps.should-run-python-jobs.outputs.run == 'true'
-          && steps.cache-libparsec.outputs.cache-hit != 'true'
+        if: steps.cache-libparsec.outputs.cache-hit != 'true'
         with:
           # We setup the cache by hand, see below
           cache: false
@@ -195,9 +172,7 @@ jobs:
 
       - name: Retrieve Rust cache
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f # pin v2.2.1
-        if: >-
-          steps.should-run-python-jobs.outputs.run == 'true'
-          && steps.cache-libparsec.outputs.cache-hit != 'true'
+        if: steps.cache-libparsec.outputs.cache-hit != 'true'
         with:
           # Cache is limited to 10Go (and cache is ~700mo per platform !). On top of that.
           # cache is only shared between master and the PRs (and not accross PRs).
@@ -207,7 +182,6 @@ jobs:
         timeout-minutes: 5
 
       - name: Install python deps
-        if: steps.should-run-python-jobs.outputs.run == 'true'
         shell: bash
         run: |
           set -ex
@@ -217,18 +191,14 @@ jobs:
         timeout-minutes: 20
 
       - name: Install pre-commit
-        if: >-
-          steps.should-run-python-jobs.outputs.run == 'true'
-          && startsWith(matrix.os, 'ubuntu-')
+        if: startsWith(matrix.os, 'ubuntu-')
         id: pre-commit
         uses: ./.github/actions/use-pre-commit
         with:
           install-only: true
 
       - name: Check python code style
-        if: >-
-          steps.should-run-python-jobs.outputs.run == 'true'
-          && startsWith(matrix.os, 'ubuntu-')
+        if: startsWith(matrix.os, 'ubuntu-')
         run: |
           set -eux
           for step in mypy black ruff; do
@@ -251,8 +221,7 @@ jobs:
       # - We haven't already cached it.
       - name: Save cached libparsec to be reused on later call
         if: >-
-          steps.should-run-python-jobs.outputs.run == 'true'
-          && steps.cache-libparsec.outputs.cache-hit != 'true'
+          steps.cache-libparsec.outputs.cache-hit != 'true'
           && !contains(github.ref, 'gh-readonly-queue')
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # pin v3.3.1
         with:
@@ -263,14 +232,12 @@ jobs:
         timeout-minutes: 2
 
       - name: Basic tests
-        if: steps.should-run-python-jobs.outputs.run == 'true'
         run: poetry run pytest ${{ env.pytest-base-args }} tests -n auto
         timeout-minutes: 10
 
       # TODO: remove me once client connection oxidation is done
       - name: (🐧 Linux) Basic tests (with unstable Rust client connection)
-        if: steps.should-run-python-jobs.outputs.run == 'true'
-          && startsWith(matrix.os, 'ubuntu-')
+        if: startsWith(matrix.os, 'ubuntu-')
         # TODO: -n auto doesn't work see: https://github.com/Scille/parsec-cloud/issues/4145
         run: poetry run pytest ${{ env.pytest-base-args }} tests
         timeout-minutes: 10
@@ -278,38 +245,29 @@ jobs:
           UNSTABLE_OXIDIZED_CLIENT_CONNECTION: true
 
       - name: (🐧🏁 Not macOS) Mountpoint tests
-        if: >-
-          steps.should-run-python-jobs.outputs.run == 'true'
-          && startsWith(matrix.os, 'macos-') != true
+        if: startsWith(matrix.os, 'macos-') != true
         run: poetry run pytest ${{ env.pytest-base-args }} tests --runmountpoint --runslow -m mountpoint
         timeout-minutes: 10
 
       - name: (🐧 Linux) Install pytest-xvfb plugin for pytest for Qt Testing
-        if: >-
-          steps.should-run-python-jobs.outputs.run == 'true'
-          && startsWith(matrix.os, 'ubuntu-')
+        if: startsWith(matrix.os, 'ubuntu-')
         run: poetry run pip install pytest-xvfb
         timeout-minutes: 2
 
       - name: (🐧🏁 Not MacOS) GUI tests
-        if: >-
-          steps.should-run-python-jobs.outputs.run == 'true'
-          && startsWith(matrix.os, 'macos-') != true
+        if: startsWith(matrix.os, 'macos-') != true
         # Note: using `--numprocesses 1` force pytest to print the test that it will be executing
         # This is usefull to pinpoint exactly which test in blocking.
         run: poetry run pytest ${{ env.pytest-base-args }} tests --runmountpoint --runslow --rungui -m gui --numprocesses 1
         timeout-minutes: 10
 
       - name: (🐧 Linux) PostgreSQL tests
-        if: >-
-          steps.should-run-python-jobs.outputs.run == 'true'
-          && startsWith(matrix.os, 'ubuntu-')
+        if: startsWith(matrix.os, 'ubuntu-')
         env:
           PGINSTALLATION: /usr/lib/postgresql/${{ env.postgresql-version }}/bin
         run: poetry run pytest ${{ env.pytest-base-args }} tests/backend tests/test_cli.py -k 'not test_shuffle_roles' --postgresql --runslow
         timeout-minutes: 20
 
       - name: Hypothesis tests
-        if: steps.should-run-python-jobs.outputs.run == 'true'
         run: poetry run pytest ${{ env.pytest-base-args }} tests --runslow -m slow --numprocesses auto
         timeout-minutes: 50

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -48,21 +48,7 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin v3.5.2
         timeout-minutes: 5
 
-      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50  # pin v2.11.1
-        id: changes
-        with:
-          filters: .github/filters/ci.yml
-
-      - name: Check modified path that require rust-ci run
-        id: should-run-rust-jobs
-        if: >-
-          steps.changes.outputs.rust-jobs == 'true'
-          || github.ref == 'refs/heads/master'
-        run: echo "run=true" >> $GITHUB_OUTPUT
-        shell: bash
-
       - uses: actions-rust-lang/setup-rust-toolchain@ac6bb38f317802fab2f463811237b0d9cba8cc80 # pin v1.4.4
-        if: steps.should-run-rust-jobs.outputs.run == 'true'
         with:
           # We setup the cache by hand, see below
           cache: false
@@ -70,7 +56,6 @@ jobs:
 
       - name: Retrieve Rust cache
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f # pin v2.2.1
-        if: steps.should-run-rust-jobs.outputs.run == 'true'
         with:
           # Cache is limited to 10Go (and cache is ~700mo per platform !). On top of that.
           # cache is only shared between master and the PRs (and not accross PRs).
@@ -84,7 +69,7 @@ jobs:
       # The default one does not provide windows-style filesystem
       # paths so we have to switch to Strawberry.
       - name: Use strawberry perl
-        if: steps.should-run-rust-jobs.outputs.run == 'true' && startsWith(matrix.os, 'windows')
+        if: startsWith(matrix.os, 'windows')
         shell: bash
         run: echo OPENSSL_SRC_PERL=C:/Strawberry/perl/bin/perl >> $GITHUB_ENV
         timeout-minutes: 1
@@ -93,7 +78,6 @@ jobs:
       # so if we modify `libparsec_crypto` which are not tested, it will pass the CI,
       # that's why we add a check
       - name: Test rust codebase
-        if: steps.should-run-rust-jobs.outputs.run == 'true'
         shell: bash
         run: |
           set -ex
@@ -107,16 +91,12 @@ jobs:
       # Clippy basically compile the project, hence it's faster to run it in
       # the test-rust-matrix job where compilation cache is reused !
       - uses: ./.github/actions/use-pre-commit
-        if: >-
-          steps.should-run-rust-jobs.outputs.run == 'true'
-          && startsWith(matrix.os, 'ubuntu-')
+        if: startsWith(matrix.os, 'ubuntu-')
         with:
           extra-args: clippy --verbose
         timeout-minutes: 5
 
       - name: Check rust code format
-        if: >-
-          steps.should-run-rust-jobs.outputs.run == 'true'
-          && startsWith(matrix.os, 'ubuntu-')
+        if: startsWith(matrix.os, 'ubuntu-')
         run: cargo fmt --check
         timeout-minutes: 2

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -42,27 +42,12 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin v3.5.2
         timeout-minutes: 5
 
-      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50  # pin v2.11.1
-        id: changes
-        with:
-          filters: .github/filters/ci.yml
-
-      - name: Check modified path that require `test-web` to run
-        id: should-run-web-jobs
-        if: >-
-          steps.changes.outputs.web-jobs == 'true'
-          || github.ref == 'refs/heads/master'
-        run: echo "run=true" >> $GITHUB_OUTPUT
-        shell: bash
-
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # pin v3.6.0
-        if: steps.should-run-web-jobs.outputs.run == 'true'
         with:
           node-version: ${{ env.node-version }}
         timeout-minutes: 2
 
       - name: Install dependencies
-        if: steps.should-run-web-jobs.outputs.run == 'true'
         run: |
           # Execute 'npm clean-install' until success,
           # This is done that way because sometime some CDN response with 503
@@ -73,13 +58,11 @@ jobs:
         timeout-minutes: 5
 
       - name: Check lint
-        if: steps.should-run-web-jobs.outputs.run == 'true'
         run: npm run lint
         working-directory: oxidation/client
         timeout-minutes: 5
 
       - name: Setup cache-key
-        if: steps.should-run-web-jobs.outputs.run == 'true'
         id: cache-key
         run: >-
           echo "key=web-${{ hashFiles(
@@ -91,7 +74,6 @@ jobs:
         shell: bash
 
       - name: Restore libparsec if Rust hasn't been modified
-        if: steps.should-run-web-jobs.outputs.run == 'true'
         id: cache-libparsec
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # pin v3.3.1
         with:
@@ -103,9 +85,7 @@ jobs:
 
       - name: Retrieve Rust cache
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f # pin v2.2.1
-        if: >-
-          steps.should-run-web-jobs.outputs.run == 'true'
-          && steps.cache-libparsec.outputs.cache-hit != 'true'
+        if: steps.cache-libparsec.outputs.cache-hit != 'true'
         with:
           # Cache is limited to 10Go (and cache is ~700mo per platform !). On top of that.
           # cache is only shared between master and the PRs (and not accross PRs).
@@ -115,9 +95,7 @@ jobs:
         timeout-minutes: 5
 
       - name: Install wasm-pack
-        if: >-
-          steps.should-run-web-jobs.outputs.run == 'true'
-          && steps.cache-libparsec.outputs.cache-hit != 'true'
+        if: steps.cache-libparsec.outputs.cache-hit != 'true'
         run: |
           set -eux
           set -o pipefail
@@ -138,17 +116,13 @@ jobs:
         timeout-minutes: 2
 
       - name: Build web bindings
-        if: >-
-          steps.should-run-web-jobs.outputs.run == 'true'
-          && steps.cache-libparsec.outputs.cache-hit != 'true'
+        if: steps.cache-libparsec.outputs.cache-hit != 'true'
         run: npm run build:dev
         working-directory: oxidation/bindings/web
         timeout-minutes: 10
 
       - name: Save libparsec to be reuse later
-        if: >-
-          steps.should-run-web-jobs.outputs.run == 'true'
-          && steps.cache-libparsec.outputs.cache-hit != 'true'
+        if: steps.cache-libparsec.outputs.cache-hit != 'true'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # pin v3.3.1
         with:
           key: ${{ steps.cache-key.outputs.key }}
@@ -158,17 +132,14 @@ jobs:
         timeout-minutes: 2
 
       - name: Unit tests
-        if: steps.should-run-web-jobs.outputs.run == 'true'
         run: npm run test:unit
         working-directory: oxidation/client
         timeout-minutes: 10
 
       - name: Check testbed server is running
-        if: steps.should-run-web-jobs.outputs.run == 'true'
         run: curl http://localhost:6777
 
       - name: E2E tests
-        if: steps.should-run-web-jobs.outputs.run == 'true'
         run: npm run test:e2e:headless
         env:
           TESTBED_SERVER_URL: parsec://localhost:6777?no_ssl=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,51 +23,86 @@ permissions:
   packages: read
 
 jobs:
+  dispatch:
+    runs-on: ubuntu-22.04
+    outputs:
+      rust: ${{ steps.need-check.outputs.rust }}
+      python: ${{ steps.need-check.outputs.python }}
+      web: ${{ steps.need-check.outputs.web }}
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin v3.5.2
+        timeout-minutes: 5
+
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50  # pin v2.11.1
+        id: changes
+        with:
+          list-files: shell
+          filters: .github/filters/ci.yml
+        timeout-minutes: 5
+
+      - name: Determine which workflows need to be run
+        id: need-check
+        run: |
+          set -eux -o pipefail
+          for check in $(env | grep -o 'NEED_CHECK_\w*' ); do
+            env_value=$(eval "echo \$$check")
+            echo "${check#NEED_CHECK_}=$env_value"
+          done | tee -a $GITHUB_OUTPUT
+        env:
+          NEED_CHECK_rust: ${{ github.ref == 'refs/heads/master' || steps.changes.outputs.python-jobs == 'true' }}
+          NEED_CHECK_web: ${{ github.ref == 'refs/heads/master' || steps.changes.outputs.web-jobs == 'true' }}
+          NEED_CHECK_python: ${{ github.ref == 'refs/heads/master' || steps.changes.outputs.rust-jobs == 'true' }}
+
   # Github PR merging is configured to only require this job to pass
   ci-is-happy:
     name: ⭐ CI is happy ⭐
     needs:
-      - check-quality-assurance
-      - test-python-matrix
-      - test-rust-matrix
-      - test-web-app
-      - check-spelling
+      - dispatch
+      - quality-assurance
+      - python
+      - rust
+      - web
+      - spelling
     runs-on: ubuntu-latest
     if: always()
     # Just a fail-safe timeout, see the fine grain per-task timeout instead
     timeout-minutes: 2
     steps:
-      # The Needs context value contains only:
-      # - the final state a jobs (if it fails or not)
-      # - it's output (actually none of our jobs are configuring outputs variable)
-      #
-      # https://docs.github.com/en/actions/learn-github-actions/contexts#needs-context
-      - name: Debug the needs context values
+      - name: Requirement fullfiled
+        run: |
+          #!python3
+          import os
+          import json
+
+          data = json.loads(os.environ["NEEDS"])
+
+          print("NEEDS:", json.dumps(data, indent=4), sep="\n")
+
+          # Check jobs aren't failed or cancelled.
+          for name, job in data.items():
+            if job["result"] in ("cancelled", "failure"):
+              raise ValueError(f"The job `{name}` is in a invalid state: {job['result']}")
+
+          # Check required jobs, here we just need to check that the state is `success` and not `skipped`.
+          for job_name, required in data["dispatch"]["outputs"].items():
+            assert required in ("true", "false")
+            job_result = data[job_name]["result"]
+            if required == "true" and job_result != "success":
+              raise ValueError(
+                  f"The required job `{job_name}` should be in a success state but is not (state={job_result})"
+              )
         env:
           NEEDS: ${{ toJSON(needs) }}
-        run: printenv NEEDS
+        shell: python
 
-      - name: We're very sorry
-        run: |
-          echo "Oh No, we have jobs that have failed/cancelled/skipped :("
-          exit 42
-        if: >-
-          contains(needs.*.result, 'failure')
-          || contains(needs.*.result, 'skipped')
-          || contains(needs.*.result, 'cancelled')
-          || ! contains(needs.*.result, 'success')
-
-      - name: It's showtime
-        run: echo "My job here is done !"
-
-  check-spelling:
+  spelling:
     uses: ./.github/workflows/cspell.yml
 
   ##############################################################################
   #                                   📊 Q&A                                   #
   ##############################################################################
 
-  check-quality-assurance:
+  quality-assurance:
     name: 📊 Q&A
     # All linux jobs must run the same ubuntu version to avoid Rust caching issues !
     runs-on: ubuntu-20.04
@@ -138,11 +173,20 @@ jobs:
           SKIP: clippy,fmt,cspell,ruff,black,mypy,eslint
         timeout-minutes: 5
 
-  test-python-matrix:
+  python:
+    needs:
+      - dispatch
+    if: needs.dispatch.outputs.python == 'true'
     uses: ./.github/workflows/ci-python.yml
 
-  test-rust-matrix:
+  rust:
+    needs:
+      - dispatch
+    if: needs.dispatch.outputs.rust == 'true'
     uses: ./.github/workflows/ci-rust.yml
 
-  test-web-app:
+  web:
+    needs:
+      - dispatch
+    if: needs.dispatch.outputs.web == 'true'
     uses: ./.github/workflows/ci-web.yml


### PR DESCRIPTION
## Describe your changes

The dispatch is now done in 1 job in the workflow `ci.yml` named `dispatch`.

This Simplify workflow `ci-{web,python,rust}` has they don't need to check if they need to run.

This reduce the CI time consumption as the check has to be done only 1 time in the job `dispatch`.

The new workflow diagram for the CI look like:

```mermaid
flowchart LR
    dispatch

    dispatch -- "If it need to run" --> rust
    dispatch -- "If it need to run" --> python
    dispatch -- "If it need to run" --> web

    quality-assurance --> ci-is-happy
    spelling --> ci-is-happy
    dispatch -- "Used to check that dispatched jobs are successful" --> ci-is-happy
    rust --> ci-is-happy
    python --> ci-is-happy
    web --> ci-is-happy
```

## Checklist

Before you submit this pull request, please make sure to:

- [x] Keep changes in the pull request as small as possible
   <!-- Move unrelated changes to a new pull request -->
- [x] Ensure the commit history is sanitized
   <!-- Commits should have a meaningful title and contain a coherent set of changes
        Squash commits that are only relevant to the branch context -->
- [x] Give a meaningful title to your PR
- [x] Describe your changes
   <!-- Give some context about the changes
        Draw attention to the details that should not be overlooked -->
