### PR TITLE
Fix `libparsec_bindings_electron` does not have the feature `use-sodiumoxide`

### DIFF
--- a/bindings/electron/src/index.d.ts
+++ b/bindings/electron/src/index.d.ts
@@ -9,6 +9,44 @@ export type Result<T, E = Error> =
   | { ok: true; value: T }
   | { ok: false; error: E }
 
+export enum UserProfile {
+    Admin = 'UserProfileAdmin',
+    Outsider = 'UserProfileOutsider',
+    Standard = 'UserProfileStandard',
+}
+
+export enum RealmRole {
+    Contributor = 'RealmRoleContributor',
+    Manager = 'RealmRoleManager',
+    Owner = 'RealmRoleOwner',
+    Reader = 'RealmRoleReader',
+}
+
+export enum DeviceFileType {
+    Password = 'DeviceFileTypePassword',
+    Recovery = 'DeviceFileTypeRecovery',
+    Smartcard = 'DeviceFileTypeSmartcard',
+}
+
+export enum InvitationStatus {
+    Deleted = 'InvitationStatusDeleted',
+    Idle = 'InvitationStatusIdle',
+    Ready = 'InvitationStatusReady',
+}
+
+export enum InvitationEmailSentStatus {
+    BadRecipient = 'InvitationEmailSentStatusBadRecipient',
+    NotAvailable = 'InvitationEmailSentStatusNotAvailable',
+    Success = 'InvitationEmailSentStatusSuccess',
+}
+
+export enum OS {
+    Android = 'OSAndroid',
+    Linux = 'OSLinux',
+    MacOs = 'OSMacOs',
+    Windows = 'OSWindows',
+}
+
 
 export interface HumanHandle {
     email: string

--- a/bindings/generator/templates/binding_electron_index.d.ts.j2
+++ b/bindings/generator/templates/binding_electron_index.d.ts.j2
@@ -48,6 +48,18 @@ Uint8Array
 export type Result<T, E = Error> =
   | { ok: true; value: T }
   | { ok: false; error: E }
+
+{# Simple enum #}
+{% for enum in api.enums %}
+export enum {{ enum.name }} {
+{% for variant_name in enum.member_names %}
+    {{ variant_name }} = '{{ enum.name + variant_name }}',
+{% endfor -%}
+}
+{% if not loop.last %}
+
+{% endif %}
+{% endfor %}
 {# Structures #}
 {% for struct in api.structs %}
 

--- a/client/src/plugins/libparsec/definitions.ts
+++ b/client/src/plugins/libparsec/definitions.ts
@@ -45,9 +45,9 @@ export enum OS {
     MacOs = 'OSMacOs',
     Windows = 'OSWindows',
 }
-export type VlobID = string
 export type InvitationToken = string
 export type OrganizationID = string
+export type VlobID = string
 export type BackendAddr = string
 export type BackendOrganizationAddr = string
 export type BackendOrganizationBootstrapAddr = string

--- a/make.py
+++ b/make.py
@@ -32,7 +32,7 @@ PYTHON_DEV_CARGO_FLAGS = "--profile=dev-python --features test-utils"
 PYTHON_CI_CARGO_FLAGS = "--profile=ci-python --features test-utils"
 
 ELECTRON_RELEASE_CARGO_FLAGS = (
-    f"--profile=release --features use-sodiumoxide {MAYBE_FORCE_VENDORED_OPENSSL}"
+    f"--profile=release --features libparsec/use-sodiumoxide {MAYBE_FORCE_VENDORED_OPENSSL}"
 )
 ELECTRON_DEV_CARGO_FLAGS = "--profile=dev --features test-utils"
 ELECTRON_CI_CARGO_FLAGS = "--profile=ci-rust --features test-utils"


### PR DESCRIPTION
Closes #5233