### PR TITLE
Replace unwrap_or_else(|_| unreachable!()) with expect(...)

### DIFF
--- a/libparsec/crates/types/src/certif.rs
+++ b/libparsec/crates/types/src/certif.rs
@@ -48,10 +48,11 @@ fn dump<T>(obj: &T) -> Vec<u8>
 where
     T: Serialize,
 {
-    let serialized = ::rmp_serde::to_vec_named(obj).unwrap_or_else(|_| unreachable!());
+    let serialized = ::rmp_serde::to_vec_named(obj).expect("object should be serializable");
     let mut e = ZlibEncoder::new(Vec::new(), flate2::Compression::default());
-    e.write_all(&serialized).unwrap_or_else(|_| unreachable!());
-    e.finish().unwrap_or_else(|_| unreachable!())
+    e.write_all(&serialized)
+        .and_then(|_| e.finish())
+        .expect("in-memory buffer should not fail")
 }
 
 fn check_author_allow_root(

--- a/libparsec/crates/types/src/ext_types.rs
+++ b/libparsec/crates/types/src/ext_types.rs
@@ -85,7 +85,7 @@ impl<'de> serde::de::Visitor<'de> for DateTimeExtVisitor {
         let ts = f64::from_be_bytes(
             data[..F64_SIZE]
                 .try_into()
-                .unwrap_or_else(|_| unreachable!()),
+                .expect("data.len() should be equal to F64_SIZE"),
         );
 
         Ok(Self::Value::from_f64_with_us_precision(ts))

--- a/libparsec/crates/types/src/id.rs
+++ b/libparsec/crates/types/src/id.rs
@@ -179,8 +179,8 @@ macro_rules! new_string_based_id_type {
             fn try_from(s: &str) -> Result<Self, Self::Error> {
                 let id: String = s.nfc().collect();
                 lazy_static! {
-                    static ref PATTERN: Regex =
-                        Regex::new($pattern).unwrap_or_else(|_| unreachable!());
+                    static ref PATTERN: Regex = Regex::new($pattern)
+                        .expect("`pattern` should be a valid regular expression");
                 }
                 // ID must respect regex AND be contained within $bytes_size bytes
                 if PATTERN.is_match(&id) && id.len() <= $bytes_size {

--- a/libparsec/crates/types/src/local_device.rs
+++ b/libparsec/crates/types/src/local_device.rs
@@ -68,7 +68,7 @@ impl LocalDevice {
     }
 
     pub fn dump(&self) -> Vec<u8> {
-        rmp_serde::to_vec_named(&self).unwrap_or_else(|_| unreachable!())
+        rmp_serde::to_vec_named(&self).expect("LocalDevice serialization should not fail")
     }
 
     pub fn load(serialized: &[u8]) -> Result<Self, &'static str> {

--- a/libparsec/crates/types/src/local_manifest.rs
+++ b/libparsec/crates/types/src/local_manifest.rs
@@ -22,7 +22,7 @@ macro_rules! impl_local_manifest_dump_load {
         impl $name {
             pub fn dump_and_encrypt(&self, key: &SecretKey) -> Vec<u8> {
                 let serialized =
-                    ::rmp_serde::to_vec_named(&self).unwrap_or_else(|_| unreachable!());
+                    ::rmp_serde::to_vec_named(&self).expect("object should be serializable");
                 key.encrypt(&serialized)
             }
 
@@ -87,10 +87,12 @@ impl Chunk {
             stop,
             raw_offset: start,
             // TODO: what to do with overflow
-            raw_size: NonZeroU64::try_from(stop.get() - start).unwrap_or_else(|_| unreachable!()),
+            raw_size: NonZeroU64::try_from(stop.get() - start)
+                .expect("Chunk raw_size should be NonZeroU64"),
             access: None,
         }
     }
+
     pub fn from_block_access(block_access: BlockAccess) -> Result<Self, &'static str> {
         Ok(Self {
             id: ChunkID::from(*block_access.id),
@@ -100,7 +102,9 @@ impl Chunk {
             // TODO: what to do with overflow
             stop: (block_access.offset + block_access.size.get())
                 .try_into()
-                .unwrap_or_else(|_| unreachable!()),
+                .expect(
+                    "Chunk stop should be NonZeroU64 since bloc_access.size is already NonZeroU64",
+                ),
             access: Some(block_access),
         })
     }

--- a/libparsec/crates/types/src/message.rs
+++ b/libparsec/crates/types/src/message.rs
@@ -113,10 +113,13 @@ impl MessageContent {
     }
 
     pub fn dump_and_sign(&self, author_signkey: &SigningKey) -> Vec<u8> {
-        let serialized = rmp_serde::to_vec_named(&self).unwrap_or_else(|_| unreachable!());
+        let serialized =
+            rmp_serde::to_vec_named(&self).expect("MessageContent should be serializable");
         let mut e = ZlibEncoder::new(Vec::new(), flate2::Compression::default());
-        e.write_all(&serialized).unwrap_or_else(|_| unreachable!());
-        let compressed = e.finish().unwrap_or_else(|_| unreachable!());
+        let compressed = e
+            .write_all(&serialized)
+            .and_then(|_| e.finish())
+            .expect("in-memory buffer should not fail");
         author_signkey.sign(&compressed)
     }
 


### PR DESCRIPTION
## Describe your changes

This PR replaces all `unwrap_or_else(|_| unreachable!())` with `expect(...)` in the `types` crate.

Error messages use the "error as precondition" style as defined in https://doc.rust-lang.org/std/error/index.html#common-message-styles

Closes #4542 

## Checklist

Before you submit this pull request, please make sure to:

- [x] Keep changes in the pull request as small as possible
   <!-- Move unrelated changes to a new pull request -->
- [x] Ensure the commit history is sanitized
   <!-- Commits should have a meaningful title and contain a coherent set of changes
        Squash commits that are only relevant to the branch context -->
- [x] Give a meaningful title to your PR
- [x] Describe your changes
   <!-- Give some context about the changes
        Draw attention to the details that should not be overlooked -->
- [x] Link any related issue in the description
   <!-- You can add `closes #<IssueID>` to close the issue when the PR is merged -->
- [x] Link any dependent pull request in the description
