### PR TITLE
Openssl not vendored

### DIFF
--- a/libparsec/Cargo.toml
+++ b/libparsec/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 [features]
 # Remember kid: RustCrypto is used if `use-sodiumoxide` is not set !
 use-sodiumoxide = ["libparsec_crypto/use-sodiumoxide"]
+vendored-openssl = ["libparsec_crypto/vendored-openssl"]
 python-bindings-support = [
     "libparsec_serialization_format/python-bindings-support"
 ]

--- a/libparsec/crates/client_connection/Cargo.toml
+++ b/libparsec/crates/client_connection/Cargo.toml
@@ -26,7 +26,10 @@ libparsec_platform_async = { workspace = true }
 
 eventsource-stream = { workspace = true, features = ["std"] }
 # Used to send HTTP request to the server.
-reqwest = { workspace = true, features = ["native-tls-vendored", "stream"] }
+# Note reqwest default to using the native SSL implementation.
+# When packing the application there is nothing special for Windows/MacOS,
+# on Linux however we have to specify our snap depends on the openssl package.
+reqwest = { workspace = true, features = ["stream"] }
 futures = { workspace = true }
 # Use abstract crypto primitive, to allow to sign request.
 # Used to encoded binary data.

--- a/libparsec/crates/crypto/Cargo.toml
+++ b/libparsec/crates/crypto/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 
 [features]
 test-unsecure-but-fast-secretkey-from-password = []
+vendored-openssl = ["openssl/vendored"]
 use-sodiumoxide = [
     "dep:sodiumoxide",
     "dep:libsodium-sys",
@@ -51,7 +52,32 @@ zeroize = { workspace = true, features = ["alloc"] }
 
 sodiumoxide = { workspace = true, optional = true, features = ["std", "serde"] }
 libsodium-sys = { workspace = true, optional = true }
-openssl = { workspace = true, optional = true, features = ["vendored"] }
+# A word about vendoring. In Parsec, OpenSSL is used for two different things:
+# - Provide X509 support when Rust-Crypto is not used (aka "openssl-for-parsec")
+# - Provide SSL support when doing web request stuff (aka "openssl-for-reqwest")
+#
+# "openssl-for-parsec" support is why the dependence is specified here.
+# "openssl-for-reqwest", however, is only needed on Linux (reqwest uses the
+# OS's SSL implementation, which on Linux *is* OpensSSL).
+#
+# On top of that non-Linux platforms don't provide an OpenSSL we can rely on,
+# hence we must vendor it when we need "openssl-for-parsec".
+#
+# On Linux on the other hand we have the choice: to vendor or not ?
+# Not-vendoring would make things consistent with the other platform regarding
+# "openssl-for-reqwest", however it complexifies packaging (e.g. by default
+# maturin bundles extra shared libraries, which defeat the purpose of not
+# vendoring !)
+#
+# So in the end what we do is:
+# - On non-Linux platform it a no-brainer: vendor when "openssl-for-parsec"
+#   is needed (only way to have openssl) and don't vendor if it's not (openssl
+#   useless in this case)
+# - On Linux, we don't vendor in dev/ci (for faster build)
+# - For release on Linux, we expose the `vendored-openssl` to fit the packager's
+#   needs (e.g. Docker image already ships openssl so no need to vendor, wheel
+#   distributed on pypi requires vendoring to comply with manylinux)
+openssl = { workspace = true, optional = true }
 
 #
 # RustCrypto stuff
@@ -122,3 +148,9 @@ rstest = { workspace = true, features = ["async-timeout"] }
 
 getrandom_01 = { workspace = true, features = ["wasm-bindgen"] }  # Optional rustcrypto dep
 getrandom_02 = { workspace = true, features = ["js"] }  # Optional rustcrypto dep
+
+[target.'cfg(target_os = "macos")'.dependencies]
+openssl = { workspace = true, optional = true, features = ["vendored"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+openssl = { workspace = true, optional = true, features = ["vendored"] }

--- a/server/packaging/server/in-docker-build.sh
+++ b/server/packaging/server/in-docker-build.sh
@@ -30,7 +30,10 @@ poetry --directory ./server export --output requirements.txt --with=main
 pip install -r ./requirements.txt
 # ...and our project
 # Compile in release mode
-POETRY_LIBPARSEC_BUILD_PROFILE=release pip install ./server
+# Also don't bundle OpenSSL shared library (it is already in the Docker image !)
+POETRY_LIBPARSEC_BUILD_PROFILE=release \
+POETRY_LIBPARSEC_BUNDLE_EXTRA_SHARED_LIBRARIES=false \
+pip install ./server
 
 # Basic to see if the wheel look like it's well built.
 (cd / && /work/venv/bin/python -m parsec.cli --version)

--- a/server/packaging/testbed-server/in-docker-build.sh
+++ b/server/packaging/testbed-server/in-docker-build.sh
@@ -31,7 +31,10 @@ poetry --directory ./server export --output requirements.txt --with=main,testbed
 pip install -r ./requirements.txt
 # ...and our project
 # Compile in CI mode to reduce size while still retain `test-utils` feature
-POETRY_LIBPARSEC_BUILD_PROFILE=ci pip install ./server
+# Also don't bundle OpenSSL shared library (it is already in the Docker image !)
+POETRY_LIBPARSEC_BUILD_PROFILE=ci \
+POETRY_LIBPARSEC_BUNDLE_EXTRA_SHARED_LIBRARIES=false \
+pip install ./server
 
 # Boto3/Botocore are pretty big dependencies and won't be used (given the testbed
 # server only uses the memory storage)

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -122,12 +122,19 @@ before-all = "bash {project}/misc/setup-rust.sh"
 before-build = "python -m pip install -U pip"
 test-command = "parsec --version"
 
+[tool.cibuildwheel.linux]
+# perl-IPC-Cmd needed to build openssl
+before-all = "yum install -y perl-IPC-Cmd && bash {project}/misc/setup-rust.sh"
+
 [tool.cibuildwheel.environment]
 # As it name suggests, `misc/setup-rust.sh` (run during cibuildwheel's before-all) will
 # install Rust if it is not already available. In this case, Rust bin dir was previously
 # non-existent and hence $PATH don't know about it (and maturin will fail when calling cargo).
 # For this reason we force $PATH to contain Rust bin dir.
 PATH = "$PATH:$HOME/.cargo/bin"
+# A wheel cannot make assumption on the host it is going to run on, hence it
+# has to bundle any extra shared libraries dependencies (so in our case openssl)
+LIBPARSEC_FORCE_VENDORED_OPENSSL = "true"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
On my machine, clean `cargo build --tests --timings` goes from 2m20 to 1m40

openssl makes ~70s on my machine to build and end up stalling the whole build (at some point, all remaining crates waits on it to finish before being able to start compilation)

We only need to vendor openssl when in `use-sodiumoxide` mode, and only on non-Linux platform (as on Linux we already depends on the openssl shipped by the system anyway)