### PR TITLE
Use vue alias configuration for `trampoline` instead of file copy

### DIFF
--- a/client/src/plugins/libparsec/index.ts
+++ b/client/src/plugins/libparsec/index.ts
@@ -3,7 +3,7 @@
 import { registerPlugin } from '@capacitor/core';
 
 import { LibParsecPlugin } from '@/plugins/libparsec/definitions';
-import { LoadWebLibParsecPlugin } from '@/plugins/libparsec/trampoline';
+import { LoadWebLibParsecPlugin } from '@libparsec_trampoline';
 
 export const libparsec = registerPlugin<LibParsecPlugin>(
   'LibParsec',

--- a/client/src/plugins/libparsec/trampoline-native.ts
+++ b/client/src/plugins/libparsec/trampoline-native.ts
@@ -1,3 +1,5 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
 export async function LoadWebLibParsecPlugin(): Promise<any> {
   throw new Error('Native build is not supposed to load the web version of LibparsecPlugin !');
 }

--- a/client/src/plugins/libparsec/trampoline-web.ts
+++ b/client/src/plugins/libparsec/trampoline-web.ts
@@ -1,4 +1,7 @@
-// eslint-disable @typescript-eslint/ban-ts-comment
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
 // @ts-ignore
 // eslint-disable-next-line camelcase
 import init_module from 'libparsec_bindings_web';

--- a/client/src/plugins/libparsec/trampoline.d.ts
+++ b/client/src/plugins/libparsec/trampoline.d.ts
@@ -1,3 +1,0 @@
-// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
-
-export function LoadWebLibParsecPlugin(): Promise<any>;

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -9,3 +9,7 @@ declare module '*.vue' {
   const component: DefineComponent<{}, {}, any>;
   export default component;
 }
+
+declare module '@libparsec_trampoline' {
+  export function LoadWebLibParsecPlugin(): Promise<any>;
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -67,30 +67,13 @@ if (platform !== 'web') {
   process.env.VITE_HOME_DIR = '';
 }
 
-// 2) Now that we know the platform, we can create `trampoline.ts` accordingly
-
-const libparsecPluginPath = path.join(__dirname, 'src/plugins/libparsec/');
-const src = path.join(libparsecPluginPath, `trampoline-${platform}.ts.in`);
-const dst = path.join(libparsecPluginPath, 'trampoline.ts');
-
-try {
-  // `readFileSync` will throw an error if `dst` doesn't exist
-  if (Buffer.compare(fs.readFileSync(src), fs.readFileSync(dst))) {
-    throw new Error('Outdated `trampoline.ts`');
-  }
-} catch (error) {
-  // `trampoline.ts` doesn't exist or is outdated, overwrite it
-  console.log(`Copy ${src} -> ${dst}`);
-  fs.copyFileSync(src, dst);
-}
-
-// 3) Add the packaging of the Wasm stuff if the platform requires it
+// 2) Add the packaging of the Wasm stuff if the platform requires it
 
 if (platform === 'web') {
   plugins.push(wasmPack([{path: '../bindings/web/', name: 'libparsec_bindings_web'}]));
 }
 
-// 4) Finally configure Vite
+// 3) Finally configure Vite
 
 // https://vitejs.dev/config/
 const config: UserConfigExport = () => ({
@@ -103,6 +86,7 @@ const config: UserConfigExport = () => ({
   },
   resolve: {
     alias: {
+      '@libparsec_trampoline': path.resolve(__dirname, `./src/plugins/libparsec/trampoline-${platform}.ts`),
       '@': path.resolve(__dirname, './src'),
     },
   },


### PR DESCRIPTION
- Use an alias to import the correct `trampoline` file instead of doing a copy each time the platform change.
- Rename the `ts.in` files to `.ts` to make typescript transpile them.
