### PR TITLE
Faster compile python bindings

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -112,7 +112,7 @@ jobs:
       # Hence if we have a cache hit we know that there is no need for a rebuild !
       - name: Setup cache-key
         id: cache-key
-        run: echo "key=ubuntu-20.04-${{ hashFiles('server/src/**', 'server/Cargo.toml', 'libparsec/**', 'rust-toolchain.toml', 'Cargo.toml', 'Cargo.lock') }}-libparsec-python-${{ env.python-version }}" >> $GITHUB_OUTPUT
+        run: echo "key=libparsec-ubuntu-20.04-${{ hashFiles( 'make.py', 'server/build.py', 'server/src/**', 'server/Cargo.toml', 'libparsec/**', 'rust-toolchain.toml', 'Cargo.toml', 'Cargo.lock'  ) }}-no-bundle-extra-shared-libraries" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Restore libparsec if Rust hasn't been modified
@@ -124,6 +124,8 @@ jobs:
           path: |
             server/parsec/_parsec.*.pyd
             server/parsec/_parsec.*.so
+            # Note `server/parsec.libs/` is not included since we are going to build
+            # with POETRY_LIBPARSEC_BUNDLE_EXTRA_SHARED_LIBRARIES=false (see below)
         timeout-minutes: 2
 
       - name: Setup Rust toolchain
@@ -152,8 +154,17 @@ jobs:
           poetry --directory ./server env info
           if ${{ env.SKIP_EXT_BUILD }}; then export POETRY_LIBPARSEC_BUILD_STRATEGY=no_build; fi
           python make.py python-ci-install
+
+          # Make sure POETRY_LIBPARSEC_BUNDLE_EXTRA_SHARED_LIBRARIES=false worked
+          if [ -n "$( ls -A ./server/parsec.libs 2>/dev/null )" ];
+          then
+            echo "::error::Extra libs disabled but parsec.libs/ is not empty :/ (contains: $( echo ./server/parsec.libs/* | xargs ))"
+            exit 1
+          fi
         env:
           SKIP_EXT_BUILD: ${{ steps.cache-libparsec.outputs.cache-hit == 'true' || inputs.style-only }}
