### PR TITLE
Specify shared dependencies in `workspace.dependencies`

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -440,6 +440,7 @@ verifykey
 Vlob
 Vlobs
 VueJs
+wasmbind
 webengine
 wfspy
 whereis

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,119 @@ default-members = [
     "libparsec/crates/types",
 ]
 
+# All dependencies should be specified here instead of just in the crate(s) requiring them:
+# - It ensures each given dependency version is consistent accross all crates
+# - It simplifies updating dependency version (only a single place to update)
+#
+# Note the dependencies are marked `default-features = false`, this is because otherwise
+# the default features are always provided (see https://github.com/rust-lang/cargo/issues/8366).
+# This means the dependencies must always specify all features they use instead of relying
+# on default features... Let's say it's a way to reduce bloat by making the developer
+# check the default feature and making sure they are actually needed ;-)
+[workspace.dependencies]
+libparsec = { path = "libparsec", default-features = false }
+libparsec_client_high_level_api = { path = "libparsec/crates/client_high_level_api", default-features = false }
+libparsec_protocol = { path = "libparsec/crates/protocol", default-features = false }
+libparsec_crypto = { path = "libparsec/crates/crypto", default-features = false }
+libparsec_types = { path = "libparsec/crates/types", default-features = false }
+libparsec_platform_device_loader = { path = "libparsec/crates/platform_device_loader", default-features = false }
+libparsec_platform_storage = { path = "libparsec/crates/platform_storage", default-features = false }
+libparsec_serialization_format = { path = "libparsec/crates/serialization_format", default-features = false }
+libparsec_testbed = { path = "libparsec/crates/testbed", default-features = false }
+libparsec_tests_fixtures = { path = "libparsec/crates/tests_fixtures", default-features = false }
+libparsec_client_connection = { path = "libparsec/crates/client_connection", default-features = false }
+libparsec_platform_async = { path = "libparsec/crates/platform_async", default-features = false }
+libparsec_platform_http_proxy = { path = "libparsec/crates/platform_http_proxy", default-features = false }
+libparsec_client = { path = "libparsec/crates/client", default-features = false }
+libparsec_tests_macros = { path = "libparsec/crates/tests_macros", default-features = false }
+
+# Third parties
+android_logger = { version = "0.13", default-features = false }
+anyhow = { version = "1.0.71", default-features = false }
+argon2 = { version = "0.5.0", default-features = false }
+base32 = { version = "0.4.0", default-features = false }
+base64 = { version = "0.21.2", default-features = false }
+blake2 = { version = "0.10.6", default-features = false }
+bytes = { version = "1.4.0", default-features = false }
+chrono = { version = "0.4.26", default-features = false }
+console_error_panic_hook = { version = "0.1.6", default-features = false }
+console_log = { version = "1.0.0", default-features = false }
+crc32fast = { version = "1.3.2", default-features = false }
+crypto_box = { version = "0.8.2", default-features = false }
+data-encoding = { version = "2.4.0", default-features = false }
+diesel = { version = "2.0.3", default-features = false }
+digest = { version = "0.10.6", default-features = false }
+ed25519-dalek = { version = "1.0.1", default-features = false }
+email-address-parser = { version = "2.0.0", default-features = false }
+env_logger = { version = "0.10.0", default-features = false }
+flate2 = { version = "1.0.26", default-features = false }
+flume = { version = "0.10.14", default-features = false }
+fnmatch-regex = { version = "0.2.0", default-features = false }
+futures-lite = { version = "1.12.0", default-features = false }
+futures = { version = "0.3.28", default-features = false }
+generic-array = { version = "0.14.7", default-features = false }
+# Two versions of `getrandom` needed in `libparsec_crypto`
+getrandom_01 = { package = "getrandom", version = "0.1.16", default-features = false }
+getrandom_02 = { package = "getrandom", version = "0.2.3", default-features = false }
+glob = { version = "0.3.0", default-features = false }
+hex-literal = { version = "0.4.1", default-features = false }
+hex = { version = "0.4", default-features = false }
+http-body = { version = "0.4.5", default-features = false }
+hyper = { version = "0.14.26", default-features = false }
+instant = { version = "0.1.12", default-features = false }
+itertools = { version = "0.10.5", default-features = false }
+jni = { version = "0.21.1", default-features = false }
+js-sys = { version = "0.3.59", default-features = false }
+lazy_static = { version = "1.4.0", default-features = false }
+libsodium-sys = { version = "0.2.7", default-features = false }
+libsqlite3-sys = { version = "0.25.2", default-features = false }
+log = { version = "0.4.17", default-features = false }
+miniserde = { version = "0.1.30", default-features = false }
+neon = { version = "0.10", default-features = false }
+once_cell = { version = "1.17.1", default-features = false }
+openssl = { version = "0.10.55", default-features = false }
+paste = { version = "1.0.12", default-features = false }
+percent-encoding = { version = "2.2.0", default-features = false }
+pretty_assertions = { version = "1.3.0", default-features = false }
+proc-macro2 = { version = "1.0.56", default-features = false }
+pyo3 = { version = "0.17.3", default-features = false }
+quote = { version = "1.0.28", default-features = false }
+# Two versions of `rand` needed in `libparsec_crypto`
+rand_07 = { package = "rand", version = "0.7", default-features = false }
+rand_08 = { package = "rand", version = "0.8", default-features = false }
+rand = { version = "0.8.5", default-features = false }
+regex = { version = "1.8.4", default-features = false }
+reqwest-eventsource = { version = "0.4.0", default-features = false }
+reqwest = { version = "0.11.17", default-features = false }
+rmp-serde = { version = "1.1.1", default-features = false }
+rsa = { version = "0.7.2", default-features = false }
+rstest_reuse = { version = "0.4.0", default-features = false }
+rstest = { version = "0.17.0", default-features = false }
+serde_bytes = { version = "0.11.9", default-features = false }
+serde_json = { version = "1.0.96", default-features = false }
+serde_test = { version = "1.0.159", default-features = false }
+serde = { version = "1.0.164", default-features = false }
+serde_with = { version = "2.3.2", default-features = false }
+sha1 = { version = "0.10.5", default-features = false }
+sha2 = { version = "0.10.6", default-features = false }
+sodiumoxide = { version = "0.2.7", default-features = false }
+syn = { version = "2.0.13", default-features = false }
+thiserror = { version = "1.0.40", default-features = false }
+tokio = { version = "1.28.1", default-features = false }
+unicode-normalization = { version = "0.1.22", default-features = false }
+url = { version = "2.3.1", default-features = false }
+uuid = { version = "1.2.2", default-features = false }
+wasm-bindgen-futures = { version = "0.4.33", default-features = false }
+wasm-bindgen-test = { version = "0.3.33", default-features = false }
+wasm-bindgen = { version = "0.2.86", default-features = false }
+web-sys = { version = "0.3.63", default-features = false }
+# Using a non-stable version is exceptionally allowed since no significant changes
+# were made from the last stable version to this major pre-release version.
+# TODO: bump to a stable version.
+x25519-dalek = { version = "2.0.0-rc.2", default-features = false }
+xsalsa20poly1305 = { version = "0.9.0", default-features = false }
+zeroize = { version = "1.6.0", default-features = false }
+
 # Rust unoptimized code is really slow with crypto algorithm and regex compilation,
 # hence we optimize our 3rd party dependencies.
 [profile.dev.package."*"]

