### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,20 +21,20 @@ package-lock.json       @Scille/js-code-owners
 
 # Rust team is responsible for the rust code.
 /libparsec/             @Scille/rust-code-owners
-/src                    @Scille/rust-code-owners
 rust-toolchain.toml     @Scille/rust-code-owners
 Cargo.toml              @Scille/rust-code-owners
 Cargo.lock              @Scille/rust-code-owners
+*.rs                    @Scille/rust-code-owners
 # For now only rust code use json schema
 /json_schema            @Scille/rust-code-owners
 
-# The /src contains rust binding that is used by the python code.
+# The /server/src contains rust binding that is used by the python code.
 # So the responsability is shared between rust & python teams.
-/src/                   @Scille/rust-code-owners @Scille/python-code-owners
+/server/src/            @Scille/rust-code-owners @Scille/python-code-owners
 
 # Python team is responsible for the python code.
-/parsec/                @Scille/python-code-owners
-/tests/                 @Scille/python-code-owners
+/server/parsec/         @Scille/python-code-owners
+/server/tests/          @Scille/python-code-owners
 pyproject.toml          @Scille/python-code-owners
 poetry.lock             @Scille/python-code-owners
 readthedocs.yml         @Scille/python-code-owners


### PR DESCRIPTION
With the code organization last month, CODEOWNERS paths aren't all up to date.

Most of the python path weren't updated.
I've also make all rust file (`*.rs`) owned by default by the rust team.

Closes #5029
