### PR TITLE
[MS] Removed .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ target/
 .cspellcache
 
 node_modules
+
+# Each dev can set up their own env
+client/.env

--- a/client/.env
+++ b/client/.env
@@ -1,1 +1,0 @@
-VITE_TESTBED_SERVER_URL='parsec://127.0.0.1:6770?no_ssl=true'


### PR DESCRIPTION
.env sets the testbed env variable even if you don't want it, which causes problems when you want to test with a real server. Getting rid of it while adding it to the .gitignore so devs can set it up as they want.