### PR TITLE
Manage `parsec` version in `docs/conf.py`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,15 +18,6 @@
 
 import os
 
-
-# Load Parsec version
-def fetch_parsec_version():
-    # Awesome hack to load `__version__`
-    _version_locals = {}
-    exec(open("../server/parsec/_version.py", encoding="utf-8").read(), _version_locals)
-    return _version_locals["__version__"]
-
-
 # -- General configuration ---------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -67,7 +58,7 @@ copyright = "2016-present, Scille SAS"
 # the built documents.
 #
 # The short X.Y version.
-version = fetch_parsec_version()
+version = "2.16.0-a.0+dev"
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/misc/version_updater.py
+++ b/misc/version_updater.py
@@ -137,6 +137,8 @@ FILES_WITH_VERSION_INFO: Dict[Path, Dict[Tool, RawRegexes]] = {
         Tool.WasmPack: [ReplaceRegex(r"wasm-pack@[0-9.]+", "wasm-pack@{version}")],
     },
     ROOT_DIR
+    / "docs/conf.py": {Tool.Parsec: [ReplaceRegex(r'version = ".*"', 'version = "{version}"')]},
+    ROOT_DIR
     / "licenses/BUSL-Scille.txt": {
         Tool.Parsec: [
             ReplaceRegex(r"^Licensed Work:  Parsec v.*$", "Licensed Work:  Parsec v{version}")


### PR DESCRIPTION
Since we already manager the `parsec` version with the script `version_updater`, we can use that script to update the version in `docs/conf.py` that simplify the script as it won't rely on a external file of `docs`