--- a/bindings/android/libparsec/rust/Cargo.toml
+++ b/bindings/android/libparsec/rust/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-libparsec = { path = "../../../../libparsec" }
-lazy_static = "1.4.0"
-jni = "0.21.1"
-log = "0.4.14"
-android_logger = "0.13"
-tokio = { version = "1.28", features = ["rt-multi-thread"] }
+libparsec = { workspace = true }
+lazy_static = { workspace = true }
+jni = { workspace = true }
+log = { workspace = true }
+android_logger = { workspace = true, features = ["regex"] }
+tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/bindings/electron/Cargo.toml
+++ b/bindings/electron/Cargo.toml
@@ -11,7 +11,7 @@ test-utils = ["libparsec/test-utils"]
 crate-type = ["cdylib"]
 
 [dependencies]
-libparsec = { path = "../../libparsec" }
-lazy_static = "1.4.0"
-tokio = { version = "1.28", features = ["rt-multi-thread"] }
-neon = { version = "0.10", default-features = false, features = ["napi-6", "channel-api", "promise-api"] }
+libparsec = { workspace = true }
+lazy_static = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+neon = { workspace = true, features = ["napi-6", "channel-api", "promise-api"] }

--- a/bindings/web/Cargo.toml
+++ b/bindings/web/Cargo.toml
@@ -11,21 +11,21 @@ test-utils = ["libparsec/test-utils"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-libparsec = { path = "../../libparsec" }
-wasm-bindgen = "0.2.86"
-wasm-bindgen-futures = "0.4.33"
-js-sys = "0.3.59"
-log = "0.4.17"
-console_log = "1.0.0"
+libparsec = { workspace = true }
+wasm-bindgen = { workspace = true, features = ["spans", "std"] }
+wasm-bindgen-futures = { workspace = true }
+js-sys = { workspace = true }
+log = { workspace = true }
+console_log = { workspace = true }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
-console_error_panic_hook = { version = "0.1.6", optional = true }
+console_error_panic_hook = { workspace = true, optional = true }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.33"
+wasm-bindgen-test = { workspace = true }
 
 # [profile.release]
 # # Tell `rustc` to optimize for small code size.

--- a/libparsec/Cargo.toml
+++ b/libparsec/Cargo.toml
@@ -2,7 +2,6 @@
 name = "libparsec"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.62.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -22,12 +21,12 @@ test-utils = [
 ]
 
 [dependencies]
-libparsec_client_high_level_api = { path = "crates/client_high_level_api"}
-libparsec_protocol = { path = "crates/protocol" }
-libparsec_crypto = { path = "crates/crypto" }
-libparsec_types = { path = "crates/types" }
-libparsec_platform_device_loader = { path = "crates/platform_device_loader" }
-libparsec_platform_storage = { path = "crates/platform_storage" }
-libparsec_serialization_format = { path = "crates/serialization_format" }
+libparsec_client_high_level_api = { workspace = true}
+libparsec_protocol = { workspace = true }
+libparsec_crypto = { workspace = true }
+libparsec_types = { workspace = true }
+libparsec_platform_device_loader = { workspace = true }
+libparsec_platform_storage = { workspace = true }
+libparsec_serialization_format = { workspace = true }
 
-libparsec_testbed = { path = "crates/testbed", optional = true }
+libparsec_testbed = { workspace = true, optional = true }

--- a/libparsec/crates/client/Cargo.toml
+++ b/libparsec/crates/client/Cargo.toml
@@ -7,15 +7,15 @@ license = " BUSL-1.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libparsec_client_connection = { path = "../client_connection" }
-libparsec_types = { path = "../types" }
-libparsec_platform_async = { path = "../platform_async" }
-libparsec_platform_storage = { path = "../platform_storage" }
-libparsec_protocol = { path = "../protocol" }
+libparsec_client_connection = { workspace = true }
+libparsec_types = { workspace = true }
+libparsec_platform_async = { workspace = true }
+libparsec_platform_storage = { workspace = true }
+libparsec_protocol = { workspace = true }
 
-tokio = { version = "1.28.0", features = ["rt", "time", "sync", "macros"] }
-paste = "1.0.12"
-log = "0.4.17"
+tokio = { workspace = true, features = ["rt", "time", "sync", "macros"] }
+paste = { workspace = true }
+log = { workspace = true }
 
 [dev-dependencies]
-libparsec_tests_fixtures = { path = "../tests_fixtures" }
+libparsec_tests_fixtures = { workspace = true }

--- a/libparsec/crates/client_connection/Cargo.toml
+++ b/libparsec/crates/client_connection/Cargo.toml
@@ -12,33 +12,33 @@ test-with-testbed = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libparsec_crypto = { path = "../crypto" }
+libparsec_crypto = { workspace = true }
 # Add primitive type to be used with the protocol
-libparsec_types = { path = "../types" }
-libparsec_protocol = { path = "../protocol" }
-libparsec_testbed = { path = "../testbed", optional = true }
-libparsec_platform_http_proxy = { path = "../platform_http_proxy" }
+libparsec_types = { workspace = true }
+libparsec_protocol = { workspace = true }
+libparsec_testbed = { workspace = true, optional = true }
+libparsec_platform_http_proxy = { workspace = true }
 
 # Used to send HTTP request to the server.
-reqwest = { version = "0.11.17", features = ["native-tls-vendored"] }
-reqwest-eventsource = "0.4.0"
-futures = "0.3.28"
+reqwest = { workspace = true, features = ["native-tls-vendored"] }
+reqwest-eventsource = { workspace = true }
+futures = { workspace = true, features = ["std", "async-await", "executor"] }
 # Used to perform operation on URL.
-url = "2.3.1"
+url = { workspace = true }
 # Use abstract crypto primitive, to allow to sign request.
 # Used to encoded binary data.
-base64 = "0.21.2"
-chrono = "0.4.26"
-thiserror = "1.0.40"
+base64 = { workspace = true, features = ["std"] }
+chrono = { workspace = true, features = ["clock", "std", "oldtime", "wasmbind"] }
+thiserror = { workspace = true }
 # Reqwest's response body is returned as Bytes
-bytes = { version = "1.4.0" }
-once_cell = { version = "1.17.1", optional = true }
+bytes = { workspace = true, features = ["std"] }
+once_cell = { workspace = true, optional = true }
 
 [dev-dependencies]
 # Note `libparsec_tests_fixtures` enables our `test-with-testbed` feature
-libparsec_tests_fixtures = { path = "../tests_fixtures", default-features = false, features = ["test-with-client-connection-testbed"] }
+libparsec_tests_fixtures = { workspace = true, features = ["test-with-client-connection-testbed"] }
 
-log = "0.4.17"
-anyhow = "1.0.70"
-http-body = "0.4.5"
-hyper = { version = "0.14.26", features = ["server"] }
+log = { workspace = true }
+anyhow = { workspace = true, features = ["std"] }
+http-body = { workspace = true }
+hyper = { workspace = true, features = ["server"] }

--- a/libparsec/crates/client_high_level_api/Cargo.toml
+++ b/libparsec/crates/client_high_level_api/Cargo.toml
@@ -8,17 +8,17 @@ license = " BUSL-1.1"
 test-utils = ["libparsec_testbed"]
 
 [dependencies]
-libparsec_crypto = { path = "../crypto" }
-libparsec_platform_async = { path = "../platform_async" }
-libparsec_platform_device_loader = { path = "../platform_device_loader" }
-libparsec_protocol = { path = "../protocol" }
-libparsec_types = { path = "../types" }
+libparsec_crypto = { workspace = true }
+libparsec_platform_async = { workspace = true }
+libparsec_platform_device_loader = { workspace = true }
+libparsec_protocol = { workspace = true }
+libparsec_types = { workspace = true }
 
-libparsec_testbed = { path = "../testbed", optional = true }
+libparsec_testbed = { workspace = true, optional = true }
 
-once_cell = "1.17.1"
-thiserror = "1.0.40"
+once_cell = { workspace = true, features = ["std"] }
+thiserror = { workspace = true }
 
 # TODO: fix wasm32
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-libparsec_client = { path = "../client" }
+libparsec_client = { workspace = true }

--- a/libparsec/crates/crypto/Cargo.toml
+++ b/libparsec/crates/crypto/Cargo.toml
@@ -36,20 +36,20 @@ use-sodiumoxide = [
 # ]
 
 [dependencies]
-serde = { version = "1.0.164", features = ["derive"] }
-serde_bytes = { version = "0.11.9" }
-hex = "0.4"
-thiserror = "1.0.40"
-base32 = "0.4.0"
+serde = { workspace = true, features = ["derive"] }
+serde_bytes = { workspace = true, features = ["std"] }
+hex = { workspace = true, features = ["std"] }
+thiserror = { workspace = true }
+base32 = { workspace = true }
 
 #
 # SodiumOxide&friends stuff
 #
 
-sodiumoxide = { version = "0.2.7", optional = true }
-libsodium-sys = { version = "0.2.7", optional = true }
-openssl = { version = "0.10.55", optional = true, features = ["vendored"] }
-zeroize = { version = "1.6.0", optional = true, features = ["alloc"]}
+sodiumoxide = { workspace = true, optional = true, features = ["std", "serde"] }
+libsodium-sys = { workspace = true, optional = true }
+openssl = { workspace = true, optional = true, features = ["vendored"] }
+zeroize = { workspace = true, optional = true, features = ["alloc"]}
 
 #
 # RustCrypto stuff
@@ -76,41 +76,41 @@ zeroize = { version = "1.6.0", optional = true, features = ["alloc"]}
 # But what about the perf ??? Well compilation is a bit longer with `use-sodiumoxide`
 # but at link time all the rustcrypto related code is discarded given it is never used.
 
-argon2 = { version = "0.5.0" }  # Optional ruscrypto dep
-blake2 = { version = "0.10.6" }  # Optional ruscrypto dep
-crypto_box = { version = "0.8.2", features = ["std"] }  # Optional ruscrypto dep
-digest = { version = "0.10.6" }  # Optional ruscrypto dep
-ed25519-dalek = { version = "1.0.1" }  # Optional ruscrypto dep
-generic-array = { version = "0.14.7", features = ["serde"] }  # Optional ruscrypto dep
-lazy_static = { version = "1.4.0" }  # Optional ruscrypto dep
-rsa = { version = "0.7.2" }  # Optional ruscrypto dep
-sha1 = { version = "0.10.5" }  # Optional ruscrypto dep
-sha2 = { version = "0.10.6" }  # Optional ruscrypto dep
+argon2 = { workspace = true, features = ["alloc", "password-hash", "rand"] }  # Optional ruscrypto dep
+blake2 = { workspace = true, features = ["std"] }  # Optional ruscrypto dep
+crypto_box = { workspace = true, features = ["std"] }  # Optional ruscrypto dep
+digest = { workspace = true, features = ["core-api"] }  # Optional ruscrypto dep
+ed25519-dalek = { workspace = true, features = ["std", "rand", "u64_backend"] }  # Optional ruscrypto dep
+generic-array = { workspace = true, features = ["serde"] }  # Optional ruscrypto dep
+lazy_static = { workspace = true } # Optional ruscrypto dep
+rsa = { workspace = true, features = ["std", "pem"] }  # Optional ruscrypto dep
+sha1 = { workspace = true, features = ["std"] }  # Optional ruscrypto dep
+sha2 = { workspace = true, features = ["std"] }  # Optional ruscrypto dep
 # This is exceptionally allowed since no significant changes
 # were made from the last stable version to this major pre-release version.
 # TODO: bump to a stable version.
-x25519-dalek = { version = "2.0.0-rc.2" }  # Optional ruscrypto dep
-xsalsa20poly1305 = { version = "0.9.0" }  # Optional ruscrypto dep
+x25519-dalek = { workspace = true, features = ["alloc", "zeroize", "precomputed-tables"] }  # Optional ruscrypto dep
+xsalsa20poly1305 = { workspace = true, features = ["alloc", "getrandom"] }  # Optional ruscrypto dep
 # Cryptographic randomness is required for generating SecretKey, SigningKey and PrivateKey
 # For SecretKey, we have `crypto_box` -> [...] -> `rand_core~=0.6` -> `getrandom~=0.2`
 # For SingingKey&PrivateKey we have `<dalek stuff>` -> `rand~=0.5` -> `getrandom~=0.1`
 # So we end up with two version of `getrandom` which have each they own way of
 # configuring wasm-unknown-unknown web support (see [features] part).
-getrandom_01 = { package = "getrandom", version = "0.1.16" }  # Optional ruscrypto dep
-getrandom_02 = { package = "getrandom", version = "0.2.3" }  # Optional ruscrypto dep
+getrandom_01 = { workspace = true }  # Optional ruscrypto dep
+getrandom_02 = { workspace = true }  # Optional ruscrypto dep
 # On top of that we need to have access to the two version of rand (0.7 and 0.8)
 # to provide the randomness configuration to the crypto functions.
 # rand 0.7 relies on rand_core~=0.5/getrandom~=0.1
-rand_07 = { package = "rand", version = "0.7" }  # Optional ruscrypto dep
+rand_07 = { workspace = true, features = ["std"] }  # Optional ruscrypto dep
 # rand 0.8 relies on rand_core~=0.6/getrandom~=0.2
-rand_08 = { package = "rand", version = "0.8" }  # Optional ruscrypto dep
+rand_08 = { workspace = true, features = ["std", "std_rng"] }  # Optional ruscrypto dep
 
 [dev-dependencies]
-pretty_assertions = { version = "1.3.0", features = ["unstable"] }
-serde_test = "1.0.159"
-hex-literal = "0.4.1"
-rmp-serde = "1.1.1"
-rstest = "0.17.0"
+pretty_assertions = { workspace = true, features = ["std", "unstable"] }
+serde_test = { workspace = true }
+hex-literal = { workspace = true }
+rmp-serde = { workspace = true }
+rstest = { workspace = true, features = ["async-timeout"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 
@@ -118,5 +118,5 @@ rstest = "0.17.0"
 # RustCrypto stuff
 #
 
-getrandom_01 = { package = "getrandom", version = "0.1.16", features = ["wasm-bindgen"] }  # Optional rustcrypto dep
-getrandom_02 = { package = "getrandom", version = "0.2.3", features = ["js"] }  # Optional rustcrypto dep
+getrandom_01 = { workspace = true, features = ["wasm-bindgen"] }  # Optional rustcrypto dep
+getrandom_02 = { workspace = true, features = ["js"] }  # Optional rustcrypto dep

--- a/libparsec/crates/platform_async/Cargo.toml
+++ b/libparsec/crates/platform_async/Cargo.toml
@@ -4,35 +4,35 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-flume = "0.10.14"
+flume = { workspace = true, features = ["async", "select", "eventual-fairness"] }
 # futures is used for its macros `select_all` and `join_all`
-futures = "0.3.28"
+futures = { workspace = true, features = ["std", "async-await"] }
 
 [dev-dependencies]
-log = "0.4.17"
+log = { workspace = true }
 # `std::time::Instant` is not available for wasm32, crate `instant` provides a
 # fallback based on `window.performance.now()`
-instant = "0.1.12"
+instant = { workspace = true }
 # Used for `futures_lite::future::or` and don't require `Unpin`
-futures-lite = "1.12.0"
+futures-lite = { workspace = true, features = ["std"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2.86"
-wasm-bindgen-futures = "0.4.31"
+wasm-bindgen = { workspace = true, features = ["spans", "std"] }
+wasm-bindgen-futures = { workspace = true }
 # Window feature is require for `Timer`.
-web-sys = { version = "0.3.63", features = ["Window"] }
-js-sys = "0.3.59"
+web-sys = { workspace = true, features = ["Window"] }
+js-sys = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = "0.3.33"
+wasm-bindgen-test = { workspace = true }
 # Used for binding `log` with `console.log*`
-console_log = "1.0.0"
-instant = { version = "0.1.12", features = ["wasm-bindgen"] }
+console_log = { workspace = true }
+instant = { workspace = true, features = ["wasm-bindgen"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.28.1", features = ["rt", "time", "sync", "macros"] }
+tokio = { workspace = true, features = ["rt", "time", "sync", "macros"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-libparsec_tests_fixtures = { path = "../tests_fixtures" }
+libparsec_tests_fixtures = { workspace = true }
 
-tokio = { version = "1.28.1", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }

--- a/libparsec/crates/platform_device_loader/Cargo.toml
+++ b/libparsec/crates/platform_device_loader/Cargo.toml
@@ -9,16 +9,16 @@ test-with-testbed = [
 ]
 
 [dependencies]
-libparsec_types = { path = "../types" }
-libparsec_crypto = { path = "../crypto" }
-libparsec_testbed = { path = "../testbed", optional = true }
+libparsec_types = { workspace = true }
+libparsec_crypto = { workspace = true }
+libparsec_testbed = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = { version = "0.3.63", features = ["Window", "Storage"] }
-serde_json = "1.0.96"
+web-sys = { workspace = true, features = ["Window", "Storage"] }
+serde_json = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 # Note `libparsec_tests_fixtures` enables our `test-with-testbed` feature
-libparsec_tests_fixtures = { path = "../tests_fixtures", default-features = false, features = ["test-with-platform-device-loader-testbed"] }
+libparsec_tests_fixtures = { workspace = true, features = ["test-with-platform-device-loader-testbed"] }
 
-hex-literal = "0.4.1"
+hex-literal = { workspace = true }

--- a/libparsec/crates/platform_http_proxy/Cargo.toml
+++ b/libparsec/crates/platform_http_proxy/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.11.17", default-features = false }
+reqwest = { workspace = true, features = ["default-tls"] }

--- a/libparsec/crates/platform_storage/Cargo.toml
+++ b/libparsec/crates/platform_storage/Cargo.toml
@@ -9,20 +9,20 @@ edition = "2021"
 test-with-testbed = ["libparsec_testbed"]
 
 [dependencies]
-libparsec_types = { path = "../types" }
-libparsec_platform_async = { path = "../platform_async" }
-libparsec_testbed = { path = "../testbed", optional = true }
+libparsec_types = { workspace = true }
+libparsec_platform_async = { workspace = true }
+libparsec_testbed = { workspace = true, optional = true }
 
-log = "0.4.17"
-lazy_static = { version = "1.4.0", optional = true }
-paste = "1.0.12"
+log = { workspace = true }
+paste = { workspace = true }
+lazy_static = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.28.0", features = ["fs", "sync"] }
-diesel = { version = "2.0.3", features = ["sqlite", "returning_clauses_for_sqlite_3_35"], default-features = false }
+tokio = { workspace = true, features = ["fs", "sync"] }
+diesel = { workspace = true, features = ["sqlite", "returning_clauses_for_sqlite_3_35"], default-features = false }
 # We add this dependency to have sqlite3 bundled into our code.
-libsqlite3-sys = { version = "0.25.2", features = ["bundled"] }
+libsqlite3-sys = { workspace = true, features = ["bundled"] }
 
 [dev-dependencies]
 # Note `libparsec_tests_fixtures` enables our `test-with-testbed` feature
-libparsec_tests_fixtures = { path = "../tests_fixtures", default-features = false, features = ["test-with-platform-storage-testbed"] }
+libparsec_tests_fixtures = { workspace = true, default-features = false, features = ["test-with-platform-storage-testbed"] }

--- a/libparsec/crates/protocol/Cargo.toml
+++ b/libparsec/crates/protocol/Cargo.toml
@@ -7,22 +7,22 @@ license = " BUSL-1.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libparsec_types = { path = "../types" }
-libparsec_serialization_format = { path = "../serialization_format" }
+libparsec_types = { workspace = true }
+libparsec_serialization_format = { workspace = true }
 
-paste = "1.0.12"
-rand = "0.8.5"
-rmp-serde = "1.1.1"
-serde = { version = "1.0.164", features = ["derive"] }
-serde_with = "2.3.2"
-thiserror = "1.0.40"
-futures = "0.3.28"
-bytes = { version = "1.4.0", features = ["serde"] }
+paste = { workspace = true }
+rand = { workspace = true, features = ["std", "std_rng"] }
+rmp-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_with = { workspace = true, features = ["std", "macros"] }
+thiserror = { workspace = true }
+futures = { workspace = true, features = ["std", "async-await", "executor"] }
+bytes = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
-libparsec_tests_fixtures = { path = "../tests_fixtures" }
-hex-literal = "0.4.1"
-serde_json = "1.0.96"
+libparsec_tests_fixtures = { workspace = true }
+hex-literal = { workspace = true }
+serde_json = { workspace = true, features = ["std"] }
 
 [build-dependencies]
-glob = "0.3.0"
+glob = { workspace = true }

--- a/libparsec/crates/serialization_format/Cargo.toml
+++ b/libparsec/crates/serialization_format/Cargo.toml
@@ -11,17 +11,17 @@ proc-macro = true
 python-bindings-support = []
 
 [dependencies]
-itertools = "0.10.5"
-miniserde = "0.1.30"
-proc-macro2 = "1.0.56"
-quote = "1.0.28"
-syn = { version = "2.0.13" }
+itertools = { workspace = true, features = ["use_std"] }
+miniserde = { workspace = true, features = ["std"] }
+proc-macro2 = { workspace = true, features = ["proc-macro"] }
+quote = { workspace = true, features = ["proc-macro"] }
+syn = { workspace = true, features = ["derive", "parsing", "printing", "clone-impls", "proc-macro"] }
 
 [dev-dependencies]
-rstest = "0.17.0"
-pretty_assertions = "1.3.0"
-serde = { version = "1.0.164", features = ["derive"] }
-serde_with = "2.3.2"
-rmp-serde = "1.1.1"
-hex-literal = "0.4.1"
-bytes = { version = "1.4.0", features = ["serde"] }
+rstest = { workspace = true, features = ["async-timeout"] }
+pretty_assertions = { workspace = true, features = ["std"] }
+serde = { workspace = true, features = ["derive"] }
+serde_with = { workspace = true, features = ["std", "macros"] }
+rmp-serde = { workspace = true }
+hex-literal = { workspace = true }
+bytes = { workspace = true, features = ["serde"] }

--- a/libparsec/crates/testbed/Cargo.toml
+++ b/libparsec/crates/testbed/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-libparsec_types = { path = "../types" }
+libparsec_types = { workspace = true }
 
-hex-literal = "0.4.1"
-crc32fast = "1.3.2"
-serde = { version = "1.0.164", features = ["derive"] }
-rmp-serde = "1.1.1"
-lazy_static = "1.4.0"
-reqwest = "0.11.17"
-regex = "1.8.4"
-log = "0.4.17"
-paste = "1.0.12"
+hex-literal = { workspace = true }
+crc32fast = { workspace = true, features = ["std"] }
+serde = { workspace = true, features = ["derive"] }
+rmp-serde = { workspace = true }
+lazy_static = { workspace = true }
+reqwest = { workspace = true, features = ["default-tls"] }
+regex = { workspace = true, features = ["std", "perf", "unicode"] }
+log = { workspace = true }
+paste = { workspace = true }

--- a/libparsec/crates/tests_fixtures/Cargo.toml
+++ b/libparsec/crates/tests_fixtures/Cargo.toml
@@ -28,26 +28,26 @@ test-with-unsecure-but-fast-secretkey-from-password = [
 ]
 
 [dependencies]
-libparsec_types = { path = "../types", features = [ "test-fixtures", "test-mock-time" ] }
-libparsec_tests_macros = { path = "../tests_macros" }
-libparsec_testbed = { path = "../testbed" }
+libparsec_types = { workspace = true, features = [ "test-fixtures", "test-mock-time" ] }
+libparsec_tests_macros = { workspace = true }
+libparsec_testbed = { workspace = true }
 # Enable testbed support in crates here
-libparsec_client_connection = { path = "../client_connection", default-features = false, optional = true }
-libparsec_platform_device_loader = { path = "../platform_device_loader", default-features = false, optional = true }
-libparsec_platform_storage = { path = "../platform_storage", default-features = false, optional = true }
-libparsec_crypto = { path = "../crypto", default-features = false, optional = true }
+libparsec_client_connection = { workspace = true, optional = true }
+libparsec_platform_device_loader = { workspace = true, optional = true }
+libparsec_platform_storage = { workspace = true, optional = true }
+libparsec_crypto = { workspace = true, optional = true }
 
-env_logger = "0.10.0"
-log = "0.4.17"
-rstest = "0.17.0"
-hex-literal = "0.4.1"
-uuid = { version = "1.2.2", features = ["v4", "fast-rng"] }
-lazy_static = "1.4.0"
+env_logger = { workspace = true, features = ["auto-color", "humantime", "regex"] }
+log = { workspace = true }
+rstest = { workspace = true, features = ["async-timeout"] }
+hex-literal = { workspace = true }
+uuid = { workspace = true, features = ["v4", "fast-rng"] }
+lazy_static = { workspace = true }
 # `assert_matches!()` requires `unstable` feature
-pretty_assertions = { version = "1.3.0", features = ["unstable"] }
+pretty_assertions = { workspace = true, features = ["std", "unstable"] }
 
 # TODO: Currently `parsec_test` doesn't support web
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.28.0", features = ["fs", "sync"] }
+tokio = { workspace = true, features = ["fs", "sync"] }
 
 # No dev-dependencies: this crate is itself only used in other crates' own dev-dependencies

--- a/libparsec/crates/tests_macros/Cargo.toml
+++ b/libparsec/crates/tests_macros/Cargo.toml
@@ -8,6 +8,6 @@ license = " BUSL-1.1"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.56"
-quote = "1.0.28"
-syn = { version = "2.0.13" }
+proc-macro2 = { workspace = true, features = ["proc-macro"] }
+quote = { workspace = true, features = ["proc-macro"] }
+syn = { workspace = true, features = ["derive", "parsing", "printing", "clone-impls", "proc-macro"] }

--- a/libparsec/crates/types/Cargo.toml
+++ b/libparsec/crates/types/Cargo.toml
@@ -9,47 +9,47 @@ test-mock-time = []
 test-fixtures = ["dep:hex-literal", "dep:rstest"]
 
 [dependencies]
-libparsec_crypto = { path = "../crypto" }
-libparsec_serialization_format = { path = "../serialization_format" }
-libparsec_platform_async = { path = "../platform_async" }
+libparsec_crypto = { workspace = true }
+libparsec_serialization_format = { workspace = true }
+libparsec_platform_async = { workspace = true }
 
-lazy_static = "1.4.0"
-serde = { version = "1.0.164", features = ["derive"] }
-serde_with = "2.3.2"
-rmp-serde = "1.1.1"
-serde_bytes = "0.11.9"
-bytes = { version = "1.4.0", features = ["serde"] }
-chrono = "0.4.26"
+serde = { workspace = true, features = ["derive"] }
+bytes = { workspace = true, features = ["serde"] }
+lazy_static = { workspace = true }
+serde_with = { workspace = true, features = ["std", "macros"] }
+rmp-serde = { workspace = true }
+serde_bytes = { workspace = true, features = ["std"] }
+chrono = { workspace = true, features = ["clock"] }
 # By default uuid crate uses `getrandom` directly instead of `rand`, however
 # the latter is much faster (see. https://github.com/uuid-rs/uuid/pull/545,
 # tl;dr: `rand` uses `getrandom` as seed then applies a fast chacha algo on it)
 # Hence `fast-rng` feature which enables the use of `rand`.
-uuid = { version = "1.2.2", features = ["serde", "v4", "fast-rng"] }
-data-encoding = "2.4.0"
-url = "2.3.1"
-percent-encoding = "2.2.0"
-regex = "1.8.4"
-unicode-normalization = "0.1.22"
-paste = "1.0.12"
-flate2 = "1.0.26"
-rand = "0.8.4"
-thiserror = "1.0.40"
-email-address-parser = "2.0.0"
-anyhow = { version="1.0.71", features = ["backtrace"] }
-fnmatch-regex = "0.2.0"
-sha2 = "0.10.6"
-hex-literal = { version = "0.4.1", optional = true }
-rstest = { version = "0.17.0", optional = true }
+uuid = { workspace = true, features = ["serde", "v4", "fast-rng"] }
+data-encoding = { workspace = true, features = ["std"] }
+url = { workspace = true }
+percent-encoding = { workspace = true, features = ["alloc"] }
+regex = { workspace = true, features = ["std", "perf", "unicode"] }
+unicode-normalization = { workspace = true, features = ["std"] }
+paste = { workspace = true }
+flate2 = { workspace = true, features = ["rust_backend"] }
+rand = { workspace = true, features = ["std", "std_rng"] }
+thiserror = { workspace = true }
+email-address-parser = { workspace = true }
+anyhow = { workspace = true, features = ["std", "backtrace"] }
+fnmatch-regex = { workspace = true }
+sha2 = { workspace = true, features = ["std"] }
+hex-literal = { workspace = true, optional = true }
+rstest = { workspace = true, optional = true }
 
 [dev-dependencies]
-libparsec_types = { path = ".", features = ["test-fixtures"] }
+libparsec_types = { workspace = true, features = ["test-fixtures"] }
 
 # `assert_matches!()` requires `unstable` feature
-pretty_assertions = { version = "1.3.0", features = ["unstable"] }
-serde_test = "1.0.159"
-hex-literal = "0.4.1"
-rstest_reuse = "0.4.0"
-rstest = "0.17.0"
+pretty_assertions = { workspace = true, features = ["std", "unstable"] }
+serde_test = { workspace = true }
+hex-literal = { workspace = true }
+rstest_reuse = { workspace = true }
+rstest = { workspace = true, features = ["async-timeout"] }
 
 [build-dependencies]
-glob = "0.3.0"
+glob = { workspace = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -14,14 +14,14 @@ default = ["test-utils"]  # TODO: remove me !
 test-utils = ["libparsec/test-utils"]
 
 [dependencies]
-libparsec = { path = "../libparsec", features = ["python-bindings-support"] }
+libparsec = { workspace = true, features = ["python-bindings-support"] }
 
-regex = "1.8.4"
-paste = "1.0.12"
-pyo3 = { version = "0.17.3", features = ["multiple-pymethods", "extension-module"] }
-uuid = { version = "1.2.2", features = ["serde", "v4", "fast-rng"] }
-tokio = { version = "1.28", features = ["rt", "rt-multi-thread"] }
-lazy_static = "1.4.0"
-futures = "0.3.28"
-rmp-serde = "1.1.1"
-serde = { version = "1.0.164", features = ["derive"] }
+regex = { workspace = true, features = ["std", "perf", "unicode"] }
+paste = { workspace = true }
+pyo3 = { workspace = true, features = ["multiple-pymethods", "extension-module", "macros"] }
+uuid = { workspace = true, features = ["serde", "v4", "fast-rng"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
+lazy_static = { workspace = true }
+futures = { workspace = true, features = ["std", "async-await", "executor"] }
+rmp-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
Move the multiple (more than 1) definition of a rust dependencies in the root `Cargo.toml`.

Using `workspace.dependencies` provide the following benefit:

- Prevent conflict when 2 actors update one of those dependencies in parallel.

  The potential conflict is simpler to resolve, only `/Cargo.toml` is modified.

- Ensure all sub-crates are using the same version.
- Reduce that amount of modified files by `dependabot`.

Here is the list of dependencies that I've moved to `workspace.dependencies`:

- `regex`
- `paste`
- `uuid`
- `tokio`
- `lazy_static`
- `futures`
- `rmp-serde`
- `serde`
- `log`
- `wasm-bindgen`
- `wasm-bindgen-futures`
- `js-sys`
- `console_log`
- `wasm-bindgen-test`
- `reqwest`
- `url`
- `chrono`
- `thiserror`
- `bytes`
- `once_cell`
- `anyhow`
- `pretty_assertions`
- `serde_test`
- `hex-literal`
- `rstest`
- `glob`
- `sha2`
- `web-sys`
- `instant`
- `serde_json`
- `itertools`
- `diesel`
- `libsqlite3-sys`
- `rand`
- `serde_with`
- `quote`
- `proc-macro2`
- `syn`
- `serde_bytes`