### PR TITLE
Fix wrong used license mixin for `rst` file

### DIFF
--- a/docs/adminguide/index.rst
+++ b/docs/adminguide/index.rst
@@ -1,4 +1,4 @@
-<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+.. Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 .. _doc_adminguide:
 

--- a/docs/adminguide/installation.rst
+++ b/docs/adminguide/installation.rst
@@ -1,4 +1,4 @@
-<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+.. Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 .. _doc_adminguide_install_client:
 

--- a/docs/adminguide/stats_organization.rst
+++ b/docs/adminguide/stats_organization.rst
@@ -1,4 +1,4 @@
-<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+.. Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 .. _doc_adminguide_stats_organization:
 

--- a/docs/adminguide/stats_server.rst
+++ b/docs/adminguide/stats_server.rst
@@ -1,4 +1,4 @@
-<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+.. Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 .. _doc_adminguide_stats_server:
 

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -1,4 +1,4 @@
-<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+.. Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 .. _doc_architecture:
 

--- a/docs/cryptography.rst
+++ b/docs/cryptography.rst
@@ -1,4 +1,4 @@
-<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+.. Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 .. _doc_cryptography:
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,4 +1,4 @@
-<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+.. Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 .. _doc_history:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+.. Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 .. only:: html
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,4 +1,4 @@
-<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+.. Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 .. _doc_introduction:
 

--- a/docs/roles.rst
+++ b/docs/roles.rst
@@ -1,4 +1,4 @@
-<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+.. Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 .. _doc_roles:
 

--- a/docs/userguide/index.rst
+++ b/docs/userguide/index.rst
@@ -1,4 +1,4 @@
-<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+.. Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 .. _doc_userguide:
 

--- a/docs/userguide/installation.rst
+++ b/docs/userguide/installation.rst
@@ -1,4 +1,4 @@
-<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+.. Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 .. _doc_userguide_install_client:
 

--- a/docs/userguide/new_device.rst
+++ b/docs/userguide/new_device.rst
@@ -1,4 +1,4 @@
-<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+.. Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 .. _doc_userguide_new_device:
 

--- a/docs/userguide/new_organization.rst
+++ b/docs/userguide/new_organization.rst
@@ -1,4 +1,4 @@
-<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+.. Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 .. _doc_userguide_installation:
 

--- a/docs/userguide/new_user.rst
+++ b/docs/userguide/new_user.rst
@@ -1,4 +1,4 @@
-<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+.. Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 .. _doc_userguide_new_user:
 

--- a/docs/userguide/revoke_user.rst
+++ b/docs/userguide/revoke_user.rst
@@ -1,4 +1,4 @@
-<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+.. Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 .. _doc_userguide_revoke_user:
 

--- a/docs/userguide/share_data.rst
+++ b/docs/userguide/share_data.rst
@@ -1,4 +1,4 @@
-<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+.. Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 .. _doc_userguide_share_data:
 

--- a/misc/license_headers.py
+++ b/misc/license_headers.py
@@ -172,7 +172,7 @@ class VueBuslLicenser(BuslLicenserMixin, HtmlLicenserMixin):
     pass
 
 
-class RstBuslLicenser(BuslLicenserMixin, HtmlLicenserMixin):
+class RstBuslLicenser(BuslLicenserMixin, RstLicenserMixin):
     pass
 
 


### PR DESCRIPTION
The script `license_headers` was using the `HtmlLicenserMixin` for `rst` files instead of `RstLicenserMixin`.

The rst files got their license header updated accordingly.

Closes #5099
