### PR TITLE
Pin certifi version to 2023.7.22

### DIFF
--- a/server/poetry.lock
+++ b/server/poetry.lock
@@ -2367,4 +2367,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.9.10"
-content-hash = "71f6f7cb62288746bfe8ad277b57f6f9c032a1169424d640542b6580b6f49b2e"
+content-hash = "70c77e69176e34ab32c4597123883dcf710ab483327c3f9c2b570f443dfde985"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -32,7 +32,7 @@ python = "~3.9.10"
 
 # Base requirements
 
-certifi = ">=2021,<2024"
+certifi = "^2023.7.22"
 attrs = ">=21.4,<24.0"
 click = "^8.0"
 msgpack = "^1.0"


### PR DESCRIPTION
This PR sets `certifi` version to `^2023.7.22`. Note that this **does not change** the current version, only pins it in `pyproject.toml`.

This should also be backported to the `releases/2.16` branch. See #5027