### PR TITLE
Update get_available_workspaces and similar methods

### DIFF
--- a/parsec/core/cli/list_workspace.py
+++ b/parsec/core/cli/list_workspace.py
@@ -75,9 +75,7 @@ async def _list_workspaces(config: CoreConfig, device: LocalDevice) -> None:
         # Force the archiving status to update
         await core.user_fs.update_archiving_status()
 
-        entries = core.user_fs.get_available_workspace_entries()
-        for entry in entries:
-            workspace = core.user_fs.get_workspace(entry.id)
+        for workspace in core.user_fs.get_available_workspaces():
             await _show_workspace(core, workspace)
 
 

--- a/parsec/core/fs/userfs/userfs.py
+++ b/parsec/core/fs/userfs/userfs.py
@@ -387,30 +387,30 @@ class UserFS:
             raise ValueError("Storage not set")
         return self.storage.get_user_manifest()
 
-    def get_all_workspace_entries(self) -> tuple[list[WorkspaceEntry], list[WorkspaceEntry]]:
+    def get_all_workspaces(self) -> tuple[list[WorkspaceFS], list[WorkspaceFS]]:
         user_manifest = self.get_user_manifest()
-        available_entries = []
-        unavailable_entries = []
+        available_workspaces: list[WorkspaceFS] = []
+        unavailable_workspaces: list[WorkspaceFS] = []
         for workspace_entry in user_manifest.workspaces:
             try:
                 workspace = self.get_workspace(workspace_entry.id)
             except FSWorkspaceNotFoundError:
                 continue
             if workspace_entry.role is None:
-                unavailable_entries.append(workspace_entry)
+                unavailable_workspaces.append(workspace)
             elif workspace.is_deleted():
-                unavailable_entries.append(workspace_entry)
+                unavailable_workspaces.append(workspace)
             else:
-                available_entries.append(workspace_entry)
-        return available_entries, unavailable_entries
+                available_workspaces.append(workspace)
+        return available_workspaces, unavailable_workspaces
 
-    def get_available_workspace_entries(self) -> list[WorkspaceEntry]:
-        available_entries, _ = self.get_all_workspace_entries()
-        return available_entries
+    def get_available_workspaces(self) -> list[WorkspaceFS]:
+        available_workspaces, _ = self.get_all_workspaces()
+        return available_workspaces
 
-    def get_unavailable_workspace_entries(self) -> list[WorkspaceEntry]:
-        _, unavailable_entries = self.get_all_workspace_entries()
-        return unavailable_entries
+    def get_unavailable_workspaces(self) -> list[WorkspaceFS]:
+        _, unavailable_workspaces = self.get_all_workspaces()
+        return unavailable_workspaces
 
     async def set_user_manifest(self, manifest: LocalUserManifest) -> None:
         if self.storage is None:

