### PR TITLE
Generate libparsec protocol serialization tests

### DIFF
--- a/libparsec/crates/protocol/README.md
+++ b/libparsec/crates/protocol/README.md
@@ -1,0 +1,11 @@
+# Libparsec Protocol
+
+This crate provides the schema definition, implementation and serialization
+tests for Parsec protocol commands.
+
+The JSON schemas defining the protocol commands can be found in the [`schema`]
+directory. The commands implementation and tests are generated with procedural
+macros from the [`libparsec serialization format`] crate based on these schemas.
+
+[`schema`]: ./schema
+[`libparsec serialization format`]: ../serialization_format

--- a/libparsec/crates/protocol/src/lib.rs
+++ b/libparsec/crates/protocol/src/lib.rs
@@ -1,4 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+#![doc = include_str!("../README.md")]
 
 mod error;
 mod version;

--- a/libparsec/crates/protocol/tests/anonymous_cmds/v3/organization_bootstrap.rs
+++ b/libparsec/crates/protocol/tests/anonymous_cmds/v3/organization_bootstrap.rs
@@ -1,0 +1,35 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::anonymous_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_certification() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_data() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_bootstrapped() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/anonymous_cmds/v3/ping.rs
+++ b/libparsec/crates/protocol/tests/anonymous_cmds/v3/ping.rs
@@ -1,0 +1,15 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::anonymous_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/anonymous_cmds/v3/pki_enrollment_info.rs
+++ b/libparsec/crates/protocol/tests/anonymous_cmds/v3/pki_enrollment_info.rs
@@ -1,0 +1,19 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::anonymous_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/anonymous_cmds/v3/pki_enrollment_submit.rs
+++ b/libparsec/crates/protocol/tests/anonymous_cmds/v3/pki_enrollment_submit.rs
@@ -1,0 +1,35 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::anonymous_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_submitted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_id_already_used() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_email_already_used() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_enrolled() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_payload_data() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/anonymous_cmds/v4/organization_bootstrap.rs
+++ b/libparsec/crates/protocol/tests/anonymous_cmds/v4/organization_bootstrap.rs
@@ -1,0 +1,35 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::anonymous_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_certification() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_data() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_bootstrapped() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/anonymous_cmds/v4/ping.rs
+++ b/libparsec/crates/protocol/tests/anonymous_cmds/v4/ping.rs
@@ -1,0 +1,15 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::anonymous_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/anonymous_cmds/v4/pki_enrollment_info.rs
+++ b/libparsec/crates/protocol/tests/anonymous_cmds/v4/pki_enrollment_info.rs
@@ -1,0 +1,19 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::anonymous_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/anonymous_cmds/v4/pki_enrollment_submit.rs
+++ b/libparsec/crates/protocol/tests/anonymous_cmds/v4/pki_enrollment_submit.rs
@@ -1,0 +1,35 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::anonymous_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_submitted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_id_already_used() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_email_already_used() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_enrolled() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_payload_data() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/block_create.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/block_create.rs
@@ -1,0 +1,45 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+// `allow-unwrap-in-test` don't behave as expected, see:
+// https://github.com/rust-lang/rust-clippy/issues/11119
+#![allow(clippy::unwrap_used)]
+
+use hex_literal::hex;
+
+// wrap this in each test function
+// macro qui contient une closure
+use super::authenticated_cmds;
+
+use libparsec_types::prelude::*;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_exists() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_in_maintenance() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_timeout() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/block_read.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/block_read.rs
@@ -1,0 +1,31 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_timeout() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_in_maintenance() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/device_create.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/device_create.rs
@@ -1,0 +1,41 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_certification() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_user_id() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_data() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_exists() {
+    // TODO #4545: Implement test
+}
+
+// TODO #4545: These status have introduced_in 4.0 but proc macro generates code anyway
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_require_greater_timestamp() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/events_listen.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/events_listen.rs
@@ -1,0 +1,23 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_cancelled() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_no_events() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/events_subscribe.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/events_subscribe.rs
@@ -1,0 +1,15 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/human_find.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/human_find.rs
@@ -1,0 +1,19 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/invite_1_greeter_wait_peer.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/invite_1_greeter_wait_peer.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/invite_2a_greeter_get_hashed_nonce.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/invite_2a_greeter_get_hashed_nonce.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/invite_2b_greeter_send_nonce.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/invite_2b_greeter_send_nonce.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/invite_3a_greeter_wait_peer_trust.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/invite_3a_greeter_wait_peer_trust.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/invite_3b_greeter_signify_trust.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/invite_3b_greeter_signify_trust.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/invite_4_greeter_communicate.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/invite_4_greeter_communicate.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/invite_delete.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/invite_delete.rs
@@ -1,0 +1,23 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/invite_list.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/invite_list.rs
@@ -1,0 +1,15 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/invite_new.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/invite_new.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_member() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_available() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/message_get.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/message_get.rs
@@ -1,0 +1,15 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/organization_config.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/organization_config.rs
@@ -1,0 +1,19 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/organization_stats.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/organization_stats.rs
@@ -1,0 +1,23 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/ping.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/ping.rs
@@ -1,0 +1,15 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/pki_enrollment_accept.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/pki_enrollment_accept.rs
@@ -1,0 +1,57 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_payload_data() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_certification() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_data() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_no_longer_available() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_exists() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_active_users_limit_reached() {
+    // TODO #4545: Implement test
+}
+
+// TODO #4545: These status have introduced_in 4.0 but proc macro generates code anyway
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_require_greater_timestamp() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/pki_enrollment_list.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/pki_enrollment_list.rs
@@ -1,0 +1,19 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/pki_enrollment_reject.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/pki_enrollment_reject.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_no_longer_available() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/realm_create.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/realm_create.rs
@@ -1,0 +1,41 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_certification() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_data() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_exists() {
+    // TODO #4545: Implement test
+}
+
+// TODO #4545: These status have introduced_in 4.0 but proc macro generates code anyway
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_require_greater_timestamp() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/realm_finish_reencryption_maintenance.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/realm_finish_reencryption_maintenance.rs
@@ -1,0 +1,35 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_encryption_revision() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_in_maintenance() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_maintenance_error() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/realm_get_role_certificates.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/realm_get_role_certificates.rs
@@ -1,0 +1,23 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/realm_start_reencryption_maintenance.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/realm_start_reencryption_maintenance.rs
@@ -1,0 +1,43 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_encryption_revision() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_participant_mismatch() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_maintenance_error() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_in_maintenance() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/realm_stats.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/realm_stats.rs
@@ -1,0 +1,23 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/realm_status.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/realm_status.rs
@@ -1,0 +1,23 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/realm_update_roles.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/realm_update_roles.rs
@@ -1,0 +1,55 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_certification() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_data() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_granted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_incompatible_profile() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_in_maintenance() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_user_revoked() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_require_greater_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/user_create.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/user_create.rs
@@ -1,0 +1,45 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_certification() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_data() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_exists() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_active_users_limit_reached() {
+    // TODO #4545: Implement test
+}
+
+// TODO #4545: These status have introduced_in 4.0 but proc macro generates code anyway
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_require_greater_timestamp() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/user_get.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/user_get.rs
@@ -1,0 +1,19 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/user_revoke.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/user_revoke.rs
@@ -1,0 +1,41 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_certification() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_revoked() {
+    // TODO #4545: Implement test
+}
+
+// TODO #4545: These status have introduced_in 4.0 but proc macro generates code anyway
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_require_greater_timestamp() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/vlob_create.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/vlob_create.rs
@@ -1,0 +1,55 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_exists() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_encryption_revision() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_in_maintenance() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_require_greater_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_a_sequestered_organization() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_sequester_inconsistency() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_rejected_by_sequester_service() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_timeout() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/vlob_list_versions.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/vlob_list_versions.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_in_maintenance() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/vlob_maintenance_get_reencryption_batch.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/vlob_maintenance_get_reencryption_batch.rs
@@ -1,0 +1,35 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_in_maintenance() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_encryption_revision() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_maintenance_error() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/vlob_maintenance_save_reencryption_batch.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/vlob_maintenance_save_reencryption_batch.rs
@@ -1,0 +1,35 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_in_maintenance() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_encryption_revision() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_maintenance_error() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/vlob_poll_changes.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/vlob_poll_changes.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_in_maintenance() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/vlob_read.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/vlob_read.rs
@@ -1,0 +1,78 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+// `allow-unwrap-in-test` don't behave as expected, see:
+// https://github.com/rust-lang/rust-clippy/issues/11119
+#![allow(clippy::unwrap_used)]
+
+use hex_literal::hex;
+
+use super::authenticated_cmds;
+
+use libparsec_types::prelude::*;
+
+// Request
+
+pub fn req() {
+    // Generated from Python implementation (Parsec v2.6.0+dev)
+    // Content:
+    //   timestamp: ext(1, 946774800.0)
+    //   version: 8
+    //   cmd: "vlob_read"
+    //   encryption_revision: 8
+    //   vlob_id: ext(2, hex!("2b5f314728134a12863da1ce49c112f6"))
+    let raw = hex!(
+        "85a3636d64a9766c6f625f72656164b3656e6372797074696f6e5f7265766973696f6e08a9"
+        "74696d657374616d70d70141cc375188000000a776657273696f6e08a7766c6f625f6964d8"
+        "022b5f314728134a12863da1ce49c112f6"
+    );
+
+    let req = authenticated_cmds::vlob_read::Req {
+        encryption_revision: 8,
+        vlob_id: VlobID::from_hex("2b5f314728134a12863da1ce49c112f6").unwrap(),
+        version: Some(8),
+        timestamp: Some("2000-1-2T01:00:00Z".parse().unwrap()),
+    };
+
+    let expected = authenticated_cmds::AnyCmdReq::VlobRead(req);
+
+    let data = authenticated_cmds::AnyCmdReq::load(&raw).unwrap();
+
+    assert_eq!(data, expected);
+
+    // Also test serialization round trip
+    let raw2 = if let authenticated_cmds::AnyCmdReq::VlobRead(data) = data {
+        data.dump().unwrap()
+    } else {
+        unreachable!()
+    };
+
+    let data2 = authenticated_cmds::AnyCmdReq::load(&raw2).unwrap();
+
+    assert_eq!(data2, expected);
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_version() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_encryption_revision() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_in_maintenance() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v3/vlob_update.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v3/vlob_update.rs
@@ -1,0 +1,59 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_version() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_encryption_revision() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_in_maintenance() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_require_greater_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_a_sequestered_organization() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_sequester_inconsistency() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_rejected_by_sequester_service() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_timeout() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/block_create.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/block_create.rs
@@ -1,0 +1,30 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+#![allow(clippy::duplicate_mod)]
+
+use super::authenticated_cmds;
+
+// The compat mod is defined to re-use tests from v3
+// Loading a file as a module more than once causes it to be compiled multiple
+// times, taking longer and putting duplicate content into the module tree.
+// In this case, this is exactly what we want.
+#[path = "../v3/block_create.rs"]
+mod compat;
+
+// Request
+
+pub use compat::req;
+
+// Responses
+
+pub use compat::rep_ok;
+
+pub use compat::rep_already_exists;
+
+pub use compat::rep_not_found;
+
+pub use compat::rep_not_allowed;
+
+pub use compat::rep_in_maintenance;
+
+pub use compat::rep_timeout;

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/block_read.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/block_read.rs
@@ -1,0 +1,31 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_timeout() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_in_maintenance() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/certificate_get.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/certificate_get.rs
@@ -1,0 +1,15 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/device_create.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/device_create.rs
@@ -1,0 +1,39 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_certification() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_user_id() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_data() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_exists() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_require_greater_timestamp() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/events_listen.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/events_listen.rs
@@ -1,0 +1,19 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_available() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/invite_1_greeter_wait_peer.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/invite_1_greeter_wait_peer.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/invite_2a_greeter_get_hashed_nonce.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/invite_2a_greeter_get_hashed_nonce.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/invite_2b_greeter_send_nonce.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/invite_2b_greeter_send_nonce.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/invite_3a_greeter_wait_peer_trust.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/invite_3a_greeter_wait_peer_trust.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/invite_3b_greeter_signify_trust.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/invite_3b_greeter_signify_trust.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/invite_4_greeter_communicate.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/invite_4_greeter_communicate.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/invite_delete.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/invite_delete.rs
@@ -1,0 +1,23 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/invite_list.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/invite_list.rs
@@ -1,0 +1,15 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/invite_new.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/invite_new.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_member() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_available() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/message_get.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/message_get.rs
@@ -1,0 +1,15 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/organization_config.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/organization_config.rs
@@ -1,0 +1,19 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/organization_stats.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/organization_stats.rs
@@ -1,0 +1,23 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/ping.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/ping.rs
@@ -1,0 +1,15 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/pki_enrollment_accept.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/pki_enrollment_accept.rs
@@ -1,0 +1,55 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_payload_data() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_certification() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_data() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_no_longer_available() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_exists() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_active_users_limit_reached() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_require_greater_timestamp() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/pki_enrollment_list.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/pki_enrollment_list.rs
@@ -1,0 +1,19 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/pki_enrollment_reject.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/pki_enrollment_reject.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_no_longer_available() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/realm_create.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/realm_create.rs
@@ -1,0 +1,39 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_certification() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_data() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_exists() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_require_greater_timestamp() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/realm_finish_reencryption_maintenance.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/realm_finish_reencryption_maintenance.rs
@@ -1,0 +1,35 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_encryption_revision() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_in_maintenance() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_maintenance_error() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/realm_start_reencryption_maintenance.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/realm_start_reencryption_maintenance.rs
@@ -1,0 +1,43 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_encryption_revision() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_participant_mismatch() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_maintenance_error() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_in_maintenance() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/realm_stats.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/realm_stats.rs
@@ -1,0 +1,23 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/realm_status.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/realm_status.rs
@@ -1,0 +1,23 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/realm_update_roles.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/realm_update_roles.rs
@@ -1,0 +1,55 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_certification() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_data() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_granted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_incompatible_profile() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_in_maintenance() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_user_revoked() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_require_greater_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/user_create.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/user_create.rs
@@ -1,0 +1,43 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_certification() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_data() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_exists() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_active_users_limit_reached() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_require_greater_timestamp() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/user_revoke.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/user_revoke.rs
@@ -1,0 +1,39 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_certification() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_revoked() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_require_greater_timestamp() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/user_update.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/user_update.rs
@@ -1,0 +1,39 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_certification() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_data() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_exists() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_require_greater_timestamp() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/vlob_create.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/vlob_create.rs
@@ -1,0 +1,55 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_exists() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_encryption_revision() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_in_maintenance() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_require_greater_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_a_sequestered_organization() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_sequester_inconsistency() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_rejected_by_sequester_service() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_timeout() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/vlob_list_versions.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/vlob_list_versions.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_in_maintenance() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/vlob_maintenance_get_reencryption_batch.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/vlob_maintenance_get_reencryption_batch.rs
@@ -1,0 +1,35 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_in_maintenance() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_encryption_revision() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_maintenance_error() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/vlob_maintenance_save_reencryption_batch.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/vlob_maintenance_save_reencryption_batch.rs
@@ -1,0 +1,35 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_in_maintenance() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_encryption_revision() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_maintenance_error() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/vlob_poll_changes.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/vlob_poll_changes.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_in_maintenance() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/vlob_read.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/vlob_read.rs
@@ -1,0 +1,29 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+#![allow(clippy::duplicate_mod)]
+
+use super::authenticated_cmds;
+
+// The compat module allows to re-use tests from previous major API
+#[path = "../v3/vlob_read.rs"]
+mod compat;
+
+// Request
+
+pub use compat::req;
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub use compat::rep_not_found;
+
+pub use compat::rep_not_allowed;
+
+pub use compat::rep_bad_version;
+
+pub use compat::rep_bad_encryption_revision;
+
+pub use compat::rep_in_maintenance;

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/vlob_update.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/vlob_update.rs
@@ -1,0 +1,59 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::authenticated_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_allowed() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_version() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_encryption_revision() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_in_maintenance() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_require_greater_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_bad_timestamp() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_a_sequestered_organization() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_sequester_inconsistency() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_rejected_by_sequester_service() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_timeout() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/invited_cmds/v3/invite_1_claimer_wait_peer.rs
+++ b/libparsec/crates/protocol/tests/invited_cmds/v3/invite_1_claimer_wait_peer.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::invited_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/invited_cmds/v3/invite_2a_claimer_send_hashed_nonce.rs
+++ b/libparsec/crates/protocol/tests/invited_cmds/v3/invite_2a_claimer_send_hashed_nonce.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::invited_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/invited_cmds/v3/invite_2b_claimer_send_nonce.rs
+++ b/libparsec/crates/protocol/tests/invited_cmds/v3/invite_2b_claimer_send_nonce.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::invited_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/invited_cmds/v3/invite_3a_claimer_signify_trust.rs
+++ b/libparsec/crates/protocol/tests/invited_cmds/v3/invite_3a_claimer_signify_trust.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::invited_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/invited_cmds/v3/invite_3b_claimer_wait_peer_trust.rs
+++ b/libparsec/crates/protocol/tests/invited_cmds/v3/invite_3b_claimer_wait_peer_trust.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::invited_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/invited_cmds/v3/invite_4_claimer_communicate.rs
+++ b/libparsec/crates/protocol/tests/invited_cmds/v3/invite_4_claimer_communicate.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::invited_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/invited_cmds/v3/invite_info.rs
+++ b/libparsec/crates/protocol/tests/invited_cmds/v3/invite_info.rs
@@ -1,0 +1,15 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::invited_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/invited_cmds/v3/ping.rs
+++ b/libparsec/crates/protocol/tests/invited_cmds/v3/ping.rs
@@ -1,0 +1,15 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::invited_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/invited_cmds/v4/invite_1_claimer_wait_peer.rs
+++ b/libparsec/crates/protocol/tests/invited_cmds/v4/invite_1_claimer_wait_peer.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::invited_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/invited_cmds/v4/invite_2a_claimer_send_hashed_nonce.rs
+++ b/libparsec/crates/protocol/tests/invited_cmds/v4/invite_2a_claimer_send_hashed_nonce.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::invited_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/invited_cmds/v4/invite_2b_claimer_send_nonce.rs
+++ b/libparsec/crates/protocol/tests/invited_cmds/v4/invite_2b_claimer_send_nonce.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::invited_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/invited_cmds/v4/invite_3a_claimer_signify_trust.rs
+++ b/libparsec/crates/protocol/tests/invited_cmds/v4/invite_3a_claimer_signify_trust.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::invited_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/invited_cmds/v4/invite_3b_claimer_wait_peer_trust.rs
+++ b/libparsec/crates/protocol/tests/invited_cmds/v4/invite_3b_claimer_wait_peer_trust.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::invited_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/invited_cmds/v4/invite_4_claimer_communicate.rs
+++ b/libparsec/crates/protocol/tests/invited_cmds/v4/invite_4_claimer_communicate.rs
@@ -1,0 +1,27 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::invited_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_already_deleted() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_not_found() {
+    // TODO #4545: Implement test
+}
+
+pub fn rep_invalid_state() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/invited_cmds/v4/invite_info.rs
+++ b/libparsec/crates/protocol/tests/invited_cmds/v4/invite_info.rs
@@ -1,0 +1,15 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::invited_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/invited_cmds/v4/ping.rs
+++ b/libparsec/crates/protocol/tests/invited_cmds/v4/ping.rs
@@ -1,0 +1,15 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use super::invited_cmds;
+
+// Request
+
+pub fn req() {
+    // TODO #4545: Implement test
+}
+
+// Responses
+
+pub fn rep_ok() {
+    // TODO #4545: Implement test
+}

--- a/libparsec/crates/protocol/tests/serialization.rs
+++ b/libparsec/crates/protocol/tests/serialization.rs
@@ -1,0 +1,16 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+// TODO: Remove me when tests are implemented.
+//       Currently it is required to avoid warnings since ALL the test files
+//       contain unused code such as `use super::authenticated_cmds;`.
+//       Once implemented, we can safely remove this (or move it
+//       to the tests files)
+#![allow(unused)]
+
+// Generate serialization test layout for all protocol commands
+// Concrete test code can be found in tests/<cmd_family>/<api_version>/<cmd>.rs
+use libparsec_serialization_format::protocol_cmds_tests;
+
+protocol_cmds_tests!("schema/invited_cmds");
+protocol_cmds_tests!("schema/anonymous_cmds");
+protocol_cmds_tests!("schema/authenticated_cmds");

--- a/libparsec/crates/protocol/tests/vlob.rs
+++ b/libparsec/crates/protocol/tests/vlob.rs
@@ -273,46 +273,6 @@ fn serde_vlob_create_rep(
 }
 
 #[parsec_test]
-fn serde_vlob_read_req() {
-    // Generated from Python implementation (Parsec v2.6.0+dev)
-    // Content:
-    //   timestamp: ext(1, 946774800.0)
-    //   version: 8
-    //   cmd: "vlob_read"
-    //   encryption_revision: 8
-    //   vlob_id: ext(2, hex!("2b5f314728134a12863da1ce49c112f6"))
-    let raw = hex!(
-        "85a3636d64a9766c6f625f72656164b3656e6372797074696f6e5f7265766973696f6e08a9"
-        "74696d657374616d70d70141cc375188000000a776657273696f6e08a7766c6f625f6964d8"
-        "022b5f314728134a12863da1ce49c112f6"
-    );
-
-    let req = authenticated_cmds::vlob_read::Req {
-        encryption_revision: 8,
-        vlob_id: VlobID::from_hex("2b5f314728134a12863da1ce49c112f6").unwrap(),
-        version: Some(8),
-        timestamp: Some("2000-1-2T01:00:00Z".parse().unwrap()),
-    };
-
-    let expected = authenticated_cmds::AnyCmdReq::VlobRead(req);
-
-    let data = authenticated_cmds::AnyCmdReq::load(&raw).unwrap();
-
-    assert_eq!(data, expected);
-
-    // Also test serialization round trip
-    let raw2 = if let authenticated_cmds::AnyCmdReq::VlobRead(data) = data {
-        data.dump().unwrap()
-    } else {
-        unreachable!()
-    };
-
-    let data2 = authenticated_cmds::AnyCmdReq::load(&raw2).unwrap();
-
-    assert_eq!(data2, expected);
-}
-
-#[parsec_test]
 #[case::ok(
     // Generated from Python implementation (Parsec v2.6.0+dev)
     // Content:

--- a/libparsec/crates/serialization_format/src/lib.rs
+++ b/libparsec/crates/serialization_format/src/lib.rs
@@ -125,6 +125,49 @@ pub fn generate_protocol_cmds_family_from_contents(json_contents: TokenStream) -
     ))
 }
 
