### PR TITLE
Don't use regex for OrganizationID/UserID/DeviceName validation to speedup tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,6 +1658,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "regex",
+ "regex-syntax",
  "rmp-serde",
  "rstest",
  "rstest_reuse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ rand_07 = { package = "rand", version = "0.7", default-features = false }
 rand_08 = { package = "rand", version = "0.8", default-features = false }
 rand = { version = "0.8.5", default-features = false }
 regex = { version = "1.9.6", default-features = false }
+regex-syntax = { version = "0.7.5", default-features = false }
 reqwest-eventsource = { version = "0.4.0", default-features = false }
 reqwest = { version = "0.11.22", default-features = false }
 rmp-serde = { version = "1.1.2", default-features = false }

--- a/libparsec/crates/types/Cargo.toml
+++ b/libparsec/crates/types/Cargo.toml
@@ -33,6 +33,7 @@ data-encoding = { workspace = true, features = ["std"] }
 url = { workspace = true }
 percent-encoding = { workspace = true, features = ["alloc"] }
 regex = { workspace = true, features = ["std", "perf", "unicode"] }
+regex-syntax = { workspace = true, features = ["unicode-perl"] }
 unicode-normalization = { workspace = true, features = ["std"] }
 paste = { workspace = true }
 flate2 = { workspace = true, features = ["rust_backend"] }

--- a/libparsec/crates/types/tests/id.rs
+++ b/libparsec/crates/types/tests/id.rs
@@ -15,31 +15,44 @@ fn device_label_bad_size() {
 }
 
 #[rstest]
-#[case("foo42")]
-#[case("FOO")]
-#[case("f")]
-#[case("f-o-o")]
-#[case("f_o_o")]
-#[case(&"x".repeat(32))]
-#[case("三国")]
+#[case::text_32_long("This_one_is_exactly_32_char_long")]
+#[case::alphanum("01239AbcdDEFA")]
+#[case::with_underscore("hello_World")]
+#[case::with_hyphen("hello-World")]
+// cspell:disable-next-line
+#[case::with_unicode_1("ªµºÖØøˆˠˬˮ\u{301}ͶͽͿΆΊ")]
+#[case::with_unicode_2("ΌΎΣҁ\u{484}Աՙֈ\u{5c7}\u{5bf}\u{5c1}\u{5af}\u{5c4}")]
+#[case::with_unicode_3("ת\u{5ef}\u{610}٩ۓە")]
+#[case::with_unicode_4("\u{6ea}\u{6df}ۿܐݍ߀ߺ\u{7fd}ࠀࡀ")]
+// cspell:disable-next-line
+#[case::hello("𝔅𝔬𝔫𝔧𝔬𝔲𝔯")]
 fn organization_id_user_id_and_device_name(#[case] raw: &str) {
+    use unicode_normalization::UnicodeNormalization;
+
+    let nfc_raw = raw.nfc().collect::<String>();
+    p_assert_eq!(raw, nfc_raw, "raw != nfc_raw (expected `{:#?}`)", nfc_raw);
+
     let organization_id = OrganizationID::from_str(raw).unwrap();
     p_assert_eq!(organization_id.to_string(), raw);
+    p_assert_eq!(organization_id.as_ref(), raw);
     p_assert_eq!(organization_id, OrganizationID::from_str(raw).unwrap());
 
     let user_id = UserID::from_str(raw).unwrap();
     p_assert_eq!(user_id.to_string(), raw);
+    p_assert_eq!(user_id.as_ref(), raw);
     p_assert_eq!(user_id, UserID::from_str(raw).unwrap());
 
     let device_name = DeviceName::from_str(raw).unwrap();
     p_assert_eq!(device_name.to_string(), raw);
+    p_assert_eq!(device_name.as_ref(), raw);
     p_assert_eq!(device_name, DeviceName::from_str(raw).unwrap());
 }
 
 #[rstest]
-#[case(&"x".repeat(33))]
-#[case("F~o")]
-#[case("f o")]
+#[case::text_33_long("This_text_is_exactly_33_char_long")]
+#[case::empty("")]
+#[case::invalid_tilde("F~o")]
+#[case::invalid_space("f o")]
 fn bad_organization_id_user_id_and_device_name(#[case] raw: &str) {
     OrganizationID::from_str(raw).unwrap_err();
     UserID::from_str(raw).unwrap_err();

--- a/libparsec/src/validation.rs
+++ b/libparsec/src/validation.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 /// Validate a label without doing a unicode normalization.
 pub fn validate_entry_name(raw: &str) -> bool {
-    libparsec_types::EntryName::is_valid(raw).is_ok()
+    libparsec_types::EntryName::from_str(raw).is_ok()
 }
 
 pub fn validate_path(raw: &str) -> bool {
@@ -23,7 +23,7 @@ pub fn validate_email(raw: &str) -> bool {
 
 /// Validate a label without doing a unicode normalization.
 pub fn validate_device_label(raw: &str) -> bool {
-    libparsec_types::DeviceLabel::is_valid(raw)
+    libparsec_types::DeviceLabel::from_str(raw).is_ok()
 }
 
 pub fn validate_invitation_token(raw: &str) -> bool {


### PR DESCRIPTION
Regex compilation is done once but is very costly. When testing this is done for every test (since nextest runs each test in it own process).
Given the regex pattern is simple, we can instead to the check by hand ;-)

Bench:
```
# master
$ cargo nextest run
[...]
     Summary [   4.271s] 1380 tests run: 1380 passed, 1 skipped
# This PR
$ cargo nextest run
[...]
Summary [   3.159s] 1380 tests run: 1380 passed, 1 skipped
```

This is still a WIP though: we use `\w` pattern rule [which corresponds to `word character (\p{Alphabetic} + \p{M} + \d + \p{Pc} + \p{Join_Control})`](https://docs.rs/regex/1.9.5/regex/#perl-character-classes-unicode-friendly)
So we should take extra care that this is correctly handled (and add more tests about that !)
