### PR TITLE
Force personal workspace to mount as letter on windows

### DIFF
--- a/parsec/core/mountpoint/manager.py
+++ b/parsec/core/mountpoint/manager.py
@@ -427,6 +427,8 @@ async def mountpoint_manager_factory(
         # Enable mountpoint in directory mode only on Windows (also, note that
         # the config dict is *unpacked* on Linux in fuse_mountpoint_runner)
         config["mountpoint_in_directory"] = mountpoint_in_directory
+        config["personal_workspace_base_path"] = personal_workspace_base_path
+        config["personal_workspace_name_pattern"] = personal_workspace_name_pattern
 
     elif sys.platform == "darwin":
         await cleanup_macos_mountpoint_folder(base_mountpoint_path)

--- a/parsec/core/mountpoint/winfsp_runner.py
+++ b/parsec/core/mountpoint/winfsp_runner.py
@@ -178,18 +178,17 @@ async def winfsp_mountpoint_runner(
 
     mountpoint_in_directory = config.get("mountpoint_in_directory", False)
     personal_workspace_base_path = config.get("personal_workspace_base_path", None)
-    is_personal_workspace = False
     personal_workspace_name_pattern = config.get("personal_workspace_name_pattern", None)
-    personal_workspace_name_regex = (
+
+    # This is a workaround to force mounting as drive letter if personal_workspace_base_path is not set
+    name_regex = (
         re.compile(personal_workspace_name_pattern) if personal_workspace_name_pattern else None
     )
-    if personal_workspace_name_regex and personal_workspace_name_regex.fullmatch(
-        workspace_fs.get_workspace_name().str
-    ):
-        is_personal_workspace = True
+    is_personal_workspace = name_regex and name_regex.fullmatch(workspace_fs.get_workspace_name().str)
+    if is_personal_workspace and not personal_workspace_base_path:
+        mountpoint_in_directory = False
 
-    # If personal_workspace_base_path is not set, personal workspace is mounted as drive letter
-    if mountpoint_in_directory and (personal_workspace_base_path or not is_personal_workspace):
+    if mountpoint_in_directory:
         # In single mountpoint mode, use base_mountpoint_path instead of drive letters
         mountpoint_path = await _bootstrap_mountpoint(base_mountpoint_path, workspace_name)
         file_system_mountpoint = file_system_name = str(mountpoint_path)

--- a/parsec/core/mountpoint/winfsp_runner.py
+++ b/parsec/core/mountpoint/winfsp_runner.py
@@ -184,7 +184,9 @@ async def winfsp_mountpoint_runner(
     name_regex = (
         re.compile(personal_workspace_name_pattern) if personal_workspace_name_pattern else None
     )
-    is_personal_workspace = name_regex and name_regex.fullmatch(workspace_fs.get_workspace_name().str)
+    is_personal_workspace = name_regex and name_regex.fullmatch(
+        workspace_fs.get_workspace_name().str
+    )
     if is_personal_workspace and not personal_workspace_base_path:
         mountpoint_in_directory = False
 

--- a/parsec/core/mountpoint/winfsp_runner.py
+++ b/parsec/core/mountpoint/winfsp_runner.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import math
+import re
 import unicodedata
 from contextlib import asynccontextmanager
 from functools import partial
@@ -175,7 +176,20 @@ async def winfsp_mountpoint_runner(
     if config.get("debug", False):
         enable_debug_log()
 
-    if config.get("mountpoint_in_directory", False):
+    mountpoint_in_directory = config.get("mountpoint_in_directory", False)
+    personal_workspace_base_path = config.get("personal_workspace_base_path", None)
+    is_personal_workspace = False
+    personal_workspace_name_pattern = config.get("personal_workspace_name_pattern", None)
+    personal_workspace_name_regex = (
+        re.compile(personal_workspace_name_pattern) if personal_workspace_name_pattern else None
+    )
+    if personal_workspace_name_regex and personal_workspace_name_regex.fullmatch(
+        workspace_fs.get_workspace_name().str
+    ):
+        is_personal_workspace = True
+
+    # If personal_workspace_base_path is not set, personal workspace is mounted as drive letter
+    if mountpoint_in_directory and (personal_workspace_base_path or not is_personal_workspace):
         # In single mountpoint mode, use base_mountpoint_path instead of drive letters
         mountpoint_path = await _bootstrap_mountpoint(base_mountpoint_path, workspace_name)
         file_system_mountpoint = file_system_name = str(mountpoint_path)


### PR DESCRIPTION
## Describe your changes

The aim of this change is to deliver the personal workspace as quickly as possible, while avoiding the use of the Windows registry.
As the personal workspace is unique per user and per organization, there is no risk of reaching letter saturation on Window.