+/// Generates serialization tests layout for protocol commands based on JSON
+/// schemas found in *path*.
+///
+/// The family is inferred from *path* (i.e. path "schema/authenticated_cmds"
+/// will result in "authenticated_cmds" family).
+///
+/// Example of code code generated for the "authenticated_cmds" family:
+/// ```rust
+/// pub mod authenticated_cmds {
+///     pub mod v3 {
+///         use libparsec_protocol::authenticated_cmds::v3 as authenticated_cmds;
+///         use libparsec_tests_fixtures::prelude::*;
+///
+///         pub mod block_create;
+///
+///         #[parsec_test]
+///         fn block_create_req(){
+///             block_create::req()
+///         }
+///
+///         #[parsec_test]
+///         fn block_create_rep_ok(){
+///            block_create::rep_ok()
+///         }
+///         ... other reps here ...
+///
+///         ... other cmds here ...
+///     }
+///     pub mod v4 {
+///         ... idem above ...
+///     }
+/// }
+/// ```
+#[proc_macro]
+pub fn protocol_cmds_tests(path: TokenStream) -> TokenStream {
+    let path = parse_macro_input!(path as LitStr).value();
+    let path = path_from_str(&path);
+    let (family_name, json_cmds) = retrieve_protocol_family_json_cmds(&path);
+    TokenStream::from(
+        protocol::cmds_tests_generator::generate_protocol_cmds_tests(json_cmds, &family_name),
+    )
+}
+
 /// Generates serialization code from a *path* to a single data type JSON schema.
 #[proc_macro]
 pub fn parsec_data(path: TokenStream) -> TokenStream {

--- a/libparsec/crates/serialization_format/src/protocol_python_bindings.rs
+++ b/libparsec/crates/serialization_format/src/protocol_python_bindings.rs
@@ -8,7 +8,11 @@ use super::*;
 use crate::utils::snake_to_pascal_case;
 
 pub(crate) fn generate_protocol_cmds_family(cmds: Vec<JsonCmd>, family_name: &str) -> TokenStream {
-    quote_cmds_family(&GenCmdsFamily::new(cmds, family_name))
+    quote_cmds_family(&GenCmdsFamily::new(
+        cmds,
+        family_name,
+        ReuseSchemaStrategy::Default,
+    ))
 }
 
 fn quote_cmds_family(family: &GenCmdsFamily) -> TokenStream {

--- a/libparsec/crates/serialization_format/src/protocol_tests.rs
+++ b/libparsec/crates/serialization_format/src/protocol_tests.rs
@@ -1,0 +1,100 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+use super::*;
+
+/// See [crate::generate_protocol_cmds_family_from_contents]
+pub(crate) fn generate_protocol_cmds_tests(cmds: Vec<JsonCmd>, family_name: &str) -> TokenStream {
+    let family = &GenCmdsFamily::new(cmds, family_name, ReuseSchemaStrategy::Never);
+    let family_name = format_ident!("{}", &family.name);
+    let versioned_cmds = family
+        .versions
+        .iter()
+        .sorted_by_key(|(v, _)| *v)
+        .map(|(version, cmds)| quote_versioned_cmds_test(*version, family, cmds));
+
+    quote! {
+        pub mod #family_name {
+            #(#versioned_cmds)*
+        }
+    }
+}
+
+fn quote_versioned_cmds_test(version: u32, family: &GenCmdsFamily, cmds: &[GenCmd]) -> TokenStream {
+    let mod_version = format_ident!("v{version}");
+    let family_name = format_ident!("{}", &family.name);
+    let cmd_tests = cmds.iter().map(|cmd| quote_cmd_tests(version, cmd));
+
+    quote! {
+        // The secret sauce is here! the cmd module will access the schema by
+        // doing e.g. `use super::authenticated_cmds` (instead of the regular
+        // `libparsec_protocol::authenticated_cmd::vX`) this allows to reuse the
+        // cmd module multiple times (i.e. not `use` it but actually compiling it),
+        // each time with a parent module defining a different version of the cmd family
+        pub mod #mod_version {
+            use libparsec_protocol::#family_name::#mod_version as #family_name;
+            use libparsec_tests_fixtures::prelude::*;
+
+            #(#cmd_tests)*
+        }
+    }
+}
+
+fn quote_cmd_tests(_cmd_version: u32, cmd: &GenCmd) -> TokenStream {
+    let module_name = &cmd.cmd;
+    let cmd_mod = format_ident!("{}", module_name);
+
+    // Command schemas are not reused for tests generation
+    match &cmd.spec {
+        GenCmdSpec::Original { req, reps, .. } => {
+            let req_tests = quote_cmd_req_tests(module_name, req);
+            let rep_tests: Vec<TokenStream> = reps
+                .iter()
+                .map(|rep| quote_cmd_rep_tests(module_name, rep))
+                .collect_vec();
+
+            quote! {
+                pub mod #cmd_mod;
+
+                #req_tests
+
+                #(#rep_tests)*
+            }
+        }
+        // Command specs should not be reused for test generation
+        _ => panic! {"Should not reuse command spec for: {}", module_name},
+    }
+}
+
+fn quote_cmd_req_tests(module_name: &String, req: &GenCmdReq) -> TokenStream {
+    // request test function name is prefixed with command name (e.g. "invite_new_req")
+    let cmd_mod = format_ident!("{}", module_name);
+    let test_function = format_ident!("{}_req", req.cmd);
+    quote! {
+        // No distinction between request kinds "Unit" or "Composed",
+        // only one test function is generated for the request
+        #[parsec_test]
+        fn #test_function(){
+            #cmd_mod::req()
+        }
+    }
+}
+
+fn quote_cmd_rep_tests(module_name: &String, rep: &GenCmdRep) -> TokenStream {
+    // response function name contains the status (e.g "rep_ok")
+    // response test function name is prefixed with module_name (e.g. "invite_new_rep_ok")
+    let cmd_mod = format_ident!("{}", module_name);
+    let rep_function = format_ident!("rep_{}", rep.status);
+    let test_function = format_ident!("{}_{}", cmd_mod, rep_function);
+
+    quote! {
+        // No distinction between response kinds "Unit" or "Composed",
+        // only one test function is generated for each response status
+        #[parsec_test]
+        fn #test_function(){
+            #cmd_mod::#rep_function()
+        }
+    }
+}


