### PR TITLE
[MS] Fixed eslint for switch-cases

### DIFF
--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -42,7 +42,7 @@ module.exports = {
     'no-multiple-empty-lines': ['error', { 'max': 1, 'maxEOF': 0 }],
     'prefer-const': 'error',
     'comma-dangle': 'error',
-    'indent': ['error', 2],
+    'indent': ['error', 2, { 'SwitchCase': 1 }],
     'camelcase': 'error',
     'max-len': ['error', 140],
     'quotes': ['error', 'single', { 'avoidEscape': true }],


### PR DESCRIPTION
By default, switch/case are formatted as
```typescript
switch(v) {
case 0: {
  ...
}
}
```
which is ugly.

Now they are formatted as
```typescript
switch(v) {
  case 0: {
    ...
  }
}
```
which is a bit better.

- [X] Keep changes in the pull request as small as possible
   <!-- Move unrelated changes to a new pull request -->
- [X] Ensure the commit history is sanitized
   <!-- Commits should have a meaningful title and contain a coherent set of changes
        Squash commits that are only relevant to the branch context -->
- [X] Give a meaningful title to your PR
- [X] Describe your changes
   <!-- Give some context about the changes
        Draw attention to the details that should not be overlooked -->