### PR TITLE
Disabled allowCompoundsWords in cspell.config.yml

### DIFF
--- a/.cspell/cspell.config.yml
+++ b/.cspell/cspell.config.yml
@@ -112,7 +112,7 @@ cache:
   cacheStrategy: metadata
   useCache: true
 useGitignore: true
-allowCompoundWords: true
+allowCompoundWords: false
 ignorePaths:
   # Cspell seems to match against the absolute path, so must always start with `**/` :(
   - "**/bindings/web/src/meths.rs"


### PR DESCRIPTION
allowCompoundWords has been disabled in cspell.config.yml

PR for #5081 

Changes that have an impact on the user:
     - A use case has been modified - Compound words can not be used as described in #5081.