--- a/parsec/core/gui/workspaces_widget.py
+++ b/parsec/core/gui/workspaces_widget.py
@@ -81,17 +81,10 @@ async def _do_workspace_rename(
 
 
 async def _do_workspace_list(core: LoggedCore) -> list[WorkspaceFS]:
-    workspaces = []
-    available_workspaces = core.user_fs.get_available_workspace_entries()
-    for workspace in available_workspaces:
-        workspace_id = workspace.id
-        workspace_fs = core.user_fs.get_workspace(workspace_id)
-        workspaces.append(workspace_fs)
+    available_workspaces = core.user_fs.get_available_workspaces()
     workspaces_timestamped_dict = await core.mountpoint_manager.get_timestamped_mounted()
-    for (workspace_id, timestamp), workspace_fs in workspaces_timestamped_dict.items():
-        workspaces.append(workspace_fs)
-
-    return workspaces
+    timestamped_workspaces: list[WorkspaceFS] = list(workspaces_timestamped_dict.values())
+    return available_workspaces + timestamped_workspaces
 
 
 async def _do_workspace_mount(

--- a/parsec/core/logged_core.py
+++ b/parsec/core/logged_core.py
@@ -130,9 +130,9 @@ class LoggedCore:
 
     def find_workspace_from_name(self, workspace_name: EntryName) -> WorkspaceEntry:
         # Note: it does not include deleted workspaces
-        for workspace in self.user_fs.get_available_workspace_entries():
-            if workspace_name == workspace.name:
-                return workspace
+        for workspace in self.user_fs.get_available_workspaces():
+            if workspace_name == workspace.get_workspace_name():
+                return workspace.get_workspace_entry()
         raise FSWorkspaceNotFoundError(f"Unknown workspace {workspace_name.str}")
 
     async def find_humans(

--- a/parsec/core/mountpoint/manager.py
+++ b/parsec/core/mountpoint/manager.py
@@ -355,17 +355,16 @@ class MountpointManager:
 
     async def safe_mount_all(self, exclude: Sequence[EntryID] = ()) -> None:
         exclude_set = set(exclude)
-        for workspace_entry in self.user_fs.get_available_workspace_entries():
-            if workspace_entry.id in exclude_set:
+        for workspace in self.user_fs.get_available_workspaces():
+            if workspace.workspace_id in exclude_set:
                 continue
-            workspace_fs = self.user_fs.get_workspace(workspace_entry.id)
             # Do not mount archived workspaces unless we're asked to
-            if workspace_fs.is_archived():
+            if workspace.is_archived():
                 continue
             # Do not mount deletion-planned workspaces unless we're asked to
-            if workspace_fs.is_deletion_planned():
+            if workspace.is_deletion_planned():
                 continue
-            await self.safe_mount(workspace_entry.id)
+            await self.safe_mount(workspace.workspace_id)
 
     async def safe_unmount_all(self) -> None:
         for workspace_id, timestamp in list(self._mountpoint_tasks.keys()):

--- a/parsec/core/mountpoint/winfsp_runner.py
+++ b/parsec/core/mountpoint/winfsp_runner.py
@@ -197,9 +197,9 @@ async def winfsp_mountpoint_runner(
         drive_letter = ""
         volume_serial_number = 0
     else:
-        workspace_ids = [entry.id for entry in user_fs.get_available_workspace_entries()]
+        workspace_ids = [workspace.workspace_id for workspace in user_fs.get_available_workspaces()]
+        # Check if we're trying to mount a workspace that is not available
         if workspace_fs.workspace_id not in workspace_ids:
-            # We're trying to mount a workspace that is not available
             # Here is not the right place to deal with it, so just add it to the list
             workspace_ids.append(workspace_fs.workspace_id)
         workspace_index = workspace_ids.index(workspace_fs.workspace_id)

--- a/parsec/core/remanence_monitor.py
+++ b/parsec/core/remanence_monitor.py
@@ -161,17 +161,19 @@ async def monitor_remanent_workspaces(
                 (CoreEvent.FS_WORKSPACE_CREATED, cast(EventCallback, _fs_workspace_created)),
             ):
                 # All workspaces should be processed at startup
-                available_workspaces, unavailable_workspaces = user_fs.get_all_workspace_entries()
+                available_workspaces, unavailable_workspaces = user_fs.get_all_workspaces()
 
                 # Clean up unavailable workspaces if necessary
                 cleanup_tasks_scheduled = any(
-                    _on_read_rights_removed(entry.id) for entry in unavailable_workspaces
+                    _on_read_rights_removed(workspace.workspace_id)
+                    for workspace in unavailable_workspaces
                 )
 
                 # Each workspace will have it own task that will start awake,
                 # then switch to idle
                 manager_tasks_scheduled = any(
-                    _start_remanence_manager(entry.id) for entry in available_workspaces
+                    _start_remanence_manager(workspace.workspace_id)
+                    for workspace in available_workspaces
                 )
 
                 # Set idle status if no task has been scheduled

--- a/parsec/core/sync_monitor.py
+++ b/parsec/core/sync_monitor.py
@@ -489,8 +489,8 @@ async def monitor_sync(
         assert ctx is not None
         await _ctx_action(ctx, "bootstrap")
         # Init workspaces sync context
-        for entry in user_fs.get_available_workspace_entries():
-            ctx = ctxs.get(entry.id)
+        for workspace in user_fs.get_available_workspaces():
+            ctx = ctxs.get(workspace.workspace_id)
             if ctx:
                 await _ctx_action(ctx, "bootstrap")
 

--- a/tests/core/fs/workspacefs/test_archiving.py
+++ b/tests/core/fs/workspacefs/test_archiving.py
@@ -123,12 +123,12 @@ async def test_configure_archiving(
 
     # Test get_available_workspace_entries
     for user_fs in (alice_user_fs, bob_user_fs):
-        available_entries = user_fs.get_available_workspace_entries()
+        available_workspaces = user_fs.get_available_workspaces()
         if configuration == "deleted":
-            assert available_entries == []
+            assert available_workspaces == []
         elif configuration in ["available", "archived", "deletion_planned"]:
-            (entry,) = available_entries
-            assert entry.name == EntryName("w")
+            (workspace,) = available_workspaces
+            assert workspace.get_workspace_name() == EntryName("w")
         else:
             assert False
 


### PR DESCRIPTION
PR #5061 introduces the following methods to `UserFS`:
- `get_all_workspace_entries()` 
- `get_available_workspace_entries()` 
- `get_unavailable_workspace_entries()` 

Instead it's more convenient to return lists of `WorkspaceFS` objects and rename them to:
- `get_all_workspaces()` 
- `get_available_workspaces()` 
- `get_unavailable_workspaces()` 