### PR TITLE
[MS] Fixed password input clear on edit

### DIFF
--- a/client/src/components/PasswordInput.vue
+++ b/client/src/components/PasswordInput.vue
@@ -20,6 +20,7 @@
             @keyup.enter="onEnterPress()"
             :autofocus="true"
             id="password-input"
+            :clear-on-edit="false"
           />
           <ion-button
             @click="passwordVisible = !passwordVisible"


### PR DESCRIPTION
Make sure that the ion-input isn't cleared when regaining focus in password mode. It's a bit confusing and doesn't bring much in our case when we can toggle password visibility.

- [X] Keep changes in the pull request as small as possible
   <!-- Move unrelated changes to a new pull request -->
- [X] Ensure the commit history is sanitized
   <!-- Commits should have a meaningful title and contain a coherent set of changes
        Squash commits that are only relevant to the branch context -->
- [X] Give a meaningful title to your PR
- [X] Describe your changes
 