### PR TITLE
Correct indentation for tuple type

### DIFF
--- a/bindings/generator/templates/binding_electron_meths.rs.j2
+++ b/bindings/generator/templates/binding_electron_meths.rs.j2
@@ -228,11 +228,11 @@ std::sync::Arc::new(
     {%- endfor -%}
     ) = {{ rs_value }};
     let js_array = JsArray::new({{ mut_cx_ref }}, {{ type.values | length }});
-    {%- for value in type.values -%}
-        {% set value_var_name = "x" ~ loop.index %}
-        let js_value = {{ render_rs_to_js(value_var_name, value, mut_cx_ref) | indent(8) }};
-        js_array.set({{ mut_cx_ref }}, {{ loop.index }}, js_value)?;
-    {%- endfor -%}
+{% for value in type.values -%}
+    {% set value_var_name = "x" ~ loop.index %}
+    let js_value = {{ render_rs_to_js(value_var_name, value, mut_cx_ref) | indent(4) }};
+    js_array.set({{ mut_cx_ref }}, {{ loop.index }}, js_value)?;
+{% endfor %}
     js_array
 }
 {%- elif type.kind == "optional" -%}


### PR DESCRIPTION
This change doesn't currently affect the generated `electron/meth.rs` but will in the future (The PR #5122 contain weird indentation that these changes fix, `cargo fmt` wasn't formatting the code :thinking: )