+          # No need to bundle given we compile and run on the same machine
+          POETRY_LIBPARSEC_BUNDLE_EXTRA_SHARED_LIBRARIES: false
         timeout-minutes: 20
 
       - name: Install pre-commit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,7 +1998,11 @@ version = "0.0.0"
 dependencies = [
  "futures",
  "lazy_static",
- "libparsec",
+ "libparsec_crypto",
+ "libparsec_protocol",
+ "libparsec_serialization_format",
+ "libparsec_testbed",
+ "libparsec_types",
  "paste",
  "pyo3",
  "regex",

--- a/libparsec/Cargo.toml
+++ b/libparsec/Cargo.toml
@@ -14,9 +14,6 @@ repository.workspace = true
 # Remember kid: RustCrypto is used if `use-sodiumoxide` is not set !
 use-sodiumoxide = ["libparsec_crypto/use-sodiumoxide"]
 vendored-openssl = ["libparsec_crypto/vendored-openssl"]
-python-bindings-support = [
-    "libparsec_serialization_format/python-bindings-support"
-]
 test-utils = [
     "dep:libparsec_testbed",
     "libparsec_platform_device_loader/test-with-testbed",

--- a/libparsec/crates/serialization_format/src/protocol_python_bindings.rs
+++ b/libparsec/crates/serialization_format/src/protocol_python_bindings.rs
@@ -34,7 +34,7 @@ fn quote_cmds_family(family: &GenCmdsFamily) -> TokenStream {
 
             use ::pyo3::prelude::*;
             use ::pyo3::types::*;
-            use libparsec::low_level::types::ProtocolRequest;
+            use libparsec_types::ProtocolRequest;
             use crate::*;
             use super::*;
 
@@ -66,7 +66,7 @@ fn quote_versioned_cmds(
     let versioned_cmds_mod_name = format_ident!("{}", versioned_cmds_mod_name_as_str);
     let py_module_path_as_str = &format!("parsec._parsec.{}.v{}", family.name, version);
     let protocol_versioned_cmds_path =
-        quote! { libparsec::low_level::protocol::#family_mod_name::#versioned_cmds_mod_name };
+        quote! { libparsec_protocol::#family_mod_name::#versioned_cmds_mod_name };
 
     let (cmds_populate_codes, cmds_impl_codes): (Vec<TokenStream>, Vec<TokenStream>) = cmds
         .iter()
@@ -106,7 +106,7 @@ fn quote_versioned_cmds(
                 #[staticmethod]
                 fn load(py: Python, raw: &[u8]) -> ProtocolResult<PyObject> {
                     let cmd = #protocol_versioned_cmds_path::AnyCmdReq::load(raw).map_err(|e| {
-                        ProtocolErrorFields(libparsec::low_level::protocol::ProtocolError::DecodingError {
+                        ProtocolErrorFields(libparsec_protocol::ProtocolError::DecodingError {
                             exc: e.to_string(),
                         })
                     })?;
@@ -128,8 +128,7 @@ fn quote_cmd(family: &GenCmdsFamily, version: u32, cmd: &GenCmd) -> (TokenStream
     let version_name = format_ident!("v{}", version);
     let cmd_mod_name_as_str = &cmd.cmd;
     let cmd_mod_name = format_ident!("{}", cmd_mod_name_as_str);
-    let protocol_path =
-        quote! { libparsec::low_level::protocol::#family_name::#version_name::#cmd_mod_name };
+    let protocol_path = quote! { libparsec_protocol::#family_name::#version_name::#cmd_mod_name };
 
     match &cmd.spec {
         GenCmdSpec::ReusedFromVersion {
@@ -276,8 +275,8 @@ fn quote_reps(
                         let conversion = quote_type_as_fn_getter_conversion(&access_field_path, &f.ty);
                         quote! {
                             match x {
-                                libparsec::low_level::types::Maybe::Present(x) => Ok(#conversion),
-                                libparsec::low_level::types::Maybe::Absent => Err(PyAttributeError::new_err("")),
+                                libparsec_types::Maybe::Present(x) => Ok(#conversion),
+                                libparsec_types::Maybe::Absent => Err(PyAttributeError::new_err("")),
                             }
                         }
                     } else {
@@ -343,7 +342,7 @@ fn quote_reps(
             #[staticmethod]
             fn load<'py>(py: Python<'py>, raw: &[u8]) -> PyResult<PyObject> {
                 let rep = #protocol_path::Rep::load(raw).map_err(|e| {
-                    ProtocolErrorFields(libparsec::low_level::protocol::ProtocolError::DecodingError {
+                    ProtocolErrorFields(libparsec_protocol::ProtocolError::DecodingError {
                         exc: e.to_string(),
                     })
                 })?;
@@ -360,7 +359,7 @@ fn quote_reps(
                 Ok(PyBytes::new(
                     py,
                     &self.0.dump().map_err(|e| {
-                        ProtocolErrorFields(libparsec::low_level::protocol::ProtocolError::EncodingError {
+                        ProtocolErrorFields(libparsec_protocol::ProtocolError::EncodingError {
                             exc: e.to_string(),
                         })
                     })?,
@@ -447,7 +446,7 @@ fn quote_req(
                         Ok(PyBytes::new(
                             py,
                             &self.0.dump().map_err(|e| {
-                                ProtocolErrorFields(libparsec::low_level::protocol::ProtocolError::EncodingError {
+                                ProtocolErrorFields(libparsec_protocol::ProtocolError::EncodingError {
                                     exc: e.to_string(),
                                 })
                             })?,
@@ -476,8 +475,8 @@ fn quote_req(
                     let conversion = quote_type_as_fn_getter_conversion(&access_field_path, &field.ty);
                     quote! {
                         match &self.0.#field_name {
-                            libparsec::low_level::types::Maybe::Present(x) => Ok(#conversion),
-                            libparsec::low_level::types::Maybe::Absent => Err(PyAttributeError::new_err("")),
+                            libparsec_types::Maybe::Present(x) => Ok(#conversion),
+                            libparsec_types::Maybe::Absent => Err(PyAttributeError::new_err("")),
                         }
                     }
                 } else {
@@ -528,7 +527,7 @@ fn quote_req(
                         Ok(PyBytes::new(
                             py,
                             &self.0.dump().map_err(|e| {
-                                ProtocolErrorFields(libparsec::low_level::protocol::ProtocolError::EncodingError {
+                                ProtocolErrorFields(libparsec_protocol::ProtocolError::EncodingError {
                                     exc: e.to_string(),
                                 })
                             })?,
@@ -623,8 +622,8 @@ fn quote_nested_type(
                         let conversion = quote_type_as_fn_getter_conversion(&access_field_path, &f.ty);
                         quote! {
                             match x {
-                                libparsec::low_level::types::Maybe::Present(x) => Ok(#conversion),
-                                libparsec::low_level::types::Maybe::Absent => Err(PyAttributeError::new_err("")),
+                                libparsec_types::Maybe::Present(x) => Ok(#conversion),
+                                libparsec_types::Maybe::Absent => Err(PyAttributeError::new_err("")),
                             }
                         }
                     } else {
@@ -733,8 +732,8 @@ fn quote_nested_type(
                     let conversion = quote_type_as_fn_getter_conversion(&access_field_path, &field.ty);
                     quote! {
                         match &self.0.#field_name {
-                            libparsec::low_level::types::Maybe::Present(x) => Ok(#conversion),
-                            libparsec::low_level::types::Maybe::Absent => Err(PyAttributeError::new_err("")),
+                            libparsec_types::Maybe::Present(x) => Ok(#conversion),
+                            libparsec_types::Maybe::Absent => Err(PyAttributeError::new_err("")),
                         }
                     }
                 } else {
@@ -1109,7 +1108,7 @@ fn quote_field_as_fn_new_conversion(field: &GenCmdField) -> TokenStream {
     let field_name = format_ident!("{}", field.name);
     let conversion = internal_quote_field_as_fn_new_conversion(&field_name, &field.ty);
     if field.added_in_minor_revision {
-        quote! { let #field_name = libparsec::low_level::types::Maybe::Present(#conversion); }
+        quote! { let #field_name = libparsec_types::Maybe::Present(#conversion); }
     } else if conversion.to_string() == field.name {
         // No conversion
         quote! {}
@@ -1177,7 +1176,7 @@ fn internal_quote_field_as_fn_new_conversion(field_name: &Ident, ty: &FieldType)
             }
         }
         FieldType::IntegerBetween1And100 => {
-            quote! { libparsec::low_level::types::IntegerBetween1And100::try_from(#field_name).map_err(PyValueError::new_err)? }
+            quote! { libparsec_types::IntegerBetween1And100::try_from(#field_name).map_err(PyValueError::new_err)? }
         }
         FieldType::NonZeroInteger => {
             quote! { ::std::num::NonZeroU64::try_from(#field_name).map_err(PyValueError::new_err)? }

--- a/libparsec/src/lib.rs
+++ b/libparsec/src/lib.rs
@@ -1,16 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-#[cfg(feature = "python-bindings-support")]
-pub mod low_level {
-    // LowLevel stuff only exposed for Python bindings
-    pub use libparsec_crypto as crypto;
-    pub use libparsec_protocol as protocol;
-    pub use libparsec_serialization_format as serialization_format;
-    #[cfg(feature = "test-utils")]
-    pub use libparsec_testbed as testbed;
-    pub use libparsec_types as types;
-}
-
 mod addr;
 mod cancel;
 mod client;

--- a/make.py
+++ b/make.py
@@ -23,16 +23,16 @@ from typing import Iterable, Union
 MAYBE_FORCE_VENDORED_OPENSSL = ""
 if sys.platform == "linux":
     if os.environ.get("LIBPARSEC_FORCE_VENDORED_OPENSSL", "false").lower() == "true":
-        MAYBE_FORCE_VENDORED_OPENSSL = "--features libparsec/vendored-openssl"
+        MAYBE_FORCE_VENDORED_OPENSSL = "--features vendored-openssl"
 
 PYTHON_RELEASE_CARGO_FLAGS = (
-    f"--profile=release --features libparsec/use-sodiumoxide {MAYBE_FORCE_VENDORED_OPENSSL}"
+    f"--profile=release --features use-sodiumoxide {MAYBE_FORCE_VENDORED_OPENSSL}"
 )
 PYTHON_DEV_CARGO_FLAGS = "--profile=dev-python --features test-utils"
 PYTHON_CI_CARGO_FLAGS = "--profile=ci-python --features test-utils"
 
 ELECTRON_RELEASE_CARGO_FLAGS = (
-    f"--profile=release --features libparsec/use-sodiumoxide {MAYBE_FORCE_VENDORED_OPENSSL}"
+    f"--profile=release --features use-sodiumoxide {MAYBE_FORCE_VENDORED_OPENSSL}"
 )
 ELECTRON_DEV_CARGO_FLAGS = "--profile=dev --features test-utils"
 ELECTRON_CI_CARGO_FLAGS = "--profile=ci-rust --features test-utils"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,11 +13,21 @@ name = "parsec"
 crate-type = ["cdylib"]
 
 [features]
-default = ["test-utils"]  # TODO: remove me !
-test-utils = ["libparsec/test-utils"]
+# Remember kid: RustCrypto is used if `use-sodiumoxide` is not set !
+use-sodiumoxide = ["libparsec_crypto/use-sodiumoxide"]
+vendored-openssl = ["libparsec_crypto/vendored-openssl"]
+test-utils = [
+    "dep:libparsec_testbed",
+    "libparsec_types/test-mock-time",
+    "libparsec_crypto/test-unsecure-but-fast-secretkey-from-password"
+]
 
 [dependencies]
-libparsec = { workspace = true, features = ["python-bindings-support"] }
+libparsec_crypto = { workspace = true }
+libparsec_protocol = { workspace = true }
+libparsec_serialization_format = { workspace = true, features = ["python-bindings-support"] }
+libparsec_types = { workspace = true }
+libparsec_testbed = { workspace = true, optional = true }
 
 regex = { workspace = true, features = ["std", "perf", "unicode"] }
 paste = { workspace = true }

--- a/server/build.py
+++ b/server/build.py
@@ -77,7 +77,9 @@ def build() -> None:
     #
     # However we want to disable this feature for some packagings (e.g. Docker, Snap)
     # given they provide a image that already ships with the correct openssl (in this
-    # case bundling would only mean ending up with two copies of the same lib)
+    # case bundling would only mean ending up with two copies of the same lib).
+    # We also want to disable this on CI given we build and run on the same machine
+    # (so bundling increases needlessly the cache size).
     bundle_extra_so = (
         os.environ.get("POETRY_LIBPARSEC_BUNDLE_EXTRA_SHARED_LIBRARIES", "true").lower() == "true"
     )

--- a/server/src/addrs.rs
+++ b/server/src/addrs.rs
@@ -12,7 +12,7 @@ use crate::{BytesWrapper, InvitationToken, InvitationType, OrganizationID, Verif
 
 crate::binding_utils::gen_py_wrapper_class!(
     BackendAddr,
-    libparsec::low_level::types::BackendAddr,
+    libparsec_types::BackendAddr,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -25,9 +25,7 @@ impl BackendAddr {
     #[new]
     #[pyo3(signature = (hostname, port, use_ssl))]
     fn new(hostname: String, port: Option<u16>, use_ssl: bool) -> Self {
-        Self(libparsec::low_level::types::BackendAddr::new(
-            hostname, port, use_ssl,
-        ))
+        Self(libparsec_types::BackendAddr::new(hostname, port, use_ssl))
     }
 
     #[getter]
@@ -71,11 +69,11 @@ impl BackendAddr {
     #[pyo3(signature = (url, allow_http_redirection = false))]
     fn from_url(_cls: &PyType, url: &str, allow_http_redirection: bool) -> PyResult<Self> {
         match allow_http_redirection {
-            true => match libparsec::low_level::types::BackendAddr::from_any(url) {
+            true => match libparsec_types::BackendAddr::from_any(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
                 Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
-            false => match libparsec::low_level::types::BackendAddr::from_str(url) {
+            false => match libparsec_types::BackendAddr::from_str(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
                 Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
@@ -85,7 +83,7 @@ impl BackendAddr {
 
 crate::binding_utils::gen_py_wrapper_class!(
     BackendOrganizationAddr,
-    libparsec::low_level::types::BackendOrganizationAddr,
+    libparsec_types::BackendOrganizationAddr,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -121,13 +119,11 @@ impl BackendOrganizationAddr {
             ),
             None => return Err(PyValueError::new_err("Missing parameters")),
         };
-        Ok(Self(
-            libparsec::low_level::types::BackendOrganizationAddr::new(
-                addr.0,
-                organization_id.0,
-                root_verify_key.0,
-            ),
-        ))
+        Ok(Self(libparsec_types::BackendOrganizationAddr::new(
+            addr.0,
+            organization_id.0,
+            root_verify_key.0,
+        )))
     }
 
     fn get_backend_addr(&self) -> BackendAddr {
@@ -188,11 +184,11 @@ impl BackendOrganizationAddr {
     #[pyo3(signature = (url, allow_http_redirection = false))]
     fn from_url(_cls: &PyType, url: &str, allow_http_redirection: bool) -> PyResult<Self> {
         match allow_http_redirection {
-            true => match libparsec::low_level::types::BackendOrganizationAddr::from_any(url) {
+            true => match libparsec_types::BackendOrganizationAddr::from_any(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
                 Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
-            false => match libparsec::low_level::types::BackendOrganizationAddr::from_str(url) {
+            false => match libparsec_types::BackendOrganizationAddr::from_str(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
                 Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
@@ -206,7 +202,7 @@ impl BackendOrganizationAddr {
         organization_id: OrganizationID,
         root_verify_key: VerifyKey,
     ) -> Self {
-        Self(libparsec::low_level::types::BackendOrganizationAddr::new(
+        Self(libparsec_types::BackendOrganizationAddr::new(
             backend_addr.0,
             organization_id.0,
             root_verify_key.0,
@@ -228,39 +224,39 @@ impl BackendActionAddr {
         allow_http_redirection: bool,
     ) -> PyResult<PyObject> {
         match allow_http_redirection {
-            true => match libparsec::low_level::types::BackendActionAddr::from_any(url) {
+            true => match libparsec_types::BackendActionAddr::from_any(url) {
                 Ok(ba) => match ba {
-                    libparsec::low_level::types::BackendActionAddr::OrganizationBootstrap(v) => {
+                    libparsec_types::BackendActionAddr::OrganizationBootstrap(v) => {
                         Ok(BackendOrganizationBootstrapAddr(v)
                             .into_py(py)
                             .to_object(py))
                     }
-                    libparsec::low_level::types::BackendActionAddr::OrganizationFileLink(v) => {
+                    libparsec_types::BackendActionAddr::OrganizationFileLink(v) => {
                         Ok(BackendOrganizationFileLinkAddr(v).into_py(py).to_object(py))
                     }
-                    libparsec::low_level::types::BackendActionAddr::Invitation(v) => {
+                    libparsec_types::BackendActionAddr::Invitation(v) => {
                         Ok(BackendInvitationAddr(v).into_py(py).to_object(py))
                     }
-                    libparsec::low_level::types::BackendActionAddr::PkiEnrollment(v) => {
+                    libparsec_types::BackendActionAddr::PkiEnrollment(v) => {
                         Ok(BackendPkiEnrollmentAddr(v).into_py(py).to_object(py))
                     }
                 },
                 Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
-            false => match url.parse::<libparsec::low_level::types::BackendActionAddr>() {
+            false => match url.parse::<libparsec_types::BackendActionAddr>() {
                 Ok(ba) => match ba {
-                    libparsec::low_level::types::BackendActionAddr::OrganizationBootstrap(v) => {
+                    libparsec_types::BackendActionAddr::OrganizationBootstrap(v) => {
                         Ok(BackendOrganizationBootstrapAddr(v)
                             .into_py(py)
                             .to_object(py))
                     }
-                    libparsec::low_level::types::BackendActionAddr::OrganizationFileLink(v) => {
+                    libparsec_types::BackendActionAddr::OrganizationFileLink(v) => {
                         Ok(BackendOrganizationFileLinkAddr(v).into_py(py).to_object(py))
                     }
-                    libparsec::low_level::types::BackendActionAddr::Invitation(v) => {
+                    libparsec_types::BackendActionAddr::Invitation(v) => {
                         Ok(BackendInvitationAddr(v).into_py(py).to_object(py))
                     }
-                    libparsec::low_level::types::BackendActionAddr::PkiEnrollment(v) => {
+                    libparsec_types::BackendActionAddr::PkiEnrollment(v) => {
                         Ok(BackendPkiEnrollmentAddr(v).into_py(py).to_object(py))
                     }
                 },
@@ -272,7 +268,7 @@ impl BackendActionAddr {
 
 crate::binding_utils::gen_py_wrapper_class!(
     BackendOrganizationBootstrapAddr,
-    libparsec::low_level::types::BackendOrganizationBootstrapAddr,
+    libparsec_types::BackendOrganizationBootstrapAddr,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -309,7 +305,7 @@ impl BackendOrganizationBootstrapAddr {
             None => return Err(PyValueError::new_err("Missing parameters")),
         };
         Ok(Self(
-            libparsec::low_level::types::BackendOrganizationBootstrapAddr::new(
+            libparsec_types::BackendOrganizationBootstrapAddr::new(
                 addr.0,
                 organization_id.0,
                 token,
@@ -387,18 +383,14 @@ impl BackendOrganizationBootstrapAddr {
     #[pyo3(signature = (url, allow_http_redirection = false))]
     fn from_url(_cls: &PyType, url: &str, allow_http_redirection: bool) -> PyResult<Self> {
         match allow_http_redirection {
-            true => {
-                match libparsec::low_level::types::BackendOrganizationBootstrapAddr::from_any(url) {
-                    Ok(backend_addr) => Ok(Self(backend_addr)),
-                    Err(err) => Err(PyValueError::new_err(err.to_string())),
-                }
-            }
-            false => {
-                match libparsec::low_level::types::BackendOrganizationBootstrapAddr::from_str(url) {
-                    Ok(backend_addr) => Ok(Self(backend_addr)),
-                    Err(err) => Err(PyValueError::new_err(err.to_string())),
-                }
-            }
+            true => match libparsec_types::BackendOrganizationBootstrapAddr::from_any(url) {
+                Ok(backend_addr) => Ok(Self(backend_addr)),
+                Err(err) => Err(PyValueError::new_err(err.to_string())),
+            },
+            false => match libparsec_types::BackendOrganizationBootstrapAddr::from_str(url) {
+                Ok(backend_addr) => Ok(Self(backend_addr)),
+                Err(err) => Err(PyValueError::new_err(err.to_string())),
+            },
         }
     }
 
@@ -409,19 +401,17 @@ impl BackendOrganizationBootstrapAddr {
         organization_id: OrganizationID,
         token: Option<String>,
     ) -> Self {
-        Self(
-            libparsec::low_level::types::BackendOrganizationBootstrapAddr::new(
-                backend_addr.0,
-                organization_id.0,
-                token,
-            ),
-        )
+        Self(libparsec_types::BackendOrganizationBootstrapAddr::new(
+            backend_addr.0,
+            organization_id.0,
+            token,
+        ))
     }
 }
 
 crate::binding_utils::gen_py_wrapper_class!(
     BackendOrganizationFileLinkAddr,
-    libparsec::low_level::types::BackendOrganizationFileLinkAddr,
+    libparsec_types::BackendOrganizationFileLinkAddr,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -460,15 +450,13 @@ impl BackendOrganizationFileLinkAddr {
             ),
             None => return Err(PyValueError::new_err("Missing parameters")),
         };
-        Ok(Self(
-            libparsec::low_level::types::BackendOrganizationFileLinkAddr::new(
-                addr.0,
-                organization_id.0,
-                workspace_id.0,
-                encrypted_path.into(),
-                encrypted_timestamp.map(|e| e.into()),
-            ),
-        ))
+        Ok(Self(libparsec_types::BackendOrganizationFileLinkAddr::new(
+            addr.0,
+            organization_id.0,
+            workspace_id.0,
+            encrypted_path.into(),
+            encrypted_timestamp.map(|e| e.into()),
+        )))
     }
 
     #[getter]
@@ -542,18 +530,14 @@ impl BackendOrganizationFileLinkAddr {
     #[pyo3(signature = (url, allow_http_redirection = false))]
     fn from_url(_cls: &PyType, url: &str, allow_http_redirection: bool) -> PyResult<Self> {
         match allow_http_redirection {
-            true => {
-                match libparsec::low_level::types::BackendOrganizationFileLinkAddr::from_any(url) {
-                    Ok(backend_addr) => Ok(Self(backend_addr)),
-                    Err(err) => Err(PyValueError::new_err(err.to_string())),
-                }
-            }
-            false => {
-                match libparsec::low_level::types::BackendOrganizationFileLinkAddr::from_str(url) {
-                    Ok(backend_addr) => Ok(Self(backend_addr)),
-                    Err(err) => Err(PyValueError::new_err(err.to_string())),
-                }
-            }
+            true => match libparsec_types::BackendOrganizationFileLinkAddr::from_any(url) {
+                Ok(backend_addr) => Ok(Self(backend_addr)),
+                Err(err) => Err(PyValueError::new_err(err.to_string())),
+            },
+            false => match libparsec_types::BackendOrganizationFileLinkAddr::from_str(url) {
+                Ok(backend_addr) => Ok(Self(backend_addr)),
+                Err(err) => Err(PyValueError::new_err(err.to_string())),
+            },
         }
     }
 
@@ -567,21 +551,19 @@ impl BackendOrganizationFileLinkAddr {
         encrypted_timestamp: Option<BytesWrapper>,
     ) -> Self {
         crate::binding_utils::unwrap_bytes!(encrypted_path, encrypted_timestamp);
-        Self(
-            libparsec::low_level::types::BackendOrganizationFileLinkAddr::new(
-                organization_addr.get_backend_addr().0,
-                organization_addr.organization_id().0,
-                workspace_id.0,
-                encrypted_path.to_vec(),
-                encrypted_timestamp.map(|e| e.to_vec()),
-            ),
-        )
+        Self(libparsec_types::BackendOrganizationFileLinkAddr::new(
+            organization_addr.get_backend_addr().0,
+            organization_addr.organization_id().0,
+            workspace_id.0,
+            encrypted_path.to_vec(),
+            encrypted_timestamp.map(|e| e.to_vec()),
+        ))
     }
 }
 
 crate::binding_utils::gen_py_wrapper_class!(
     BackendInvitationAddr,
-    libparsec::low_level::types::BackendInvitationAddr,
+    libparsec_types::BackendInvitationAddr,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -618,14 +600,12 @@ impl BackendInvitationAddr {
             ),
             None => return Err(PyValueError::new_err("Missing parameters")),
         };
-        Ok(Self(
-            libparsec::low_level::types::BackendInvitationAddr::new(
-                addr.0,
-                organization_id.0,
-                invitation_type.0,
-                token.0,
-            ),
-        ))
+        Ok(Self(libparsec_types::BackendInvitationAddr::new(
+            addr.0,
+            organization_id.0,
+            invitation_type.0,
+            token.0,
+        )))
     }
 
     #[getter]
@@ -695,11 +675,11 @@ impl BackendInvitationAddr {
     #[pyo3(signature = (url, allow_http_redirection = false))]
     fn from_url(_cls: &PyType, url: &str, allow_http_redirection: bool) -> PyResult<Self> {
         match allow_http_redirection {
-            true => match libparsec::low_level::types::BackendInvitationAddr::from_any(url) {
+            true => match libparsec_types::BackendInvitationAddr::from_any(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
                 Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
-            false => match libparsec::low_level::types::BackendInvitationAddr::from_str(url) {
+            false => match libparsec_types::BackendInvitationAddr::from_str(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
                 Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
@@ -714,7 +694,7 @@ impl BackendInvitationAddr {
         invitation_type: InvitationType,
         token: InvitationToken,
     ) -> Self {
-        Self(libparsec::low_level::types::BackendInvitationAddr::new(
+        Self(libparsec_types::BackendInvitationAddr::new(
             backend_addr.0,
             organization_id.0,
             invitation_type.0,
@@ -725,7 +705,7 @@ impl BackendInvitationAddr {
 
 crate::binding_utils::gen_py_wrapper_class!(
     BackendPkiEnrollmentAddr,
-    libparsec::low_level::types::BackendPkiEnrollmentAddr,
+    libparsec_types::BackendPkiEnrollmentAddr,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -757,9 +737,10 @@ impl BackendPkiEnrollmentAddr {
             ),
             None => return Err(PyValueError::new_err("Missing parameters")),
         };
-        Ok(Self(
-            libparsec::low_level::types::BackendPkiEnrollmentAddr::new(addr.0, organization_id.0),
-        ))
+        Ok(Self(libparsec_types::BackendPkiEnrollmentAddr::new(
+            addr.0,
+            organization_id.0,
+        )))
     }
 
     #[getter]
@@ -824,11 +805,11 @@ impl BackendPkiEnrollmentAddr {
     #[pyo3(signature = (url, allow_http_redirection = false))]
     fn from_url(_cls: &PyType, url: &str, allow_http_redirection: bool) -> PyResult<Self> {
         match allow_http_redirection {
-            true => match libparsec::low_level::types::BackendPkiEnrollmentAddr::from_any(url) {
+            true => match libparsec_types::BackendPkiEnrollmentAddr::from_any(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
                 Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
-            false => match libparsec::low_level::types::BackendPkiEnrollmentAddr::from_str(url) {
+            false => match libparsec_types::BackendPkiEnrollmentAddr::from_str(url) {
                 Ok(backend_addr) => Ok(Self(backend_addr)),
                 Err(err) => Err(PyValueError::new_err(err.to_string())),
             },
@@ -837,7 +818,7 @@ impl BackendPkiEnrollmentAddr {
 
     #[classmethod]
     fn build(_cls: &PyType, backend_addr: BackendAddr, organization_id: OrganizationID) -> Self {
-        Self(libparsec::low_level::types::BackendPkiEnrollmentAddr::new(
+        Self(libparsec_types::BackendPkiEnrollmentAddr::new(
             backend_addr.0,
             organization_id.0,
         ))
@@ -846,5 +827,5 @@ impl BackendPkiEnrollmentAddr {
 
 #[pyfunction]
 pub(crate) fn export_root_verify_key(key: &VerifyKey) -> String {
-    libparsec::low_level::types::export_root_verify_key(&key.0)
+    libparsec_types::export_root_verify_key(&key.0)
 }

--- a/server/src/backend_events.rs
+++ b/server/src/backend_events.rs
@@ -13,79 +13,79 @@ use crate::{
 enum RawBackendEvent {
     #[serde(rename = "certificates.updated")]
     CertificatesUpdated {
-        organization_id: libparsec::low_level::types::OrganizationID,
-        index: libparsec::low_level::types::IndexInt,
+        organization_id: libparsec_types::OrganizationID,
+        index: libparsec_types::IndexInt,
     },
     #[serde(rename = "invite.conduit_updated")]
     InviteConduitUpdated {
-        organization_id: libparsec::low_level::types::OrganizationID,
-        token: libparsec::low_level::types::InvitationToken,
+        organization_id: libparsec_types::OrganizationID,
+        token: libparsec_types::InvitationToken,
     },
     #[serde(rename = "user.profile_updated_or_revoked")]
     UserProfileUpdatedOrRevoked {
-        organization_id: libparsec::low_level::types::OrganizationID,
-        user_id: libparsec::low_level::types::UserID,
-        profile: Option<libparsec::low_level::types::UserProfile>,
+        organization_id: libparsec_types::OrganizationID,
+        user_id: libparsec_types::UserID,
+        profile: Option<libparsec_types::UserProfile>,
     },
     #[serde(rename = "organization.expired")]
     OrganizationExpired {
-        organization_id: libparsec::low_level::types::OrganizationID,
+        organization_id: libparsec_types::OrganizationID,
     },
     #[serde(rename = "pinged")]
     Pinged {
-        organization_id: libparsec::low_level::types::OrganizationID,
-        author: libparsec::low_level::types::DeviceID,
+        organization_id: libparsec_types::OrganizationID,
+        author: libparsec_types::DeviceID,
         ping: String,
     },
     #[serde(rename = "message.received")]
     MessageReceived {
-        organization_id: libparsec::low_level::types::OrganizationID,
-        author: libparsec::low_level::types::DeviceID,
-        recipient: libparsec::low_level::types::UserID,
+        organization_id: libparsec_types::OrganizationID,
+        author: libparsec_types::DeviceID,
+        recipient: libparsec_types::UserID,
         index: u64,
         message: Vec<u8>,
     },
     #[serde(rename = "invite.status_changed")]
     InviteStatusChanged {
-        organization_id: libparsec::low_level::types::OrganizationID,
-        greeter: libparsec::low_level::types::UserID,
-        token: libparsec::low_level::types::InvitationToken,
-        status: libparsec::low_level::types::InvitationStatus,
+        organization_id: libparsec_types::OrganizationID,
+        greeter: libparsec_types::UserID,
+        token: libparsec_types::InvitationToken,
+        status: libparsec_types::InvitationStatus,
     },
     #[serde(rename = "realm.maintenance_finished")]
     RealmMaintenanceFinished {
-        organization_id: libparsec::low_level::types::OrganizationID,
-        author: libparsec::low_level::types::DeviceID,
-        realm_id: libparsec::low_level::types::VlobID,
+        organization_id: libparsec_types::OrganizationID,
+        author: libparsec_types::DeviceID,
+        realm_id: libparsec_types::VlobID,
         encryption_revision: u64,
     },
     #[serde(rename = "realm.maintenance_started")]
     RealmMaintenanceStarted {
-        organization_id: libparsec::low_level::types::OrganizationID,
-        author: libparsec::low_level::types::DeviceID,
-        realm_id: libparsec::low_level::types::VlobID,
+        organization_id: libparsec_types::OrganizationID,
+        author: libparsec_types::DeviceID,
+        realm_id: libparsec_types::VlobID,
         encryption_revision: u64,
     },
     #[serde(rename = "realm.vlobs_updated")]
     RealmVlobsUpdated {
-        organization_id: libparsec::low_level::types::OrganizationID,
-        author: libparsec::low_level::types::DeviceID,
-        realm_id: libparsec::low_level::types::VlobID,
+        organization_id: libparsec_types::OrganizationID,
+        author: libparsec_types::DeviceID,
+        realm_id: libparsec_types::VlobID,
         checkpoint: u64,
-        src_id: libparsec::low_level::types::VlobID,
+        src_id: libparsec_types::VlobID,
         src_version: u64,
     },
     #[serde(rename = "realm.roles_updated")]
     RealmRolesUpdated {
-        organization_id: libparsec::low_level::types::OrganizationID,
-        author: libparsec::low_level::types::DeviceID,
-        realm_id: libparsec::low_level::types::VlobID,
-        user: libparsec::low_level::types::UserID,
-        role: Option<libparsec::low_level::types::RealmRole>,
+        organization_id: libparsec_types::OrganizationID,
+        author: libparsec_types::DeviceID,
+        realm_id: libparsec_types::VlobID,
+        user: libparsec_types::UserID,
+        role: Option<libparsec_types::RealmRole>,
     },
     #[serde(rename = "pki_enrollment.updated")]
     PkiEnrollmentUpdated {
-        organization_id: libparsec::low_level::types::OrganizationID,
+        organization_id: libparsec_types::OrganizationID,
     },
 }
 

--- a/server/src/binding_utils.rs
+++ b/server/src/binding_utils.rs
@@ -46,7 +46,7 @@ impl From<BytesWrapper<'_>> for Vec<u8> {
     }
 }
 
-impl From<BytesWrapper<'_>> for libparsec::low_level::types::Bytes {
+impl From<BytesWrapper<'_>> for libparsec_types::Bytes {
     fn from(wrapper: BytesWrapper) -> Self {
         match wrapper {
             BytesWrapper::Bytes(bytes) => bytes.as_bytes().to_owned().into(),
@@ -66,7 +66,7 @@ pub trait UnwrapBytesWrapper {
 }
 
 impl UnwrapBytesWrapper for BytesWrapper<'_> {
-    type ResultType = libparsec::low_level::types::Bytes;
+    type ResultType = libparsec_types::Bytes;
     fn unwrap_bytes(self) -> Self::ResultType {
         self.into()
     }

--- a/server/src/data/certif.rs
+++ b/server/src/data/certif.rs
@@ -7,9 +7,7 @@ use pyo3::{
     types::{PyBytes, PyDict, PyType},
 };
 
-use libparsec::low_level::types::{
-    CertificateSignerOwned, CertificateSignerRef, UnsecureSkipValidationReason,
-};
+use libparsec_types::{CertificateSignerOwned, CertificateSignerRef, UnsecureSkipValidationReason};
 
 use crate::{
     api_crypto::{PublicKey, SequesterPublicKeyDer, SequesterVerifyKeyDer, SigningKey, VerifyKey},
@@ -21,7 +19,7 @@ use crate::{
 
 crate::binding_utils::gen_py_wrapper_class!(
     UserCertificate,
-    Arc<libparsec::low_level::types::UserCertificate>,
+    Arc<libparsec_types::UserCertificate>,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -40,19 +38,17 @@ impl UserCertificate {
         public_key: PublicKey,
         profile: UserProfile,
     ) -> PyResult<Self> {
-        Ok(Self(Arc::new(
-            libparsec::low_level::types::UserCertificate {
-                author: match author {
-                    Some(device_id) => CertificateSignerOwned::User(device_id.0),
-                    None => CertificateSignerOwned::Root,
-                },
-                timestamp: timestamp.0,
-                user_id: user_id.0,
-                human_handle: human_handle.map(|human_handle| human_handle.0),
-                public_key: public_key.0,
-                profile: profile.0,
+        Ok(Self(Arc::new(libparsec_types::UserCertificate {
+            author: match author {
+                Some(device_id) => CertificateSignerOwned::User(device_id.0),
+                None => CertificateSignerOwned::Root,
             },
-        )))
+            timestamp: timestamp.0,
+            user_id: user_id.0,
+            human_handle: human_handle.map(|human_handle| human_handle.0),
+            public_key: public_key.0,
+            profile: profile.0,
+        })))
     }
 
     #[pyo3(signature = (**py_kwargs))]
@@ -104,19 +100,17 @@ impl UserCertificate {
         expected_user: Option<&UserID>,
         expected_human_handle: Option<&HumanHandle>,
     ) -> DataResult<Self> {
-        Ok(
-            libparsec::low_level::types::UserCertificate::verify_and_load(
-                signed,
-                &author_verify_key.0,
-                match expected_author {
-                    Some(device_id) => CertificateSignerRef::User(&device_id.0),
-                    None => CertificateSignerRef::Root,
-                },
-                expected_user.map(|x| &x.0),
-                expected_human_handle.map(|x| &x.0),
-            )
-            .map(|x| Self(Arc::new(x)))?,
+        Ok(libparsec_types::UserCertificate::verify_and_load(
+            signed,
+            &author_verify_key.0,
+            match expected_author {
+                Some(device_id) => CertificateSignerRef::User(&device_id.0),
+                None => CertificateSignerRef::Root,
+            },
+            expected_user.map(|x| &x.0),
+            expected_human_handle.map(|x| &x.0),
         )
+        .map(|x| Self(Arc::new(x)))?)
     }
 
     fn dump_and_sign<'py>(&self, author_signkey: &SigningKey, py: Python<'py>) -> &'py PyBytes {
@@ -126,7 +120,7 @@ impl UserCertificate {
     #[classmethod]
     fn unsecure_load(_cls: &PyType, signed: &[u8]) -> DataResult<Self> {
         Ok(
-            libparsec::low_level::types::UserCertificate::unsecure_load(signed.to_vec().into())
+            libparsec_types::UserCertificate::unsecure_load(signed.to_vec().into())
                 .map(|u| u.skip_validation(UnsecureSkipValidationReason::DataFromLocalStorage))
                 .map(|x| Self(Arc::new(x)))?,
         )
@@ -134,7 +128,7 @@ impl UserCertificate {
 
     #[getter]
     fn is_admin(&self) -> bool {
-        self.0.profile == libparsec::low_level::types::UserProfile::Admin
+        self.0.profile == libparsec_types::UserProfile::Admin
     }
 
     #[getter]
@@ -173,7 +167,7 @@ impl UserCertificate {
 
 crate::binding_utils::gen_py_wrapper_class!(
     DeviceCertificate,
-    Arc<libparsec::low_level::types::DeviceCertificate>,
+    Arc<libparsec_types::DeviceCertificate>,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -191,18 +185,16 @@ impl DeviceCertificate {
         device_label: Option<DeviceLabel>,
         verify_key: VerifyKey,
     ) -> PyResult<Self> {
-        Ok(Self(Arc::new(
-            libparsec::low_level::types::DeviceCertificate {
-                author: match author {
-                    Some(device_id) => CertificateSignerOwned::User(device_id.0),
-                    None => CertificateSignerOwned::Root,
-                },
-                timestamp: timestamp.0,
-                device_id: device_id.0,
-                device_label: device_label.map(|x| x.0),
-                verify_key: verify_key.0,
+        Ok(Self(Arc::new(libparsec_types::DeviceCertificate {
+            author: match author {
+                Some(device_id) => CertificateSignerOwned::User(device_id.0),
+                None => CertificateSignerOwned::Root,
             },
-        )))
+            timestamp: timestamp.0,
+            device_id: device_id.0,
+            device_label: device_label.map(|x| x.0),
+            verify_key: verify_key.0,
+        })))
     }
 
     #[pyo3(signature = (**py_kwargs))]
@@ -249,18 +241,16 @@ impl DeviceCertificate {
         expected_author: Option<&DeviceID>,
         expected_device: Option<&DeviceID>,
     ) -> DataResult<Self> {
-        Ok(
-            libparsec::low_level::types::DeviceCertificate::verify_and_load(
-                signed,
-                &author_verify_key.0,
-                match &expected_author {
-                    Some(device_id) => CertificateSignerRef::User(&device_id.0),
-                    None => CertificateSignerRef::Root,
-                },
-                expected_device.map(|x| &x.0),
-            )
-            .map(|x| Self(Arc::new(x)))?,
+        Ok(libparsec_types::DeviceCertificate::verify_and_load(
+            signed,
+            &author_verify_key.0,
+            match &expected_author {
+                Some(device_id) => CertificateSignerRef::User(&device_id.0),
+                None => CertificateSignerRef::Root,
+            },
+            expected_device.map(|x| &x.0),
         )
+        .map(|x| Self(Arc::new(x)))?)
     }
 
     fn dump_and_sign<'py>(&self, author_signkey: &SigningKey, py: Python<'py>) -> &'py PyBytes {
@@ -270,7 +260,7 @@ impl DeviceCertificate {
     #[classmethod]
     fn unsecure_load(_cls: &PyType, signed: &[u8]) -> DataResult<Self> {
         Ok(
-            libparsec::low_level::types::DeviceCertificate::unsecure_load(signed.to_vec().into())
+            libparsec_types::DeviceCertificate::unsecure_load(signed.to_vec().into())
                 .map(|u| u.skip_validation(UnsecureSkipValidationReason::DataFromLocalStorage))
                 .map(|x| Self(Arc::new(x)))?,
         )
@@ -307,7 +297,7 @@ impl DeviceCertificate {
 
 crate::binding_utils::gen_py_wrapper_class!(
     RevokedUserCertificate,
-    Arc<libparsec::low_level::types::RevokedUserCertificate>,
+    Arc<libparsec_types::RevokedUserCertificate>,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -319,13 +309,11 @@ impl RevokedUserCertificate {
     #[new]
     #[pyo3(signature = (author, timestamp, user_id))]
     fn new(author: DeviceID, timestamp: DateTime, user_id: UserID) -> PyResult<Self> {
-        Ok(Self(Arc::new(
-            libparsec::low_level::types::RevokedUserCertificate {
-                author: author.0,
-                timestamp: timestamp.0,
-                user_id: user_id.0,
-            },
-        )))
+        Ok(Self(Arc::new(libparsec_types::RevokedUserCertificate {
+            author: author.0,
+            timestamp: timestamp.0,
+            user_id: user_id.0,
+        })))
     }
 
     #[pyo3(signature = (**py_kwargs))]
@@ -361,15 +349,13 @@ impl RevokedUserCertificate {
         expected_author: &DeviceID,
         expected_user: Option<&UserID>,
     ) -> DataResult<Self> {
-        Ok(
-            libparsec::low_level::types::RevokedUserCertificate::verify_and_load(
-                signed,
-                &author_verify_key.0,
-                &expected_author.0,
-                expected_user.map(|x| &x.0),
-            )
-            .map(|x| Self(Arc::new(x)))?,
+        Ok(libparsec_types::RevokedUserCertificate::verify_and_load(
+            signed,
+            &author_verify_key.0,
+            &expected_author.0,
+            expected_user.map(|x| &x.0),
         )
+        .map(|x| Self(Arc::new(x)))?)
     }
 
     fn dump_and_sign<'py>(&self, author_signkey: &SigningKey, py: Python<'py>) -> &'py PyBytes {
@@ -379,11 +365,9 @@ impl RevokedUserCertificate {
     #[classmethod]
     fn unsecure_load(_cls: &PyType, signed: &[u8]) -> DataResult<Self> {
         Ok(
-            libparsec::low_level::types::RevokedUserCertificate::unsecure_load(
-                signed.to_vec().into(),
-            )
-            .map(|u| u.skip_validation(UnsecureSkipValidationReason::DataFromLocalStorage))
-            .map(|x| Self(Arc::new(x)))?,
+            libparsec_types::RevokedUserCertificate::unsecure_load(signed.to_vec().into())
+                .map(|u| u.skip_validation(UnsecureSkipValidationReason::DataFromLocalStorage))
+                .map(|x| Self(Arc::new(x)))?,
         )
     }
 
@@ -405,7 +389,7 @@ impl RevokedUserCertificate {
 
 crate::binding_utils::gen_py_wrapper_class!(
     UserUpdateCertificate,
-    Arc<libparsec::low_level::types::UserUpdateCertificate>,
+    Arc<libparsec_types::UserUpdateCertificate>,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -422,14 +406,12 @@ impl UserUpdateCertificate {
         user_id: UserID,
         new_profile: UserProfile,
     ) -> PyResult<Self> {
-        Ok(Self(Arc::new(
-            libparsec::low_level::types::UserUpdateCertificate {
-                author: author.0,
-                timestamp: timestamp.0,
-                user_id: user_id.0,
-                new_profile: new_profile.0,
-            },
-        )))
+        Ok(Self(Arc::new(libparsec_types::UserUpdateCertificate {
+            author: author.0,
+            timestamp: timestamp.0,
+            user_id: user_id.0,
+            new_profile: new_profile.0,
+        })))
     }
 
     #[pyo3(signature = (**py_kwargs))]
@@ -469,15 +451,13 @@ impl UserUpdateCertificate {
         expected_author: &DeviceID,
         expected_user: Option<&UserID>,
     ) -> DataResult<Self> {
-        Ok(
-            libparsec::low_level::types::UserUpdateCertificate::verify_and_load(
-                signed,
-                &author_verify_key.0,
-                &expected_author.0,
-                expected_user.map(|x| &x.0),
-            )
-            .map(|x| Self(Arc::new(x)))?,
+        Ok(libparsec_types::UserUpdateCertificate::verify_and_load(
+            signed,
+            &author_verify_key.0,
+            &expected_author.0,
+            expected_user.map(|x| &x.0),
         )
+        .map(|x| Self(Arc::new(x)))?)
     }
 
     fn dump_and_sign<'py>(&self, author_signkey: &SigningKey, py: Python<'py>) -> &'py PyBytes {
@@ -487,11 +467,9 @@ impl UserUpdateCertificate {
     #[classmethod]
     fn unsecure_load(_cls: &PyType, signed: &[u8]) -> DataResult<Self> {
         Ok(
-            libparsec::low_level::types::UserUpdateCertificate::unsecure_load(
-                signed.to_vec().into(),
-            )
-            .map(|u| u.skip_validation(UnsecureSkipValidationReason::DataFromLocalStorage))
-            .map(|x| Self(Arc::new(x)))?,
+            libparsec_types::UserUpdateCertificate::unsecure_load(signed.to_vec().into())
+                .map(|u| u.skip_validation(UnsecureSkipValidationReason::DataFromLocalStorage))
+                .map(|x| Self(Arc::new(x)))?,
         )
     }
 
@@ -518,7 +496,7 @@ impl UserUpdateCertificate {
 
 crate::binding_utils::gen_py_wrapper_class!(
     RealmRoleCertificate,
-    Arc<libparsec::low_level::types::RealmRoleCertificate>,
+    Arc<libparsec_types::RealmRoleCertificate>,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -536,18 +514,16 @@ impl RealmRoleCertificate {
         user_id: UserID,
         role: Option<RealmRole>,
     ) -> PyResult<Self> {
-        Ok(Self(Arc::new(
-            libparsec::low_level::types::RealmRoleCertificate {
-                timestamp: timestamp.0,
-                author: match author {
-                    Some(device_id) => CertificateSignerOwned::User(device_id.0),
-                    None => CertificateSignerOwned::Root,
-                },
-                realm_id: realm_id.0,
-                user_id: user_id.0,
-                role: role.map(|x| x.0),
+        Ok(Self(Arc::new(libparsec_types::RealmRoleCertificate {
+            timestamp: timestamp.0,
+            author: match author {
+                Some(device_id) => CertificateSignerOwned::User(device_id.0),
+                None => CertificateSignerOwned::Root,
             },
-        )))
+            realm_id: realm_id.0,
+            user_id: user_id.0,
+            role: role.map(|x| x.0),
+        })))
     }
 
     #[pyo3(signature = (**py_kwargs))]
@@ -595,19 +571,17 @@ impl RealmRoleCertificate {
         expected_realm: Option<VlobID>,
         expected_user: Option<&UserID>,
     ) -> DataResult<Self> {
-        Ok(
-            libparsec::low_level::types::RealmRoleCertificate::verify_and_load(
-                signed,
-                &author_verify_key.0,
-                match &expected_author {
-                    Some(device_id) => CertificateSignerRef::User(&device_id.0),
-                    None => CertificateSignerRef::Root,
-                },
-                expected_realm.map(|x| x.0),
-                expected_user.map(|x| &x.0),
-            )
-            .map(|x| Self(Arc::new(x)))?,
+        Ok(libparsec_types::RealmRoleCertificate::verify_and_load(
+            signed,
+            &author_verify_key.0,
+            match &expected_author {
+                Some(device_id) => CertificateSignerRef::User(&device_id.0),
+                None => CertificateSignerRef::Root,
+            },
+            expected_realm.map(|x| x.0),
+            expected_user.map(|x| &x.0),
         )
+        .map(|x| Self(Arc::new(x)))?)
     }
 
     fn dump_and_sign<'py>(&self, author_signkey: &SigningKey, py: Python<'py>) -> &'py PyBytes {
@@ -617,11 +591,9 @@ impl RealmRoleCertificate {
     #[classmethod]
     fn unsecure_load(_cls: &PyType, signed: &[u8]) -> DataResult<Self> {
         Ok(
-            libparsec::low_level::types::RealmRoleCertificate::unsecure_load(
-                signed.to_vec().into(),
-            )
-            .map(|u| u.skip_validation(UnsecureSkipValidationReason::DataFromLocalStorage))
-            .map(|x| Self(Arc::new(x)))?,
+            libparsec_types::RealmRoleCertificate::unsecure_load(signed.to_vec().into())
+                .map(|u| u.skip_validation(UnsecureSkipValidationReason::DataFromLocalStorage))
+                .map(|x| Self(Arc::new(x)))?,
         )
     }
 
@@ -632,15 +604,13 @@ impl RealmRoleCertificate {
         timestamp: DateTime,
         realm_id: VlobID,
     ) -> Self {
-        Self(Arc::new(
-            libparsec::low_level::types::RealmRoleCertificate {
-                user_id: author.0.user_id().clone(),
-                author: CertificateSignerOwned::User(author.0),
-                timestamp: timestamp.0,
-                realm_id: realm_id.0,
-                role: Some(libparsec::low_level::types::RealmRole::Owner),
-            },
-        ))
+        Self(Arc::new(libparsec_types::RealmRoleCertificate {
+            user_id: author.0.user_id().clone(),
+            author: CertificateSignerOwned::User(author.0),
+            timestamp: timestamp.0,
+            realm_id: realm_id.0,
+            role: Some(libparsec_types::RealmRole::Owner),
+        }))
     }
 
     #[getter]
@@ -674,7 +644,7 @@ impl RealmRoleCertificate {
 
 crate::binding_utils::gen_py_wrapper_class!(
     SequesterAuthorityCertificate,
-    Arc<libparsec::low_level::types::SequesterAuthorityCertificate>,
+    Arc<libparsec_types::SequesterAuthorityCertificate>,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -685,12 +655,10 @@ crate::binding_utils::gen_py_wrapper_class!(
 impl SequesterAuthorityCertificate {
     #[new]
     fn new(timestamp: DateTime, verify_key_der: SequesterVerifyKeyDer) -> Self {
-        Self(Arc::new(
-            libparsec::low_level::types::SequesterAuthorityCertificate {
-                timestamp: timestamp.0,
-                verify_key_der: verify_key_der.0,
-            },
-        ))
+        Self(Arc::new(libparsec_types::SequesterAuthorityCertificate {
+            timestamp: timestamp.0,
+            verify_key_der: verify_key_der.0,
+        }))
     }
 
     #[classmethod]
@@ -700,7 +668,7 @@ impl SequesterAuthorityCertificate {
         author_verify_key: &VerifyKey,
     ) -> DataResult<Self> {
         Ok(
-            libparsec::low_level::types::SequesterAuthorityCertificate::verify_and_load(
+            libparsec_types::SequesterAuthorityCertificate::verify_and_load(
                 signed,
                 &author_verify_key.0,
             )
@@ -725,7 +693,7 @@ impl SequesterAuthorityCertificate {
 
 crate::binding_utils::gen_py_wrapper_class!(
     SequesterServiceCertificate,
-    Arc<libparsec::low_level::types::SequesterServiceCertificate>,
+    Arc<libparsec_types::SequesterServiceCertificate>,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -741,22 +709,17 @@ impl SequesterServiceCertificate {
         service_label: String,
         encryption_key_der: SequesterPublicKeyDer,
     ) -> Self {
-        Self(Arc::new(
-            libparsec::low_level::types::SequesterServiceCertificate {
-                timestamp: timestamp.0,
-                service_id: service_id.0,
-                service_label,
-                encryption_key_der: encryption_key_der.0,
-            },
-        ))
+        Self(Arc::new(libparsec_types::SequesterServiceCertificate {
+            timestamp: timestamp.0,
+            service_id: service_id.0,
+            service_label,
+            encryption_key_der: encryption_key_der.0,
+        }))
     }
 
     #[classmethod]
     fn load(_cls: &PyType, data: &[u8]) -> DataResult<Self> {
-        Ok(
-            libparsec::low_level::types::SequesterServiceCertificate::load(data)
-                .map(|x| Self(Arc::new(x)))?,
-        )
+        Ok(libparsec_types::SequesterServiceCertificate::load(data).map(|x| Self(Arc::new(x)))?)
     }
 
     fn dump<'py>(&self, py: Python<'py>) -> &'py PyBytes {

--- a/server/src/data/error.rs
+++ b/server/src/data/error.rs
@@ -5,12 +5,8 @@ use pyo3::{
     PyErr,
 };
 
-crate::binding_utils::create_exception!(Data, PyException, libparsec::low_level::types::DataError);
-crate::binding_utils::create_exception!(
-    EntryName,
-    PyValueError,
-    libparsec::low_level::types::EntryNameError
-);
+crate::binding_utils::create_exception!(Data, PyException, libparsec_types::DataError);
+crate::binding_utils::create_exception!(EntryName, PyValueError, libparsec_types::EntryNameError);
 
 // PkiEnrollmentError
 
@@ -40,13 +36,11 @@ pyo3::create_exception!(
     PkiEnrollmentLocalPendingError
 );
 
-pub(crate) struct PkiEnrollmentLocalPendingExc(
-    libparsec::low_level::types::PkiEnrollmentLocalPendingError,
-);
+pub(crate) struct PkiEnrollmentLocalPendingExc(libparsec_types::PkiEnrollmentLocalPendingError);
 
 impl From<PkiEnrollmentLocalPendingExc> for PyErr {
     fn from(err: PkiEnrollmentLocalPendingExc) -> Self {
-        use libparsec::low_level::types::PkiEnrollmentLocalPendingError::*;
+        use libparsec_types::PkiEnrollmentLocalPendingError::*;
         match err.0 {
             CannotRead { .. } => {
                 PkiEnrollmentLocalPendingCannotReadError::new_err(err.0.to_string())
@@ -64,10 +58,8 @@ impl From<PkiEnrollmentLocalPendingExc> for PyErr {
     }
 }
 
-impl From<libparsec::low_level::types::PkiEnrollmentLocalPendingError>
-    for PkiEnrollmentLocalPendingExc
-{
-    fn from(err: libparsec::low_level::types::PkiEnrollmentLocalPendingError) -> Self {
+impl From<libparsec_types::PkiEnrollmentLocalPendingError> for PkiEnrollmentLocalPendingExc {
+    fn from(err: libparsec_types::PkiEnrollmentLocalPendingError) -> Self {
         PkiEnrollmentLocalPendingExc(err)
     }
 }

--- a/server/src/data/manifest.rs
+++ b/server/src/data/manifest.rs
@@ -12,11 +12,11 @@ use crate::{
     BlockID, DataResult, DateTime, DeviceID, EntryNameResult, HashDigest, RealmRole, SecretKey,
     SigningKey, VerifyKey, VlobID,
 };
-use libparsec::low_level::types::{ChildManifest, IndexInt};
+use libparsec_types::{ChildManifest, IndexInt};
 
 crate::binding_utils::gen_py_wrapper_class_for_id!(
     EntryName,
-    libparsec::low_level::types::EntryName,
+    libparsec_types::EntryName,
     __str__,
     __richcmp__ ord,
     __hash__,
@@ -26,7 +26,7 @@ crate::binding_utils::gen_py_wrapper_class_for_id!(
 impl EntryName {
     #[new]
     fn new(name: &str) -> EntryNameResult<Self> {
-        Ok(libparsec::low_level::types::EntryName::try_from(name).map(Self)?)
+        Ok(libparsec_types::EntryName::try_from(name).map(Self)?)
     }
 
     fn __repr__(&self) -> PyResult<String> {
@@ -41,7 +41,7 @@ impl EntryName {
 
 crate::binding_utils::gen_py_wrapper_class!(
     WorkspaceEntry,
-    libparsec::low_level::types::WorkspaceEntry,
+    libparsec_types::WorkspaceEntry,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -61,7 +61,7 @@ impl WorkspaceEntry {
         legacy_role_cache_timestamp: DateTime,
         legacy_role_cache_value: Option<RealmRole>,
     ) -> PyResult<Self> {
-        Ok(Self(libparsec::low_level::types::WorkspaceEntry {
+        Ok(Self(libparsec_types::WorkspaceEntry {
             id: id.0,
             name: name.0,
             key: key.0,
@@ -121,7 +121,7 @@ impl WorkspaceEntry {
     #[classmethod]
     #[pyo3(name = "new")]
     fn class_new(_cls: &PyType, name: &EntryName, timestamp: DateTime) -> PyResult<Self> {
-        Ok(Self(libparsec::low_level::types::WorkspaceEntry::generate(
+        Ok(Self(libparsec_types::WorkspaceEntry::generate(
             name.0.to_owned(),
             timestamp.0,
         )))
@@ -165,7 +165,7 @@ impl WorkspaceEntry {
 
 crate::binding_utils::gen_py_wrapper_class!(
     BlockAccess,
-    libparsec::low_level::types::BlockAccess,
+    libparsec_types::BlockAccess,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -183,7 +183,7 @@ impl BlockAccess {
         size: u64,
         digest: HashDigest,
     ) -> PyResult<Self> {
-        Ok(Self(libparsec::low_level::types::BlockAccess {
+        Ok(Self(libparsec_types::BlockAccess {
             id: id.0,
             key: key.0,
             offset,
@@ -257,7 +257,7 @@ impl BlockAccess {
 
 crate::binding_utils::gen_py_wrapper_class!(
     FileManifest,
-    libparsec::low_level::types::FileManifest,
+    libparsec_types::FileManifest,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -281,7 +281,7 @@ impl FileManifest {
         blocksize: u64,
         blocks: Vec<BlockAccess>,
     ) -> PyResult<Self> {
-        Ok(Self(libparsec::low_level::types::FileManifest {
+        Ok(Self(libparsec_types::FileManifest {
             author: author.0,
             timestamp: timestamp.0,
             id: id.0,
@@ -290,7 +290,7 @@ impl FileManifest {
             created: created.0,
             updated: updated.0,
             size,
-            blocksize: libparsec::low_level::types::Blocksize::try_from(blocksize)
+            blocksize: libparsec_types::Blocksize::try_from(blocksize)
                 .map_err(|_| PyValueError::new_err("Invalid `blocksize` field"))?,
             blocks: blocks.into_iter().map(|b| b.0).collect(),
         }))
@@ -328,18 +328,16 @@ impl FileManifest {
         expected_id: Option<VlobID>,
         expected_version: Option<u32>,
     ) -> DataResult<Self> {
-        Ok(
-            libparsec::low_level::types::FileManifest::decrypt_verify_and_load(
-                encrypted,
-                &key.0,
-                &author_verify_key.0,
-                &expected_author.0,
-                expected_timestamp.0,
-                expected_id.map(|id| id.0),
-                expected_version,
-            )
-            .map(Self)?,
+        Ok(libparsec_types::FileManifest::decrypt_verify_and_load(
+            encrypted,
+            &key.0,
+            &author_verify_key.0,
+            &expected_author.0,
+            expected_timestamp.0,
+            expected_id.map(|id| id.0),
+            expected_version,
         )
+        .map(Self)?)
     }
 
     #[pyo3(signature = (**py_kwargs))]
@@ -385,7 +383,7 @@ impl FileManifest {
             r.size = v;
         }
         if let Some(v) = blocksize {
-            r.blocksize = libparsec::low_level::types::Blocksize::try_from(v)
+            r.blocksize = libparsec_types::Blocksize::try_from(v)
                 .map_err(|_| PyValueError::new_err("Invalid `blocksize` field"))?;
         }
         if let Some(v) = blocks {
@@ -454,7 +452,7 @@ impl FileManifest {
 
 crate::binding_utils::gen_py_wrapper_class!(
     FolderManifest,
-    libparsec::low_level::types::FolderManifest,
+    libparsec_types::FolderManifest,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -476,7 +474,7 @@ impl FolderManifest {
         updated: DateTime,
         children: HashMap<EntryName, VlobID>,
     ) -> PyResult<Self> {
-        Ok(Self(libparsec::low_level::types::FolderManifest {
+        Ok(Self(libparsec_types::FolderManifest {
             author: author.0,
             timestamp: timestamp.0,
             version,
@@ -523,18 +521,16 @@ impl FolderManifest {
         expected_id: Option<VlobID>,
         expected_version: Option<u32>,
     ) -> DataResult<Self> {
-        Ok(
-            libparsec::low_level::types::FolderManifest::decrypt_verify_and_load(
-                encrypted,
-                &key.0,
-                &author_verify_key.0,
-                &expected_author.0,
-                expected_timestamp.0,
-                expected_id.map(|id| id.0),
-                expected_version,
-            )
-            .map(Self)?,
+        Ok(libparsec_types::FolderManifest::decrypt_verify_and_load(
+            encrypted,
+            &key.0,
+            &author_verify_key.0,
+            &expected_author.0,
+            expected_timestamp.0,
+            expected_id.map(|id| id.0),
+            expected_version,
         )
+        .map(Self)?)
     }
 
     #[pyo3(signature = (**py_kwargs))]
@@ -631,7 +627,7 @@ impl FolderManifest {
 
 crate::binding_utils::gen_py_wrapper_class!(
     WorkspaceManifest,
-    libparsec::low_level::types::WorkspaceManifest,
+    libparsec_types::WorkspaceManifest,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -651,7 +647,7 @@ impl WorkspaceManifest {
         updated: DateTime,
         children: HashMap<EntryName, VlobID>,
     ) -> PyResult<Self> {
-        Ok(Self(libparsec::low_level::types::WorkspaceManifest {
+        Ok(Self(libparsec_types::WorkspaceManifest {
             author: author.0,
             timestamp: timestamp.0,
             id: id.0,
@@ -697,18 +693,16 @@ impl WorkspaceManifest {
         expected_id: Option<VlobID>,
         expected_version: Option<u32>,
     ) -> DataResult<Self> {
-        Ok(
-            libparsec::low_level::types::WorkspaceManifest::decrypt_verify_and_load(
-                encrypted,
-                &key.0,
-                &author_verify_key.0,
-                &expected_author.0,
-                expected_timestamp.0,
-                expected_id.map(|id| id.0),
-                expected_version,
-            )
-            .map(Self)?,
+        Ok(libparsec_types::WorkspaceManifest::decrypt_verify_and_load(
+            encrypted,
+            &key.0,
+            &author_verify_key.0,
+            &expected_author.0,
+            expected_timestamp.0,
+            expected_id.map(|id| id.0),
+            expected_version,
         )
+        .map(Self)?)
     }
 
     #[classmethod]
@@ -722,17 +716,15 @@ impl WorkspaceManifest {
         expected_id: Option<VlobID>,
         expected_version: Option<u32>,
     ) -> DataResult<Self> {
-        Ok(
-            libparsec::low_level::types::WorkspaceManifest::verify_and_load(
-                signed,
-                &author_verify_key.0,
-                &expected_author.0,
-                expected_timestamp.0,
-                expected_id.map(|id| id.0),
-                expected_version,
-            )
-            .map(Self)?,
+        Ok(libparsec_types::WorkspaceManifest::verify_and_load(
+            signed,
+            &author_verify_key.0,
+            &expected_author.0,
+            expected_timestamp.0,
+            expected_id.map(|id| id.0),
+            expected_version,
         )
+        .map(Self)?)
     }
 
     #[pyo3(signature = (**py_kwargs))]
@@ -820,7 +812,7 @@ impl WorkspaceManifest {
 
 crate::binding_utils::gen_py_wrapper_class!(
     UserManifest,
-    libparsec::low_level::types::UserManifest,
+    libparsec_types::UserManifest,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -842,7 +834,7 @@ impl UserManifest {
         last_processed_message: u64,
         workspaces: Vec<WorkspaceEntry>,
     ) -> PyResult<Self> {
-        Ok(Self(libparsec::low_level::types::UserManifest {
+        Ok(Self(libparsec_types::UserManifest {
             author: author.0,
             timestamp: timestamp.0,
             id: id.0,
@@ -886,18 +878,16 @@ impl UserManifest {
         expected_id: Option<VlobID>,
         expected_version: Option<u32>,
     ) -> DataResult<Self> {
-        Ok(
-            libparsec::low_level::types::UserManifest::decrypt_verify_and_load(
-                encrypted,
-                &key.0,
-                &author_verify_key.0,
-                &expected_author.0,
-                expected_timestamp.0,
-                expected_id.map(|id| id.0),
-                expected_version,
-            )
-            .map(Self)?,
+        Ok(libparsec_types::UserManifest::decrypt_verify_and_load(
+            encrypted,
+            &key.0,
+            &author_verify_key.0,
+            &expected_author.0,
+            expected_timestamp.0,
+            expected_id.map(|id| id.0),
+            expected_version,
         )
+        .map(Self)?)
     }
 
     #[pyo3(signature = (**py_kwargs))]

--- a/server/src/data/organization.rs
+++ b/server/src/data/organization.rs
@@ -9,7 +9,7 @@ use crate::{ActiveUsersLimit, BytesWrapper, UsersPerProfileDetailItem};
 
 crate::binding_utils::gen_py_wrapper_class!(
     OrganizationStats,
-    libparsec::low_level::types::OrganizationStats,
+    libparsec_types::OrganizationStats,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -27,7 +27,7 @@ impl OrganizationStats {
         metadata_size: u64,
         users_per_profile_detail: Vec<UsersPerProfileDetailItem>,
     ) -> Self {
-        Self(libparsec::low_level::types::OrganizationStats {
+        Self(libparsec_types::OrganizationStats {
             users,
             active_users,
             realms,
@@ -76,7 +76,7 @@ impl OrganizationStats {
 
 crate::binding_utils::gen_py_wrapper_class!(
     OrganizationConfig,
-    libparsec::low_level::types::OrganizationConfig,
+    libparsec_types::OrganizationConfig,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -93,7 +93,7 @@ impl OrganizationConfig {
         sequester_services: Option<Vec<BytesWrapper>>,
     ) -> Self {
         crate::binding_utils::unwrap_bytes!(sequester_authority, sequester_services);
-        Self(libparsec::low_level::types::OrganizationConfig {
+        Self(libparsec_types::OrganizationConfig {
             user_profile_outsider_allowed,
             active_users_limit: active_users_limit.0,
             sequester_authority,

--- a/server/src/data/pki.rs
+++ b/server/src/data/pki.rs
@@ -14,7 +14,7 @@ use crate::{
 
 crate::binding_utils::gen_py_wrapper_class!(
     PkiEnrollmentAnswerPayload,
-    libparsec::low_level::types::PkiEnrollmentAnswerPayload,
+    libparsec_types::PkiEnrollmentAnswerPayload,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -32,7 +32,7 @@ impl PkiEnrollmentAnswerPayload {
         profile: UserProfile,
         root_verify_key: VerifyKey,
     ) -> Self {
-        Self(libparsec::low_level::types::PkiEnrollmentAnswerPayload {
+        Self(libparsec_types::PkiEnrollmentAnswerPayload {
             device_id: device_id.0,
             device_label: device_label.map(|x| x.0),
             human_handle: human_handle.map(|x| x.0),
@@ -68,7 +68,7 @@ impl PkiEnrollmentAnswerPayload {
 
     #[classmethod]
     fn load(_cls: &PyType, raw: &[u8]) -> DataResult<Self> {
-        Ok(libparsec::low_level::types::PkiEnrollmentAnswerPayload::load(raw).map(Self)?)
+        Ok(libparsec_types::PkiEnrollmentAnswerPayload::load(raw).map(Self)?)
     }
 
     fn dump<'py>(&self, py: Python<'py>) -> &'py PyBytes {
@@ -78,7 +78,7 @@ impl PkiEnrollmentAnswerPayload {
 
 crate::binding_utils::gen_py_wrapper_class!(
     PkiEnrollmentSubmitPayload,
-    libparsec::low_level::types::PkiEnrollmentSubmitPayload,
+    libparsec_types::PkiEnrollmentSubmitPayload,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -93,7 +93,7 @@ impl PkiEnrollmentSubmitPayload {
         public_key: PublicKey,
         requested_device_label: DeviceLabel,
     ) -> Self {
-        Self(libparsec::low_level::types::PkiEnrollmentSubmitPayload {
+        Self(libparsec_types::PkiEnrollmentSubmitPayload {
             verify_key: verify_key.0,
             public_key: public_key.0,
             requested_device_label: requested_device_label.0,
@@ -117,7 +117,7 @@ impl PkiEnrollmentSubmitPayload {
 
     #[classmethod]
     fn load(_cls: &PyType, raw: &[u8]) -> DataResult<Self> {
-        Ok(libparsec::low_level::types::PkiEnrollmentSubmitPayload::load(raw).map(Self)?)
+        Ok(libparsec_types::PkiEnrollmentSubmitPayload::load(raw).map(Self)?)
     }
 
     fn dump<'py>(&self, py: Python<'py>) -> &'py PyBytes {
@@ -127,7 +127,7 @@ impl PkiEnrollmentSubmitPayload {
 
 crate::binding_utils::gen_py_wrapper_class!(
     X509Certificate,
-    libparsec::low_level::types::X509Certificate,
+    libparsec_types::X509Certificate,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -145,7 +145,7 @@ impl X509Certificate {
         certificate_id: Option<String>,
     ) -> Self {
         crate::binding_utils::unwrap_bytes!(der_x509_certificate, certificate_sha1);
-        Self(libparsec::low_level::types::X509Certificate {
+        Self(libparsec_types::X509Certificate {
             issuer,
             subject,
             der_x509_certificate,
@@ -234,7 +234,7 @@ impl X509Certificate {
 
 crate::binding_utils::gen_py_wrapper_class!(
     LocalPendingEnrollment,
-    libparsec::low_level::types::LocalPendingEnrollment,
+    libparsec_types::LocalPendingEnrollment,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -254,7 +254,7 @@ impl LocalPendingEnrollment {
         ciphertext: BytesWrapper,
     ) -> Self {
         crate::binding_utils::unwrap_bytes!(encrypted_key, ciphertext);
-        Self(libparsec::low_level::types::LocalPendingEnrollment {
+        Self(libparsec_types::LocalPendingEnrollment {
             x509_certificate: x509_certificate.0,
             addr: addr.0,
             submitted_on: submitted_on.0,
@@ -267,7 +267,7 @@ impl LocalPendingEnrollment {
 
     #[classmethod]
     fn load(_cls: &PyType, raw: &[u8]) -> DataResult<Self> {
-        Ok(libparsec::low_level::types::LocalPendingEnrollment::load(raw).map(Self)?)
+        Ok(libparsec_types::LocalPendingEnrollment::load(raw).map(Self)?)
     }
 
     fn dump<'py>(&self, py: Python<'py>) -> &'py PyBytes {
@@ -295,7 +295,7 @@ impl LocalPendingEnrollment {
             .extract::<&str>()
             .map(Path::new)
             .expect("Unreachable");
-        Ok(libparsec::low_level::types::LocalPendingEnrollment::load_from_path(path).map(Self)?)
+        Ok(libparsec_types::LocalPendingEnrollment::load_from_path(path).map(Self)?)
     }
 
     #[classmethod]
@@ -311,7 +311,7 @@ impl LocalPendingEnrollment {
             .map(Path::new)
             .expect("Unreachable");
         Ok(
-            libparsec::low_level::types::LocalPendingEnrollment::load_from_enrollment_id(
+            libparsec_types::LocalPendingEnrollment::load_from_enrollment_id(
                 config_dir,
                 enrollment_id.0,
             )
@@ -332,7 +332,7 @@ impl LocalPendingEnrollment {
             .map(Path::new)
             .expect("Unreachable");
         Ok(
-            libparsec::low_level::types::LocalPendingEnrollment::remove_from_enrollment_id(
+            libparsec_types::LocalPendingEnrollment::remove_from_enrollment_id(
                 config_dir,
                 enrollment_id.0,
             )?,
@@ -347,7 +347,7 @@ impl LocalPendingEnrollment {
             .extract::<&str>()
             .map(Path::new)
             .expect("Unreachable");
-        libparsec::low_level::types::LocalPendingEnrollment::list(config_dir)
+        libparsec_types::LocalPendingEnrollment::list(config_dir)
             .into_iter()
             .map(Self)
             .collect()

--- a/server/src/data/user.rs
+++ b/server/src/data/user.rs
@@ -6,7 +6,7 @@ use crate::enumerate::UserProfile;
 
 crate::binding_utils::gen_py_wrapper_class!(
     UsersPerProfileDetailItem,
-    libparsec::low_level::types::UsersPerProfileDetailItem,
+    libparsec_types::UsersPerProfileDetailItem,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -17,13 +17,11 @@ crate::binding_utils::gen_py_wrapper_class!(
 impl UsersPerProfileDetailItem {
     #[new]
     fn new(profile: UserProfile, active: u64, revoked: u64) -> PyResult<Self> {
-        Ok(Self(
-            libparsec::low_level::types::UsersPerProfileDetailItem {
-                profile: profile.0,
-                active,
-                revoked,
-            },
-        ))
+        Ok(Self(libparsec_types::UsersPerProfileDetailItem {
+            profile: profile.0,
+            active,
+            revoked,
+        }))
     }
 
     #[getter]

--- a/server/src/enumerate.rs
+++ b/server/src/enumerate.rs
@@ -15,101 +15,61 @@ use crate::{ProtocolErrorFields, ProtocolResult};
 
 crate::binding_utils::gen_py_wrapper_class_for_enum!(
     InvitationStatus,
-    libparsec::low_level::types::InvitationStatus,
-    [
-        "IDLE",
-        idle,
-        libparsec::low_level::types::InvitationStatus::Idle
-    ],
-    [
-        "READY",
-        ready,
-        libparsec::low_level::types::InvitationStatus::Ready
-    ],
+    libparsec_types::InvitationStatus,
+    ["IDLE", idle, libparsec_types::InvitationStatus::Idle],
+    ["READY", ready, libparsec_types::InvitationStatus::Ready],
     [
         "DELETED",
         deleted,
-        libparsec::low_level::types::InvitationStatus::Deleted
+        libparsec_types::InvitationStatus::Deleted
     ]
 );
 
 crate::binding_utils::gen_py_wrapper_class_for_enum!(
     InvitationType,
-    libparsec::low_level::types::InvitationType,
-    [
-        "DEVICE",
-        device,
-        libparsec::low_level::types::InvitationType::Device
-    ],
-    [
-        "USER",
-        user,
-        libparsec::low_level::types::InvitationType::User
-    ]
+    libparsec_types::InvitationType,
+    ["DEVICE", device, libparsec_types::InvitationType::Device],
+    ["USER", user, libparsec_types::InvitationType::User]
 );
 
 crate::binding_utils::gen_py_wrapper_class_for_enum!(
     RealmRole,
-    libparsec::low_level::types::RealmRole,
-    [
-        "OWNER",
-        owner,
-        libparsec::low_level::types::RealmRole::Owner
-    ],
-    [
-        "MANAGER",
-        manager,
-        libparsec::low_level::types::RealmRole::Manager
-    ],
+    libparsec_types::RealmRole,
+    ["OWNER", owner, libparsec_types::RealmRole::Owner],
+    ["MANAGER", manager, libparsec_types::RealmRole::Manager],
     [
         "CONTRIBUTOR",
         contributor,
-        libparsec::low_level::types::RealmRole::Contributor
+        libparsec_types::RealmRole::Contributor
     ],
-    [
-        "READER",
-        reader,
-        libparsec::low_level::types::RealmRole::Reader
-    ]
+    ["READER", reader, libparsec_types::RealmRole::Reader]
 );
 
 crate::binding_utils::gen_py_wrapper_class_for_enum!(
     UserProfile,
-    libparsec::low_level::types::UserProfile,
-    [
-        "ADMIN",
-        admin,
-        libparsec::low_level::types::UserProfile::Admin
-    ],
-    [
-        "STANDARD",
-        standard,
-        libparsec::low_level::types::UserProfile::Standard
-    ],
-    [
-        "OUTSIDER",
-        outsider,
-        libparsec::low_level::types::UserProfile::Outsider
-    ]
+    libparsec_types::UserProfile,
+    ["ADMIN", admin, libparsec_types::UserProfile::Admin],
+    ["STANDARD", standard, libparsec_types::UserProfile::Standard],
+    ["OUTSIDER", outsider, libparsec_types::UserProfile::Outsider]
 );
 
 crate::binding_utils::gen_py_wrapper_class_for_enum!(
     DeviceFileType,
-    libparsec::low_level::types::DeviceFileType,
+    libparsec_types::DeviceFileType,
     [
         "PASSWORD",
         password,
-        libparsec::low_level::types::DeviceFileType::Password
+        libparsec_types::DeviceFileType::Password
     ],
     [
         "SMARTCARD",
         smartcard,
-        libparsec::low_level::types::DeviceFileType::Smartcard
+        libparsec_types::DeviceFileType::Smartcard
     ],
     [
         "RECOVERY",
         recovery,
-        libparsec::low_level::types::DeviceFileType::Recovery
+        libparsec_types::DeviceFileType::Recovery
     ]
 );
 
@@ -119,11 +79,9 @@ impl DeviceFileType {
         Ok(PyBytes::new(
             py,
             &self.0.dump().map_err(|e| {
-                ProtocolErrorFields(
-                    libparsec::low_level::protocol::ProtocolError::EncodingError {
-                        exc: e.to_string(),
-                    },
-                )
+                ProtocolErrorFields(libparsec_protocol::ProtocolError::EncodingError {
+                    exc: e.to_string(),
+                })
             })?,
         ))
     }
@@ -131,7 +89,7 @@ impl DeviceFileType {
     #[classmethod]
     pub fn load(_cls: &PyType, bytes: &[u8]) -> PyResult<&'static PyObject> {
         Ok(Self::convert(
-            libparsec::low_level::types::DeviceFileType::load(bytes)
+            libparsec_types::DeviceFileType::load(bytes)
                 .map_err(|_| PyValueError::new_err("Failed to deserialize"))?,
         ))
     }

--- a/server/src/ids.rs
+++ b/server/src/ids.rs
@@ -10,14 +10,14 @@ macro_rules! gen_uuid {
         impl $class {
             #[classmethod]
             fn from_bytes(_cls: &::pyo3::types::PyType, bytes: &[u8]) -> PyResult<Self> {
-                libparsec::low_level::types::$class::try_from(bytes)
+                libparsec_types::$class::try_from(bytes)
                     .map(Self)
                     .map_err(::pyo3::exceptions::PyValueError::new_err)
             }
 
             #[classmethod]
             fn from_hex(_cls: &::pyo3::types::PyType, hex: &str) -> PyResult<Self> {
-                libparsec::low_level::types::$class::from_hex(hex)
+                libparsec_types::$class::from_hex(hex)
                     .map(Self)
                     .map_err(::pyo3::exceptions::PyValueError::new_err)
             }
@@ -25,7 +25,7 @@ macro_rules! gen_uuid {
             #[classmethod]
             #[pyo3(name = "new")]
             fn default(_cls: &::pyo3::types::PyType) -> Self {
-                Self(libparsec::low_level::types::$class::default())
+                Self(libparsec_types::$class::default())
             }
 
             #[getter]
@@ -53,7 +53,7 @@ macro_rules! gen_uuid {
 
 crate::binding_utils::gen_py_wrapper_class_for_id!(
     VlobID,
-    libparsec::low_level::types::VlobID,
+    libparsec_types::VlobID,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -66,7 +66,7 @@ gen_uuid!(VlobID);
 
 crate::binding_utils::gen_py_wrapper_class_for_id!(
     BlockID,
-    libparsec::low_level::types::BlockID,
+    libparsec_types::BlockID,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -79,7 +79,7 @@ gen_uuid!(BlockID);
 
 crate::binding_utils::gen_py_wrapper_class_for_id!(
     ChunkID,
-    libparsec::low_level::types::ChunkID,
+    libparsec_types::ChunkID,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -94,13 +94,13 @@ gen_uuid!(ChunkID);
 impl ChunkID {
     #[classmethod]
     fn from_block_id(_cls: &PyType, id: BlockID) -> Self {
-        Self(libparsec::low_level::types::ChunkID::from(*id.0))
+        Self(libparsec_types::ChunkID::from(*id.0))
     }
 }
 
 crate::binding_utils::gen_py_wrapper_class_for_id!(
     SequesterServiceID,
-    libparsec::low_level::types::SequesterServiceID,
+    libparsec_types::SequesterServiceID,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -112,7 +112,7 @@ gen_uuid!(SequesterServiceID);
 
 crate::binding_utils::gen_py_wrapper_class_for_id!(
     InvitationToken,
-    libparsec::low_level::types::InvitationToken,
+    libparsec_types::InvitationToken,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -124,7 +124,7 @@ gen_uuid!(InvitationToken);
 
 crate::binding_utils::gen_py_wrapper_class_for_id!(
     EnrollmentID,
-    libparsec::low_level::types::EnrollmentID,
+    libparsec_types::EnrollmentID,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -138,7 +138,7 @@ gen_uuid!(EnrollmentID);
 
 crate::binding_utils::gen_py_wrapper_class_for_id!(
     OrganizationID,
-    libparsec::low_level::types::OrganizationID,
+    libparsec_types::OrganizationID,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -154,7 +154,7 @@ impl OrganizationID {
         if let Ok(organization_id) = organization_id.extract::<Self>() {
             Ok(organization_id)
         } else if let Ok(organization_id) = organization_id.extract::<&str>() {
-            match organization_id.parse::<libparsec::low_level::types::OrganizationID>() {
+            match organization_id.parse::<libparsec_types::OrganizationID>() {
                 Ok(organization_id) => Ok(Self(organization_id)),
                 Err(err) => Err(PyValueError::new_err(err)),
             }
@@ -171,7 +171,7 @@ impl OrganizationID {
 
 crate::binding_utils::gen_py_wrapper_class_for_id!(
     UserID,
-    libparsec::low_level::types::UserID,
+    libparsec_types::UserID,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -187,7 +187,7 @@ impl UserID {
         if let Ok(user_id) = user_id.extract::<Self>() {
             Ok(user_id)
         } else if let Ok(user_id) = user_id.extract::<&str>() {
-            match user_id.parse::<libparsec::low_level::types::UserID>() {
+            match user_id.parse::<libparsec_types::UserID>() {
                 Ok(user_id) => Ok(Self(user_id)),
                 Err(err) => Err(PyValueError::new_err(err)),
             }
@@ -212,7 +212,7 @@ impl UserID {
 
 crate::binding_utils::gen_py_wrapper_class_for_id!(
     DeviceName,
-    libparsec::low_level::types::DeviceName,
+    libparsec_types::DeviceName,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -228,7 +228,7 @@ impl DeviceName {
         if let Ok(device_name) = device_name.extract::<Self>() {
             Ok(device_name)
         } else if let Ok(device_name) = device_name.extract::<&str>() {
-            match device_name.parse::<libparsec::low_level::types::DeviceName>() {
+            match device_name.parse::<libparsec_types::DeviceName>() {
                 Ok(device_name) => Ok(Self(device_name)),
                 Err(err) => Err(PyValueError::new_err(err)),
             }
@@ -245,13 +245,13 @@ impl DeviceName {
     #[classmethod]
     #[pyo3(name = "new")]
     fn class_new(_cls: &PyType) -> PyResult<Self> {
-        Ok(Self(libparsec::low_level::types::DeviceName::default()))
+        Ok(Self(libparsec_types::DeviceName::default()))
     }
 }
 
 crate::binding_utils::gen_py_wrapper_class_for_id!(
     DeviceLabel,
-    libparsec::low_level::types::DeviceLabel,
+    libparsec_types::DeviceLabel,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -267,7 +267,7 @@ impl DeviceLabel {
         if let Ok(device_label) = device_label.extract::<Self>() {
             Ok(device_label)
         } else if let Ok(device_label) = device_label.extract::<&str>() {
-            match device_label.parse::<libparsec::low_level::types::DeviceLabel>() {
+            match device_label.parse::<libparsec_types::DeviceLabel>() {
                 Ok(device_label) => Ok(Self(device_label)),
                 Err(err) => Err(PyValueError::new_err(err)),
             }
@@ -284,7 +284,7 @@ impl DeviceLabel {
 
 crate::binding_utils::gen_py_wrapper_class_for_id!(
     DeviceID,
-    libparsec::low_level::types::DeviceID,
+    libparsec_types::DeviceID,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -300,7 +300,7 @@ impl DeviceID {
         if let Ok(device_id) = device_id.extract::<Self>() {
             Ok(device_id)
         } else if let Ok(device_id) = device_id.extract::<&str>() {
-            match device_id.parse::<libparsec::low_level::types::DeviceID>() {
+            match device_id.parse::<libparsec_types::DeviceID>() {
                 Ok(device_id) => Ok(Self(device_id)),
                 Err(err) => Err(PyValueError::new_err(err)),
             }
@@ -327,13 +327,13 @@ impl DeviceID {
     #[classmethod]
     #[pyo3(name = "new")]
     fn class_new(_cls: &PyType) -> PyResult<Self> {
-        Ok(Self(libparsec::low_level::types::DeviceID::default()))
+        Ok(Self(libparsec_types::DeviceID::default()))
     }
 }
 
 crate::binding_utils::gen_py_wrapper_class_for_id!(
     HumanHandle,
-    libparsec::low_level::types::HumanHandle,
+    libparsec_types::HumanHandle,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -346,7 +346,7 @@ crate::binding_utils::gen_py_wrapper_class_for_id!(
 impl HumanHandle {
     #[new]
     pub fn new(email: &str, label: &str) -> PyResult<Self> {
-        match libparsec::low_level::types::HumanHandle::new(email, label) {
+        match libparsec_types::HumanHandle::new(email, label) {
             Ok(human_handle) => Ok(Self(human_handle)),
             Err(err) => Err(PyValueError::new_err(err)),
         }

--- a/server/src/misc.rs
+++ b/server/src/misc.rs
@@ -11,7 +11,7 @@ use crate::{ProtocolErrorFields, ProtocolResult};
 
 crate::binding_utils::gen_py_wrapper_class!(
     ApiVersion,
-    libparsec::low_level::types::ApiVersion,
+    libparsec_types::ApiVersion,
     __str__,
     __copy__,
     __deepcopy__,
@@ -23,38 +23,34 @@ crate::binding_utils::gen_py_wrapper_class!(
 impl ApiVersion {
     #[new]
     fn new(version: u32, revision: u32) -> Self {
-        Self(libparsec::low_level::types::ApiVersion { version, revision })
+        Self(libparsec_types::ApiVersion { version, revision })
     }
 
     fn dump<'py>(&self, py: Python<'py>) -> ProtocolResult<&'py PyBytes> {
         Ok(PyBytes::new(
             py,
             &self.0.clone().dump().map_err(|e| {
-                ProtocolErrorFields(
-                    libparsec::low_level::protocol::ProtocolError::EncodingError {
-                        exc: e.to_string(),
-                    },
-                )
+                ProtocolErrorFields(libparsec_protocol::ProtocolError::EncodingError {
+                    exc: e.to_string(),
+                })
             })?,
         ))
     }
 
     #[classmethod]
     fn from_bytes(_cls: &PyType, bytes: &[u8]) -> ProtocolResult<Self> {
-        Ok(Self(
-            libparsec::low_level::types::ApiVersion::load(bytes).map_err(|err| {
-                ProtocolErrorFields(
-                    libparsec::low_level::protocol::ProtocolError::EncodingError {
-                        exc: err.to_string(),
-                    },
-                )
-            })?,
-        ))
+        Ok(Self(libparsec_types::ApiVersion::load(bytes).map_err(
+            |err| {
+                ProtocolErrorFields(libparsec_protocol::ProtocolError::EncodingError {
+                    exc: err.to_string(),
+                })
+            },
+        )?))
     }
 
     #[classmethod]
     fn from_str(_cls: &PyType, version_str: &str) -> PyResult<Self> {
-        libparsec::low_level::types::ApiVersion::try_from(version_str)
+        libparsec_types::ApiVersion::try_from(version_str)
             .map(Self)
             .map_err(PyValueError::new_err)
     }
@@ -72,36 +68,35 @@ impl ApiVersion {
     #[classattr]
     #[pyo3(name = "API_V1_VERSION")]
     fn api_v1_version() -> Self {
-        const API_V1_VERSION: ApiVersion = Self(*libparsec::low_level::protocol::API_V1_VERSION);
+        const API_V1_VERSION: ApiVersion = Self(*libparsec_protocol::API_V1_VERSION);
         API_V1_VERSION
     }
 
     #[classattr]
     #[pyo3(name = "API_V2_VERSION")]
     fn api_v2_version() -> Self {
-        const API_V2_VERSION: ApiVersion = Self(*libparsec::low_level::protocol::API_V2_VERSION);
+        const API_V2_VERSION: ApiVersion = Self(*libparsec_protocol::API_V2_VERSION);
         API_V2_VERSION
     }
 
     #[classattr]
     #[pyo3(name = "API_V3_VERSION")]
     fn api_v3_version() -> Self {
-        const API_V3_VERSION: ApiVersion = Self(*libparsec::low_level::protocol::API_V3_VERSION);
+        const API_V3_VERSION: ApiVersion = Self(*libparsec_protocol::API_V3_VERSION);
         API_V3_VERSION
     }
 
     #[classattr]
     #[pyo3(name = "API_V4_VERSION")]
     fn api_v4_version() -> Self {
-        const API_V4_VERSION: ApiVersion = Self(*libparsec::low_level::protocol::API_V4_VERSION);
+        const API_V4_VERSION: ApiVersion = Self(*libparsec_protocol::API_V4_VERSION);
         API_V4_VERSION
     }
 
     #[classattr]
     #[pyo3(name = "API_LATEST_VERSION")]
     fn api_version_number() -> Self {
-        const API_LATEST_VERSION: ApiVersion =
-            Self(*libparsec::low_level::protocol::API_LATEST_VERSION);
+        const API_LATEST_VERSION: ApiVersion = Self(*libparsec_protocol::API_LATEST_VERSION);
         API_LATEST_VERSION
     }
 }

--- a/server/src/protocol.rs
+++ b/server/src/protocol.rs
@@ -8,7 +8,7 @@ use pyo3::{
     IntoPy, PyAny, PyErr, PyObject, PyResult, Python,
 };
 
-use libparsec::low_level::serialization_format::python_bindings_parsec_protocol_cmds_family;
+use libparsec_serialization_format::python_bindings_parsec_protocol_cmds_family;
 
 /*
  * ProtocolError
@@ -18,7 +18,7 @@ create_exception!(_parsec, ProtocolError, PyException);
 
 crate::binding_utils::gen_py_wrapper_class!(
     ProtocolErrorFields,
-    libparsec::low_level::protocol::ProtocolError,
+    libparsec_protocol::ProtocolError,
     __repr__,
     __str__, // Needed for python's exceptions
     __copy__,
@@ -31,7 +31,7 @@ impl ProtocolErrorFields {
     #[classmethod]
     #[pyo3(name = "EncodingError")]
     fn encoding_error(_cls: &PyType, exc: String) -> Self {
-        Self(libparsec::low_level::protocol::ProtocolError::EncodingError { exc })
+        Self(libparsec_protocol::ProtocolError::EncodingError { exc })
     }
 
     #[classattr]
@@ -40,7 +40,7 @@ impl ProtocolErrorFields {
         lazy_static::lazy_static! {
             static ref VALUE: PyObject = {
                 Python::with_gil(|py| {
-                    ProtocolErrorFields(libparsec::low_level::protocol::ProtocolError::NotHandled).into_py(py)
+                    ProtocolErrorFields(libparsec_protocol::ProtocolError::NotHandled).into_py(py)
                 })
             };
         }
@@ -51,15 +51,15 @@ impl ProtocolErrorFields {
     #[classmethod]
     #[pyo3(name = "BadRequest")]
     fn bad_request(_cls: &PyType, exc: String) -> Self {
-        Self(libparsec::low_level::protocol::ProtocolError::BadRequest { exc })
+        Self(libparsec_protocol::ProtocolError::BadRequest { exc })
     }
 
     #[getter]
     fn exc(&self) -> PyResult<&str> {
         match &self.0 {
-            libparsec::low_level::protocol::ProtocolError::EncodingError { exc } => Ok(exc),
-            libparsec::low_level::protocol::ProtocolError::DecodingError { exc } => Ok(exc),
-            libparsec::low_level::protocol::ProtocolError::BadRequest { exc } => Ok(exc),
+            libparsec_protocol::ProtocolError::EncodingError { exc } => Ok(exc),
+            libparsec_protocol::ProtocolError::DecodingError { exc } => Ok(exc),
+            libparsec_protocol::ProtocolError::BadRequest { exc } => Ok(exc),
             _ => Err(PyAttributeError::new_err("No such attribute `exc`")),
         }
     }
@@ -79,7 +79,7 @@ pub(crate) type ProtocolResult<T> = Result<T, ProtocolErrorFields>;
 
 crate::binding_utils::gen_py_wrapper_class!(
     ReencryptionBatchEntry,
-    libparsec::low_level::types::ReencryptionBatchEntry,
+    libparsec_types::ReencryptionBatchEntry,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -96,7 +96,7 @@ impl ReencryptionBatchEntry {
     ) -> PyResult<Self> {
         crate::binding_utils::unwrap_bytes!(blob);
         let vlob_id = vlob_id.0;
-        Ok(Self(libparsec::low_level::types::ReencryptionBatchEntry {
+        Ok(Self(libparsec_types::ReencryptionBatchEntry {
             vlob_id,
             version,
             blob,
@@ -125,7 +125,7 @@ impl ReencryptionBatchEntry {
 
 crate::binding_utils::gen_py_wrapper_class!(
     ActiveUsersLimit,
-    libparsec::low_level::types::ActiveUsersLimit,
+    libparsec_types::ActiveUsersLimit,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -137,7 +137,7 @@ impl ActiveUsersLimit {
     #[classmethod]
     #[pyo3(name = "LimitedTo")]
     fn limited_to(_cls: &PyType, user_count_limit: u64) -> Self {
-        Self(libparsec::low_level::types::ActiveUsersLimit::LimitedTo(
+        Self(libparsec_types::ActiveUsersLimit::LimitedTo(
             user_count_limit,
         ))
     }
@@ -148,7 +148,7 @@ impl ActiveUsersLimit {
         lazy_static::lazy_static! {
             static ref VALUE: PyObject = {
                 Python::with_gil(|py| {
-                    ActiveUsersLimit(libparsec::low_level::types::ActiveUsersLimit::NoLimit)
+                    ActiveUsersLimit(libparsec_types::ActiveUsersLimit::NoLimit)
                         .into_py(py)
                 })
             };
@@ -168,10 +168,10 @@ impl ActiveUsersLimit {
 
     fn to_int(&self) -> Option<u64> {
         match self.0 {
-            libparsec::low_level::types::ActiveUsersLimit::LimitedTo(user_count_limit) => {
+            libparsec_types::ActiveUsersLimit::LimitedTo(user_count_limit) => {
                 Some(user_count_limit)
             }
-            libparsec::low_level::types::ActiveUsersLimit::NoLimit => None,
+            libparsec_types::ActiveUsersLimit::NoLimit => None,
         }
     }
 }

--- a/server/src/regex.rs
+++ b/server/src/regex.rs
@@ -6,7 +6,7 @@ use pyo3::{exceptions::PyValueError, pyclass, pymethods, types::PyType, PyResult
 
 crate::binding_utils::gen_py_wrapper_class!(
     Regex,
-    libparsec::low_level::types::Regex,
+    libparsec_types::Regex,
     __repr__,
     __str__,
     __richcmp__ eq,
@@ -16,21 +16,21 @@ crate::binding_utils::gen_py_wrapper_class!(
 impl Regex {
     #[classmethod]
     fn from_file(_cls: &PyType, path: &str) -> PyResult<Self> {
-        libparsec::low_level::types::Regex::from_file(Path::new(path))
+        libparsec_types::Regex::from_file(Path::new(path))
             .map(Self)
             .map_err(|err| PyValueError::new_err(err.to_string()))
     }
 
     #[classmethod]
     fn from_raw_regexes(_cls: &PyType, raw_regexes: Vec<&str>) -> PyResult<Self> {
-        libparsec::low_level::types::Regex::from_raw_regexes(&raw_regexes)
+        libparsec_types::Regex::from_raw_regexes(&raw_regexes)
             .map(Regex)
             .map_err(|err| PyValueError::new_err(err.to_string()))
     }
 
     #[classmethod]
     fn from_glob_pattern(_cls: &PyType, glob_pattern: &str) -> PyResult<Self> {
-        libparsec::low_level::types::Regex::from_glob_pattern(glob_pattern)
+        libparsec_types::Regex::from_glob_pattern(glob_pattern)
             .map(Regex)
             .map_err(|err| {
                 PyValueError::new_err(format!(
@@ -42,7 +42,7 @@ impl Regex {
 
     #[classmethod]
     fn from_regex_str(_cls: &PyType, regex_str: &str) -> PyResult<Self> {
-        libparsec::low_level::types::Regex::from_regex_str(regex_str)
+        libparsec_types::Regex::from_regex_str(regex_str)
             .map(Regex)
             .map_err(|err| {
                 PyValueError::new_err(format!(
@@ -97,7 +97,7 @@ mod test {
                 continue;
             }
 
-            let sub_regex_str = libparsec::low_level::types::Regex::from_glob_pattern(line.trim())
+            let sub_regex_str = libparsec_types::Regex::from_glob_pattern(line.trim())
                 .unwrap()
                 .to_string();
 

--- a/server/src/time.rs
+++ b/server/src/time.rs
@@ -22,25 +22,23 @@ pub(crate) fn mock_time(time: &PyAny) -> PyResult<()> {
 
     #[cfg(feature = "test-utils")]
     {
-        use libparsec::low_level::types::MockedTime;
-        libparsec::low_level::types::DateTime::mock_time(
-            if let Ok(dt) = time.extract::<DateTime>() {
-                MockedTime::FrozenTime(dt.0)
-            } else if let Ok(us) = time.extract::<i64>() {
-                MockedTime::ShiftedTime { microseconds: us }
-            } else if time.is_none() {
-                MockedTime::RealTime
-            } else {
-                return Err(pyo3::exceptions::PyTypeError::new_err("Invalid field time"));
-            },
-        );
+        use libparsec_types::MockedTime;
+        libparsec_types::DateTime::mock_time(if let Ok(dt) = time.extract::<DateTime>() {
+            MockedTime::FrozenTime(dt.0)
+        } else if let Ok(us) = time.extract::<i64>() {
+            MockedTime::ShiftedTime { microseconds: us }
+        } else if time.is_none() {
+            MockedTime::RealTime
+        } else {
+            return Err(pyo3::exceptions::PyTypeError::new_err("Invalid field time"));
+        });
         Ok(())
     }
 }
 
 crate::binding_utils::gen_py_wrapper_class!(
     TimeProvider,
-    libparsec::low_level::types::TimeProvider,
+    libparsec_types::TimeProvider,
     __repr__,
     __copy__,
 );
@@ -49,7 +47,7 @@ crate::binding_utils::gen_py_wrapper_class!(
 impl TimeProvider {
     #[new]
     fn new() -> PyResult<Self> {
-        Ok(Self(libparsec::low_level::types::TimeProvider::default()))
+        Ok(Self(libparsec_types::TimeProvider::default()))
     }
 
     pub fn now(&self) -> PyResult<DateTime> {
@@ -87,9 +85,7 @@ impl TimeProvider {
         let time_provider = self.0.clone();
         let coroutine = FutureIntoCoroutine::from(async move {
             time_provider
-                .sleep(libparsec::low_level::types::Duration::microseconds(
-                    (time * 1e6) as i64,
-                ))
+                .sleep(libparsec_types::Duration::microseconds((time * 1e6) as i64))
                 .await;
             Ok(())
         });
@@ -131,7 +127,7 @@ impl TimeProvider {
 
         #[cfg(feature = "test-utils")]
         {
-            use libparsec::low_level::types::MockedTime;
+            use libparsec_types::MockedTime;
             let mock_config = match (freeze, shift, speed, realtime) {
                 (None, None, None, true) => MockedTime::RealTime,
                 (Some(dt), None, None, false) => MockedTime::FrozenTime(dt.0),
@@ -162,7 +158,7 @@ impl TimeProvider {
 
 crate::binding_utils::gen_py_wrapper_class!(
     DateTime,
-    libparsec::low_level::types::DateTime,
+    libparsec_types::DateTime,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -184,7 +180,7 @@ impl DateTime {
         second: u32,
         microsecond: u32,
     ) -> PyResult<Self> {
-        libparsec::low_level::types::DateTime::from_ymd_hms_us(
+        libparsec_types::DateTime::from_ymd_hms_us(
             year,
             month,
             day,
@@ -235,7 +231,7 @@ impl DateTime {
 
     #[classmethod]
     fn now(_cls: &PyType) -> PyResult<Self> {
-        Ok(Self(libparsec::low_level::types::DateTime::now_legacy()))
+        Ok(Self(libparsec_types::DateTime::now_legacy()))
     }
 
     fn timestamp(&self) -> PyResult<f64> {
@@ -244,14 +240,14 @@ impl DateTime {
 
     #[classmethod]
     fn from_timestamp(_cls: &PyType, ts: f64) -> PyResult<Self> {
-        Ok(Self(
-            libparsec::low_level::types::DateTime::from_f64_with_us_precision(ts),
-        ))
+        Ok(Self(libparsec_types::DateTime::from_f64_with_us_precision(
+            ts,
+        )))
     }
 
     #[classmethod]
     fn from_rfc3339(_cls: &PyType, value: &str) -> PyResult<Self> {
-        libparsec::low_level::types::DateTime::from_rfc3339(value)
+        libparsec_types::DateTime::from_rfc3339(value)
             .map(Self)
             .map_err(|e| PyValueError::new_err(format!("Invalid rfc3339 date `{}`: {}", value, e)))
     }
@@ -308,7 +304,7 @@ impl DateTime {
 
 crate::binding_utils::gen_py_wrapper_class!(
     LocalDateTime,
-    libparsec::low_level::types::LocalDateTime,
+    libparsec_types::LocalDateTime,
     __repr__,
     __copy__,
     __deepcopy__,
@@ -330,7 +326,7 @@ impl LocalDateTime {
         second: u32,
         microsecond: u32,
     ) -> PyResult<Self> {
-        libparsec::low_level::types::LocalDateTime::from_ymd_hms_us(
+        libparsec_types::LocalDateTime::from_ymd_hms_us(
             year,
             month,
             day,
@@ -381,7 +377,7 @@ impl LocalDateTime {
     #[classmethod]
     fn from_timestamp(_cls: &PyType, ts: f64) -> PyResult<Self> {
         Ok(Self(
-            libparsec::low_level::types::LocalDateTime::from_f64_with_us_precision(ts),
+            libparsec_types::LocalDateTime::from_f64_with_us_precision(ts),
         ))
     }
 


### PR DESCRIPTION
On my machine, clean `./make.py r` goes from 2m42 to 1mn40 with this

Python bindings don't need all the client-related stuff from libparsec (which itself has plenty of heavy dependencies such as diesel), so only keeping the crate we actually need seems to really pay off ^^