### PR DESCRIPTION
## Describe your changes

As described in #4545, this PR implements a proc macro to generate the test layout for protocol commands. It behaves as other proc macros in the crate: it scans for JSON schemas in the specified path and expands to protocol test functions. 

Essentially it generates **1 test per `req` and per `rep` status**, for example:
```rust
// libparsec/crates/protocol/tests/serialization.rs
//
// generate_protocol_cmds_tests!("schema/authenticated_cmds") expands to:
pub mod authenticated_cmds {
     pub mod v3 {
         use libparsec_protocol::authenticated_cmds::v3 as authenticated_cmds;
         use libparsec_tests_fixtures::prelude::*;

         pub mod block_create;

         #[parsec_test]
         fn block_create_req(){
             block_create::req()  // <-- to be implemented in "tests/authenticated_cmds/v3/block_create.rs"
         }

         #[parsec_test]
         fn block_create_rep_ok(){
            block_create::rep_ok()  // <-- to be implemented in "tests/authenticated_cmds/v3/block_create.rs"
         }
         ... other reps here ...

         ... other cmds here ...
     }
     pub mod v4 {
         ... idem above ...
     }
 }
```

The ultimate goal is that whenever a protocol schema is changed --> the serialization tests will signal if a `req` or `rep` test is missing \o/

This PR also adds skeleton test functions (to be implemented gradually) in `libparsec/crates/protocol/tests/`.

Closes #4545

## Checklist

Before you submit this pull request, please make sure to:

- [x] Keep changes in the pull request as small as possible
- [x] Ensure the commit history is sanitized
- [x] Give a meaningful title to your PR
- [x] Describe your changes
- [x] Link any related issue in the description