### PR TITLE
Provide typescript enum for basic rust enum (flat enum) 

### DIFF
--- a/bindings/electron/src/index.d.ts
+++ b/bindings/electron/src/index.d.ts
@@ -154,26 +154,6 @@ export type CancelError =
   | CancelErrorNotBound
 
 
-// RealmRole
-export interface RealmRoleContributor {
-    tag: "Contributor"
-}
-export interface RealmRoleManager {
-    tag: "Manager"
-}
-export interface RealmRoleOwner {
-    tag: "Owner"
-}
-export interface RealmRoleReader {
-    tag: "Reader"
-}
-export type RealmRole =
-  | RealmRoleContributor
-  | RealmRoleManager
-  | RealmRoleOwner
-  | RealmRoleReader
-
-
 // DeviceAccessStrategy
 export interface DeviceAccessStrategyPassword {
     tag: "Password"
@@ -317,22 +297,6 @@ export type ClientWorkspaceShareError =
   | ClientWorkspaceShareErrorWorkspaceInMaintenance
 
 
-// UserProfile
-export interface UserProfileAdmin {
-    tag: "Admin"
-}
-export interface UserProfileOutsider {
-    tag: "Outsider"
-}
-export interface UserProfileStandard {
-    tag: "Standard"
-}
-export type UserProfile =
-  | UserProfileAdmin
-  | UserProfileOutsider
-  | UserProfileStandard
-
-
 // WorkspaceStorageCacheSize
 export interface WorkspaceStorageCacheSizeCustom {
     tag: "Custom"
@@ -362,22 +326,6 @@ export interface ClaimerGreeterAbortOperationErrorInternal {
 }
 export type ClaimerGreeterAbortOperationError =
   | ClaimerGreeterAbortOperationErrorInternal
-
-
-// DeviceFileType
-export interface DeviceFileTypePassword {
-    tag: "Password"
-}
-export interface DeviceFileTypeRecovery {
-    tag: "Recovery"
-}
-export interface DeviceFileTypeSmartcard {
-    tag: "Smartcard"
-}
-export type DeviceFileType =
-  | DeviceFileTypePassword
-  | DeviceFileTypeRecovery
-  | DeviceFileTypeSmartcard
 
 
 // DeviceSaveStrategy
@@ -516,38 +464,6 @@ export interface UserOrDeviceClaimInitialInfoUser {
 export type UserOrDeviceClaimInitialInfo =
   | UserOrDeviceClaimInitialInfoDevice
   | UserOrDeviceClaimInitialInfoUser
-
-
-// InvitationStatus
-export interface InvitationStatusDeleted {
-    tag: "Deleted"
-}
-export interface InvitationStatusIdle {
-    tag: "Idle"
-}
-export interface InvitationStatusReady {
-    tag: "Ready"
-}
-export type InvitationStatus =
-  | InvitationStatusDeleted
-  | InvitationStatusIdle
-  | InvitationStatusReady
-
-
-// InvitationEmailSentStatus
-export interface InvitationEmailSentStatusBadRecipient {
-    tag: "BadRecipient"
-}
-export interface InvitationEmailSentStatusNotAvailable {
-    tag: "NotAvailable"
-}
-export interface InvitationEmailSentStatusSuccess {
-    tag: "Success"
-}
-export type InvitationEmailSentStatus =
-  | InvitationEmailSentStatusBadRecipient
-  | InvitationEmailSentStatusNotAvailable
-  | InvitationEmailSentStatusSuccess
 
 
 // NewUserInvitationError
@@ -730,26 +646,6 @@ export type GreetInProgressError =
   | GreetInProgressErrorPeerReset
   | GreetInProgressErrorUserAlreadyExists
   | GreetInProgressErrorUserCreateNotAllowed
-
-
-// OS
-export interface OSAndroid {
-    tag: "Android"
-}
-export interface OSLinux {
-    tag: "Linux"
-}
-export interface OSMacOs {
-    tag: "MacOs"
-}
-export interface OSWindows {
-    tag: "Windows"
-}
-export type OS =
-  | OSAndroid
-  | OSLinux
-  | OSMacOs
-  | OSWindows
 
 
 export function cancel(

--- a/bindings/electron/src/meths.rs
+++ b/bindings/electron/src/meths.rs
@@ -7,10 +7,171 @@
 #[allow(unused_imports)]
 use neon::{prelude::*, types::buffer::TypedArray};
 
+// RealmRole
+
+#[allow(dead_code)]
+fn enum_realm_role_js_to_rs<'a>(
+    cx: &mut impl Context<'a>,
+    raw_value: &str,
+) -> NeonResult<libparsec::RealmRole> {
+    match raw_value {
+        "RealmRoleContributor" => Ok(libparsec::RealmRole::Contributor),
+        "RealmRoleManager" => Ok(libparsec::RealmRole::Manager),
+        "RealmRoleOwner" => Ok(libparsec::RealmRole::Owner),
+        "RealmRoleReader" => Ok(libparsec::RealmRole::Reader),
+        _ => cx.throw_range_error(format!("Invalid value `{raw_value}` for enum RealmRole")),
+    }
+}
+
+#[allow(dead_code)]
+fn enum_realm_role_rs_to_js(value: libparsec::RealmRole) -> &'static str {
+    match value {
+        libparsec::RealmRole::Contributor => "RealmRoleContributor",
+        libparsec::RealmRole::Manager => "RealmRoleManager",
+        libparsec::RealmRole::Owner => "RealmRoleOwner",
+        libparsec::RealmRole::Reader => "RealmRoleReader",
+    }
+}
+
+// UserProfile
+
+#[allow(dead_code)]
+fn enum_user_profile_js_to_rs<'a>(
+    cx: &mut impl Context<'a>,
+    raw_value: &str,
+) -> NeonResult<libparsec::UserProfile> {
+    match raw_value {
+        "UserProfileAdmin" => Ok(libparsec::UserProfile::Admin),
+        "UserProfileOutsider" => Ok(libparsec::UserProfile::Outsider),
+        "UserProfileStandard" => Ok(libparsec::UserProfile::Standard),
+        _ => cx.throw_range_error(format!("Invalid value `{raw_value}` for enum UserProfile")),
+    }
+}
+
+#[allow(dead_code)]
+fn enum_user_profile_rs_to_js(value: libparsec::UserProfile) -> &'static str {
+    match value {
+        libparsec::UserProfile::Admin => "UserProfileAdmin",
+        libparsec::UserProfile::Outsider => "UserProfileOutsider",
+        libparsec::UserProfile::Standard => "UserProfileStandard",
+    }
+}
+
+// DeviceFileType
+
+#[allow(dead_code)]
+fn enum_device_file_type_js_to_rs<'a>(
+    cx: &mut impl Context<'a>,
+    raw_value: &str,
+) -> NeonResult<libparsec::DeviceFileType> {
+    match raw_value {
+        "DeviceFileTypePassword" => Ok(libparsec::DeviceFileType::Password),
+        "DeviceFileTypeRecovery" => Ok(libparsec::DeviceFileType::Recovery),
+        "DeviceFileTypeSmartcard" => Ok(libparsec::DeviceFileType::Smartcard),
+        _ => cx.throw_range_error(format!(
+            "Invalid value `{raw_value}` for enum DeviceFileType"
+        )),
+    }
+}
+
+#[allow(dead_code)]
+fn enum_device_file_type_rs_to_js(value: libparsec::DeviceFileType) -> &'static str {
+    match value {
+        libparsec::DeviceFileType::Password => "DeviceFileTypePassword",
+        libparsec::DeviceFileType::Recovery => "DeviceFileTypeRecovery",
+        libparsec::DeviceFileType::Smartcard => "DeviceFileTypeSmartcard",
+    }
+}
+
+// InvitationStatus
+
+#[allow(dead_code)]
+fn enum_invitation_status_js_to_rs<'a>(
+    cx: &mut impl Context<'a>,
+    raw_value: &str,
+) -> NeonResult<libparsec::InvitationStatus> {
+    match raw_value {
+        "InvitationStatusDeleted" => Ok(libparsec::InvitationStatus::Deleted),
+        "InvitationStatusIdle" => Ok(libparsec::InvitationStatus::Idle),
+        "InvitationStatusReady" => Ok(libparsec::InvitationStatus::Ready),
+        _ => cx.throw_range_error(format!(
+            "Invalid value `{raw_value}` for enum InvitationStatus"
+        )),
+    }
+}
+
+#[allow(dead_code)]
+fn enum_invitation_status_rs_to_js(value: libparsec::InvitationStatus) -> &'static str {
+    match value {
+        libparsec::InvitationStatus::Deleted => "InvitationStatusDeleted",
+        libparsec::InvitationStatus::Idle => "InvitationStatusIdle",
+        libparsec::InvitationStatus::Ready => "InvitationStatusReady",
+    }
+}
+
+// InvitationEmailSentStatus
+
+#[allow(dead_code)]
+fn enum_invitation_email_sent_status_js_to_rs<'a>(
+    cx: &mut impl Context<'a>,
+    raw_value: &str,
+) -> NeonResult<libparsec::InvitationEmailSentStatus> {
+    match raw_value {
+        "InvitationEmailSentStatusBadRecipient" => {
+            Ok(libparsec::InvitationEmailSentStatus::BadRecipient)
+        }
+        "InvitationEmailSentStatusNotAvailable" => {
+            Ok(libparsec::InvitationEmailSentStatus::NotAvailable)
+        }
+        "InvitationEmailSentStatusSuccess" => Ok(libparsec::InvitationEmailSentStatus::Success),
+        _ => cx.throw_range_error(format!(
+            "Invalid value `{raw_value}` for enum InvitationEmailSentStatus"
+        )),
+    }
+}
+
+#[allow(dead_code)]
+fn enum_invitation_email_sent_status_rs_to_js(
+    value: libparsec::InvitationEmailSentStatus,
+) -> &'static str {
+    match value {
+        libparsec::InvitationEmailSentStatus::BadRecipient => {
+            "InvitationEmailSentStatusBadRecipient"
+        }
+        libparsec::InvitationEmailSentStatus::NotAvailable => {
+            "InvitationEmailSentStatusNotAvailable"
+        }
+        libparsec::InvitationEmailSentStatus::Success => "InvitationEmailSentStatusSuccess",
+    }
+}
+
+// OS
+
+#[allow(dead_code)]
+fn enum_os_js_to_rs<'a>(cx: &mut impl Context<'a>, raw_value: &str) -> NeonResult<libparsec::OS> {
+    match raw_value {
+        "OSAndroid" => Ok(libparsec::OS::Android),
+        "OSLinux" => Ok(libparsec::OS::Linux),
+        "OSMacOs" => Ok(libparsec::OS::MacOs),
+        "OSWindows" => Ok(libparsec::OS::Windows),
+        _ => cx.throw_range_error(format!("Invalid value `{raw_value}` for enum OS")),
+    }
+}
+
+#[allow(dead_code)]
+fn enum_os_rs_to_js(value: libparsec::OS) -> &'static str {
+    match value {
+        libparsec::OS::Android => "OSAndroid",
+        libparsec::OS::Linux => "OSLinux",
+        libparsec::OS::MacOs => "OSMacOs",
+        libparsec::OS::Windows => "OSWindows",
+    }
+}
+
 // ClientConfig
 
 #[allow(dead_code)]
