### PR TITLE
Rewrite a small part of crypto comment about OpenSSL on Linux

### DIFF
--- a/libparsec/crates/crypto/Cargo.toml
+++ b/libparsec/crates/crypto/Cargo.toml
@@ -58,7 +58,7 @@ libsodium-sys = { workspace = true, optional = true }
 #
 # "openssl-for-parsec" support is why the dependence is specified here.
 # "openssl-for-reqwest", however, is only needed on Linux (reqwest uses the
-# OS's SSL implementation, which on Linux *is* OpensSSL).
+# OS's SSL implementation, we consider it to be provided by OpenSSL).
 #
 # On top of that non-Linux platforms don't provide an OpenSSL we can rely on,
 # hence we must vendor it when we need "openssl-for-parsec".


### PR DESCRIPTION
That SSL implementation on linux isn't limited to OpenSSL (LibreSSL or WolfSSL can be used).
So I rectified the comment indicating that we `consider` the SSL implementation to be provided by OpenSSL.
