### PR TITLE
Add single mountpoint mode for Windows

### DIFF
--- a/parsec/core/config.py
+++ b/parsec/core/config.py
@@ -60,6 +60,7 @@ class CoreConfig:
     invitation_token_size: int = 8
 
     mountpoint_enabled: bool = False
+    mountpoint_in_directory: bool = False
     disabled_workspaces: FrozenSet[EntryID] = frozenset()
 
     sentry_dsn: str | None = None
@@ -99,6 +100,7 @@ def config_factory(
     mountpoint_base_dir: Path | None = None,
     prevent_sync_pattern_path: Path | None = None,
     mountpoint_enabled: bool = False,
+    mountpoint_in_directory: bool = False,
     disabled_workspaces: FrozenSet[EntryID] = frozenset(),
     backend_max_cooldown: int = 30,
     backend_connection_keepalive: int | None = 29,
@@ -145,6 +147,7 @@ def config_factory(
         mountpoint_base_dir=mountpoint_base_dir,
         prevent_sync_pattern_path=prevent_sync_pattern_path,
         mountpoint_enabled=mountpoint_enabled,
+        mountpoint_in_directory=mountpoint_in_directory,
         disabled_workspaces=disabled_workspaces,
         backend_max_cooldown=backend_max_cooldown,
         backend_connection_keepalive=backend_connection_keepalive,
@@ -175,7 +178,7 @@ def config_factory(
     core_config.data_base_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
 
     # Mountpoint base directory is not used on windows
-    if sys.platform != "win32":
+    if sys.platform != "win32" or core_config.mountpoint_in_directory:
         core_config.mountpoint_base_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
 
     return core_config

--- a/parsec/core/gui/workspaces_widget.py
+++ b/parsec/core/gui/workspaces_widget.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 from enum import Enum
 from pathlib import PurePath
-from typing import Any, Iterator, Sequence, cast
+from typing import Any, Iterator, Optional, Sequence, cast
 
 from PyQt5.QtCore import QDate, QEvent, QObject, Qt, QTime, QTimer, pyqtBoundSignal, pyqtSignal
 from PyQt5.QtWidgets import QAbstractButton, QLabel, QWidget
@@ -452,8 +452,9 @@ class WorkspacesWidget(QWidget, Ui_WorkspacesWidget):
             workspace_id = job.arguments.get("workspace_id")
             timestamp = job.arguments.get("timestamp")
             assert workspace_id is not None
-            assert timestamp is not None
-            wb = self.get_workspace_button(cast(EntryID, workspace_id), cast(DateTime, timestamp))
+            wb = self.get_workspace_button(
+                cast(EntryID, workspace_id), cast(Optional[DateTime], timestamp)
+            )
             if wb:
                 wb.set_mountpoint_state(False)
             if isinstance(job.exc, MountpointNoDriveAvailable):

--- a/parsec/core/logged_core.py
+++ b/parsec/core/logged_core.py
@@ -410,6 +410,7 @@ async def logged_core_factory(
                 mount_on_workspace_shared=config.mountpoint_enabled,
                 unmount_on_workspace_revoked=config.mountpoint_enabled,
                 exclude_from_mount_all=config.disabled_workspaces,
+                mountpoint_in_directory=config.mountpoint_in_directory,
             ) as mountpoint_manager:
                 yield LoggedCore(
                     config=config,

--- a/parsec/core/mountpoint/manager.py
+++ b/parsec/core/mountpoint/manager.py
@@ -382,6 +382,7 @@ async def mountpoint_manager_factory(
     mount_on_workspace_shared: bool = False,
     unmount_on_workspace_revoked: bool = False,
     exclude_from_mount_all: frozenset[EntryID] = frozenset(),
+    mountpoint_in_directory: bool = False,
 ) -> AsyncGenerator[MountpointManager, Any]:
     config = {"debug": debug}
 
@@ -390,6 +391,11 @@ async def mountpoint_manager_factory(
     # Now is a good time to perform some cleanup in the registry
     if sys.platform == "win32":
         cleanup_parsec_drive_icons()
+
+        # Enable mountpoint in directory mode only on Windows (also, note that
+        # the config dict is *unpacked* on Linux in fuse_mountpoint_runner)
+        config["mountpoint_in_directory"] = mountpoint_in_directory
+
     elif sys.platform == "darwin":
         await cleanup_macos_mountpoint_folder(base_mountpoint_path)
 

--- a/parsec/core/win_registry.py
+++ b/parsec/core/win_registry.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 
 import importlib.resources
 import os
+import pathlib
 import string
 import sys
 from contextlib import contextmanager
 from importlib.abc import Traversable
 from types import ModuleType
-from typing import Any, Iterator
+from typing import Iterator
 
 from structlog import get_logger
 
@@ -24,7 +25,8 @@ PROCESS_ID = "ProcessID"
 DRIVE_ICON_NAME = "parsec.ico"
 EXPLORER_DRIVES = "Software\\Classes\\Applications\\Explorer.exe\\Drives"
 EXPLORER_DRIVES_DEFAULT_ICON_TEMPLATE = EXPLORER_DRIVES + "\\{}\\DefaultIcon"
-
+APPGUID = "{6C37F945-7EFC-480A-A444-A6D44A3D107F}"
+APPNAME = "Parsec"
 
 # Winreg helper
 
@@ -69,11 +71,18 @@ def winreg_read_user_dword(key: str, name: str) -> object:
     return value
 
 
-def winreg_write_user_dword(key: str, name: str, value: Any) -> None:
+def winreg_write_user_dword(key: str, name: str, value: int) -> None:
     winreg = get_winreg()
     hkcu = winreg.HKEY_CURRENT_USER
     with winreg.OpenKey(hkcu, key, access=winreg.KEY_SET_VALUE) as key_obj:
         winreg.SetValueEx(key_obj, name, None, winreg.REG_DWORD, value)
+
+
+def winreg_write_user_string(key: str, name: str, value: str) -> None:
+    winreg = get_winreg()
+    hkcu = winreg.HKEY_CURRENT_USER
+    with winreg.OpenKey(hkcu, key, access=winreg.KEY_SET_VALUE) as key_obj:
+        winreg.SetValueEx(key_obj, name, None, winreg.REG_SZ, value)
 
 
 def winreg_delete_user_dword(key: str, name: str) -> None:
@@ -91,6 +100,15 @@ def winreg_has_user_key(key: str) -> bool:
             return True
     except OSError:
         return False
+
+
+def winreg_delete_user_key(key: str) -> None:
+    winreg = get_winreg()
+    hkcu = winreg.HKEY_CURRENT_USER
+    try:
+        winreg.DeleteKey(hkcu, key)
+    except OSError:
+        pass
 
 
 # Acrobat container app workaround
@@ -115,7 +133,7 @@ def get_acrobat_app_container_enabled() -> bool:
     return bool(value)
 
 
-def set_acrobat_app_container_enabled(value: object) -> None:
+def set_acrobat_app_container_enabled(value: int) -> None:
     if not is_acrobat_reader_dc_present():
         return
     winreg_write_user_dword(ACROBAT_READER_DC_PRIVILEGED, ENABLE_APP_CONTAINER, value)
@@ -176,7 +194,7 @@ def del_parsec_drive_icon(letter: str) -> None:
         pass
 
 
-def _get_drive_icon_path(device: LocalDevice) -> Traversable:
+def _get_drive_icon_path(device: LocalDevice | None = None) -> Traversable:
     # This function is just here so that other applications can
     # change the icon by monkeypatching it. `device` argument
     # can be used to add conditions, e.g. return different icons
@@ -187,7 +205,7 @@ def _get_drive_icon_path(device: LocalDevice) -> Traversable:
 @contextmanager
 def parsec_drive_icon_context(letter: str, device: LocalDevice) -> Iterator[None]:
     # Winreg is not available for some reasons
-    if sys.platform != "win32" or not try_winreg():
+    if sys.platform != "win32" or not try_winreg() or not letter:
         yield
         return
 
@@ -211,3 +229,67 @@ def cleanup_parsec_drive_icons() -> None:
         _, pid = get_parsec_drive_icon(letter)
         if pid and not get_psutil().pid_exists(pid):
             del_parsec_drive_icon(letter)
+
+
+def add_parsec_mountpoint_directory_to_quick_access(
+    base_mountpoint_directory: pathlib.PurePath,
+    appguid: str | None = None,
+    appname: str | None = None,
+) -> None:
+    winreg = get_winreg()
+    appguid = APPGUID if appguid is None else appguid
+    appname = APPNAME if appname is None else appname
+    hkcu = winreg.HKEY_CURRENT_USER
+    base_key_1 = rf"Software\Classes\CLSID\{appguid}"
+    base_key_2 = rf"Software\Classes\Wow6432Node\CLSID\{appguid}"
+    systemroot = os.environ.get("SYSTEMROOT", rf"C:\Windows")
+    icon_path = _get_drive_icon_path()
+    for key in (base_key_1, base_key_2):
+        winreg.SetValue(hkcu, key, winreg.REG_SZ, appname)
+        winreg_write_user_dword(key, "SortOrderIndex", 0x42)
+        winreg_write_user_dword(key, "System.IsPinnedToNamespaceTree", 0x01)
+
+        winreg.SetValue(hkcu, rf"{key}\DefaultIcon", winreg.REG_SZ, rf"{icon_path},0")
+
+        winreg.SetValue(
+            hkcu, rf"{key}\InProcServer32", winreg.REG_SZ, rf"{systemroot}\system32\shell32.dll"
+        )
+
+        winreg.SetValue(hkcu, rf"{key}\Instance", winreg.REG_SZ, rf"")
+        winreg_write_user_string(
+            rf"{key}\Instance", "CLSID", "{0E5AAE11-A475-4c5b-AB00-C66DE400274E}"
+        )
+
+        winreg.SetValue(hkcu, rf"{key}\Instance\InitPropertyBag", winreg.REG_SZ, rf"")
+        winreg_write_user_dword(rf"{key}\Instance\InitPropertyBag", "Attributes", 0x11)
+        winreg_write_user_string(
+            rf"{key}\Instance\InitPropertyBag", "TargetFolderPath", rf"{base_mountpoint_directory}"
+        )
+
+        winreg.SetValue(hkcu, rf"{key}\ShellFolder", winreg.REG_SZ, rf"")
+        winreg_write_user_dword(rf"{key}\ShellFolder", "Attributes", 0xF080004D)
+        winreg_write_user_dword(rf"{key}\ShellFolder", "FolderValueFlags", 0x28)
+
+    key = rf"Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\{appguid}"
+    winreg.SetValue(hkcu, key, winreg.REG_SZ, appname)
+
+    key = rf"Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel"
+    winreg_write_user_dword(key, rf"{appguid}", 0x1)
+
+
+def remove_parsec_mountpoint_directory_from_quick_access(appguid: str | None = None) -> None:
+    get_winreg()
+    appguid = APPGUID if appguid is None else appguid
+    base_key_1 = rf"Software\Classes\CLSID\{appguid}"
+    base_key_2 = rf"Software\Classes\Wow6432Node\CLSID\{appguid}"
+    for key in (base_key_1, base_key_2):
+        winreg_delete_user_key(key)
+        winreg_delete_user_key(rf"{key}\DefaultIcon")
+        winreg_delete_user_key(rf"{key}\InProcServer32")
+        winreg_delete_user_key(rf"{key}\Instance")
+        winreg_delete_user_key(rf"{key}\Instance\InitPropertyBag")
+        winreg_delete_user_key(rf"{key}\ShellFolder")
+
+    winreg_delete_user_key(
+        rf"Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\{APPGUID}"
+    )

--- a/tests/core/mountpoint/conftest.py
+++ b/tests/core/mountpoint/conftest.py
@@ -20,9 +20,16 @@ def base_mountpoint(tmpdir):
     return Path(tmpdir / "base_mountpoint")
 
 
+@pytest.fixture(params=[True, False], ids=["mountpoint_in_directory", "mountpoint_in_drive"])
+def mountpoint_in_directory(request: pytest.FixtureRequest):
+    return request.param
+
+
 @pytest.fixture
 @pytest.mark.mountpoint
-def mountpoint_service_factory(tmpdir, local_device_factory, user_fs_factory, reset_testbed):
+def mountpoint_service_factory(
+    tmpdir, local_device_factory, user_fs_factory, reset_testbed, mountpoint_in_directory
+):
     """
     Run a trio loop with fs and mountpoint manager in a separate thread to
     allow blocking operations on the mountpoint in the test
@@ -40,7 +47,11 @@ def mountpoint_service_factory(tmpdir, local_device_factory, user_fs_factory, re
         device = local_device_factory()
         async with user_fs_factory(device) as user_fs:
             async with mountpoint_manager_factory(
-                user_fs, user_fs.event_bus, base_mountpoint, debug=False
+                user_fs,
+                user_fs.event_bus,
+                base_mountpoint,
+                debug=False,
+                mountpoint_in_directory=mountpoint_in_directory,
             ) as mountpoint_manager:
                 if bootstrap_cb:
                     await bootstrap_cb(user_fs, mountpoint_manager)

--- a/windows-icon-handler/common/include/parsec.h
+++ b/windows-icon-handler/common/include/parsec.h
@@ -24,34 +24,6 @@ namespace parsec
 
     inline SyncState get_file_state(const std::wstring_view& pwsz_path)
     {
-        constexpr std::array<wchar_t, 26> DRIVES = {
-            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
-            'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'
-        };
-
-        int drive_number = PathGetDriveNumberW(pwsz_path.data());
-
-        //// Parsec supports drive from H to Z (included). If the drive letter is not
-        //// one of those, we can return FALSE immediately
-        //// A is 0, Z is 25, our drive should be between 7 and 25 included
-        if (drive_number == -1 || drive_number < 7 || PathIsRootW(pwsz_path.data()))
-        {
-            return SyncState::NotSet;
-        }
-
-        // Parsec write a registry key to set the icon for its workspaces.
-        // We check if the key is present for the current drive.
-        std::wstringstream ss;
-        ss << L"Software\\Classes\\Applications\\Explorer.exe\\Drives\\"
-            << DRIVES[drive_number]
-            << L"\\DefaultIcon";
-
-        HKEY key = nullptr;
-        if (RegOpenKeyEx(HKEY_CURRENT_USER, ss.str().c_str(), 0, KEY_READ, &key) != ERROR_SUCCESS)
-        {
-            return SyncState::NotSet;
-        }
-
         auto entry_infos = std::ifstream(std::format(L"{}.__parsec_entry_info__", pwsz_path));
 
         // Can't open file for some reason, stop there


### PR DESCRIPTION
## Describe your changes

This PR adds support for single mountpoint mode on Windows: when enabled via the `single_mountpoint_enabled` option, workspaces are mounted into the `base_mountpoint_path` directory instead of using drive letters. 

It is a simpler and safer alternative solution to https://github.com/Scille/parsec-cloud/pull/4538 for #4668.

Closes #4668

## Checklist

Before you submit this pull request, please make sure to:

- [x] Keep changes in the pull request as small as possible
- [x] Ensure the commit history is sanitized
- [x] Give a meaningful title to your PR
- [x] Describe your changes
- [x] Link any related issue in the description
- [x] Link any dependent pull request in the description

If this PR adds a new feature or fixes a bug:

- [x] I have added or updated relevant tests