-fn struct_clientconfig_js_to_rs<'a>(
+fn struct_client_config_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::ClientConfig> {
@@ -49,7 +210,7 @@ fn struct_clientconfig_js_to_rs<'a>(
     };
     let workspace_storage_cache_size = {
         let js_val: Handle<JsObject> = obj.get(cx, "workspaceStorageCacheSize")?;
-        variant_workspacestoragecachesize_js_to_rs(cx, js_val)?
+        variant_workspace_storage_cache_size_js_to_rs(cx, js_val)?
     };
     Ok(libparsec::ClientConfig {
         config_dir,
@@ -60,7 +221,7 @@ fn struct_clientconfig_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_clientconfig_rs_to_js<'a>(
+fn struct_client_config_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::ClientConfig,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -105,7 +266,7 @@ fn struct_clientconfig_rs_to_js<'a>(
     .or_throw(cx)?;
     js_obj.set(cx, "mountpointBaseDir", js_mountpoint_base_dir)?;
     let js_workspace_storage_cache_size =
-        variant_workspacestoragecachesize_rs_to_js(cx, rs_obj.workspace_storage_cache_size)?;
+        variant_workspace_storage_cache_size_rs_to_js(cx, rs_obj.workspace_storage_cache_size)?;
     js_obj.set(
         cx,
         "workspaceStorageCacheSize",
@@ -117,7 +278,7 @@ fn struct_clientconfig_rs_to_js<'a>(
 // HumanHandle
 
 #[allow(dead_code)]
-fn struct_humanhandle_js_to_rs<'a>(
+fn struct_human_handle_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::HumanHandle> {
@@ -137,7 +298,7 @@ fn struct_humanhandle_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_humanhandle_rs_to_js<'a>(
+fn struct_human_handle_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::HumanHandle,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -168,7 +329,7 @@ fn struct_humanhandle_rs_to_js<'a>(
 // AvailableDevice
 
 #[allow(dead_code)]
-fn struct_availabledevice_js_to_rs<'a>(
+fn struct_available_device_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::AvailableDevice> {
@@ -208,7 +369,7 @@ fn struct_availabledevice_js_to_rs<'a>(
                 None
             } else {
                 let js_val = js_val.downcast_or_throw::<JsObject, _>(cx)?;
-                Some(struct_humanhandle_js_to_rs(cx, js_val)?)
+                Some(struct_human_handle_js_to_rs(cx, js_val)?)
             }
         }
     };
@@ -233,8 +394,11 @@ fn struct_availabledevice_js_to_rs<'a>(
         js_val.value(cx)
     };
     let ty = {
-        let js_val: Handle<JsObject> = obj.get(cx, "ty")?;
-        variant_devicefiletype_js_to_rs(cx, js_val)?
+        let js_val: Handle<JsString> = obj.get(cx, "ty")?;
+        {
+            let js_string = js_val.value(cx);
+            enum_device_file_type_js_to_rs(cx, js_string.as_str())?
+        }
     };
     Ok(libparsec::AvailableDevice {
         key_file_path,
@@ -248,7 +412,7 @@ fn struct_availabledevice_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_availabledevice_rs_to_js<'a>(
+fn struct_available_device_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::AvailableDevice,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -271,7 +435,7 @@ fn struct_availabledevice_rs_to_js<'a>(
     let js_device_id = JsString::try_new(cx, rs_obj.device_id).or_throw(cx)?;
     js_obj.set(cx, "deviceId", js_device_id)?;
     let js_human_handle = match rs_obj.human_handle {
-        Some(elem) => struct_humanhandle_rs_to_js(cx, elem)?.as_value(cx),
+        Some(elem) => struct_human_handle_rs_to_js(cx, elem)?.as_value(cx),
         None => JsNull::new(cx).as_value(cx),
     };
     js_obj.set(cx, "humanHandle", js_human_handle)?;
@@ -282,7 +446,7 @@ fn struct_availabledevice_rs_to_js<'a>(
     js_obj.set(cx, "deviceLabel", js_device_label)?;
     let js_slug = JsString::try_new(cx, rs_obj.slug).or_throw(cx)?;
     js_obj.set(cx, "slug", js_slug)?;
-    let js_ty = variant_devicefiletype_rs_to_js(cx, rs_obj.ty)?;
+    let js_ty = JsString::try_new(cx, enum_device_file_type_rs_to_js(rs_obj.ty)).or_throw(cx)?;
     js_obj.set(cx, "ty", js_ty)?;
     Ok(js_obj)
 }
@@ -290,7 +454,7 @@ fn struct_availabledevice_rs_to_js<'a>(
 // UserClaimInProgress1Info
 
 #[allow(dead_code)]
-fn struct_userclaiminprogress1info_js_to_rs<'a>(
+fn struct_user_claim_in_progress1_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::UserClaimInProgress1Info> {
@@ -338,7 +502,7 @@ fn struct_userclaiminprogress1info_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_userclaiminprogress1info_rs_to_js<'a>(
+fn struct_user_claim_in_progress1_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::UserClaimInProgress1Info,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -363,7 +527,7 @@ fn struct_userclaiminprogress1info_rs_to_js<'a>(
 // DeviceClaimInProgress1Info
 
 #[allow(dead_code)]
-fn struct_deviceclaiminprogress1info_js_to_rs<'a>(
+fn struct_device_claim_in_progress1_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::DeviceClaimInProgress1Info> {
@@ -411,7 +575,7 @@ fn struct_deviceclaiminprogress1info_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_deviceclaiminprogress1info_rs_to_js<'a>(
+fn struct_device_claim_in_progress1_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::DeviceClaimInProgress1Info,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -436,7 +600,7 @@ fn struct_deviceclaiminprogress1info_rs_to_js<'a>(
 // UserClaimInProgress2Info
 
 #[allow(dead_code)]
-fn struct_userclaiminprogress2info_js_to_rs<'a>(
+fn struct_user_claim_in_progress2_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::UserClaimInProgress2Info> {
@@ -466,7 +630,7 @@ fn struct_userclaiminprogress2info_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_userclaiminprogress2info_rs_to_js<'a>(
+fn struct_user_claim_in_progress2_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::UserClaimInProgress2Info,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -481,7 +645,7 @@ fn struct_userclaiminprogress2info_rs_to_js<'a>(
 // DeviceClaimInProgress2Info
 
 #[allow(dead_code)]
-fn struct_deviceclaiminprogress2info_js_to_rs<'a>(
+fn struct_device_claim_in_progress2_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::DeviceClaimInProgress2Info> {
@@ -511,7 +675,7 @@ fn struct_deviceclaiminprogress2info_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_deviceclaiminprogress2info_rs_to_js<'a>(
+fn struct_device_claim_in_progress2_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::DeviceClaimInProgress2Info,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -526,7 +690,7 @@ fn struct_deviceclaiminprogress2info_rs_to_js<'a>(
 // UserClaimInProgress3Info
 
 #[allow(dead_code)]
-fn struct_userclaiminprogress3info_js_to_rs<'a>(
+fn struct_user_claim_in_progress3_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::UserClaimInProgress3Info> {
@@ -544,7 +708,7 @@ fn struct_userclaiminprogress3info_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_userclaiminprogress3info_rs_to_js<'a>(
+fn struct_user_claim_in_progress3_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::UserClaimInProgress3Info,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -557,7 +721,7 @@ fn struct_userclaiminprogress3info_rs_to_js<'a>(
 // DeviceClaimInProgress3Info
 
 #[allow(dead_code)]
-fn struct_deviceclaiminprogress3info_js_to_rs<'a>(
+fn struct_device_claim_in_progress3_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::DeviceClaimInProgress3Info> {
@@ -575,7 +739,7 @@ fn struct_deviceclaiminprogress3info_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_deviceclaiminprogress3info_rs_to_js<'a>(
+fn struct_device_claim_in_progress3_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::DeviceClaimInProgress3Info,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -588,7 +752,7 @@ fn struct_deviceclaiminprogress3info_rs_to_js<'a>(
 // UserClaimFinalizeInfo
 
 #[allow(dead_code)]
-fn struct_userclaimfinalizeinfo_js_to_rs<'a>(
+fn struct_user_claim_finalize_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::UserClaimFinalizeInfo> {
@@ -606,7 +770,7 @@ fn struct_userclaimfinalizeinfo_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_userclaimfinalizeinfo_rs_to_js<'a>(
+fn struct_user_claim_finalize_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::UserClaimFinalizeInfo,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -619,7 +783,7 @@ fn struct_userclaimfinalizeinfo_rs_to_js<'a>(
 // DeviceClaimFinalizeInfo
 
 #[allow(dead_code)]
-fn struct_deviceclaimfinalizeinfo_js_to_rs<'a>(
+fn struct_device_claim_finalize_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::DeviceClaimFinalizeInfo> {
@@ -637,7 +801,7 @@ fn struct_deviceclaimfinalizeinfo_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_deviceclaimfinalizeinfo_rs_to_js<'a>(
+fn struct_device_claim_finalize_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::DeviceClaimFinalizeInfo,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -650,7 +814,7 @@ fn struct_deviceclaimfinalizeinfo_rs_to_js<'a>(
 // UserGreetInitialInfo
 
 #[allow(dead_code)]
-fn struct_usergreetinitialinfo_js_to_rs<'a>(
+fn struct_user_greet_initial_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::UserGreetInitialInfo> {
@@ -668,7 +832,7 @@ fn struct_usergreetinitialinfo_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_usergreetinitialinfo_rs_to_js<'a>(
+fn struct_user_greet_initial_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::UserGreetInitialInfo,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -681,7 +845,7 @@ fn struct_usergreetinitialinfo_rs_to_js<'a>(
 // DeviceGreetInitialInfo
 
 #[allow(dead_code)]
-fn struct_devicegreetinitialinfo_js_to_rs<'a>(
+fn struct_device_greet_initial_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::DeviceGreetInitialInfo> {
@@ -699,7 +863,7 @@ fn struct_devicegreetinitialinfo_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_devicegreetinitialinfo_rs_to_js<'a>(
+fn struct_device_greet_initial_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::DeviceGreetInitialInfo,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -712,7 +876,7 @@ fn struct_devicegreetinitialinfo_rs_to_js<'a>(
 // UserGreetInProgress1Info
 
 #[allow(dead_code)]
-fn struct_usergreetinprogress1info_js_to_rs<'a>(
+fn struct_user_greet_in_progress1_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::UserGreetInProgress1Info> {
@@ -742,7 +906,7 @@ fn struct_usergreetinprogress1info_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_usergreetinprogress1info_rs_to_js<'a>(
+fn struct_user_greet_in_progress1_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::UserGreetInProgress1Info,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -757,7 +921,7 @@ fn struct_usergreetinprogress1info_rs_to_js<'a>(
 // DeviceGreetInProgress1Info
 
 #[allow(dead_code)]
-fn struct_devicegreetinprogress1info_js_to_rs<'a>(
+fn struct_device_greet_in_progress1_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::DeviceGreetInProgress1Info> {
@@ -787,7 +951,7 @@ fn struct_devicegreetinprogress1info_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_devicegreetinprogress1info_rs_to_js<'a>(
+fn struct_device_greet_in_progress1_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::DeviceGreetInProgress1Info,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -802,7 +966,7 @@ fn struct_devicegreetinprogress1info_rs_to_js<'a>(
 // UserGreetInProgress2Info
 
 #[allow(dead_code)]
-fn struct_usergreetinprogress2info_js_to_rs<'a>(
+fn struct_user_greet_in_progress2_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::UserGreetInProgress2Info> {
@@ -850,7 +1014,7 @@ fn struct_usergreetinprogress2info_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_usergreetinprogress2info_rs_to_js<'a>(
+fn struct_user_greet_in_progress2_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::UserGreetInProgress2Info,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -875,7 +1039,7 @@ fn struct_usergreetinprogress2info_rs_to_js<'a>(
 // DeviceGreetInProgress2Info
 
 #[allow(dead_code)]
-fn struct_devicegreetinprogress2info_js_to_rs<'a>(
+fn struct_device_greet_in_progress2_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::DeviceGreetInProgress2Info> {
@@ -923,7 +1087,7 @@ fn struct_devicegreetinprogress2info_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_devicegreetinprogress2info_rs_to_js<'a>(
+fn struct_device_greet_in_progress2_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::DeviceGreetInProgress2Info,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -948,7 +1112,7 @@ fn struct_devicegreetinprogress2info_rs_to_js<'a>(
 // UserGreetInProgress3Info
 
 #[allow(dead_code)]
-fn struct_usergreetinprogress3info_js_to_rs<'a>(
+fn struct_user_greet_in_progress3_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::UserGreetInProgress3Info> {
@@ -966,7 +1130,7 @@ fn struct_usergreetinprogress3info_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_usergreetinprogress3info_rs_to_js<'a>(
+fn struct_user_greet_in_progress3_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::UserGreetInProgress3Info,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -979,7 +1143,7 @@ fn struct_usergreetinprogress3info_rs_to_js<'a>(
 // DeviceGreetInProgress3Info
 
 #[allow(dead_code)]
-fn struct_devicegreetinprogress3info_js_to_rs<'a>(
+fn struct_device_greet_in_progress3_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::DeviceGreetInProgress3Info> {
@@ -997,7 +1161,7 @@ fn struct_devicegreetinprogress3info_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_devicegreetinprogress3info_rs_to_js<'a>(
+fn struct_device_greet_in_progress3_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::DeviceGreetInProgress3Info,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -1010,7 +1174,7 @@ fn struct_devicegreetinprogress3info_rs_to_js<'a>(
 // UserGreetInProgress4Info
 
 #[allow(dead_code)]
-fn struct_usergreetinprogress4info_js_to_rs<'a>(
+fn struct_user_greet_in_progress4_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::UserGreetInProgress4Info> {
@@ -1031,7 +1195,7 @@ fn struct_usergreetinprogress4info_js_to_rs<'a>(
                 None
             } else {
                 let js_val = js_val.downcast_or_throw::<JsObject, _>(cx)?;
-                Some(struct_humanhandle_js_to_rs(cx, js_val)?)
+                Some(struct_human_handle_js_to_rs(cx, js_val)?)
             }
         }
     };
@@ -1059,7 +1223,7 @@ fn struct_usergreetinprogress4info_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_usergreetinprogress4info_rs_to_js<'a>(
+fn struct_user_greet_in_progress4_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::UserGreetInProgress4Info,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -1067,7 +1231,7 @@ fn struct_usergreetinprogress4info_rs_to_js<'a>(
     let js_handle = JsNumber::new(cx, rs_obj.handle as f64);
     js_obj.set(cx, "handle", js_handle)?;
     let js_requested_human_handle = match rs_obj.requested_human_handle {
-        Some(elem) => struct_humanhandle_rs_to_js(cx, elem)?.as_value(cx),
+        Some(elem) => struct_human_handle_rs_to_js(cx, elem)?.as_value(cx),
         None => JsNull::new(cx).as_value(cx),
     };
     js_obj.set(cx, "requestedHumanHandle", js_requested_human_handle)?;
@@ -1082,7 +1246,7 @@ fn struct_usergreetinprogress4info_rs_to_js<'a>(
 // DeviceGreetInProgress4Info
 
 #[allow(dead_code)]
-fn struct_devicegreetinprogress4info_js_to_rs<'a>(
+fn struct_device_greet_in_progress4_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::DeviceGreetInProgress4Info> {
@@ -1119,7 +1283,7 @@ fn struct_devicegreetinprogress4info_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn struct_devicegreetinprogress4info_rs_to_js<'a>(
+fn struct_device_greet_in_progress4_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::DeviceGreetInProgress4Info,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -1137,7 +1301,7 @@ fn struct_devicegreetinprogress4info_rs_to_js<'a>(
 // CancelError
 
 #[allow(dead_code)]
-fn variant_cancelerror_rs_to_js<'a>(
+fn variant_cancel_error_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::CancelError,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -1157,54 +1321,10 @@ fn variant_cancelerror_rs_to_js<'a>(
     Ok(js_obj)
 }
 
-// RealmRole
-
-#[allow(dead_code)]
-fn variant_realmrole_js_to_rs<'a>(
-    cx: &mut impl Context<'a>,
-    obj: Handle<'a, JsObject>,
-) -> NeonResult<libparsec::RealmRole> {
-    let tag = obj.get::<JsString, _, _>(cx, "tag")?.value(cx);
-    match tag.as_str() {
-        "Contributor" => Ok(libparsec::RealmRole::Contributor {}),
-        "Manager" => Ok(libparsec::RealmRole::Manager {}),
-        "Owner" => Ok(libparsec::RealmRole::Owner {}),
-        "Reader" => Ok(libparsec::RealmRole::Reader {}),
-        _ => cx.throw_type_error("Object is not a RealmRole"),
-    }
-}
-
-#[allow(dead_code)]
-fn variant_realmrole_rs_to_js<'a>(
-    cx: &mut impl Context<'a>,
-    rs_obj: libparsec::RealmRole,
-) -> NeonResult<Handle<'a, JsObject>> {
-    let js_obj = cx.empty_object();
-    match rs_obj {
-        libparsec::RealmRole::Contributor { .. } => {
-            let js_tag = JsString::try_new(cx, "Contributor").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-        libparsec::RealmRole::Manager { .. } => {
-            let js_tag = JsString::try_new(cx, "Manager").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-        libparsec::RealmRole::Owner { .. } => {
-            let js_tag = JsString::try_new(cx, "Owner").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-        libparsec::RealmRole::Reader { .. } => {
-            let js_tag = JsString::try_new(cx, "Reader").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-    }
-    Ok(js_obj)
-}
-
 // DeviceAccessStrategy
 
 #[allow(dead_code)]
-fn variant_deviceaccessstrategy_js_to_rs<'a>(
+fn variant_device_access_strategy_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::DeviceAccessStrategy> {
@@ -1253,7 +1373,7 @@ fn variant_deviceaccessstrategy_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn variant_deviceaccessstrategy_rs_to_js<'a>(
+fn variant_device_access_strategy_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::DeviceAccessStrategy,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -1304,7 +1424,7 @@ fn variant_deviceaccessstrategy_rs_to_js<'a>(
 // ClientStartError
 
 #[allow(dead_code)]
-fn variant_clientstarterror_rs_to_js<'a>(
+fn variant_client_start_error_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::ClientStartError,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -1335,7 +1455,7 @@ fn variant_clientstarterror_rs_to_js<'a>(
 // ClientStopError
 
 #[allow(dead_code)]
-fn variant_clientstoperror_rs_to_js<'a>(
+fn variant_client_stop_error_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::ClientStopError,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -1354,7 +1474,7 @@ fn variant_clientstoperror_rs_to_js<'a>(
 // ClientListWorkspacesError
 
 #[allow(dead_code)]
-fn variant_clientlistworkspaceserror_rs_to_js<'a>(
+fn variant_client_list_workspaces_error_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::ClientListWorkspacesError,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -1373,7 +1493,7 @@ fn variant_clientlistworkspaceserror_rs_to_js<'a>(
 // ClientWorkspaceCreateError
 
 #[allow(dead_code)]
-fn variant_clientworkspacecreateerror_rs_to_js<'a>(
+fn variant_client_workspace_create_error_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::ClientWorkspaceCreateError,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -1392,7 +1512,7 @@ fn variant_clientworkspacecreateerror_rs_to_js<'a>(
 // ClientWorkspaceRenameError
 
 #[allow(dead_code)]
-fn variant_clientworkspacerenameerror_rs_to_js<'a>(
+fn variant_client_workspace_rename_error_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::ClientWorkspaceRenameError,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -1415,7 +1535,7 @@ fn variant_clientworkspacerenameerror_rs_to_js<'a>(
 // ClientWorkspaceShareError
 
 #[allow(dead_code)]
-fn variant_clientworkspaceshareerror_rs_to_js<'a>(
+fn variant_client_workspace_share_error_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::ClientWorkspaceShareError,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -1513,49 +1633,10 @@ fn variant_clientworkspaceshareerror_rs_to_js<'a>(
     Ok(js_obj)
 }
 
-// UserProfile
-
-#[allow(dead_code)]
-fn variant_userprofile_js_to_rs<'a>(
-    cx: &mut impl Context<'a>,
-    obj: Handle<'a, JsObject>,
-) -> NeonResult<libparsec::UserProfile> {
-    let tag = obj.get::<JsString, _, _>(cx, "tag")?.value(cx);
-    match tag.as_str() {
-        "Admin" => Ok(libparsec::UserProfile::Admin {}),
-        "Outsider" => Ok(libparsec::UserProfile::Outsider {}),
-        "Standard" => Ok(libparsec::UserProfile::Standard {}),
-        _ => cx.throw_type_error("Object is not a UserProfile"),
-    }
-}
-
-#[allow(dead_code)]
-fn variant_userprofile_rs_to_js<'a>(
-    cx: &mut impl Context<'a>,
-    rs_obj: libparsec::UserProfile,
-) -> NeonResult<Handle<'a, JsObject>> {
-    let js_obj = cx.empty_object();
-    match rs_obj {
-        libparsec::UserProfile::Admin { .. } => {
-            let js_tag = JsString::try_new(cx, "Admin").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-        libparsec::UserProfile::Outsider { .. } => {
-            let js_tag = JsString::try_new(cx, "Outsider").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-        libparsec::UserProfile::Standard { .. } => {
-            let js_tag = JsString::try_new(cx, "Standard").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-    }
-    Ok(js_obj)
-}
-
 // WorkspaceStorageCacheSize
 
 #[allow(dead_code)]
-fn variant_workspacestoragecachesize_js_to_rs<'a>(
+fn variant_workspace_storage_cache_size_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::WorkspaceStorageCacheSize> {
@@ -1580,7 +1661,7 @@ fn variant_workspacestoragecachesize_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn variant_workspacestoragecachesize_rs_to_js<'a>(
+fn variant_workspace_storage_cache_size_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::WorkspaceStorageCacheSize,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -1603,7 +1684,7 @@ fn variant_workspacestoragecachesize_rs_to_js<'a>(
 // ClientEvent
 
 #[allow(dead_code)]
-fn variant_clientevent_js_to_rs<'a>(
+fn variant_client_event_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::ClientEvent> {
@@ -1621,7 +1702,7 @@ fn variant_clientevent_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn variant_clientevent_rs_to_js<'a>(
+fn variant_client_event_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::ClientEvent,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -1640,7 +1721,7 @@ fn variant_clientevent_rs_to_js<'a>(
 // ClaimerGreeterAbortOperationError
 
 #[allow(dead_code)]
-fn variant_claimergreeterabortoperationerror_rs_to_js<'a>(
+fn variant_claimer_greeter_abort_operation_error_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::ClaimerGreeterAbortOperationError,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -1656,49 +1737,10 @@ fn variant_claimergreeterabortoperationerror_rs_to_js<'a>(
     Ok(js_obj)
 }
 
-// DeviceFileType
-
-#[allow(dead_code)]
-fn variant_devicefiletype_js_to_rs<'a>(
-    cx: &mut impl Context<'a>,
-    obj: Handle<'a, JsObject>,
-) -> NeonResult<libparsec::DeviceFileType> {
-    let tag = obj.get::<JsString, _, _>(cx, "tag")?.value(cx);
-    match tag.as_str() {
-        "Password" => Ok(libparsec::DeviceFileType::Password {}),
-        "Recovery" => Ok(libparsec::DeviceFileType::Recovery {}),
-        "Smartcard" => Ok(libparsec::DeviceFileType::Smartcard {}),
-        _ => cx.throw_type_error("Object is not a DeviceFileType"),
-    }
-}
-
-#[allow(dead_code)]
-fn variant_devicefiletype_rs_to_js<'a>(
-    cx: &mut impl Context<'a>,
-    rs_obj: libparsec::DeviceFileType,
-) -> NeonResult<Handle<'a, JsObject>> {
-    let js_obj = cx.empty_object();
-    match rs_obj {
-        libparsec::DeviceFileType::Password { .. } => {
-            let js_tag = JsString::try_new(cx, "Password").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-        libparsec::DeviceFileType::Recovery { .. } => {
-            let js_tag = JsString::try_new(cx, "Recovery").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-        libparsec::DeviceFileType::Smartcard { .. } => {
-            let js_tag = JsString::try_new(cx, "Smartcard").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-    }
-    Ok(js_obj)
-}
-
 // DeviceSaveStrategy
 
 #[allow(dead_code)]
-fn variant_devicesavestrategy_js_to_rs<'a>(
+fn variant_device_save_strategy_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::DeviceSaveStrategy> {
@@ -1723,7 +1765,7 @@ fn variant_devicesavestrategy_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn variant_devicesavestrategy_rs_to_js<'a>(
+fn variant_device_save_strategy_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::DeviceSaveStrategy,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -1746,7 +1788,7 @@ fn variant_devicesavestrategy_rs_to_js<'a>(
 // BootstrapOrganizationError
 
 #[allow(dead_code)]
-fn variant_bootstraporganizationerror_rs_to_js<'a>(
+fn variant_bootstrap_organization_error_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::BootstrapOrganizationError,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -1827,7 +1869,7 @@ fn variant_bootstraporganizationerror_rs_to_js<'a>(
 // ClaimerRetrieveInfoError
 
 #[allow(dead_code)]
-fn variant_claimerretrieveinfoerror_rs_to_js<'a>(
+fn variant_claimer_retrieve_info_error_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::ClaimerRetrieveInfoError,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -1858,7 +1900,7 @@ fn variant_claimerretrieveinfoerror_rs_to_js<'a>(
 // ClaimInProgressError
 
 #[allow(dead_code)]
-fn variant_claiminprogresserror_rs_to_js<'a>(
+fn variant_claim_in_progress_error_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::ClaimInProgressError,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -1905,7 +1947,7 @@ fn variant_claiminprogresserror_rs_to_js<'a>(
 // UserOrDeviceClaimInitialInfo
 
 #[allow(dead_code)]
-fn variant_userordeviceclaiminitialinfo_js_to_rs<'a>(
+fn variant_user_or_device_claim_initial_info_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::UserOrDeviceClaimInitialInfo> {
@@ -1938,7 +1980,7 @@ fn variant_userordeviceclaiminitialinfo_js_to_rs<'a>(
                         None
                     } else {
                         let js_val = js_val.downcast_or_throw::<JsObject, _>(cx)?;
-                        Some(struct_humanhandle_js_to_rs(cx, js_val)?)
+                        Some(struct_human_handle_js_to_rs(cx, js_val)?)
                     }
                 }
             };
@@ -1979,7 +2021,7 @@ fn variant_userordeviceclaiminitialinfo_js_to_rs<'a>(
                         None
                     } else {
                         let js_val = js_val.downcast_or_throw::<JsObject, _>(cx)?;
-                        Some(struct_humanhandle_js_to_rs(cx, js_val)?)
+                        Some(struct_human_handle_js_to_rs(cx, js_val)?)
                     }
                 }
             };
@@ -1995,7 +2037,7 @@ fn variant_userordeviceclaiminitialinfo_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn variant_userordeviceclaiminitialinfo_rs_to_js<'a>(
+fn variant_user_or_device_claim_initial_info_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::UserOrDeviceClaimInitialInfo,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -2014,7 +2056,7 @@ fn variant_userordeviceclaiminitialinfo_rs_to_js<'a>(
             let js_greeter_user_id = JsString::try_new(cx, greeter_user_id).or_throw(cx)?;
             js_obj.set(cx, "greeterUserId", js_greeter_user_id)?;
             let js_greeter_human_handle = match greeter_human_handle {
-                Some(elem) => struct_humanhandle_rs_to_js(cx, elem)?.as_value(cx),
+                Some(elem) => struct_human_handle_rs_to_js(cx, elem)?.as_value(cx),
                 None => JsNull::new(cx).as_value(cx),
             };
             js_obj.set(cx, "greeterHumanHandle", js_greeter_human_handle)?;
@@ -2035,7 +2077,7 @@ fn variant_userordeviceclaiminitialinfo_rs_to_js<'a>(
             let js_greeter_user_id = JsString::try_new(cx, greeter_user_id).or_throw(cx)?;
             js_obj.set(cx, "greeterUserId", js_greeter_user_id)?;
             let js_greeter_human_handle = match greeter_human_handle {
-                Some(elem) => struct_humanhandle_rs_to_js(cx, elem)?.as_value(cx),
+                Some(elem) => struct_human_handle_rs_to_js(cx, elem)?.as_value(cx),
                 None => JsNull::new(cx).as_value(cx),
             };
             js_obj.set(cx, "greeterHumanHandle", js_greeter_human_handle)?;
@@ -2044,88 +2086,10 @@ fn variant_userordeviceclaiminitialinfo_rs_to_js<'a>(
     Ok(js_obj)
 }
 
-// InvitationStatus
-
-#[allow(dead_code)]
-fn variant_invitationstatus_js_to_rs<'a>(
-    cx: &mut impl Context<'a>,
-    obj: Handle<'a, JsObject>,
-) -> NeonResult<libparsec::InvitationStatus> {
-    let tag = obj.get::<JsString, _, _>(cx, "tag")?.value(cx);
-    match tag.as_str() {
-        "Deleted" => Ok(libparsec::InvitationStatus::Deleted {}),
-        "Idle" => Ok(libparsec::InvitationStatus::Idle {}),
-        "Ready" => Ok(libparsec::InvitationStatus::Ready {}),
-        _ => cx.throw_type_error("Object is not a InvitationStatus"),
-    }
-}
-
-#[allow(dead_code)]
-fn variant_invitationstatus_rs_to_js<'a>(
-    cx: &mut impl Context<'a>,
-    rs_obj: libparsec::InvitationStatus,
-) -> NeonResult<Handle<'a, JsObject>> {
-    let js_obj = cx.empty_object();
-    match rs_obj {
-        libparsec::InvitationStatus::Deleted { .. } => {
-            let js_tag = JsString::try_new(cx, "Deleted").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-        libparsec::InvitationStatus::Idle { .. } => {
-            let js_tag = JsString::try_new(cx, "Idle").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-        libparsec::InvitationStatus::Ready { .. } => {
-            let js_tag = JsString::try_new(cx, "Ready").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-    }
-    Ok(js_obj)
-}
-
-// InvitationEmailSentStatus
-
-#[allow(dead_code)]
-fn variant_invitationemailsentstatus_js_to_rs<'a>(
-    cx: &mut impl Context<'a>,
-    obj: Handle<'a, JsObject>,
-) -> NeonResult<libparsec::InvitationEmailSentStatus> {
-    let tag = obj.get::<JsString, _, _>(cx, "tag")?.value(cx);
-    match tag.as_str() {
-        "BadRecipient" => Ok(libparsec::InvitationEmailSentStatus::BadRecipient {}),
-        "NotAvailable" => Ok(libparsec::InvitationEmailSentStatus::NotAvailable {}),
-        "Success" => Ok(libparsec::InvitationEmailSentStatus::Success {}),
-        _ => cx.throw_type_error("Object is not a InvitationEmailSentStatus"),
-    }
-}
-
-#[allow(dead_code)]
-fn variant_invitationemailsentstatus_rs_to_js<'a>(
-    cx: &mut impl Context<'a>,
-    rs_obj: libparsec::InvitationEmailSentStatus,
-) -> NeonResult<Handle<'a, JsObject>> {
-    let js_obj = cx.empty_object();
-    match rs_obj {
-        libparsec::InvitationEmailSentStatus::BadRecipient { .. } => {
-            let js_tag = JsString::try_new(cx, "BadRecipient").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-        libparsec::InvitationEmailSentStatus::NotAvailable { .. } => {
-            let js_tag = JsString::try_new(cx, "NotAvailable").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-        libparsec::InvitationEmailSentStatus::Success { .. } => {
-            let js_tag = JsString::try_new(cx, "Success").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-    }
-    Ok(js_obj)
-}
-
 // NewUserInvitationError
 
 #[allow(dead_code)]
-fn variant_newuserinvitationerror_rs_to_js<'a>(
+fn variant_new_user_invitation_error_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::NewUserInvitationError,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -2156,7 +2120,7 @@ fn variant_newuserinvitationerror_rs_to_js<'a>(
 // NewDeviceInvitationError
 
 #[allow(dead_code)]
-fn variant_newdeviceinvitationerror_rs_to_js<'a>(
+fn variant_new_device_invitation_error_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::NewDeviceInvitationError,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -2183,7 +2147,7 @@ fn variant_newdeviceinvitationerror_rs_to_js<'a>(
 // DeleteInvitationError
 
 #[allow(dead_code)]
-fn variant_deleteinvitationerror_rs_to_js<'a>(
+fn variant_delete_invitation_error_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::DeleteInvitationError,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -2214,7 +2178,7 @@ fn variant_deleteinvitationerror_rs_to_js<'a>(
 // InviteListItem
 
 #[allow(dead_code)]
-fn variant_invitelistitem_js_to_rs<'a>(
+fn variant_invite_list_item_js_to_rs<'a>(
     cx: &mut impl Context<'a>,
     obj: Handle<'a, JsObject>,
 ) -> NeonResult<libparsec::InviteListItem> {
@@ -2248,8 +2212,11 @@ fn variant_invitelistitem_js_to_rs<'a>(
                 }
             };
             let status = {
-                let js_val: Handle<JsObject> = obj.get(cx, "status")?;
-                variant_invitationstatus_js_to_rs(cx, js_val)?
+                let js_val: Handle<JsString> = obj.get(cx, "status")?;
+                {
+                    let js_string = js_val.value(cx);
+                    enum_invitation_status_js_to_rs(cx, js_string.as_str())?
+                }
             };
             Ok(libparsec::InviteListItem::Device {
                 token,
@@ -2289,8 +2256,11 @@ fn variant_invitelistitem_js_to_rs<'a>(
                 js_val.value(cx)
             };
             let status = {
-                let js_val: Handle<JsObject> = obj.get(cx, "status")?;
-                variant_invitationstatus_js_to_rs(cx, js_val)?
+                let js_val: Handle<JsString> = obj.get(cx, "status")?;
+                {
+                    let js_string = js_val.value(cx);
+                    enum_invitation_status_js_to_rs(cx, js_string.as_str())?
+                }
             };
             Ok(libparsec::InviteListItem::User {
                 token,
@@ -2304,7 +2274,7 @@ fn variant_invitelistitem_js_to_rs<'a>(
 }
 
 #[allow(dead_code)]
-fn variant_invitelistitem_rs_to_js<'a>(
+fn variant_invite_list_item_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::InviteListItem,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -2340,7 +2310,8 @@ fn variant_invitelistitem_rs_to_js<'a>(
             })
             .or_throw(cx)?;
             js_obj.set(cx, "createdOn", js_created_on)?;
-            let js_status = variant_invitationstatus_rs_to_js(cx, status)?;
+            let js_status =
+                JsString::try_new(cx, enum_invitation_status_rs_to_js(status)).or_throw(cx)?;
             js_obj.set(cx, "status", js_status)?;
         }
         libparsec::InviteListItem::User {
@@ -2376,7 +2347,8 @@ fn variant_invitelistitem_rs_to_js<'a>(
             js_obj.set(cx, "createdOn", js_created_on)?;
             let js_claimer_email = JsString::try_new(cx, claimer_email).or_throw(cx)?;
             js_obj.set(cx, "claimerEmail", js_claimer_email)?;
-            let js_status = variant_invitationstatus_rs_to_js(cx, status)?;
+            let js_status =
+                JsString::try_new(cx, enum_invitation_status_rs_to_js(status)).or_throw(cx)?;
             js_obj.set(cx, "status", js_status)?;
         }
     }
@@ -2386,7 +2358,7 @@ fn variant_invitelistitem_rs_to_js<'a>(
 // ListInvitationsError
 
 #[allow(dead_code)]
-fn variant_listinvitationserror_rs_to_js<'a>(
+fn variant_list_invitations_error_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::ListInvitationsError,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -2409,7 +2381,7 @@ fn variant_listinvitationserror_rs_to_js<'a>(
 // ClientStartInvitationGreetError
 
 #[allow(dead_code)]
-fn variant_clientstartinvitationgreeterror_rs_to_js<'a>(
+fn variant_client_start_invitation_greet_error_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::ClientStartInvitationGreetError,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -2428,7 +2400,7 @@ fn variant_clientstartinvitationgreeterror_rs_to_js<'a>(
 // GreetInProgressError
 
 #[allow(dead_code)]
-fn variant_greetinprogresserror_rs_to_js<'a>(
+fn variant_greet_in_progress_error_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
     rs_obj: libparsec::GreetInProgressError,
 ) -> NeonResult<Handle<'a, JsObject>> {
@@ -2534,50 +2506,6 @@ fn variant_greetinprogresserror_rs_to_js<'a>(
     Ok(js_obj)
 }
 
-// OS
-
-#[allow(dead_code)]
-fn variant_os_js_to_rs<'a>(
-    cx: &mut impl Context<'a>,
-    obj: Handle<'a, JsObject>,
-) -> NeonResult<libparsec::OS> {
-    let tag = obj.get::<JsString, _, _>(cx, "tag")?.value(cx);
-    match tag.as_str() {
-        "Android" => Ok(libparsec::OS::Android {}),
-        "Linux" => Ok(libparsec::OS::Linux {}),
-        "MacOs" => Ok(libparsec::OS::MacOs {}),
-        "Windows" => Ok(libparsec::OS::Windows {}),
-        _ => cx.throw_type_error("Object is not a OS"),
-    }
-}
-
-#[allow(dead_code)]
-fn variant_os_rs_to_js<'a>(
-    cx: &mut impl Context<'a>,
-    rs_obj: libparsec::OS,
-) -> NeonResult<Handle<'a, JsObject>> {
-    let js_obj = cx.empty_object();
-    match rs_obj {
-        libparsec::OS::Android { .. } => {
-            let js_tag = JsString::try_new(cx, "Android").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-        libparsec::OS::Linux { .. } => {
-            let js_tag = JsString::try_new(cx, "Linux").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-        libparsec::OS::MacOs { .. } => {
-            let js_tag = JsString::try_new(cx, "MacOs").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-        libparsec::OS::Windows { .. } => {
-            let js_tag = JsString::try_new(cx, "Windows").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-    }
-    Ok(js_obj)
-}
-
 // cancel
 fn cancel(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let canceller = {
@@ -2608,7 +2536,7 @@ fn cancel(mut cx: FunctionContext) -> JsResult<JsPromise> {
             let js_obj = cx.empty_object();
             let js_tag = JsBoolean::new(&mut cx, false);
             js_obj.set(&mut cx, "ok", js_tag)?;
-            let js_err = variant_cancelerror_rs_to_js(&mut cx, err)?;
+            let js_err = variant_cancel_error_rs_to_js(&mut cx, err)?;
             js_obj.set(&mut cx, "error", js_err)?;
             js_obj
         }
@@ -2631,7 +2559,7 @@ fn new_canceller(mut cx: FunctionContext) -> JsResult<JsPromise> {
 fn client_start(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let config = {
         let js_val = cx.argument::<JsObject>(0)?;
-        struct_clientconfig_js_to_rs(&mut cx, js_val)?
+        struct_client_config_js_to_rs(&mut cx, js_val)?
     };
     let on_event_callback = {
         let js_val = cx.argument::<JsFunction>(1)?;
@@ -2667,7 +2595,7 @@ fn client_start(mut cx: FunctionContext) -> JsResult<JsPromise> {
             callback.channel.send(move |mut cx| {
                 // TODO: log an error instead of panic ? (it is a bit harsh to crash
                 // the current task if an unrelated event handler has a bug...)
-                let js_event = variant_clientevent_rs_to_js(&mut cx, event)?;
+                let js_event = variant_client_event_rs_to_js(&mut cx, event)?;
                 if let Some(ref js_fn) = callback2.js_fn {
                     js_fn
                         .to_inner(&mut cx)
@@ -2681,7 +2609,7 @@ fn client_start(mut cx: FunctionContext) -> JsResult<JsPromise> {
     };
     let access = {
         let js_val = cx.argument::<JsObject>(2)?;
-        variant_deviceaccessstrategy_js_to_rs(&mut cx, js_val)?
+        variant_device_access_strategy_js_to_rs(&mut cx, js_val)?
     };
     let channel = cx.channel();
     let (deferred, promise) = cx.promise();
@@ -2707,7 +2635,7 @@ fn client_start(mut cx: FunctionContext) -> JsResult<JsPromise> {
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_clientstarterror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_client_start_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -2759,7 +2687,7 @@ fn client_stop(mut cx: FunctionContext) -> JsResult<JsPromise> {
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_clientstoperror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_client_stop_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -2829,7 +2757,7 @@ fn client_list_workspaces(mut cx: FunctionContext) -> JsResult<JsPromise> {
                 let js_obj = cx.empty_object();
                 let js_tag = JsBoolean::new(&mut cx, false);
                 js_obj.set(&mut cx, "ok", js_tag)?;
-                let js_err = variant_clientlistworkspaceserror_rs_to_js(&mut cx, err)?;
+                let js_err = variant_client_list_workspaces_error_rs_to_js(&mut cx, err)?;
                 js_obj.set(&mut cx, "error", js_err)?;
                 js_obj
             }
@@ -2899,7 +2827,7 @@ fn client_workspace_create(mut cx: FunctionContext) -> JsResult<JsPromise> {
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_clientworkspacecreateerror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_client_workspace_create_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -2975,7 +2903,7 @@ fn client_workspace_rename(mut cx: FunctionContext) -> JsResult<JsPromise> {
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_clientworkspacerenameerror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_client_workspace_rename_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -3021,8 +2949,11 @@ fn client_workspace_share(mut cx: FunctionContext) -> JsResult<JsPromise> {
         }
     };
     let role = match cx.argument_opt(3) {
-        Some(v) => match v.downcast::<JsObject, _>(&mut cx) {
-            Ok(js_val) => Some(variant_realmrole_js_to_rs(&mut cx, js_val)?),
+        Some(v) => match v.downcast::<JsString, _>(&mut cx) {
+            Ok(js_val) => Some({
+                let js_string = js_val.value(&mut cx);
+                enum_realm_role_js_to_rs(&mut cx, js_string.as_str())?
+            }),
             Err(_) => None,
         },
         None => None,
@@ -3055,7 +2986,7 @@ fn client_workspace_share(mut cx: FunctionContext) -> JsResult<JsPromise> {
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_clientworkspaceshareerror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_client_workspace_share_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -3097,7 +3028,7 @@ fn claimer_greeter_abort_operation(mut cx: FunctionContext) -> JsResult<JsPromis
             let js_obj = cx.empty_object();
             let js_tag = JsBoolean::new(&mut cx, false);
             js_obj.set(&mut cx, "ok", js_tag)?;
-            let js_err = variant_claimergreeterabortoperationerror_rs_to_js(&mut cx, err)?;
+            let js_err = variant_claimer_greeter_abort_operation_error_rs_to_js(&mut cx, err)?;
             js_obj.set(&mut cx, "error", js_err)?;
             js_obj
         }
@@ -3135,7 +3066,7 @@ fn list_available_devices(mut cx: FunctionContext) -> JsResult<JsPromise> {
                     // JsArray::new allocates with `undefined` value, that's why we `set` value
                     let js_array = JsArray::new(&mut cx, ret.len() as u32);
                     for (i, elem) in ret.into_iter().enumerate() {
-                        let js_elem = struct_availabledevice_rs_to_js(&mut cx, elem)?;
+                        let js_elem = struct_available_device_rs_to_js(&mut cx, elem)?;
                         js_array.set(&mut cx, i as u32, js_elem)?;
                     }
                     js_array
@@ -3151,7 +3082,7 @@ fn list_available_devices(mut cx: FunctionContext) -> JsResult<JsPromise> {
 fn bootstrap_organization(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let config = {
         let js_val = cx.argument::<JsObject>(0)?;
-        struct_clientconfig_js_to_rs(&mut cx, js_val)?
+        struct_client_config_js_to_rs(&mut cx, js_val)?
     };
     let on_event_callback = {
         let js_val = cx.argument::<JsFunction>(1)?;
@@ -3187,7 +3118,7 @@ fn bootstrap_organization(mut cx: FunctionContext) -> JsResult<JsPromise> {
             callback.channel.send(move |mut cx| {
                 // TODO: log an error instead of panic ? (it is a bit harsh to crash
                 // the current task if an unrelated event handler has a bug...)
-                let js_event = variant_clientevent_rs_to_js(&mut cx, event)?;
+                let js_event = variant_client_event_rs_to_js(&mut cx, event)?;
                 if let Some(ref js_fn) = callback2.js_fn {
                     js_fn
                         .to_inner(&mut cx)
@@ -3213,11 +3144,11 @@ fn bootstrap_organization(mut cx: FunctionContext) -> JsResult<JsPromise> {
     };
     let save_strategy = {
         let js_val = cx.argument::<JsObject>(3)?;
-        variant_devicesavestrategy_js_to_rs(&mut cx, js_val)?
+        variant_device_save_strategy_js_to_rs(&mut cx, js_val)?
     };
     let human_handle = match cx.argument_opt(4) {
         Some(v) => match v.downcast::<JsObject, _>(&mut cx) {
-            Ok(js_val) => Some(struct_humanhandle_js_to_rs(&mut cx, js_val)?),
+            Ok(js_val) => Some(struct_human_handle_js_to_rs(&mut cx, js_val)?),
             Err(_) => None,
         },
         None => None,
@@ -3278,7 +3209,7 @@ fn bootstrap_organization(mut cx: FunctionContext) -> JsResult<JsPromise> {
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_availabledevice_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_available_device_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -3286,7 +3217,7 @@ fn bootstrap_organization(mut cx: FunctionContext) -> JsResult<JsPromise> {
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_bootstraporganizationerror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_bootstrap_organization_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -3302,7 +3233,7 @@ fn bootstrap_organization(mut cx: FunctionContext) -> JsResult<JsPromise> {
 fn claimer_retrieve_info(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let config = {
         let js_val = cx.argument::<JsObject>(0)?;
-        struct_clientconfig_js_to_rs(&mut cx, js_val)?
+        struct_client_config_js_to_rs(&mut cx, js_val)?
     };
     let on_event_callback = {
         let js_val = cx.argument::<JsFunction>(1)?;
@@ -3338,7 +3269,7 @@ fn claimer_retrieve_info(mut cx: FunctionContext) -> JsResult<JsPromise> {
             callback.channel.send(move |mut cx| {
                 // TODO: log an error instead of panic ? (it is a bit harsh to crash
                 // the current task if an unrelated event handler has a bug...)
-                let js_event = variant_clientevent_rs_to_js(&mut cx, event)?;
+                let js_event = variant_client_event_rs_to_js(&mut cx, event)?;
                 if let Some(ref js_fn) = callback2.js_fn {
                     js_fn
                         .to_inner(&mut cx)
@@ -3378,7 +3309,8 @@ fn claimer_retrieve_info(mut cx: FunctionContext) -> JsResult<JsPromise> {
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = variant_userordeviceclaiminitialinfo_rs_to_js(&mut cx, ok)?;
+                        let js_value =
+                            variant_user_or_device_claim_initial_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -3386,7 +3318,7 @@ fn claimer_retrieve_info(mut cx: FunctionContext) -> JsResult<JsPromise> {
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_claimerretrieveinfoerror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_claimer_retrieve_info_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -3436,7 +3368,7 @@ fn claimer_user_initial_do_wait_peer(mut cx: FunctionContext) -> JsResult<JsProm
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_userclaiminprogress1info_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_user_claim_in_progress1_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -3444,7 +3376,7 @@ fn claimer_user_initial_do_wait_peer(mut cx: FunctionContext) -> JsResult<JsProm
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_claiminprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_claim_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -3494,7 +3426,7 @@ fn claimer_device_initial_do_wait_peer(mut cx: FunctionContext) -> JsResult<JsPr
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_deviceclaiminprogress1info_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_device_claim_in_progress1_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -3502,7 +3434,7 @@ fn claimer_device_initial_do_wait_peer(mut cx: FunctionContext) -> JsResult<JsPr
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_claiminprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_claim_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -3553,7 +3485,7 @@ fn claimer_user_in_progress_1_do_signify_trust(mut cx: FunctionContext) -> JsRes
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_userclaiminprogress2info_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_user_claim_in_progress2_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -3561,7 +3493,7 @@ fn claimer_user_in_progress_1_do_signify_trust(mut cx: FunctionContext) -> JsRes
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_claiminprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_claim_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -3612,7 +3544,7 @@ fn claimer_device_in_progress_1_do_signify_trust(mut cx: FunctionContext) -> JsR
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_deviceclaiminprogress2info_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_device_claim_in_progress2_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -3620,7 +3552,7 @@ fn claimer_device_in_progress_1_do_signify_trust(mut cx: FunctionContext) -> JsR
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_claiminprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_claim_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -3671,7 +3603,7 @@ fn claimer_user_in_progress_2_do_wait_peer_trust(mut cx: FunctionContext) -> JsR
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_userclaiminprogress3info_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_user_claim_in_progress3_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -3679,7 +3611,7 @@ fn claimer_user_in_progress_2_do_wait_peer_trust(mut cx: FunctionContext) -> JsR
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_claiminprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_claim_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -3730,7 +3662,7 @@ fn claimer_device_in_progress_2_do_wait_peer_trust(mut cx: FunctionContext) -> J
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_deviceclaiminprogress3info_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_device_claim_in_progress3_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -3738,7 +3670,7 @@ fn claimer_device_in_progress_2_do_wait_peer_trust(mut cx: FunctionContext) -> J
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_claiminprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_claim_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -3786,7 +3718,7 @@ fn claimer_user_in_progress_3_do_claim(mut cx: FunctionContext) -> JsResult<JsPr
     };
     let requested_human_handle = match cx.argument_opt(3) {
         Some(v) => match v.downcast::<JsObject, _>(&mut cx) {
-            Ok(js_val) => Some(struct_humanhandle_js_to_rs(&mut cx, js_val)?),
+            Ok(js_val) => Some(struct_human_handle_js_to_rs(&mut cx, js_val)?),
             Err(_) => None,
         },
         None => None,
@@ -3813,7 +3745,7 @@ fn claimer_user_in_progress_3_do_claim(mut cx: FunctionContext) -> JsResult<JsPr
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_userclaimfinalizeinfo_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_user_claim_finalize_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -3821,7 +3753,7 @@ fn claimer_user_in_progress_3_do_claim(mut cx: FunctionContext) -> JsResult<JsPr
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_claiminprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_claim_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -3888,7 +3820,7 @@ fn claimer_device_in_progress_3_do_claim(mut cx: FunctionContext) -> JsResult<Js
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_deviceclaimfinalizeinfo_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_device_claim_finalize_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -3896,7 +3828,7 @@ fn claimer_device_in_progress_3_do_claim(mut cx: FunctionContext) -> JsResult<Js
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_claiminprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_claim_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -3922,7 +3854,7 @@ fn claimer_user_finalize_save_local_device(mut cx: FunctionContext) -> JsResult<
     };
     let save_strategy = {
         let js_val = cx.argument::<JsObject>(1)?;
-        variant_devicesavestrategy_js_to_rs(&mut cx, js_val)?
+        variant_device_save_strategy_js_to_rs(&mut cx, js_val)?
     };
     let channel = cx.channel();
     let (deferred, promise) = cx.promise();
@@ -3941,7 +3873,7 @@ fn claimer_user_finalize_save_local_device(mut cx: FunctionContext) -> JsResult<
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_availabledevice_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_available_device_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -3949,7 +3881,7 @@ fn claimer_user_finalize_save_local_device(mut cx: FunctionContext) -> JsResult<
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_claiminprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_claim_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -3975,7 +3907,7 @@ fn claimer_device_finalize_save_local_device(mut cx: FunctionContext) -> JsResul
     };
     let save_strategy = {
         let js_val = cx.argument::<JsObject>(1)?;
-        variant_devicesavestrategy_js_to_rs(&mut cx, js_val)?
+        variant_device_save_strategy_js_to_rs(&mut cx, js_val)?
     };
     let channel = cx.channel();
     let (deferred, promise) = cx.promise();
@@ -3994,7 +3926,7 @@ fn claimer_device_finalize_save_local_device(mut cx: FunctionContext) -> JsResul
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_availabledevice_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_available_device_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -4002,7 +3934,7 @@ fn claimer_device_finalize_save_local_device(mut cx: FunctionContext) -> JsResul
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_claiminprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_claim_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -4063,7 +3995,7 @@ fn client_new_user_invitation(mut cx: FunctionContext) -> JsResult<JsPromise> {
                         }
                     }).or_throw(&mut cx)?;
                     js_array.set(&mut cx, 1, js_value)?;
-                    let js_value = variant_invitationemailsentstatus_rs_to_js(&mut cx, x2)?;
+                    let js_value = JsString::try_new(&mut cx, enum_invitation_email_sent_status_rs_to_js(x2)).or_throw(&mut cx)?;
                     js_array.set(&mut cx, 2, js_value)?;
                     js_array
                 };
@@ -4074,7 +4006,7 @@ fn client_new_user_invitation(mut cx: FunctionContext) -> JsResult<JsPromise> {
                 let js_obj = cx.empty_object();
                 let js_tag = JsBoolean::new(&mut cx, false);
                 js_obj.set(&mut cx, "ok", js_tag)?;
-                let js_err = variant_newuserinvitationerror_rs_to_js(&mut cx, err)?;
+                let js_err = variant_new_user_invitation_error_rs_to_js(&mut cx, err)?;
                 js_obj.set(&mut cx, "error", js_err)?;
                 js_obj
             }
@@ -4130,7 +4062,7 @@ fn client_new_device_invitation(mut cx: FunctionContext) -> JsResult<JsPromise> 
                         }
                     }).or_throw(&mut cx)?;
                     js_array.set(&mut cx, 1, js_value)?;
-                    let js_value = variant_invitationemailsentstatus_rs_to_js(&mut cx, x2)?;
+                    let js_value = JsString::try_new(&mut cx, enum_invitation_email_sent_status_rs_to_js(x2)).or_throw(&mut cx)?;
                     js_array.set(&mut cx, 2, js_value)?;
                     js_array
                 };
@@ -4141,7 +4073,7 @@ fn client_new_device_invitation(mut cx: FunctionContext) -> JsResult<JsPromise> 
                 let js_obj = cx.empty_object();
                 let js_tag = JsBoolean::new(&mut cx, false);
                 js_obj.set(&mut cx, "ok", js_tag)?;
-                let js_err = variant_newdeviceinvitationerror_rs_to_js(&mut cx, err)?;
+                let js_err = variant_new_device_invitation_error_rs_to_js(&mut cx, err)?;
                 js_obj.set(&mut cx, "error", js_err)?;
                 js_obj
             }
@@ -4205,7 +4137,7 @@ fn client_delete_invitation(mut cx: FunctionContext) -> JsResult<JsPromise> {
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_deleteinvitationerror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_delete_invitation_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -4249,7 +4181,7 @@ fn client_list_invitations(mut cx: FunctionContext) -> JsResult<JsPromise> {
                             // JsArray::new allocates with `undefined` value, that's why we `set` value
                             let js_array = JsArray::new(&mut cx, ok.len() as u32);
                             for (i, elem) in ok.into_iter().enumerate() {
-                                let js_elem = variant_invitelistitem_rs_to_js(&mut cx, elem)?;
+                                let js_elem = variant_invite_list_item_rs_to_js(&mut cx, elem)?;
                                 js_array.set(&mut cx, i as u32, js_elem)?;
                             }
                             js_array
@@ -4261,7 +4193,7 @@ fn client_list_invitations(mut cx: FunctionContext) -> JsResult<JsPromise> {
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_listinvitationserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_list_invitations_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -4313,7 +4245,7 @@ fn client_start_user_invitation_greet(mut cx: FunctionContext) -> JsResult<JsPro
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_usergreetinitialinfo_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_user_greet_initial_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -4322,7 +4254,7 @@ fn client_start_user_invitation_greet(mut cx: FunctionContext) -> JsResult<JsPro
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
                         let js_err =
-                            variant_clientstartinvitationgreeterror_rs_to_js(&mut cx, err)?;
+                            variant_client_start_invitation_greet_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -4374,7 +4306,7 @@ fn client_start_device_invitation_greet(mut cx: FunctionContext) -> JsResult<JsP
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_devicegreetinitialinfo_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_device_greet_initial_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -4383,7 +4315,7 @@ fn client_start_device_invitation_greet(mut cx: FunctionContext) -> JsResult<JsP
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
                         let js_err =
-                            variant_clientstartinvitationgreeterror_rs_to_js(&mut cx, err)?;
+                            variant_client_start_invitation_greet_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -4433,7 +4365,7 @@ fn greeter_user_initial_do_wait_peer(mut cx: FunctionContext) -> JsResult<JsProm
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_usergreetinprogress1info_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_user_greet_in_progress1_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -4441,7 +4373,7 @@ fn greeter_user_initial_do_wait_peer(mut cx: FunctionContext) -> JsResult<JsProm
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_greetinprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_greet_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -4491,7 +4423,7 @@ fn greeter_device_initial_do_wait_peer(mut cx: FunctionContext) -> JsResult<JsPr
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_devicegreetinprogress1info_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_device_greet_in_progress1_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -4499,7 +4431,7 @@ fn greeter_device_initial_do_wait_peer(mut cx: FunctionContext) -> JsResult<JsPr
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_greetinprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_greet_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -4550,7 +4482,7 @@ fn greeter_user_in_progress_1_do_wait_peer_trust(mut cx: FunctionContext) -> JsR
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_usergreetinprogress2info_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_user_greet_in_progress2_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -4558,7 +4490,7 @@ fn greeter_user_in_progress_1_do_wait_peer_trust(mut cx: FunctionContext) -> JsR
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_greetinprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_greet_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -4609,7 +4541,7 @@ fn greeter_device_in_progress_1_do_wait_peer_trust(mut cx: FunctionContext) -> J
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_devicegreetinprogress2info_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_device_greet_in_progress2_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -4617,7 +4549,7 @@ fn greeter_device_in_progress_1_do_wait_peer_trust(mut cx: FunctionContext) -> J
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_greetinprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_greet_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -4668,7 +4600,7 @@ fn greeter_user_in_progress_2_do_signify_trust(mut cx: FunctionContext) -> JsRes
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_usergreetinprogress3info_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_user_greet_in_progress3_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -4676,7 +4608,7 @@ fn greeter_user_in_progress_2_do_signify_trust(mut cx: FunctionContext) -> JsRes
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_greetinprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_greet_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -4727,7 +4659,7 @@ fn greeter_device_in_progress_2_do_signify_trust(mut cx: FunctionContext) -> JsR
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_devicegreetinprogress3info_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_device_greet_in_progress3_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -4735,7 +4667,7 @@ fn greeter_device_in_progress_2_do_signify_trust(mut cx: FunctionContext) -> JsR
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_greetinprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_greet_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -4789,7 +4721,7 @@ fn greeter_user_in_progress_3_do_get_claim_requests(
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_usergreetinprogress4info_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_user_greet_in_progress4_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -4797,7 +4729,7 @@ fn greeter_user_in_progress_3_do_get_claim_requests(
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_greetinprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_greet_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -4851,7 +4783,7 @@ fn greeter_device_in_progress_3_do_get_claim_requests(
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = struct_devicegreetinprogress4info_rs_to_js(&mut cx, ok)?;
+                        let js_value = struct_device_greet_in_progress4_info_rs_to_js(&mut cx, ok)?;
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -4859,7 +4791,7 @@ fn greeter_device_in_progress_3_do_get_claim_requests(
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_greetinprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_greet_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -4895,7 +4827,7 @@ fn greeter_user_in_progress_4_do_create(mut cx: FunctionContext) -> JsResult<JsP
     };
     let human_handle = match cx.argument_opt(2) {
         Some(v) => match v.downcast::<JsObject, _>(&mut cx) {
-            Ok(js_val) => Some(struct_humanhandle_js_to_rs(&mut cx, js_val)?),
+            Ok(js_val) => Some(struct_human_handle_js_to_rs(&mut cx, js_val)?),
             Err(_) => None,
         },
         None => None,
@@ -4913,8 +4845,11 @@ fn greeter_user_in_progress_4_do_create(mut cx: FunctionContext) -> JsResult<JsP
         None => None,
     };
     let profile = {
-        let js_val = cx.argument::<JsObject>(4)?;
-        variant_userprofile_js_to_rs(&mut cx, js_val)?
+        let js_val = cx.argument::<JsString>(4)?;
+        {
+            let js_string = js_val.value(&mut cx);
+            enum_user_profile_js_to_rs(&mut cx, js_string.as_str())?
+        }
     };
     let channel = cx.channel();
     let (deferred, promise) = cx.promise();
@@ -4951,7 +4886,7 @@ fn greeter_user_in_progress_4_do_create(mut cx: FunctionContext) -> JsResult<JsP
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_greetinprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_greet_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -5027,7 +4962,7 @@ fn greeter_device_in_progress_4_do_create(mut cx: FunctionContext) -> JsResult<J
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_greetinprogresserror_rs_to_js(&mut cx, err)?;
+                        let js_err = variant_greet_in_progress_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -5042,7 +4977,7 @@ fn greeter_device_in_progress_4_do_create(mut cx: FunctionContext) -> JsResult<J
 // get_os
 fn get_os(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let ret = libparsec::get_os();
-    let js_ret = variant_os_rs_to_js(&mut cx, ret)?;
+    let js_ret = JsString::try_new(&mut cx, enum_os_rs_to_js(ret)).or_throw(&mut cx)?;
     let (deferred, promise) = cx.promise();
     deferred.resolve(&mut cx, js_ret);
     Ok(promise)

--- a/bindings/generator/api/client.py
+++ b/bindings/generator/api/client.py
@@ -13,17 +13,18 @@ from .common import (
     Result,
     UserID,
     Variant,
-    VariantItemUnit,
+    Enum,
+    EnumItemUnit,
 )
 from .config import ClientConfig
 from .events import OnClientEventCallback
 
 
-class RealmRole(Variant):
-    Owner = VariantItemUnit
-    Manager = VariantItemUnit
-    Contributor = VariantItemUnit
-    Reader = VariantItemUnit
+class RealmRole(Enum):
+    Owner = EnumItemUnit
+    Manager = EnumItemUnit
+    Contributor = EnumItemUnit
+    Reader = EnumItemUnit
 
 
 class DeviceAccessStrategy(Variant):

--- a/bindings/generator/api/common.py
+++ b/bindings/generator/api/common.py
@@ -17,6 +17,14 @@ class Result(Generic[OK, ERR]):
     pass
 
 
+class Enum:
+    pass
+
+
+class EnumItemUnit:
+    pass
+
+
 # e.g.
 #
 #       enum Foo {
@@ -195,7 +203,7 @@ class InvitationToken(StrBasedType):
     )
 
 
-class UserProfile(Variant):
-    Admin = VariantItemUnit
-    Standard = VariantItemUnit
-    Outsider = VariantItemUnit
+class UserProfile(Enum):
+    Admin = EnumItemUnit
+    Standard = EnumItemUnit
+    Outsider = EnumItemUnit

--- a/bindings/generator/api/invite.py
+++ b/bindings/generator/api/invite.py
@@ -23,7 +23,8 @@ from .common import (
     UserID,
     UserProfile,
     Variant,
-    VariantItemUnit,
+    Enum,
+    EnumItemUnit,
 )
 from .config import ClientConfig
 from .events import OnClientEventCallback
@@ -40,15 +41,10 @@ def claimer_greeter_abort_operation(
     raise NotImplementedError
 
 
-class DeviceFileType(Variant):
-    class Password:
-        pass
-
-    class Recovery:
-        pass
-
-    class Smartcard:
-        pass
+class DeviceFileType(Enum):
+    Password = EnumItemUnit
+    Recovery = EnumItemUnit
+    Smartcard = EnumItemUnit
 
 
 class AvailableDevice(Structure):
@@ -295,16 +291,16 @@ async def claimer_device_finalize_save_local_device(
 #
 
 
-class InvitationStatus(Variant):
-    Idle = VariantItemUnit
-    Ready = VariantItemUnit
-    Deleted = VariantItemUnit
+class InvitationStatus(Enum):
+    Idle = EnumItemUnit
+    Ready = EnumItemUnit
+    Deleted = EnumItemUnit
 
 
-class InvitationEmailSentStatus(Variant):
-    Success = VariantItemUnit
-    NotAvailable = VariantItemUnit
-    BadRecipient = VariantItemUnit
+class InvitationEmailSentStatus(Enum):
+    Success = EnumItemUnit
+    NotAvailable = EnumItemUnit
+    BadRecipient = EnumItemUnit
 
 
 class NewUserInvitationError(ErrorVariant):

--- a/bindings/generator/api/os.py
+++ b/bindings/generator/api/os.py
@@ -1,20 +1,13 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-from .common import Variant
+from .common import Enum, EnumItemUnit
 
 
-class OS(Variant):
-    class Linux:
-        pass
-
-    class MacOs:
-        pass
-
-    class Windows:
-        pass
-
-    class Android:
-        pass
+class OS(Enum):
+    Linux = EnumItemUnit
+    MacOs = EnumItemUnit
+    Windows = EnumItemUnit
+    Android = EnumItemUnit
 
 
 def get_os() -> OS:

--- a/bindings/generator/templates/binding_electron_index.d.ts.j2
+++ b/bindings/generator/templates/binding_electron_index.d.ts.j2
@@ -30,6 +30,8 @@ string
 Uint8Array
 {%- elif t.kind == "OnClientEventCallback" -%}
 (event: ClientEvent) => void
+{%- elif t.kind == "enum" -%}
+{{ t.name }}
 {%- else -%}
 {{ raise("Unsupported type %r" % t) }}
 {%- endif -%}

--- a/bindings/generator/templates/binding_electron_meths.rs.j2
+++ b/bindings/generator/templates/binding_electron_meths.rs.j2
@@ -33,6 +33,8 @@ JsObject
 JsObject
 {%- elif type.kind == "OnClientEventCallback" -%}
 JsFunction
+{%- elif type.kind == "enum" -%}
+JsString
 {%- else -%}
 {{ raise("Unsupported type %r" % type) }}
 {%- endif -%}
@@ -200,6 +202,11 @@ std::sync::Arc::new(
         });
     }
 ) as std::sync::Arc<dyn Fn(libparsec::ClientEvent) + Send + Sync>
+{%- elif type.kind == "enum" -%}
+{
+    let js_string = {{ js_val }}.value({{ mut_cx_ref }});
+    {{ enum_js_to_rs_function_name(type) }}({{ mut_cx_ref }}, js_string.as_str())?
+}
 {%- else -%}
 {{ js_val }}.value({{ mut_cx_ref }})
 {%- endif %}
@@ -322,6 +329,8 @@ JsString::try_new({{ mut_cx_ref }},
 {{ struct_rs_to_js_function_name(type) }}({{ mut_cx_ref }}, {{ rs_value }})?
 {%- elif type.kind == "variant" -%}
 {{ variant_rs_to_js_function_name(type) }}({{ mut_cx_ref }}, {{ rs_value }})?
+{%- elif type.kind == "enum" %}
+JsString::try_new({{ mut_cx_ref }}, {{ enum_rs_to_js_function_name(type) }}({{ rs_value }})).or_throw({{ mut_cx_ref }})?
 {%- else -%}
 {{ raise("Unsupported type %r" % type) }}
 {%- endif -%}
@@ -333,8 +342,8 @@ JsString::try_new({{ mut_cx_ref }},
  #}
 
 
-{%- macro struct_js_to_rs_function_name(struct) %}struct_{{ struct.name | lower }}_js_to_rs{% endmacro -%}
-{%- macro struct_rs_to_js_function_name(struct) %}struct_{{ struct.name | lower }}_rs_to_js{% endmacro -%}
+{%- macro struct_js_to_rs_function_name(struct) %}struct_{{ struct.name | pascal2snake }}_js_to_rs{% endmacro -%}
+{%- macro struct_rs_to_js_function_name(struct) %}struct_{{ struct.name | pascal2snake }}_rs_to_js{% endmacro -%}
 
 
 {%- macro render_struct_js_to_rs(struct) %}
@@ -389,8 +398,8 @@ fn {{ struct_rs_to_js_function_name(struct) }}<'a>(
  #}
 
 
-{%- macro variant_js_to_rs_function_name(variant) %}variant_{{ variant.name | lower }}_js_to_rs{% endmacro -%}
-{%- macro variant_rs_to_js_function_name(variant) %}variant_{{ variant.name | lower }}_rs_to_js{% endmacro -%}
+{%- macro variant_js_to_rs_function_name(variant) %}variant_{{ variant.name | pascal2snake }}_js_to_rs{% endmacro -%}
+{%- macro variant_rs_to_js_function_name(variant) %}variant_{{ variant.name | pascal2snake }}_rs_to_js{% endmacro -%}
 
 
 {%- macro render_variant_js_to_rs(variant) %}
@@ -479,7 +488,33 @@ fn {{ variant_rs_to_js_function_name(variant) }}<'a>(
 }
 {% endmacro -%}
 
+{%- macro enum_js_to_rs_function_name(type) %}enum_{{ type.name | pascal2snake }}_js_to_rs{% endmacro -%}
+{%- macro enum_rs_to_js_function_name(type) %}enum_{{ type.name | pascal2snake }}_rs_to_js{% endmacro -%}
 
+{%- macro render_enum_rs_to_js(enum) %}
+#[allow(dead_code)]
+fn {{ enum_rs_to_js_function_name(enum) }}(value: libparsec::{{ enum.name }}) -> &'static str {
+    match value {
+{% for variant in enum.member_names %}
+        libparsec::{{ enum.name }}::{{ variant }} => "{{ enum.name + variant }}",
+{% endfor %}
+    }
+}
+{% endmacro -%}
+
+{%- macro render_enum_js_to_rs(enum) %}
+#[allow(dead_code)]
+fn {{ enum_js_to_rs_function_name(enum) }}<'a>(cx: &mut impl Context<'a>, raw_value: &str) -> NeonResult<libparsec::{{ enum.name }}> {
+    match raw_value {
+{% for variant in enum.member_names %}
+        "{{ enum.name + variant }}" => Ok(libparsec::{{ enum.name }}::{{ variant}}),
+{% endfor %}
+        _ => {
+            cx.throw_range_error(format!("Invalid value `{raw_value}` for enum {{ enum.name }}"))
+        }
+    }
+}
+{% endmacro -%}
 {#-
  # Function-related macros
  #}
@@ -598,6 +633,16 @@ fn {{ meth.name }}(mut cx: FunctionContext) -> JsResult<JsPromise> {
 
 #[allow(unused_imports)]
 use neon::{prelude::*, types::buffer::TypedArray};
+{# Enum #}
+{% for enum in api.enums %}
+
+// {{ enum.name}}
+
+{{ render_enum_js_to_rs(enum) }}
+
+{{ render_enum_rs_to_js(enum) }}
+
+{% endfor %}
 {# Structures #}
 {% for struct in api.structs %}
 

--- a/bindings/generator/templates/binding_web_meths.rs.j2
+++ b/bindings/generator/templates/binding_web_meths.rs.j2
@@ -41,6 +41,8 @@ Object
 Object
 {%- elif type.kind == "OnClientEventCallback" -%}
 Function
+{%- elif type.kind == "enum" -%}
+String
 {%- else -%}
 {{ raise("Unsupported type %r" % type) }}
 {%- endif -%}
@@ -99,6 +101,8 @@ let {{ param_name }} = std::sync::Arc::new(move |event: libparsec::ClientEvent| 
     let js_event = {{ variant_rs_to_js_function_name(type.event_type) }}(event).expect("event type conversion error");
     on_event_callback.call1(&JsValue::NULL, &js_event).expect("error in event callback");
 }) as std::sync::Arc<dyn Fn(libparsec::ClientEvent)>;
+{% elif type.kind == "enum"%}
+let {{ param_name }} = {{ enum_js_to_rs_function_name(type) }}(&{{ param_name }})?;
 {% endif %}
 {%- endmacro -%}
 
@@ -207,6 +211,17 @@ if {{ js_val }}.is_null() {
             return Err(TypeError::new("Invalid `ok` field in Result object: Not a boolean"));
         }
     }
+{%- elif type.kind == "enum" -%}
+{
+    let raw_string = {{ js_val }}
+        .as_string()
+        .ok_or_else(|| {
+            let type_error = TypeError::new("value is not a string");
+            type_error.set_cause(&{{ js_val }});
+            JsValue::from(type_error)
+        })?;
+    {{ enum_js_to_rs_function_name(type) }}(raw_string.as_str())
+}?
 {%- else -%}
 {{ raise("Unsupported type %r" % type) }}
 {%- endif -%}
@@ -301,6 +316,8 @@ match {{ rs_value }} {
 {{ struct_rs_to_js_function_name(type) }}({{ rs_value }})?
 {%- elif type.kind == "variant" -%}
 {{ variant_rs_to_js_function_name(type) }}({{ rs_value }})?
+{%- elif type.kind == "enum" -%}
+JsValue::from_str({{ enum_rs_to_js_function_name(type) }}({{ rs_value }}))
 {%- else -%}
 {{ rs_value }}.into()
 {%- endif -%}
@@ -312,8 +329,8 @@ match {{ rs_value }} {
  #}
 
 
-{%- macro struct_js_to_rs_function_name(struct) %}struct_{{ struct.name | lower }}_js_to_rs{% endmacro -%}
-{%- macro struct_rs_to_js_function_name(struct) %}struct_{{ struct.name | lower }}_rs_to_js{% endmacro -%}
+{%- macro struct_js_to_rs_function_name(struct) %}struct_{{ struct.name | pascal2snake }}_js_to_rs{% endmacro -%}
+{%- macro struct_rs_to_js_function_name(struct) %}struct_{{ struct.name | pascal2snake }}_rs_to_js{% endmacro -%}
 
 
 {%- macro render_struct_js_to_rs(struct) %}
@@ -362,9 +379,8 @@ fn {{ struct_rs_to_js_function_name(struct) }}(rs_obj: libparsec::{{ struct.name
  #}
 
 
-{%- macro variant_js_to_rs_function_name(variant) %}variant_{{ variant.name | lower }}_js_to_rs{% endmacro -%}
-{%- macro variant_rs_to_js_function_name(variant) %}variant_{{ variant.name | lower }}_rs_to_js{% endmacro -%}
-
+{%- macro variant_js_to_rs_function_name(variant) %}variant_{{ variant.name | pascal2snake }}_js_to_rs{% endmacro -%}
+{%- macro variant_rs_to_js_function_name(variant) %}variant_{{ variant.name | pascal2snake }}_rs_to_js{% endmacro -%}
 
 {%- macro render_variant_js_to_rs(variant) %}
 #[allow(dead_code)]
@@ -518,6 +534,35 @@ pub fn {{ meth.name | snake2camel }}(
 }
 {% endmacro -%}
 
+{%- macro enum_js_to_rs_function_name(enum) %}enum_{{ enum.name | pascal2snake }}_js_to_rs{% endmacro %}
+{%- macro enum_rs_to_js_function_name(enum) %}enum_{{ enum.name | pascal2snake }}_rs_to_js{% endmacro %}
+
+{%- macro render_enum_js_to_rs(enum) %}
+#[allow(dead_code)]
+fn {{ enum_js_to_rs_function_name(enum) }}(raw_value: &str) -> Result<libparsec::{{ enum.name }}, JsValue> {
+    match raw_value {
+{% for variant_name in enum.member_names %}
+        "{{ enum.name + variant_name }}" => Ok(libparsec::{{ enum.name }}::{{ variant_name }}),
+{% endfor %}
+        _ => {
+            let range_error = RangeError::new("Invalid value for enum {{ enum.name }}");
+            range_error.set_cause(&JsValue::from(raw_value));
+            Err(JsValue::from(range_error))
+        },
+    }
+}
+{% endmacro -%}
+
+{%- macro render_enum_rs_to_js(enum) %}
+#[allow(dead_code)]
+fn {{ enum_rs_to_js_function_name(enum) }}(value: libparsec::{{ enum.name }}) -> &'static str {
+    match value {
+{% for variant_name in enum.member_names %}
+        libparsec::{{ enum.name}}::{{ variant_name }} => "{{ enum.name + variant_name }}",
+{% endfor %}
+    }
+}
+{% endmacro -%}
 
 {#- End of macros #}
 
@@ -535,6 +580,16 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 #[allow(unused_imports)]
 use wasm_bindgen_futures::*;
+
+{# Enum #}
+{% for enum in api.enums %}
+// {{ enum.name }}
+
+{{ render_enum_js_to_rs(enum) }}
+
+{{ render_enum_rs_to_js(enum) }}
+
+{% endfor %}
 {# Structures #}
 {% for struct in api.structs %}
 

--- a/bindings/generator/templates/client_plugin_definitions.ts.j2
+++ b/bindings/generator/templates/client_plugin_definitions.ts.j2
@@ -32,6 +32,8 @@ string
 Uint8Array
 {%- elif t.kind == "OnClientEventCallback" -%}
 (event: ClientEvent) => void
+{%- elif t.kind == "enum" -%}
+{{ t.name }}
 {%- else -%}
 {{ raise("Unsupported type %r" % t) }}
 {%- endif -%}
@@ -48,20 +50,31 @@ export type Result<T, E = Error> =
   | { ok: true; value: T }
   | { ok: false; error: E }
 
+{# Simple enum #}
+{% for enum in api.enums %}
+export enum {{ enum.name }} {
+{% for variant_name in enum.member_names %}
+    {{ variant_name }} = '{{ enum.name + variant_name }}',
+{% endfor -%}
+}
+{% if not loop.last %}
+
+{% endif %}
+{% endfor %}
 {# Str-based types #}
 {% for type_name in api.str_based_types %}
-type {{ type_name }} = string
+export type {{ type_name }} = string
 {% endfor %}
 {# Bytes-based types #}
 {% for type_name in api.bytes_based_types %}
-type {{ type_name }} = Uint8Array
+export type {{ type_name }} = Uint8Array
 {% endfor %}
 {# Int-based types #}
 {% for type_name in api.i32_based_types %}
-type {{ type_name }} = number
+export type {{ type_name }} = number
 {% endfor %}
 {% for type_name in api.u32_based_types %}
-type {{ type_name }} = number
+export type {{ type_name }} = number
 {% endfor %}
 {# Structures #}
 {% for struct in api.structs %}

--- a/bindings/web/src/meths.rs
+++ b/bindings/web/src/meths.rs
@@ -12,10 +12,178 @@ use wasm_bindgen::JsCast;
 #[allow(unused_imports)]
 use wasm_bindgen_futures::*;
 
+// RealmRole
+
+#[allow(dead_code)]
+fn enum_realm_role_js_to_rs(raw_value: &str) -> Result<libparsec::RealmRole, JsValue> {
+    match raw_value {
+        "RealmRoleContributor" => Ok(libparsec::RealmRole::Contributor),
+        "RealmRoleManager" => Ok(libparsec::RealmRole::Manager),
+        "RealmRoleOwner" => Ok(libparsec::RealmRole::Owner),
+        "RealmRoleReader" => Ok(libparsec::RealmRole::Reader),
+        _ => {
+            let range_error = RangeError::new("Invalid value for enum RealmRole");
+            range_error.set_cause(&JsValue::from(raw_value));
+            Err(JsValue::from(range_error))
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn enum_realm_role_rs_to_js(value: libparsec::RealmRole) -> &'static str {
+    match value {
+        libparsec::RealmRole::Contributor => "RealmRoleContributor",
+        libparsec::RealmRole::Manager => "RealmRoleManager",
+        libparsec::RealmRole::Owner => "RealmRoleOwner",
+        libparsec::RealmRole::Reader => "RealmRoleReader",
+    }
+}
+
+// UserProfile
+
+#[allow(dead_code)]
+fn enum_user_profile_js_to_rs(raw_value: &str) -> Result<libparsec::UserProfile, JsValue> {
+    match raw_value {
+        "UserProfileAdmin" => Ok(libparsec::UserProfile::Admin),
+        "UserProfileOutsider" => Ok(libparsec::UserProfile::Outsider),
+        "UserProfileStandard" => Ok(libparsec::UserProfile::Standard),
+        _ => {
+            let range_error = RangeError::new("Invalid value for enum UserProfile");
+            range_error.set_cause(&JsValue::from(raw_value));
+            Err(JsValue::from(range_error))
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn enum_user_profile_rs_to_js(value: libparsec::UserProfile) -> &'static str {
+    match value {
+        libparsec::UserProfile::Admin => "UserProfileAdmin",
+        libparsec::UserProfile::Outsider => "UserProfileOutsider",
+        libparsec::UserProfile::Standard => "UserProfileStandard",
+    }
+}
+
+// DeviceFileType
+
+#[allow(dead_code)]
+fn enum_device_file_type_js_to_rs(raw_value: &str) -> Result<libparsec::DeviceFileType, JsValue> {
+    match raw_value {
+        "DeviceFileTypePassword" => Ok(libparsec::DeviceFileType::Password),
+        "DeviceFileTypeRecovery" => Ok(libparsec::DeviceFileType::Recovery),
+        "DeviceFileTypeSmartcard" => Ok(libparsec::DeviceFileType::Smartcard),
+        _ => {
+            let range_error = RangeError::new("Invalid value for enum DeviceFileType");
+            range_error.set_cause(&JsValue::from(raw_value));
+            Err(JsValue::from(range_error))
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn enum_device_file_type_rs_to_js(value: libparsec::DeviceFileType) -> &'static str {
+    match value {
+        libparsec::DeviceFileType::Password => "DeviceFileTypePassword",
+        libparsec::DeviceFileType::Recovery => "DeviceFileTypeRecovery",
+        libparsec::DeviceFileType::Smartcard => "DeviceFileTypeSmartcard",
+    }
+}
+
+// InvitationStatus
+
+#[allow(dead_code)]
+fn enum_invitation_status_js_to_rs(
+    raw_value: &str,
+) -> Result<libparsec::InvitationStatus, JsValue> {
+    match raw_value {
+        "InvitationStatusDeleted" => Ok(libparsec::InvitationStatus::Deleted),
+        "InvitationStatusIdle" => Ok(libparsec::InvitationStatus::Idle),
+        "InvitationStatusReady" => Ok(libparsec::InvitationStatus::Ready),
+        _ => {
+            let range_error = RangeError::new("Invalid value for enum InvitationStatus");
+            range_error.set_cause(&JsValue::from(raw_value));
+            Err(JsValue::from(range_error))
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn enum_invitation_status_rs_to_js(value: libparsec::InvitationStatus) -> &'static str {
+    match value {
+        libparsec::InvitationStatus::Deleted => "InvitationStatusDeleted",
+        libparsec::InvitationStatus::Idle => "InvitationStatusIdle",
+        libparsec::InvitationStatus::Ready => "InvitationStatusReady",
+    }
+}
+
+// InvitationEmailSentStatus
+
+#[allow(dead_code)]
+fn enum_invitation_email_sent_status_js_to_rs(
+    raw_value: &str,
+) -> Result<libparsec::InvitationEmailSentStatus, JsValue> {
+    match raw_value {
+        "InvitationEmailSentStatusBadRecipient" => {
+            Ok(libparsec::InvitationEmailSentStatus::BadRecipient)
+        }
+        "InvitationEmailSentStatusNotAvailable" => {
+            Ok(libparsec::InvitationEmailSentStatus::NotAvailable)
+        }
+        "InvitationEmailSentStatusSuccess" => Ok(libparsec::InvitationEmailSentStatus::Success),
+        _ => {
+            let range_error = RangeError::new("Invalid value for enum InvitationEmailSentStatus");
+            range_error.set_cause(&JsValue::from(raw_value));
+            Err(JsValue::from(range_error))
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn enum_invitation_email_sent_status_rs_to_js(
+    value: libparsec::InvitationEmailSentStatus,
+) -> &'static str {
+    match value {
+        libparsec::InvitationEmailSentStatus::BadRecipient => {
+            "InvitationEmailSentStatusBadRecipient"
+        }
+        libparsec::InvitationEmailSentStatus::NotAvailable => {
+            "InvitationEmailSentStatusNotAvailable"
+        }
+        libparsec::InvitationEmailSentStatus::Success => "InvitationEmailSentStatusSuccess",
+    }
+}
+
+// OS
+
+#[allow(dead_code)]
+fn enum_os_js_to_rs(raw_value: &str) -> Result<libparsec::OS, JsValue> {
+    match raw_value {
+        "OSAndroid" => Ok(libparsec::OS::Android),
+        "OSLinux" => Ok(libparsec::OS::Linux),
+        "OSMacOs" => Ok(libparsec::OS::MacOs),
+        "OSWindows" => Ok(libparsec::OS::Windows),
+        _ => {
+            let range_error = RangeError::new("Invalid value for enum OS");
+            range_error.set_cause(&JsValue::from(raw_value));
+            Err(JsValue::from(range_error))
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn enum_os_rs_to_js(value: libparsec::OS) -> &'static str {
+    match value {
+        libparsec::OS::Android => "OSAndroid",
+        libparsec::OS::Linux => "OSLinux",
+        libparsec::OS::MacOs => "OSMacOs",
+        libparsec::OS::Windows => "OSWindows",
+    }
+}
+
 // ClientConfig
 
 #[allow(dead_code)]
-fn struct_clientconfig_js_to_rs(obj: JsValue) -> Result<libparsec::ClientConfig, JsValue> {
+fn struct_client_config_js_to_rs(obj: JsValue) -> Result<libparsec::ClientConfig, JsValue> {
     let config_dir = {
         let js_val = Reflect::get(&obj, &"configDir".into())?;
         js_val
@@ -60,7 +228,7 @@ fn struct_clientconfig_js_to_rs(obj: JsValue) -> Result<libparsec::ClientConfig,
     };
     let workspace_storage_cache_size = {
         let js_val = Reflect::get(&obj, &"workspaceStorageCacheSize".into())?;
-        variant_workspacestoragecachesize_js_to_rs(js_val)?
+        variant_workspace_storage_cache_size_js_to_rs(js_val)?
     };
     Ok(libparsec::ClientConfig {
         config_dir,
@@ -71,7 +239,7 @@ fn struct_clientconfig_js_to_rs(obj: JsValue) -> Result<libparsec::ClientConfig,
 }
 
 #[allow(dead_code)]
-fn struct_clientconfig_rs_to_js(rs_obj: libparsec::ClientConfig) -> Result<JsValue, JsValue> {
+fn struct_client_config_rs_to_js(rs_obj: libparsec::ClientConfig) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
     let js_config_dir = JsValue::from_str({
         let custom_to_rs_string = |path: std::path::PathBuf| -> Result<_, _> {
@@ -117,7 +285,7 @@ fn struct_clientconfig_rs_to_js(rs_obj: libparsec::ClientConfig) -> Result<JsVal
         &js_mountpoint_base_dir,
     )?;
     let js_workspace_storage_cache_size =
-        variant_workspacestoragecachesize_rs_to_js(rs_obj.workspace_storage_cache_size)?;
+        variant_workspace_storage_cache_size_rs_to_js(rs_obj.workspace_storage_cache_size)?;
     Reflect::set(
         &js_obj,
         &"workspaceStorageCacheSize".into(),
@@ -129,7 +297,7 @@ fn struct_clientconfig_rs_to_js(rs_obj: libparsec::ClientConfig) -> Result<JsVal
 // HumanHandle
 
 #[allow(dead_code)]
-fn struct_humanhandle_js_to_rs(obj: JsValue) -> Result<libparsec::HumanHandle, JsValue> {
+fn struct_human_handle_js_to_rs(obj: JsValue) -> Result<libparsec::HumanHandle, JsValue> {
     let email = {
         let js_val = Reflect::get(&obj, &"email".into())?;
         js_val
@@ -154,7 +322,7 @@ fn struct_humanhandle_js_to_rs(obj: JsValue) -> Result<libparsec::HumanHandle, J
 }
 
 #[allow(dead_code)]
-fn struct_humanhandle_rs_to_js(rs_obj: libparsec::HumanHandle) -> Result<JsValue, JsValue> {
+fn struct_human_handle_rs_to_js(rs_obj: libparsec::HumanHandle) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
     let js_email = {
         let custom_getter = |obj| {
@@ -182,7 +350,7 @@ fn struct_humanhandle_rs_to_js(rs_obj: libparsec::HumanHandle) -> Result<JsValue
 // AvailableDevice
 
 #[allow(dead_code)]
-fn struct_availabledevice_js_to_rs(obj: JsValue) -> Result<libparsec::AvailableDevice, JsValue> {
+fn struct_available_device_js_to_rs(obj: JsValue) -> Result<libparsec::AvailableDevice, JsValue> {
     let key_file_path = {
         let js_val = Reflect::get(&obj, &"keyFilePath".into())?;
         js_val
@@ -222,7 +390,7 @@ fn struct_availabledevice_js_to_rs(obj: JsValue) -> Result<libparsec::AvailableD
         if js_val.is_null() {
             None
         } else {
-            Some(struct_humanhandle_js_to_rs(js_val)?)
+            Some(struct_human_handle_js_to_rs(js_val)?)
         }
     };
     let device_label = {
@@ -251,7 +419,14 @@ fn struct_availabledevice_js_to_rs(obj: JsValue) -> Result<libparsec::AvailableD
     };
     let ty = {
         let js_val = Reflect::get(&obj, &"ty".into())?;
-        variant_devicefiletype_js_to_rs(js_val)?
+        {
+            let raw_string = js_val.as_string().ok_or_else(|| {
+                let type_error = TypeError::new("value is not a string");
+                type_error.set_cause(&js_val);
+                JsValue::from(type_error)
+            })?;
+            enum_device_file_type_js_to_rs(raw_string.as_str())
+        }?
     };
     Ok(libparsec::AvailableDevice {
         key_file_path,
@@ -265,7 +440,9 @@ fn struct_availabledevice_js_to_rs(obj: JsValue) -> Result<libparsec::AvailableD
 }
 
 #[allow(dead_code)]
-fn struct_availabledevice_rs_to_js(rs_obj: libparsec::AvailableDevice) -> Result<JsValue, JsValue> {
+fn struct_available_device_rs_to_js(
+    rs_obj: libparsec::AvailableDevice,
+) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
     let js_key_file_path = JsValue::from_str({
         let custom_to_rs_string = |path: std::path::PathBuf| -> Result<_, _> {
@@ -285,7 +462,7 @@ fn struct_availabledevice_rs_to_js(rs_obj: libparsec::AvailableDevice) -> Result
     let js_device_id = JsValue::from_str(rs_obj.device_id.as_ref());
     Reflect::set(&js_obj, &"deviceId".into(), &js_device_id)?;
     let js_human_handle = match rs_obj.human_handle {
-        Some(val) => struct_humanhandle_rs_to_js(val)?,
+        Some(val) => struct_human_handle_rs_to_js(val)?,
         None => JsValue::NULL,
     };
     Reflect::set(&js_obj, &"humanHandle".into(), &js_human_handle)?;
@@ -296,7 +473,7 @@ fn struct_availabledevice_rs_to_js(rs_obj: libparsec::AvailableDevice) -> Result
     Reflect::set(&js_obj, &"deviceLabel".into(), &js_device_label)?;
     let js_slug = rs_obj.slug.into();
     Reflect::set(&js_obj, &"slug".into(), &js_slug)?;
-    let js_ty = variant_devicefiletype_rs_to_js(rs_obj.ty)?;
+    let js_ty = JsValue::from_str(enum_device_file_type_rs_to_js(rs_obj.ty));
     Reflect::set(&js_obj, &"ty".into(), &js_ty)?;
     Ok(js_obj)
 }
@@ -304,7 +481,7 @@ fn struct_availabledevice_rs_to_js(rs_obj: libparsec::AvailableDevice) -> Result
 // UserClaimInProgress1Info
 
 #[allow(dead_code)]
-fn struct_userclaiminprogress1info_js_to_rs(
+fn struct_user_claim_in_progress1_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::UserClaimInProgress1Info, JsValue> {
     let handle = {
@@ -358,7 +535,7 @@ fn struct_userclaiminprogress1info_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn struct_userclaiminprogress1info_rs_to_js(
+fn struct_user_claim_in_progress1_info_rs_to_js(
     rs_obj: libparsec::UserClaimInProgress1Info,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -386,7 +563,7 @@ fn struct_userclaiminprogress1info_rs_to_js(
 // DeviceClaimInProgress1Info
 
 #[allow(dead_code)]
-fn struct_deviceclaiminprogress1info_js_to_rs(
+fn struct_device_claim_in_progress1_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::DeviceClaimInProgress1Info, JsValue> {
     let handle = {
@@ -440,7 +617,7 @@ fn struct_deviceclaiminprogress1info_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn struct_deviceclaiminprogress1info_rs_to_js(
+fn struct_device_claim_in_progress1_info_rs_to_js(
     rs_obj: libparsec::DeviceClaimInProgress1Info,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -468,7 +645,7 @@ fn struct_deviceclaiminprogress1info_rs_to_js(
 // UserClaimInProgress2Info
 
 #[allow(dead_code)]
-fn struct_userclaiminprogress2info_js_to_rs(
+fn struct_user_claim_in_progress2_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::UserClaimInProgress2Info, JsValue> {
     let handle = {
@@ -501,7 +678,7 @@ fn struct_userclaiminprogress2info_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn struct_userclaiminprogress2info_rs_to_js(
+fn struct_user_claim_in_progress2_info_rs_to_js(
     rs_obj: libparsec::UserClaimInProgress2Info,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -515,7 +692,7 @@ fn struct_userclaiminprogress2info_rs_to_js(
 // DeviceClaimInProgress2Info
 
 #[allow(dead_code)]
-fn struct_deviceclaiminprogress2info_js_to_rs(
+fn struct_device_claim_in_progress2_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::DeviceClaimInProgress2Info, JsValue> {
     let handle = {
@@ -548,7 +725,7 @@ fn struct_deviceclaiminprogress2info_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn struct_deviceclaiminprogress2info_rs_to_js(
+fn struct_device_claim_in_progress2_info_rs_to_js(
     rs_obj: libparsec::DeviceClaimInProgress2Info,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -562,7 +739,7 @@ fn struct_deviceclaiminprogress2info_rs_to_js(
 // UserClaimInProgress3Info
 
 #[allow(dead_code)]
-fn struct_userclaiminprogress3info_js_to_rs(
+fn struct_user_claim_in_progress3_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::UserClaimInProgress3Info, JsValue> {
     let handle = {
@@ -582,7 +759,7 @@ fn struct_userclaiminprogress3info_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn struct_userclaiminprogress3info_rs_to_js(
+fn struct_user_claim_in_progress3_info_rs_to_js(
     rs_obj: libparsec::UserClaimInProgress3Info,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -594,7 +771,7 @@ fn struct_userclaiminprogress3info_rs_to_js(
 // DeviceClaimInProgress3Info
 
 #[allow(dead_code)]
-fn struct_deviceclaiminprogress3info_js_to_rs(
+fn struct_device_claim_in_progress3_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::DeviceClaimInProgress3Info, JsValue> {
     let handle = {
@@ -614,7 +791,7 @@ fn struct_deviceclaiminprogress3info_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn struct_deviceclaiminprogress3info_rs_to_js(
+fn struct_device_claim_in_progress3_info_rs_to_js(
     rs_obj: libparsec::DeviceClaimInProgress3Info,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -626,7 +803,7 @@ fn struct_deviceclaiminprogress3info_rs_to_js(
 // UserClaimFinalizeInfo
 
 #[allow(dead_code)]
-fn struct_userclaimfinalizeinfo_js_to_rs(
+fn struct_user_claim_finalize_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::UserClaimFinalizeInfo, JsValue> {
     let handle = {
@@ -646,7 +823,7 @@ fn struct_userclaimfinalizeinfo_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn struct_userclaimfinalizeinfo_rs_to_js(
+fn struct_user_claim_finalize_info_rs_to_js(
     rs_obj: libparsec::UserClaimFinalizeInfo,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -658,7 +835,7 @@ fn struct_userclaimfinalizeinfo_rs_to_js(
 // DeviceClaimFinalizeInfo
 
 #[allow(dead_code)]
-fn struct_deviceclaimfinalizeinfo_js_to_rs(
+fn struct_device_claim_finalize_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::DeviceClaimFinalizeInfo, JsValue> {
     let handle = {
@@ -678,7 +855,7 @@ fn struct_deviceclaimfinalizeinfo_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn struct_deviceclaimfinalizeinfo_rs_to_js(
+fn struct_device_claim_finalize_info_rs_to_js(
     rs_obj: libparsec::DeviceClaimFinalizeInfo,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -690,7 +867,7 @@ fn struct_deviceclaimfinalizeinfo_rs_to_js(
 // UserGreetInitialInfo
 
 #[allow(dead_code)]
-fn struct_usergreetinitialinfo_js_to_rs(
+fn struct_user_greet_initial_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::UserGreetInitialInfo, JsValue> {
     let handle = {
@@ -710,7 +887,7 @@ fn struct_usergreetinitialinfo_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn struct_usergreetinitialinfo_rs_to_js(
+fn struct_user_greet_initial_info_rs_to_js(
     rs_obj: libparsec::UserGreetInitialInfo,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -722,7 +899,7 @@ fn struct_usergreetinitialinfo_rs_to_js(
 // DeviceGreetInitialInfo
 
 #[allow(dead_code)]
-fn struct_devicegreetinitialinfo_js_to_rs(
+fn struct_device_greet_initial_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::DeviceGreetInitialInfo, JsValue> {
     let handle = {
@@ -742,7 +919,7 @@ fn struct_devicegreetinitialinfo_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn struct_devicegreetinitialinfo_rs_to_js(
+fn struct_device_greet_initial_info_rs_to_js(
     rs_obj: libparsec::DeviceGreetInitialInfo,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -754,7 +931,7 @@ fn struct_devicegreetinitialinfo_rs_to_js(
 // UserGreetInProgress1Info
 
 #[allow(dead_code)]
-fn struct_usergreetinprogress1info_js_to_rs(
+fn struct_user_greet_in_progress1_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::UserGreetInProgress1Info, JsValue> {
     let handle = {
@@ -787,7 +964,7 @@ fn struct_usergreetinprogress1info_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn struct_usergreetinprogress1info_rs_to_js(
+fn struct_user_greet_in_progress1_info_rs_to_js(
     rs_obj: libparsec::UserGreetInProgress1Info,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -801,7 +978,7 @@ fn struct_usergreetinprogress1info_rs_to_js(
 // DeviceGreetInProgress1Info
 
 #[allow(dead_code)]
-fn struct_devicegreetinprogress1info_js_to_rs(
+fn struct_device_greet_in_progress1_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::DeviceGreetInProgress1Info, JsValue> {
     let handle = {
@@ -834,7 +1011,7 @@ fn struct_devicegreetinprogress1info_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn struct_devicegreetinprogress1info_rs_to_js(
+fn struct_device_greet_in_progress1_info_rs_to_js(
     rs_obj: libparsec::DeviceGreetInProgress1Info,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -848,7 +1025,7 @@ fn struct_devicegreetinprogress1info_rs_to_js(
 // UserGreetInProgress2Info
 
 #[allow(dead_code)]
-fn struct_usergreetinprogress2info_js_to_rs(
+fn struct_user_greet_in_progress2_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::UserGreetInProgress2Info, JsValue> {
     let handle = {
@@ -902,7 +1079,7 @@ fn struct_usergreetinprogress2info_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn struct_usergreetinprogress2info_rs_to_js(
+fn struct_user_greet_in_progress2_info_rs_to_js(
     rs_obj: libparsec::UserGreetInProgress2Info,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -930,7 +1107,7 @@ fn struct_usergreetinprogress2info_rs_to_js(
 // DeviceGreetInProgress2Info
 
 #[allow(dead_code)]
-fn struct_devicegreetinprogress2info_js_to_rs(
+fn struct_device_greet_in_progress2_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::DeviceGreetInProgress2Info, JsValue> {
     let handle = {
@@ -984,7 +1161,7 @@ fn struct_devicegreetinprogress2info_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn struct_devicegreetinprogress2info_rs_to_js(
+fn struct_device_greet_in_progress2_info_rs_to_js(
     rs_obj: libparsec::DeviceGreetInProgress2Info,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -1012,7 +1189,7 @@ fn struct_devicegreetinprogress2info_rs_to_js(
 // UserGreetInProgress3Info
 
 #[allow(dead_code)]
-fn struct_usergreetinprogress3info_js_to_rs(
+fn struct_user_greet_in_progress3_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::UserGreetInProgress3Info, JsValue> {
     let handle = {
@@ -1032,7 +1209,7 @@ fn struct_usergreetinprogress3info_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn struct_usergreetinprogress3info_rs_to_js(
+fn struct_user_greet_in_progress3_info_rs_to_js(
     rs_obj: libparsec::UserGreetInProgress3Info,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -1044,7 +1221,7 @@ fn struct_usergreetinprogress3info_rs_to_js(
 // DeviceGreetInProgress3Info
 
 #[allow(dead_code)]
-fn struct_devicegreetinprogress3info_js_to_rs(
+fn struct_device_greet_in_progress3_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::DeviceGreetInProgress3Info, JsValue> {
     let handle = {
@@ -1064,7 +1241,7 @@ fn struct_devicegreetinprogress3info_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn struct_devicegreetinprogress3info_rs_to_js(
+fn struct_device_greet_in_progress3_info_rs_to_js(
     rs_obj: libparsec::DeviceGreetInProgress3Info,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -1076,7 +1253,7 @@ fn struct_devicegreetinprogress3info_rs_to_js(
 // UserGreetInProgress4Info
 
 #[allow(dead_code)]
-fn struct_usergreetinprogress4info_js_to_rs(
+fn struct_user_greet_in_progress4_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::UserGreetInProgress4Info, JsValue> {
     let handle = {
@@ -1097,7 +1274,7 @@ fn struct_usergreetinprogress4info_js_to_rs(
         if js_val.is_null() {
             None
         } else {
-            Some(struct_humanhandle_js_to_rs(js_val)?)
+            Some(struct_human_handle_js_to_rs(js_val)?)
         }
     };
     let requested_device_label = {
@@ -1124,14 +1301,14 @@ fn struct_usergreetinprogress4info_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn struct_usergreetinprogress4info_rs_to_js(
+fn struct_user_greet_in_progress4_info_rs_to_js(
     rs_obj: libparsec::UserGreetInProgress4Info,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
     let js_handle = JsValue::from(rs_obj.handle);
     Reflect::set(&js_obj, &"handle".into(), &js_handle)?;
     let js_requested_human_handle = match rs_obj.requested_human_handle {
-        Some(val) => struct_humanhandle_rs_to_js(val)?,
+        Some(val) => struct_human_handle_rs_to_js(val)?,
         None => JsValue::NULL,
     };
     Reflect::set(
@@ -1154,7 +1331,7 @@ fn struct_usergreetinprogress4info_rs_to_js(
 // DeviceGreetInProgress4Info
 
 #[allow(dead_code)]
-fn struct_devicegreetinprogress4info_js_to_rs(
+fn struct_device_greet_in_progress4_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::DeviceGreetInProgress4Info, JsValue> {
     let handle = {
@@ -1193,7 +1370,7 @@ fn struct_devicegreetinprogress4info_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn struct_devicegreetinprogress4info_rs_to_js(
+fn struct_device_greet_in_progress4_info_rs_to_js(
     rs_obj: libparsec::DeviceGreetInProgress4Info,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -1214,7 +1391,7 @@ fn struct_devicegreetinprogress4info_rs_to_js(
 // CancelError
 
 #[allow(dead_code)]
-fn variant_cancelerror_rs_to_js(rs_obj: libparsec::CancelError) -> Result<JsValue, JsValue> {
+fn variant_cancel_error_rs_to_js(rs_obj: libparsec::CancelError) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
     let js_display = &rs_obj.to_string();
     Reflect::set(&js_obj, &"error".into(), &js_display.into())?;
@@ -1229,44 +1406,10 @@ fn variant_cancelerror_rs_to_js(rs_obj: libparsec::CancelError) -> Result<JsValu
     Ok(js_obj)
 }
 
-// RealmRole
-
-#[allow(dead_code)]
-fn variant_realmrole_js_to_rs(obj: JsValue) -> Result<libparsec::RealmRole, JsValue> {
-    let tag = Reflect::get(&obj, &"tag".into())?;
-    match tag {
-        tag if tag == JsValue::from_str("Contributor") => Ok(libparsec::RealmRole::Contributor {}),
-        tag if tag == JsValue::from_str("Manager") => Ok(libparsec::RealmRole::Manager {}),
-        tag if tag == JsValue::from_str("Owner") => Ok(libparsec::RealmRole::Owner {}),
-        tag if tag == JsValue::from_str("Reader") => Ok(libparsec::RealmRole::Reader {}),
-        _ => Err(JsValue::from(TypeError::new("Object is not a RealmRole"))),
-    }
-}
-
-#[allow(dead_code)]
-fn variant_realmrole_rs_to_js(rs_obj: libparsec::RealmRole) -> Result<JsValue, JsValue> {
-    let js_obj = Object::new().into();
-    match rs_obj {
-        libparsec::RealmRole::Contributor { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"Contributor".into())?;
-        }
-        libparsec::RealmRole::Manager { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"Manager".into())?;
-        }
-        libparsec::RealmRole::Owner { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"Owner".into())?;
-        }
-        libparsec::RealmRole::Reader { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"Reader".into())?;
-        }
-    }
-    Ok(js_obj)
-}
-
 // DeviceAccessStrategy
 
 #[allow(dead_code)]
-fn variant_deviceaccessstrategy_js_to_rs(
+fn variant_device_access_strategy_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::DeviceAccessStrategy, JsValue> {
     let tag = Reflect::get(&obj, &"tag".into())?;
@@ -1328,7 +1471,7 @@ fn variant_deviceaccessstrategy_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn variant_deviceaccessstrategy_rs_to_js(
+fn variant_device_access_strategy_rs_to_js(
     rs_obj: libparsec::DeviceAccessStrategy,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -1376,7 +1519,7 @@ fn variant_deviceaccessstrategy_rs_to_js(
 // ClientStartError
 
 #[allow(dead_code)]
-fn variant_clientstarterror_rs_to_js(
+fn variant_client_start_error_rs_to_js(
     rs_obj: libparsec::ClientStartError,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -1402,7 +1545,7 @@ fn variant_clientstarterror_rs_to_js(
 // ClientStopError
 
 #[allow(dead_code)]
-fn variant_clientstoperror_rs_to_js(
+fn variant_client_stop_error_rs_to_js(
     rs_obj: libparsec::ClientStopError,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -1419,7 +1562,7 @@ fn variant_clientstoperror_rs_to_js(
 // ClientListWorkspacesError
 
 #[allow(dead_code)]
-fn variant_clientlistworkspaceserror_rs_to_js(
+fn variant_client_list_workspaces_error_rs_to_js(
     rs_obj: libparsec::ClientListWorkspacesError,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -1436,7 +1579,7 @@ fn variant_clientlistworkspaceserror_rs_to_js(
 // ClientWorkspaceCreateError
 
 #[allow(dead_code)]
-fn variant_clientworkspacecreateerror_rs_to_js(
+fn variant_client_workspace_create_error_rs_to_js(
     rs_obj: libparsec::ClientWorkspaceCreateError,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -1453,7 +1596,7 @@ fn variant_clientworkspacecreateerror_rs_to_js(
 // ClientWorkspaceRenameError
 
 #[allow(dead_code)]
-fn variant_clientworkspacerenameerror_rs_to_js(
+fn variant_client_workspace_rename_error_rs_to_js(
     rs_obj: libparsec::ClientWorkspaceRenameError,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -1473,7 +1616,7 @@ fn variant_clientworkspacerenameerror_rs_to_js(
 // ClientWorkspaceShareError
 
 #[allow(dead_code)]
-fn variant_clientworkspaceshareerror_rs_to_js(
+fn variant_client_workspace_share_error_rs_to_js(
     rs_obj: libparsec::ClientWorkspaceShareError,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -1567,40 +1710,10 @@ fn variant_clientworkspaceshareerror_rs_to_js(
     Ok(js_obj)
 }
 
-// UserProfile
-
-#[allow(dead_code)]
-fn variant_userprofile_js_to_rs(obj: JsValue) -> Result<libparsec::UserProfile, JsValue> {
-    let tag = Reflect::get(&obj, &"tag".into())?;
-    match tag {
-        tag if tag == JsValue::from_str("Admin") => Ok(libparsec::UserProfile::Admin {}),
-        tag if tag == JsValue::from_str("Outsider") => Ok(libparsec::UserProfile::Outsider {}),
-        tag if tag == JsValue::from_str("Standard") => Ok(libparsec::UserProfile::Standard {}),
-        _ => Err(JsValue::from(TypeError::new("Object is not a UserProfile"))),
-    }
-}
-
-#[allow(dead_code)]
-fn variant_userprofile_rs_to_js(rs_obj: libparsec::UserProfile) -> Result<JsValue, JsValue> {
-    let js_obj = Object::new().into();
-    match rs_obj {
-        libparsec::UserProfile::Admin { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"Admin".into())?;
-        }
-        libparsec::UserProfile::Outsider { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"Outsider".into())?;
-        }
-        libparsec::UserProfile::Standard { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"Standard".into())?;
-        }
-    }
-    Ok(js_obj)
-}
-
 // WorkspaceStorageCacheSize
 
 #[allow(dead_code)]
-fn variant_workspacestoragecachesize_js_to_rs(
+fn variant_workspace_storage_cache_size_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::WorkspaceStorageCacheSize, JsValue> {
     let tag = Reflect::get(&obj, &"tag".into())?;
@@ -1631,7 +1744,7 @@ fn variant_workspacestoragecachesize_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn variant_workspacestoragecachesize_rs_to_js(
+fn variant_workspace_storage_cache_size_rs_to_js(
     rs_obj: libparsec::WorkspaceStorageCacheSize,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -1651,7 +1764,7 @@ fn variant_workspacestoragecachesize_rs_to_js(
 // ClientEvent
 
 #[allow(dead_code)]
-fn variant_clientevent_js_to_rs(obj: JsValue) -> Result<libparsec::ClientEvent, JsValue> {
+fn variant_client_event_js_to_rs(obj: JsValue) -> Result<libparsec::ClientEvent, JsValue> {
     let tag = Reflect::get(&obj, &"tag".into())?;
     match tag {
         tag if tag == JsValue::from_str("Ping") => {
@@ -1670,7 +1783,7 @@ fn variant_clientevent_js_to_rs(obj: JsValue) -> Result<libparsec::ClientEvent, 
 }
 
 #[allow(dead_code)]
-fn variant_clientevent_rs_to_js(rs_obj: libparsec::ClientEvent) -> Result<JsValue, JsValue> {
+fn variant_client_event_rs_to_js(rs_obj: libparsec::ClientEvent) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
     match rs_obj {
         libparsec::ClientEvent::Ping { ping, .. } => {
@@ -1685,7 +1798,7 @@ fn variant_clientevent_rs_to_js(rs_obj: libparsec::ClientEvent) -> Result<JsValu
 // ClaimerGreeterAbortOperationError
 
 #[allow(dead_code)]
-fn variant_claimergreeterabortoperationerror_rs_to_js(
+fn variant_claimer_greeter_abort_operation_error_rs_to_js(
     rs_obj: libparsec::ClaimerGreeterAbortOperationError,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -1699,42 +1812,10 @@ fn variant_claimergreeterabortoperationerror_rs_to_js(
     Ok(js_obj)
 }
 
-// DeviceFileType
-
-#[allow(dead_code)]
-fn variant_devicefiletype_js_to_rs(obj: JsValue) -> Result<libparsec::DeviceFileType, JsValue> {
-    let tag = Reflect::get(&obj, &"tag".into())?;
-    match tag {
-        tag if tag == JsValue::from_str("Password") => Ok(libparsec::DeviceFileType::Password {}),
-        tag if tag == JsValue::from_str("Recovery") => Ok(libparsec::DeviceFileType::Recovery {}),
-        tag if tag == JsValue::from_str("Smartcard") => Ok(libparsec::DeviceFileType::Smartcard {}),
-        _ => Err(JsValue::from(TypeError::new(
-            "Object is not a DeviceFileType",
-        ))),
-    }
-}
-
-#[allow(dead_code)]
-fn variant_devicefiletype_rs_to_js(rs_obj: libparsec::DeviceFileType) -> Result<JsValue, JsValue> {
-    let js_obj = Object::new().into();
-    match rs_obj {
-        libparsec::DeviceFileType::Password { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"Password".into())?;
-        }
-        libparsec::DeviceFileType::Recovery { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"Recovery".into())?;
-        }
-        libparsec::DeviceFileType::Smartcard { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"Smartcard".into())?;
-        }
-    }
-    Ok(js_obj)
-}
-
 // DeviceSaveStrategy
 
 #[allow(dead_code)]
-fn variant_devicesavestrategy_js_to_rs(
+fn variant_device_save_strategy_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::DeviceSaveStrategy, JsValue> {
     let tag = Reflect::get(&obj, &"tag".into())?;
@@ -1766,7 +1847,7 @@ fn variant_devicesavestrategy_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn variant_devicesavestrategy_rs_to_js(
+fn variant_device_save_strategy_rs_to_js(
     rs_obj: libparsec::DeviceSaveStrategy,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -1786,7 +1867,7 @@ fn variant_devicesavestrategy_rs_to_js(
 // BootstrapOrganizationError
 
 #[allow(dead_code)]
-fn variant_bootstraporganizationerror_rs_to_js(
+fn variant_bootstrap_organization_error_rs_to_js(
     rs_obj: libparsec::BootstrapOrganizationError,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -1860,7 +1941,7 @@ fn variant_bootstraporganizationerror_rs_to_js(
 // ClaimerRetrieveInfoError
 
 #[allow(dead_code)]
-fn variant_claimerretrieveinfoerror_rs_to_js(
+fn variant_claimer_retrieve_info_error_rs_to_js(
     rs_obj: libparsec::ClaimerRetrieveInfoError,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -1886,7 +1967,7 @@ fn variant_claimerretrieveinfoerror_rs_to_js(
 // ClaimInProgressError
 
 #[allow(dead_code)]
-fn variant_claiminprogresserror_rs_to_js(
+fn variant_claim_in_progress_error_rs_to_js(
     rs_obj: libparsec::ClaimInProgressError,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -1924,7 +2005,7 @@ fn variant_claiminprogresserror_rs_to_js(
 // UserOrDeviceClaimInitialInfo
 
 #[allow(dead_code)]
-fn variant_userordeviceclaiminitialinfo_js_to_rs(
+fn variant_user_or_device_claim_initial_info_js_to_rs(
     obj: JsValue,
 ) -> Result<libparsec::UserOrDeviceClaimInitialInfo, JsValue> {
     let tag = Reflect::get(&obj, &"tag".into())?;
@@ -1958,7 +2039,7 @@ fn variant_userordeviceclaiminitialinfo_js_to_rs(
                 if js_val.is_null() {
                     None
                 } else {
-                    Some(struct_humanhandle_js_to_rs(js_val)?)
+                    Some(struct_human_handle_js_to_rs(js_val)?)
                 }
             };
             Ok(libparsec::UserOrDeviceClaimInitialInfo::Device {
@@ -2004,7 +2085,7 @@ fn variant_userordeviceclaiminitialinfo_js_to_rs(
                 if js_val.is_null() {
                     None
                 } else {
-                    Some(struct_humanhandle_js_to_rs(js_val)?)
+                    Some(struct_human_handle_js_to_rs(js_val)?)
                 }
             };
             Ok(libparsec::UserOrDeviceClaimInitialInfo::User {
@@ -2021,7 +2102,7 @@ fn variant_userordeviceclaiminitialinfo_js_to_rs(
 }
 
 #[allow(dead_code)]
-fn variant_userordeviceclaiminitialinfo_rs_to_js(
+fn variant_user_or_device_claim_initial_info_rs_to_js(
     rs_obj: libparsec::UserOrDeviceClaimInitialInfo,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -2038,7 +2119,7 @@ fn variant_userordeviceclaiminitialinfo_rs_to_js(
             let js_greeter_user_id = JsValue::from_str(greeter_user_id.as_ref());
             Reflect::set(&js_obj, &"greeterUserId".into(), &js_greeter_user_id)?;
             let js_greeter_human_handle = match greeter_human_handle {
-                Some(val) => struct_humanhandle_rs_to_js(val)?,
+                Some(val) => struct_human_handle_rs_to_js(val)?,
                 None => JsValue::NULL,
             };
             Reflect::set(
@@ -2062,7 +2143,7 @@ fn variant_userordeviceclaiminitialinfo_rs_to_js(
             let js_greeter_user_id = JsValue::from_str(greeter_user_id.as_ref());
             Reflect::set(&js_obj, &"greeterUserId".into(), &js_greeter_user_id)?;
             let js_greeter_human_handle = match greeter_human_handle {
-                Some(val) => struct_humanhandle_rs_to_js(val)?,
+                Some(val) => struct_human_handle_rs_to_js(val)?,
                 None => JsValue::NULL,
             };
             Reflect::set(
@@ -2075,86 +2156,10 @@ fn variant_userordeviceclaiminitialinfo_rs_to_js(
     Ok(js_obj)
 }
 
-// InvitationStatus
-
-#[allow(dead_code)]
-fn variant_invitationstatus_js_to_rs(obj: JsValue) -> Result<libparsec::InvitationStatus, JsValue> {
-    let tag = Reflect::get(&obj, &"tag".into())?;
-    match tag {
-        tag if tag == JsValue::from_str("Deleted") => Ok(libparsec::InvitationStatus::Deleted {}),
-        tag if tag == JsValue::from_str("Idle") => Ok(libparsec::InvitationStatus::Idle {}),
-        tag if tag == JsValue::from_str("Ready") => Ok(libparsec::InvitationStatus::Ready {}),
-        _ => Err(JsValue::from(TypeError::new(
-            "Object is not a InvitationStatus",
-        ))),
-    }
-}
-
-#[allow(dead_code)]
-fn variant_invitationstatus_rs_to_js(
-    rs_obj: libparsec::InvitationStatus,
-) -> Result<JsValue, JsValue> {
-    let js_obj = Object::new().into();
-    match rs_obj {
-        libparsec::InvitationStatus::Deleted { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"Deleted".into())?;
-        }
-        libparsec::InvitationStatus::Idle { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"Idle".into())?;
-        }
-        libparsec::InvitationStatus::Ready { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"Ready".into())?;
-        }
-    }
-    Ok(js_obj)
-}
-
-// InvitationEmailSentStatus
-
-#[allow(dead_code)]
-fn variant_invitationemailsentstatus_js_to_rs(
-    obj: JsValue,
-) -> Result<libparsec::InvitationEmailSentStatus, JsValue> {
-    let tag = Reflect::get(&obj, &"tag".into())?;
-    match tag {
-        tag if tag == JsValue::from_str("BadRecipient") => {
-            Ok(libparsec::InvitationEmailSentStatus::BadRecipient {})
-        }
-        tag if tag == JsValue::from_str("NotAvailable") => {
-            Ok(libparsec::InvitationEmailSentStatus::NotAvailable {})
-        }
-        tag if tag == JsValue::from_str("Success") => {
-            Ok(libparsec::InvitationEmailSentStatus::Success {})
-        }
-        _ => Err(JsValue::from(TypeError::new(
-            "Object is not a InvitationEmailSentStatus",
-        ))),
-    }
-}
-
-#[allow(dead_code)]
-fn variant_invitationemailsentstatus_rs_to_js(
-    rs_obj: libparsec::InvitationEmailSentStatus,
-) -> Result<JsValue, JsValue> {
-    let js_obj = Object::new().into();
-    match rs_obj {
-        libparsec::InvitationEmailSentStatus::BadRecipient { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"BadRecipient".into())?;
-        }
-        libparsec::InvitationEmailSentStatus::NotAvailable { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"NotAvailable".into())?;
-        }
-        libparsec::InvitationEmailSentStatus::Success { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"Success".into())?;
-        }
-    }
-    Ok(js_obj)
-}
-
 // NewUserInvitationError
 
 #[allow(dead_code)]
-fn variant_newuserinvitationerror_rs_to_js(
+fn variant_new_user_invitation_error_rs_to_js(
     rs_obj: libparsec::NewUserInvitationError,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -2180,7 +2185,7 @@ fn variant_newuserinvitationerror_rs_to_js(
 // NewDeviceInvitationError
 
 #[allow(dead_code)]
-fn variant_newdeviceinvitationerror_rs_to_js(
+fn variant_new_device_invitation_error_rs_to_js(
     rs_obj: libparsec::NewDeviceInvitationError,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -2207,7 +2212,7 @@ fn variant_newdeviceinvitationerror_rs_to_js(
 // DeleteInvitationError
 
 #[allow(dead_code)]
-fn variant_deleteinvitationerror_rs_to_js(
+fn variant_delete_invitation_error_rs_to_js(
     rs_obj: libparsec::DeleteInvitationError,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -2233,7 +2238,7 @@ fn variant_deleteinvitationerror_rs_to_js(
 // InviteListItem
 
 #[allow(dead_code)]
-fn variant_invitelistitem_js_to_rs(obj: JsValue) -> Result<libparsec::InviteListItem, JsValue> {
+fn variant_invite_list_item_js_to_rs(obj: JsValue) -> Result<libparsec::InviteListItem, JsValue> {
     let tag = Reflect::get(&obj, &"tag".into())?;
     match tag {
         tag if tag == JsValue::from_str("Device") => {
@@ -2271,7 +2276,14 @@ fn variant_invitelistitem_js_to_rs(obj: JsValue) -> Result<libparsec::InviteList
             };
             let status = {
                 let js_val = Reflect::get(&obj, &"status".into())?;
-                variant_invitationstatus_js_to_rs(js_val)?
+                {
+                    let raw_string = js_val.as_string().ok_or_else(|| {
+                        let type_error = TypeError::new("value is not a string");
+                        type_error.set_cause(&js_val);
+                        JsValue::from(type_error)
+                    })?;
+                    enum_invitation_status_js_to_rs(raw_string.as_str())
+                }?
             };
             Ok(libparsec::InviteListItem::Device {
                 token,
@@ -2322,7 +2334,14 @@ fn variant_invitelistitem_js_to_rs(obj: JsValue) -> Result<libparsec::InviteList
             };
             let status = {
                 let js_val = Reflect::get(&obj, &"status".into())?;
-                variant_invitationstatus_js_to_rs(js_val)?
+                {
+                    let raw_string = js_val.as_string().ok_or_else(|| {
+                        let type_error = TypeError::new("value is not a string");
+                        type_error.set_cause(&js_val);
+                        JsValue::from(type_error)
+                    })?;
+                    enum_invitation_status_js_to_rs(raw_string.as_str())
+                }?
             };
             Ok(libparsec::InviteListItem::User {
                 token,
@@ -2338,7 +2357,9 @@ fn variant_invitelistitem_js_to_rs(obj: JsValue) -> Result<libparsec::InviteList
 }
 
 #[allow(dead_code)]
-fn variant_invitelistitem_rs_to_js(rs_obj: libparsec::InviteListItem) -> Result<JsValue, JsValue> {
+fn variant_invite_list_item_rs_to_js(
+    rs_obj: libparsec::InviteListItem,
+) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
     match rs_obj {
         libparsec::InviteListItem::Device {
@@ -2370,7 +2391,7 @@ fn variant_invitelistitem_rs_to_js(rs_obj: libparsec::InviteListItem) -> Result<
                 .as_ref()
             });
             Reflect::set(&js_obj, &"createdOn".into(), &js_created_on)?;
-            let js_status = variant_invitationstatus_rs_to_js(status)?;
+            let js_status = JsValue::from_str(enum_invitation_status_rs_to_js(status));
             Reflect::set(&js_obj, &"status".into(), &js_status)?;
         }
         libparsec::InviteListItem::User {
@@ -2405,7 +2426,7 @@ fn variant_invitelistitem_rs_to_js(rs_obj: libparsec::InviteListItem) -> Result<
             Reflect::set(&js_obj, &"createdOn".into(), &js_created_on)?;
             let js_claimer_email = claimer_email.into();
             Reflect::set(&js_obj, &"claimerEmail".into(), &js_claimer_email)?;
-            let js_status = variant_invitationstatus_rs_to_js(status)?;
+            let js_status = JsValue::from_str(enum_invitation_status_rs_to_js(status));
             Reflect::set(&js_obj, &"status".into(), &js_status)?;
         }
     }
@@ -2415,7 +2436,7 @@ fn variant_invitelistitem_rs_to_js(rs_obj: libparsec::InviteListItem) -> Result<
 // ListInvitationsError
 
 #[allow(dead_code)]
-fn variant_listinvitationserror_rs_to_js(
+fn variant_list_invitations_error_rs_to_js(
     rs_obj: libparsec::ListInvitationsError,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -2435,7 +2456,7 @@ fn variant_listinvitationserror_rs_to_js(
 // ClientStartInvitationGreetError
 
 #[allow(dead_code)]
-fn variant_clientstartinvitationgreeterror_rs_to_js(
+fn variant_client_start_invitation_greet_error_rs_to_js(
     rs_obj: libparsec::ClientStartInvitationGreetError,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -2452,7 +2473,7 @@ fn variant_clientstartinvitationgreeterror_rs_to_js(
 // GreetInProgressError
 
 #[allow(dead_code)]
-fn variant_greetinprogresserror_rs_to_js(
+fn variant_greet_in_progress_error_rs_to_js(
     rs_obj: libparsec::GreetInProgressError,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
@@ -2544,40 +2565,6 @@ fn variant_greetinprogresserror_rs_to_js(
     Ok(js_obj)
 }
 
-// OS
-
-#[allow(dead_code)]
-fn variant_os_js_to_rs(obj: JsValue) -> Result<libparsec::OS, JsValue> {
-    let tag = Reflect::get(&obj, &"tag".into())?;
-    match tag {
-        tag if tag == JsValue::from_str("Android") => Ok(libparsec::OS::Android {}),
-        tag if tag == JsValue::from_str("Linux") => Ok(libparsec::OS::Linux {}),
-        tag if tag == JsValue::from_str("MacOs") => Ok(libparsec::OS::MacOs {}),
-        tag if tag == JsValue::from_str("Windows") => Ok(libparsec::OS::Windows {}),
-        _ => Err(JsValue::from(TypeError::new("Object is not a OS"))),
-    }
-}
-
-#[allow(dead_code)]
-fn variant_os_rs_to_js(rs_obj: libparsec::OS) -> Result<JsValue, JsValue> {
-    let js_obj = Object::new().into();
-    match rs_obj {
-        libparsec::OS::Android { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"Android".into())?;
-        }
-        libparsec::OS::Linux { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"Linux".into())?;
-        }
-        libparsec::OS::MacOs { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"MacOs".into())?;
-        }
-        libparsec::OS::Windows { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"Windows".into())?;
-        }
-    }
-    Ok(js_obj)
-}
-
 // cancel
 #[allow(non_snake_case)]
 #[wasm_bindgen]
@@ -2598,7 +2585,7 @@ pub fn cancel(canceller: u32) -> Promise {
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_cancelerror_rs_to_js(err)?;
+                let js_err = variant_cancel_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -2622,19 +2609,19 @@ pub fn newCanceller() -> Promise {
 pub fn clientStart(config: Object, on_event_callback: Function, access: Object) -> Promise {
     future_to_promise(async move {
         let config = config.into();
-        let config = struct_clientconfig_js_to_rs(config)?;
+        let config = struct_client_config_js_to_rs(config)?;
 
         let on_event_callback = std::sync::Arc::new(move |event: libparsec::ClientEvent| {
             // TODO: Better error handling here (log error ?)
             let js_event =
-                variant_clientevent_rs_to_js(event).expect("event type conversion error");
+                variant_client_event_rs_to_js(event).expect("event type conversion error");
             on_event_callback
                 .call1(&JsValue::NULL, &js_event)
                 .expect("error in event callback");
         }) as std::sync::Arc<dyn Fn(libparsec::ClientEvent)>;
 
         let access = access.into();
-        let access = variant_deviceaccessstrategy_js_to_rs(access)?;
+        let access = variant_device_access_strategy_js_to_rs(access)?;
 
         let ret = libparsec::client_start(config, on_event_callback, access).await;
         Ok(match ret {
@@ -2648,7 +2635,7 @@ pub fn clientStart(config: Object, on_event_callback: Function, access: Object) 
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_clientstarterror_rs_to_js(err)?;
+                let js_err = variant_client_start_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -2676,7 +2663,7 @@ pub fn clientStop(client: u32) -> Promise {
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_clientstoperror_rs_to_js(err)?;
+                let js_err = variant_client_stop_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -2729,7 +2716,7 @@ pub fn clientListWorkspaces(client: u32) -> Promise {
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_clientlistworkspaceserror_rs_to_js(err)?;
+                let js_err = variant_client_list_workspaces_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -2768,7 +2755,7 @@ pub fn clientWorkspaceCreate(client: u32, name: String) -> Promise {
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_clientworkspacecreateerror_rs_to_js(err)?;
+                let js_err = variant_client_workspace_create_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -2808,7 +2795,7 @@ pub fn clientWorkspaceRename(client: u32, realm_id: String, new_name: String) ->
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_clientworkspacerenameerror_rs_to_js(err)?;
+                let js_err = variant_client_workspace_rename_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -2823,7 +2810,7 @@ pub fn clientWorkspaceShare(
     client: u32,
     realm_id: String,
     recipient: String,
-    role: Option<Object>,
+    role: Option<String>,
 ) -> Promise {
     future_to_promise(async move {
         let realm_id = {
@@ -2838,8 +2825,7 @@ pub fn clientWorkspaceShare(
 
         let role = match role {
             Some(role) => {
-                let role = role.into();
-                let role = variant_realmrole_js_to_rs(role)?;
+                let role = enum_realm_role_js_to_rs(&role)?;
 
                 Some(role)
             }
@@ -2861,7 +2847,7 @@ pub fn clientWorkspaceShare(
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_clientworkspaceshareerror_rs_to_js(err)?;
+                let js_err = variant_client_workspace_share_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -2889,7 +2875,7 @@ pub fn claimerGreeterAbortOperation(handle: u32) -> Promise {
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_claimergreeterabortoperationerror_rs_to_js(err)?;
+                let js_err = variant_claimer_greeter_abort_operation_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -2913,7 +2899,7 @@ pub fn listAvailableDevices(path: String) -> Promise {
             // Array::new_with_length allocates with `undefined` value, that's why we `set` value
             let js_array = Array::new_with_length(ret.len() as u32);
             for (i, elem) in ret.into_iter().enumerate() {
-                let js_elem = struct_availabledevice_rs_to_js(elem)?;
+                let js_elem = struct_available_device_rs_to_js(elem)?;
                 js_array.set(i as u32, js_elem);
             }
             js_array.into()
@@ -2935,12 +2921,12 @@ pub fn bootstrapOrganization(
 ) -> Promise {
     future_to_promise(async move {
         let config = config.into();
-        let config = struct_clientconfig_js_to_rs(config)?;
+        let config = struct_client_config_js_to_rs(config)?;
 
         let on_event_callback = std::sync::Arc::new(move |event: libparsec::ClientEvent| {
             // TODO: Better error handling here (log error ?)
             let js_event =
-                variant_clientevent_rs_to_js(event).expect("event type conversion error");
+                variant_client_event_rs_to_js(event).expect("event type conversion error");
             on_event_callback
                 .call1(&JsValue::NULL, &js_event)
                 .expect("error in event callback");
@@ -2954,12 +2940,12 @@ pub fn bootstrapOrganization(
                 .map_err(|e| TypeError::new(e.as_ref()))
         }?;
         let save_strategy = save_strategy.into();
-        let save_strategy = variant_devicesavestrategy_js_to_rs(save_strategy)?;
+        let save_strategy = variant_device_save_strategy_js_to_rs(save_strategy)?;
 
         let human_handle = match human_handle {
             Some(human_handle) => {
                 let human_handle = human_handle.into();
-                let human_handle = struct_humanhandle_js_to_rs(human_handle)?;
+                let human_handle = struct_human_handle_js_to_rs(human_handle)?;
 
                 Some(human_handle)
             }
@@ -3006,14 +2992,14 @@ pub fn bootstrapOrganization(
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_availabledevice_rs_to_js(value)?;
+                let js_value = struct_available_device_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_bootstraporganizationerror_rs_to_js(err)?;
+                let js_err = variant_bootstrap_organization_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3027,12 +3013,12 @@ pub fn bootstrapOrganization(
 pub fn claimerRetrieveInfo(config: Object, on_event_callback: Function, addr: String) -> Promise {
     future_to_promise(async move {
         let config = config.into();
-        let config = struct_clientconfig_js_to_rs(config)?;
+        let config = struct_client_config_js_to_rs(config)?;
 
         let on_event_callback = std::sync::Arc::new(move |event: libparsec::ClientEvent| {
             // TODO: Better error handling here (log error ?)
             let js_event =
-                variant_clientevent_rs_to_js(event).expect("event type conversion error");
+                variant_client_event_rs_to_js(event).expect("event type conversion error");
             on_event_callback
                 .call1(&JsValue::NULL, &js_event)
                 .expect("error in event callback");
@@ -3049,14 +3035,14 @@ pub fn claimerRetrieveInfo(config: Object, on_event_callback: Function, addr: St
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = variant_userordeviceclaiminitialinfo_rs_to_js(value)?;
+                let js_value = variant_user_or_device_claim_initial_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_claimerretrieveinfoerror_rs_to_js(err)?;
+                let js_err = variant_claimer_retrieve_info_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3074,14 +3060,14 @@ pub fn claimerUserInitialDoWaitPeer(canceller: u32, handle: u32) -> Promise {
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_userclaiminprogress1info_rs_to_js(value)?;
+                let js_value = struct_user_claim_in_progress1_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_claiminprogresserror_rs_to_js(err)?;
+                let js_err = variant_claim_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3099,14 +3085,14 @@ pub fn claimerDeviceInitialDoWaitPeer(canceller: u32, handle: u32) -> Promise {
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_deviceclaiminprogress1info_rs_to_js(value)?;
+                let js_value = struct_device_claim_in_progress1_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_claiminprogresserror_rs_to_js(err)?;
+                let js_err = variant_claim_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3124,14 +3110,14 @@ pub fn claimerUserInProgress1DoSignifyTrust(canceller: u32, handle: u32) -> Prom
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_userclaiminprogress2info_rs_to_js(value)?;
+                let js_value = struct_user_claim_in_progress2_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_claiminprogresserror_rs_to_js(err)?;
+                let js_err = variant_claim_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3149,14 +3135,14 @@ pub fn claimerDeviceInProgress1DoSignifyTrust(canceller: u32, handle: u32) -> Pr
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_deviceclaiminprogress2info_rs_to_js(value)?;
+                let js_value = struct_device_claim_in_progress2_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_claiminprogresserror_rs_to_js(err)?;
+                let js_err = variant_claim_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3174,14 +3160,14 @@ pub fn claimerUserInProgress2DoWaitPeerTrust(canceller: u32, handle: u32) -> Pro
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_userclaiminprogress3info_rs_to_js(value)?;
+                let js_value = struct_user_claim_in_progress3_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_claiminprogresserror_rs_to_js(err)?;
+                let js_err = variant_claim_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3200,14 +3186,14 @@ pub fn claimerDeviceInProgress2DoWaitPeerTrust(canceller: u32, handle: u32) -> P
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_deviceclaiminprogress3info_rs_to_js(value)?;
+                let js_value = struct_device_claim_in_progress3_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_claiminprogresserror_rs_to_js(err)?;
+                let js_err = variant_claim_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3239,7 +3225,7 @@ pub fn claimerUserInProgress3DoClaim(
         let requested_human_handle = match requested_human_handle {
             Some(requested_human_handle) => {
                 let requested_human_handle = requested_human_handle.into();
-                let requested_human_handle = struct_humanhandle_js_to_rs(requested_human_handle)?;
+                let requested_human_handle = struct_human_handle_js_to_rs(requested_human_handle)?;
 
                 Some(requested_human_handle)
             }
@@ -3257,14 +3243,14 @@ pub fn claimerUserInProgress3DoClaim(
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_userclaimfinalizeinfo_rs_to_js(value)?;
+                let js_value = struct_user_claim_finalize_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_claiminprogresserror_rs_to_js(err)?;
+                let js_err = variant_claim_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3302,14 +3288,14 @@ pub fn claimerDeviceInProgress3DoClaim(
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_deviceclaimfinalizeinfo_rs_to_js(value)?;
+                let js_value = struct_device_claim_finalize_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_claiminprogresserror_rs_to_js(err)?;
+                let js_err = variant_claim_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3323,21 +3309,21 @@ pub fn claimerDeviceInProgress3DoClaim(
 pub fn claimerUserFinalizeSaveLocalDevice(handle: u32, save_strategy: Object) -> Promise {
     future_to_promise(async move {
         let save_strategy = save_strategy.into();
-        let save_strategy = variant_devicesavestrategy_js_to_rs(save_strategy)?;
+        let save_strategy = variant_device_save_strategy_js_to_rs(save_strategy)?;
 
         let ret = libparsec::claimer_user_finalize_save_local_device(handle, save_strategy).await;
         Ok(match ret {
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_availabledevice_rs_to_js(value)?;
+                let js_value = struct_available_device_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_claiminprogresserror_rs_to_js(err)?;
+                let js_err = variant_claim_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3351,21 +3337,21 @@ pub fn claimerUserFinalizeSaveLocalDevice(handle: u32, save_strategy: Object) ->
 pub fn claimerDeviceFinalizeSaveLocalDevice(handle: u32, save_strategy: Object) -> Promise {
     future_to_promise(async move {
         let save_strategy = save_strategy.into();
-        let save_strategy = variant_devicesavestrategy_js_to_rs(save_strategy)?;
+        let save_strategy = variant_device_save_strategy_js_to_rs(save_strategy)?;
 
         let ret = libparsec::claimer_device_finalize_save_local_device(handle, save_strategy).await;
         Ok(match ret {
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_availabledevice_rs_to_js(value)?;
+                let js_value = struct_available_device_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_claiminprogresserror_rs_to_js(err)?;
+                let js_err = variant_claim_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3398,7 +3384,8 @@ pub fn clientNewUserInvitation(client: u32, claimer_email: String, send_email: b
                         .as_ref()
                     });
                     js_array.push(&js_value);
-                    let js_value = variant_invitationemailsentstatus_rs_to_js(x2)?;
+                    let js_value =
+                        JsValue::from_str(enum_invitation_email_sent_status_rs_to_js(x2));
                     js_array.push(&js_value);
                     js_array.into()
                 };
@@ -3408,7 +3395,7 @@ pub fn clientNewUserInvitation(client: u32, claimer_email: String, send_email: b
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_newuserinvitationerror_rs_to_js(err)?;
+                let js_err = variant_new_user_invitation_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3441,7 +3428,8 @@ pub fn clientNewDeviceInvitation(client: u32, send_email: bool) -> Promise {
                         .as_ref()
                     });
                     js_array.push(&js_value);
-                    let js_value = variant_invitationemailsentstatus_rs_to_js(x2)?;
+                    let js_value =
+                        JsValue::from_str(enum_invitation_email_sent_status_rs_to_js(x2));
                     js_array.push(&js_value);
                     js_array.into()
                 };
@@ -3451,7 +3439,7 @@ pub fn clientNewDeviceInvitation(client: u32, send_email: bool) -> Promise {
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_newdeviceinvitationerror_rs_to_js(err)?;
+                let js_err = variant_new_device_invitation_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3485,7 +3473,7 @@ pub fn clientDeleteInvitation(client: u32, token: String) -> Promise {
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_deleteinvitationerror_rs_to_js(err)?;
+                let js_err = variant_delete_invitation_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3507,7 +3495,7 @@ pub fn clientListInvitations(client: u32) -> Promise {
                     // Array::new_with_length allocates with `undefined` value, that's why we `set` value
                     let js_array = Array::new_with_length(value.len() as u32);
                     for (i, elem) in value.into_iter().enumerate() {
-                        let js_elem = variant_invitelistitem_rs_to_js(elem)?;
+                        let js_elem = variant_invite_list_item_rs_to_js(elem)?;
                         js_array.set(i as u32, js_elem);
                     }
                     js_array.into()
@@ -3518,7 +3506,7 @@ pub fn clientListInvitations(client: u32) -> Promise {
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_listinvitationserror_rs_to_js(err)?;
+                let js_err = variant_list_invitations_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3542,14 +3530,14 @@ pub fn clientStartUserInvitationGreet(client: u32, token: String) -> Promise {
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_usergreetinitialinfo_rs_to_js(value)?;
+                let js_value = struct_user_greet_initial_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_clientstartinvitationgreeterror_rs_to_js(err)?;
+                let js_err = variant_client_start_invitation_greet_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3573,14 +3561,14 @@ pub fn clientStartDeviceInvitationGreet(client: u32, token: String) -> Promise {
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_devicegreetinitialinfo_rs_to_js(value)?;
+                let js_value = struct_device_greet_initial_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_clientstartinvitationgreeterror_rs_to_js(err)?;
+                let js_err = variant_client_start_invitation_greet_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3598,14 +3586,14 @@ pub fn greeterUserInitialDoWaitPeer(canceller: u32, handle: u32) -> Promise {
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_usergreetinprogress1info_rs_to_js(value)?;
+                let js_value = struct_user_greet_in_progress1_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_greetinprogresserror_rs_to_js(err)?;
+                let js_err = variant_greet_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3623,14 +3611,14 @@ pub fn greeterDeviceInitialDoWaitPeer(canceller: u32, handle: u32) -> Promise {
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_devicegreetinprogress1info_rs_to_js(value)?;
+                let js_value = struct_device_greet_in_progress1_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_greetinprogresserror_rs_to_js(err)?;
+                let js_err = variant_greet_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3648,14 +3636,14 @@ pub fn greeterUserInProgress1DoWaitPeerTrust(canceller: u32, handle: u32) -> Pro
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_usergreetinprogress2info_rs_to_js(value)?;
+                let js_value = struct_user_greet_in_progress2_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_greetinprogresserror_rs_to_js(err)?;
+                let js_err = variant_greet_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3674,14 +3662,14 @@ pub fn greeterDeviceInProgress1DoWaitPeerTrust(canceller: u32, handle: u32) -> P
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_devicegreetinprogress2info_rs_to_js(value)?;
+                let js_value = struct_device_greet_in_progress2_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_greetinprogresserror_rs_to_js(err)?;
+                let js_err = variant_greet_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3699,14 +3687,14 @@ pub fn greeterUserInProgress2DoSignifyTrust(canceller: u32, handle: u32) -> Prom
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_usergreetinprogress3info_rs_to_js(value)?;
+                let js_value = struct_user_greet_in_progress3_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_greetinprogresserror_rs_to_js(err)?;
+                let js_err = variant_greet_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3724,14 +3712,14 @@ pub fn greeterDeviceInProgress2DoSignifyTrust(canceller: u32, handle: u32) -> Pr
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_devicegreetinprogress3info_rs_to_js(value)?;
+                let js_value = struct_device_greet_in_progress3_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_greetinprogresserror_rs_to_js(err)?;
+                let js_err = variant_greet_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3750,14 +3738,14 @@ pub fn greeterUserInProgress3DoGetClaimRequests(canceller: u32, handle: u32) -> 
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_usergreetinprogress4info_rs_to_js(value)?;
+                let js_value = struct_user_greet_in_progress4_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_greetinprogresserror_rs_to_js(err)?;
+                let js_err = variant_greet_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3776,14 +3764,14 @@ pub fn greeterDeviceInProgress3DoGetClaimRequests(canceller: u32, handle: u32) -
             Ok(value) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = struct_devicegreetinprogress4info_rs_to_js(value)?;
+                let js_value = struct_device_greet_in_progress4_info_rs_to_js(value)?;
                 Reflect::set(&js_obj, &"value".into(), &js_value)?;
                 js_obj
             }
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_greetinprogresserror_rs_to_js(err)?;
+                let js_err = variant_greet_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3799,13 +3787,13 @@ pub fn greeterUserInProgress4DoCreate(
     handle: u32,
     human_handle: Option<Object>,
     device_label: Option<String>,
-    profile: Object,
+    profile: String,
 ) -> Promise {
     future_to_promise(async move {
         let human_handle = match human_handle {
             Some(human_handle) => {
                 let human_handle = human_handle.into();
-                let human_handle = struct_humanhandle_js_to_rs(human_handle)?;
+                let human_handle = struct_human_handle_js_to_rs(human_handle)?;
 
                 Some(human_handle)
             }
@@ -3823,8 +3811,7 @@ pub fn greeterUserInProgress4DoCreate(
             None => None,
         };
 
-        let profile = profile.into();
-        let profile = variant_userprofile_js_to_rs(profile)?;
+        let profile = enum_user_profile_js_to_rs(&profile)?;
 
         let ret = libparsec::greeter_user_in_progress_4_do_create(
             canceller,
@@ -3848,7 +3835,7 @@ pub fn greeterUserInProgress4DoCreate(
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_greetinprogresserror_rs_to_js(err)?;
+                let js_err = variant_greet_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3893,7 +3880,7 @@ pub fn greeterDeviceInProgress4DoCreate(
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_greetinprogresserror_rs_to_js(err)?;
+                let js_err = variant_greet_in_progress_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -3907,7 +3894,7 @@ pub fn greeterDeviceInProgress4DoCreate(
 pub fn getOs() -> Promise {
     future_to_promise(async move {
         let ret = libparsec::get_os();
-        Ok(variant_os_rs_to_js(ret)?)
+        Ok(JsValue::from_str(enum_os_rs_to_js(ret)))
     })
 }
 

--- a/client/src/common/mocks.ts
+++ b/client/src/common/mocks.ts
@@ -3,7 +3,7 @@
 // cSpell:disable
 
 import { DateTime } from 'luxon';
-import { AvailableDevice, Handle } from '@/plugins/libparsec/definitions';
+import { AvailableDevice, Handle, DeviceFileType } from '@/plugins/libparsec/definitions';
 import { StorageManager } from '@/services/storageManager';
 import { uniqueNamesGenerator, adjectives, colors, animals } from 'unique-names-generator';
 
@@ -321,7 +321,7 @@ const MOCK_DEVICES: AvailableDevice[] = [
     keyFilePath: 'key_file_path',
     deviceId: 'device_id',
     slug: 'slug1',
-    ty: { tag: 'Password' },
+    ty: DeviceFileType.Password,
   },
   {
     organizationId: 'Princeton-Plainsboro Hospital',
@@ -333,7 +333,7 @@ const MOCK_DEVICES: AvailableDevice[] = [
     keyFilePath: 'key_file_path',
     deviceId: 'device_id',
     slug: 'slug2',
-    ty: { tag: 'Password' },
+    ty: DeviceFileType.Password,
   },
   {
     organizationId: 'Black Mesa',
@@ -345,7 +345,7 @@ const MOCK_DEVICES: AvailableDevice[] = [
     keyFilePath: 'key_file_path',
     deviceId: 'device_id',
     slug: 'slug3',
-    ty: { tag: 'Password' },
+    ty: DeviceFileType.Password,
   },
   {
     organizationId: 'OsCorp',
@@ -357,7 +357,7 @@ const MOCK_DEVICES: AvailableDevice[] = [
     keyFilePath: 'key_file_path',
     deviceId: 'device_id',
     slug: 'slug4',
-    ty: { tag: 'Password' },
+    ty: DeviceFileType.Password,
   },
   {
     organizationId: 'Sanctum Sanctorum',
@@ -369,7 +369,7 @@ const MOCK_DEVICES: AvailableDevice[] = [
     keyFilePath: 'key_file_path',
     deviceId: 'device_id',
     slug: 'slug5',
-    ty: { tag: 'Password' },
+    ty: DeviceFileType.Password,
   },
   {
     organizationId: 'Holmes Consulting',
@@ -381,7 +381,7 @@ const MOCK_DEVICES: AvailableDevice[] = [
     keyFilePath: 'key_file_path',
     deviceId: 'device_id',
     slug: 'slug6',
-    ty: { tag: 'Password' },
+    ty: DeviceFileType.Password,
   },
   {
     organizationId: 'Riviera M.D.',
@@ -393,7 +393,7 @@ const MOCK_DEVICES: AvailableDevice[] = [
     keyFilePath: 'key_file_path',
     deviceId: 'device_id',
     slug: 'slug7',
-    ty: { tag: 'Password' },
+    ty: DeviceFileType.Password,
   },
 ];
 

--- a/client/src/common/parsec.ts
+++ b/client/src/common/parsec.ts
@@ -11,7 +11,6 @@ import {
   ClientConfig,
   EntryName,
   InvitationToken,
-  InvitationEmailSentStatus,
   NewUserInvitationError,
   NewDeviceInvitationError,
   InviteListItemUser,
@@ -22,6 +21,9 @@ import {
   SASCode,
   HumanHandle,
   UserOrDeviceClaimInitialInfoUser,
+  InvitationEmailSentStatus,
+  DeviceFileType,
+  InvitationStatus,
   ClientStartError,
   ListInvitationsError,
   DeleteInvitationError,
@@ -96,7 +98,7 @@ export async function inviteUser(email: string): Promise<Result<[InvitationToken
     return await libparsec.clientNewUserInvitation(handle, email, true);
   } else {
     return new Promise<Result<[InvitationToken, InvitationEmailSentStatus], NewUserInvitationError>>((resolve, _reject) => {
-      resolve({ok: true, value: ['1234', {tag: 'Success'}]});
+      resolve({ ok: true, value: ['1234', InvitationEmailSentStatus.Success] });
     });
   }
 }
@@ -108,14 +110,16 @@ export async function listWorkspaces(): Promise<Result<Array<[WorkspaceID, Works
     return await libparsec.clientListWorkspaces(handle);
   } else {
     return new Promise<Result<Array<[WorkspaceID, WorkspaceName]>, ClientListWorkspacesError>>((resolve, _reject) => {
-      resolve({ok: true, value: [
-        ['1', 'Trademeet'],
-        ['2', 'The Copper Coronet'],
-        ['3', 'The Asylum'],
-        ['4', 'Druid Grove'],
-        // cspell:disable-next-line
-        ['5', 'Menzoberranzan'],
-      ]});
+      resolve({
+        ok: true, value: [
+          ['1', 'Trademeet'],
+          ['2', 'The Copper Coronet'],
+          ['3', 'The Asylum'],
+          ['4', 'Druid Grove'],
+          // cspell:disable-next-line
+          ['5', 'Menzoberranzan'],
+        ],
+      });
     });
   }
 }
@@ -127,7 +131,7 @@ export async function createWorkspace(name: WorkspaceName): Promise<Result<Works
     return await libparsec.clientWorkspaceCreate(handle, name);
   } else {
     return new Promise<Result<WorkspaceID, ClientWorkspaceCreateError>>((resolve, _reject) => {
-      resolve({ok: true, value: '1337'});
+      resolve({ ok: true, value: '1337' });
     });
   }
 }
@@ -140,7 +144,7 @@ export async function inviteDevice(sendEmail: boolean):
     return await libparsec.clientNewDeviceInvitation(handle, sendEmail);
   }
   return new Promise<Result<[InvitationToken, InvitationEmailSentStatus], NewDeviceInvitationError>>((resolve, _reject) => {
-    resolve({ok: true, value: ['1234', {tag: 'Success'}]});
+    resolve({ ok: true, value: ['1234', InvitationEmailSentStatus.Success] });
   });
 }
 
@@ -168,17 +172,17 @@ export async function listUserInvitations(): Promise<Result<Array<UserInvitation
         token: '1234',
         createdOn: DateTime.now().toISO() || '',
         claimerEmail: 'shadowheart@swordcoast.faerun',
-        status: {tag: 'Ready'},
+        status: InvitationStatus.Ready,
         date: DateTime.now(),
       }, {
         tag: 'User',
         token: '5678',
         createdOn: DateTime.now().toISO() || '',
         claimerEmail: 'gale@waterdeep.faerun',
-        status: {tag: 'Ready'},
+        status: InvitationStatus.Ready,
         date: DateTime.now(),
       }];
-      resolve({ok: true, value: ret});
+      resolve({ ok: true, value: ret });
     });
   }
 }
@@ -409,7 +413,7 @@ export class UserClaim {
           },
           deviceLabel: 'a@b',
           slug: 'slug',
-          ty: {tag: 'Password'},
+          ty: DeviceFileType.Password,
         };
         resolve({ok: true, value: this.device});
       });

--- a/client/src/plugins/libparsec/definitions.ts
+++ b/client/src/plugins/libparsec/definitions.ts
@@ -8,25 +8,62 @@ export type Result<T, E = Error> =
   | { ok: true; value: T }
   | { ok: false; error: E }
 
-type DateTime = string
-type EntryName = string
-type Password = string
-type Path = string
-type RealmID = string
-type UserID = string
-type OrganizationID = string
-type DeviceID = string
-type DeviceLabel = string
-type BackendAddr = string
-type BackendOrganizationAddr = string
-type BackendOrganizationBootstrapAddr = string
-type BackendInvitationAddr = string
-type SASCode = string
-type EntryID = string
-type InvitationToken = string
-type SequesterVerifyKeyDer = Uint8Array
-type Handle = number
-type CacheSize = number
+export enum RealmRole {
+    Contributor = 'RealmRoleContributor',
+    Manager = 'RealmRoleManager',
+    Owner = 'RealmRoleOwner',
+    Reader = 'RealmRoleReader',
+}
+
+export enum UserProfile {
+    Admin = 'UserProfileAdmin',
+    Outsider = 'UserProfileOutsider',
+    Standard = 'UserProfileStandard',
+}
+
+export enum DeviceFileType {
+    Password = 'DeviceFileTypePassword',
+    Recovery = 'DeviceFileTypeRecovery',
+    Smartcard = 'DeviceFileTypeSmartcard',
+}
+
+export enum InvitationStatus {
+    Deleted = 'InvitationStatusDeleted',
+    Idle = 'InvitationStatusIdle',
+    Ready = 'InvitationStatusReady',
+}
+
+export enum InvitationEmailSentStatus {
+    BadRecipient = 'InvitationEmailSentStatusBadRecipient',
+    NotAvailable = 'InvitationEmailSentStatusNotAvailable',
+    Success = 'InvitationEmailSentStatusSuccess',
+}
+
+export enum OS {
+    Android = 'OSAndroid',
+    Linux = 'OSLinux',
+    MacOs = 'OSMacOs',
+    Windows = 'OSWindows',
+}
+export type DateTime = string
+export type EntryName = string
+export type Password = string
+export type Path = string
+export type RealmID = string
+export type UserID = string
+export type OrganizationID = string
+export type DeviceID = string
+export type DeviceLabel = string
+export type BackendAddr = string
+export type BackendOrganizationAddr = string
+export type BackendOrganizationBootstrapAddr = string
+export type BackendInvitationAddr = string
+export type SASCode = string
+export type EntryID = string
+export type InvitationToken = string
+export type SequesterVerifyKeyDer = Uint8Array
+export type Handle = number
+export type CacheSize = number
 
 export interface ClientConfig {
     configDir: Path
@@ -149,25 +186,6 @@ export interface CancelErrorNotBound {
 export type CancelError =
   | CancelErrorInternal
   | CancelErrorNotBound
-
-// RealmRole
-export interface RealmRoleContributor {
-    tag: 'Contributor'
-}
-export interface RealmRoleManager {
-    tag: 'Manager'
-}
-export interface RealmRoleOwner {
-    tag: 'Owner'
-}
-export interface RealmRoleReader {
-    tag: 'Reader'
-}
-export type RealmRole =
-  | RealmRoleContributor
-  | RealmRoleManager
-  | RealmRoleOwner
-  | RealmRoleReader
 
 // DeviceAccessStrategy
 export interface DeviceAccessStrategyPassword {
@@ -305,21 +323,6 @@ export type ClientWorkspaceShareError =
   | ClientWorkspaceShareErrorUnknownWorkspace
   | ClientWorkspaceShareErrorWorkspaceInMaintenance
 
-// UserProfile
-export interface UserProfileAdmin {
-    tag: 'Admin'
-}
-export interface UserProfileOutsider {
-    tag: 'Outsider'
-}
-export interface UserProfileStandard {
-    tag: 'Standard'
-}
-export type UserProfile =
-  | UserProfileAdmin
-  | UserProfileOutsider
-  | UserProfileStandard
-
 // WorkspaceStorageCacheSize
 export interface WorkspaceStorageCacheSizeCustom {
     tag: 'Custom'
@@ -347,21 +350,6 @@ export interface ClaimerGreeterAbortOperationErrorInternal {
 }
 export type ClaimerGreeterAbortOperationError =
   | ClaimerGreeterAbortOperationErrorInternal
-
-// DeviceFileType
-export interface DeviceFileTypePassword {
-    tag: 'Password'
-}
-export interface DeviceFileTypeRecovery {
-    tag: 'Recovery'
-}
-export interface DeviceFileTypeSmartcard {
-    tag: 'Smartcard'
-}
-export type DeviceFileType =
-  | DeviceFileTypePassword
-  | DeviceFileTypeRecovery
-  | DeviceFileTypeSmartcard
 
 // DeviceSaveStrategy
 export interface DeviceSaveStrategyPassword {
@@ -495,36 +483,6 @@ export interface UserOrDeviceClaimInitialInfoUser {
 export type UserOrDeviceClaimInitialInfo =
   | UserOrDeviceClaimInitialInfoDevice
   | UserOrDeviceClaimInitialInfoUser
-
-// InvitationStatus
-export interface InvitationStatusDeleted {
-    tag: 'Deleted'
-}
-export interface InvitationStatusIdle {
-    tag: 'Idle'
-}
-export interface InvitationStatusReady {
-    tag: 'Ready'
-}
-export type InvitationStatus =
-  | InvitationStatusDeleted
-  | InvitationStatusIdle
-  | InvitationStatusReady
-
-// InvitationEmailSentStatus
-export interface InvitationEmailSentStatusBadRecipient {
-    tag: 'BadRecipient'
-}
-export interface InvitationEmailSentStatusNotAvailable {
-    tag: 'NotAvailable'
-}
-export interface InvitationEmailSentStatusSuccess {
-    tag: 'Success'
-}
-export type InvitationEmailSentStatus =
-  | InvitationEmailSentStatusBadRecipient
-  | InvitationEmailSentStatusNotAvailable
-  | InvitationEmailSentStatusSuccess
 
 // NewUserInvitationError
 export interface NewUserInvitationErrorAlreadyMember {
@@ -700,25 +658,6 @@ export type GreetInProgressError =
   | GreetInProgressErrorPeerReset
   | GreetInProgressErrorUserAlreadyExists
   | GreetInProgressErrorUserCreateNotAllowed
-
-// OS
-export interface OSAndroid {
-    tag: 'Android'
-}
-export interface OSLinux {
-    tag: 'Linux'
-}
-export interface OSMacOs {
-    tag: 'MacOs'
-}
-export interface OSWindows {
-    tag: 'Windows'
-}
-export type OS =
-  | OSAndroid
-  | OSLinux
-  | OSMacOs
-  | OSWindows
 
 export interface LibParsecPlugin {
     cancel(

--- a/client/src/views/home/CreateOrganizationModal.vue
+++ b/client/src/views/home/CreateOrganizationModal.vue
@@ -191,7 +191,7 @@ import SummaryStep from '@/views/home/SummaryStep.vue';
 import { OrgInfo } from '@/views/home/SummaryStep.vue';
 import MsSpinner from '@/components/core/ms-spinner/MsSpinner.vue';
 import MsInput from '@/components/core/ms-input/MsInput.vue';
-import { AvailableDevice } from '@/plugins/libparsec/definitions';
+import { AvailableDevice, DeviceFileType } from '@/plugins/libparsec/definitions';
 import { MsModalResult } from '@/components/core/ms-modal/MsModal.vue';
 import { organizationValidator, Validity } from '@/common/validators';
 
@@ -343,7 +343,7 @@ function createOrg(orgName: string, userName: string, userEmail: string, deviceN
     keyFilePath: 'key_file_path',
     deviceId: 'device1@device1',
     slug: 'slug1',
-    ty: { tag: 'Password' },
+    ty: DeviceFileType.Password,
   };
   // Simulate connection to the backend
   window.setTimeout(nextStep, 2000);

--- a/client/src/views/home/DeviceJoinOrganizationModal.vue
+++ b/client/src/views/home/DeviceJoinOrganizationModal.vue
@@ -156,7 +156,7 @@ import SasCodeProvide from '@/components/sas-code/SasCodeProvide.vue';
 import SasCodeChoice from '@/components/sas-code/SasCodeChoice.vue';
 import InformationJoinDevice from '@/views/home/InformationJoinDeviceStep.vue';
 import MsInformativeText from '@/components/core/ms-text/MsInformativeText.vue';
-import { AvailableDevice } from '@/plugins/libparsec/definitions';
+import { AvailableDevice, DeviceFileType } from '@/plugins/libparsec/definitions';
 import { MsModalResult } from '@/components/core/ms-modal/MsModal.vue';
 import MsChoosePasswordInput from '@/components/core/ms-input/MsChoosePasswordInput.vue';
 
@@ -278,7 +278,7 @@ function mockCreateDevice(): AvailableDevice {
     keyFilePath: 'key_file_path',
     deviceId: 'device1@device1',
     slug: 'slug1',
-    ty: { tag: 'Password' },
+    ty: DeviceFileType.Password,
   };
 
   return device;

--- a/client/tests/component/specs/testInvitationCard.spec.ts
+++ b/client/tests/component/specs/testInvitationCard.spec.ts
@@ -5,6 +5,7 @@ import { mount } from '@vue/test-utils';
 import { DateTime } from 'luxon';
 import { mockI18n, getDefaultProvideConfig } from 'tests/component/support/mocks';
 import * as Parsec from '@/common/parsec';
+import { InvitationStatus } from '@/plugins/libparsec/definitions';
 
 mockI18n();
 
@@ -15,7 +16,7 @@ describe('User Invitation Card', () => {
       token: '1234',
       createdOn: DateTime.now().toISO() || '',
       claimerEmail: 'dung.eater@lands-between',
-      status: {tag: 'Ready'},
+      status: InvitationStatus.Ready,
       date: DateTime.now(),
     };
 

--- a/client/tests/component/specs/testInvitationListItem.spec.ts
+++ b/client/tests/component/specs/testInvitationListItem.spec.ts
@@ -5,6 +5,7 @@ import { mount } from '@vue/test-utils';
 import { DateTime } from 'luxon';
 import { mockI18n, getDefaultProvideConfig } from 'tests/component/support/mocks';
 import * as Parsec from '@/common/parsec';
+import { InvitationStatus } from '@/plugins/libparsec/definitions';
 
 mockI18n();
 
@@ -15,7 +16,7 @@ describe('User Invitation List Item', () => {
       token: '1234',
       createdOn: DateTime.now().toISO() || '',
       claimerEmail: 'dung.eater@lands-between',
-      status: {tag: 'Ready'},
+      status: InvitationStatus.Ready,
       date: DateTime.now(),
     };
 

--- a/client/tests/component/specs/testOrganizationCard.spec.ts
+++ b/client/tests/component/specs/testOrganizationCard.spec.ts
@@ -1,7 +1,7 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 import OrganizationCard from '@/components/organizations/OrganizationCard.vue';
-import { AvailableDevice } from '@/plugins/libparsec/definitions';
+import { DeviceFileType,  AvailableDevice } from '@/plugins/libparsec/definitions';
 import { VueWrapper, mount } from '@vue/test-utils';
 
 describe('Organization Card', () => {
@@ -17,7 +17,7 @@ describe('Organization Card', () => {
     },
     deviceLabel: 'hev',
     slug: '1',
-    ty: { tag: 'Password' },
+    ty: DeviceFileType.Password,
   };
 
   beforeEach(() => {


### PR DESCRIPTION
The conversion between `typescript enum <-> rust enum` is made using by strings.
The enums needed to be defined in `common.ts` because if it where
defined in `definitions.d.ts` we would not be able to use it as a value.

Other changes
-------------

- Use `type` instead of `str` for `BaseTypeInUse::parse`