### PR TITLE
[MS] Removed WorkspaceID, WorkspaceRole and WorkspaceName from mocks

### DIFF
--- a/client/src/common/mocks.ts
+++ b/client/src/common/mocks.ts
@@ -3,7 +3,7 @@
 // cSpell:disable
 
 import { DateTime } from 'luxon';
-import { AvailableDevice, Handle, DeviceFileType, UserProfile } from '@/parsec';
+import { AvailableDevice, Handle, DeviceFileType, UserProfile, WorkspaceRole, WorkspaceID, WorkspaceName } from '@/parsec';
 import { StorageManager } from '@/services/storageManager';
 import { uniqueNamesGenerator, adjectives, colors, animals } from 'unique-names-generator';
 
@@ -89,16 +89,6 @@ export function pathInfo(_path: string, random = false): MockFile {
   }
   return fixedPathInfo();
 }
-
-export enum WorkspaceRole {
-  Owner = 'owner',
-  Manager = 'manager',
-  Contributor = 'contributor',
-  Reader = 'reader',
-}
-
-export type WorkspaceName = string;
-export type WorkspaceID = string;
 
 export function getSharedWith(workspace: MockWorkspace): string[] {
   const people = [];

--- a/client/src/components/workspaces/WorkspaceTagRole.vue
+++ b/client/src/components/workspaces/WorkspaceTagRole.vue
@@ -14,7 +14,7 @@
 <script setup lang="ts">
 import { IonChip, IonLabel } from '@ionic/vue';
 import { defineProps } from 'vue';
-import { WorkspaceRole } from '@/common/mocks';
+import { WorkspaceRole } from '@/parsec';
 import { useI18n } from 'vue-i18n';
 
 const { t } = useI18n();

--- a/client/src/components/workspaces/WorkspaceUserRole.vue
+++ b/client/src/components/workspaces/WorkspaceUserRole.vue
@@ -22,7 +22,7 @@
 
 <script setup lang="ts">
 import { defineProps, defineEmits } from 'vue';
-import { WorkspaceRole } from '@/common/mocks';
+import { WorkspaceRole } from '@/parsec';
 import MsSelect from '@/components/core/ms-select/MsSelect.vue';
 import { Ref, ref } from 'vue';
 import { useI18n } from 'vue-i18n';

--- a/client/src/parsec/types.ts
+++ b/client/src/parsec/types.ts
@@ -57,6 +57,7 @@ import {
   InvitationEmailSentStatus,
   InvitationStatus,
   UserProfile,
+  RealmRole as WorkspaceRole,
 } from '@/plugins/libparsec';
 import { DateTime } from 'luxon';
 
@@ -118,6 +119,7 @@ export {
   UserGreetInProgress2Info,
   UserGreetInProgress3Info,
   UserGreetInProgress4Info,
+  WorkspaceRole,
 };
 
 export {

--- a/client/src/views/workspaces/WorkspaceSharingModal.vue
+++ b/client/src/views/workspaces/WorkspaceSharingModal.vue
@@ -40,8 +40,9 @@ import {
   modalController,
 } from '@ionic/vue';
 import { ref, watch, onUnmounted, onMounted } from 'vue';
-import { getWorkspaceSharingInfo, WorkspaceRole, WorkspaceID } from '@/common/mocks';
+import { getWorkspaceSharingInfo } from '@/common/mocks';
 import { MsModalResult } from '@/components/core/ms-types';
+import { WorkspaceID, WorkspaceRole } from '@/parsec';
 
 import WorkspaceUserRole from '@/components/workspaces/WorkspaceUserRole.vue';
 import MsModal from '@/components/core/ms-modal/MsModal.vue';

--- a/client/tests/component/specs/testWorkspaceCard.spec.ts
+++ b/client/tests/component/specs/testWorkspaceCard.spec.ts
@@ -1,11 +1,12 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { MockWorkspace, WorkspaceRole } from '@/common/mocks';
+import { MockWorkspace } from '@/common/mocks';
 import { mount, VueWrapper } from '@vue/test-utils';
 import { DateTime } from 'luxon';
 import { mockI18n, getDefaultProvideConfig } from 'tests/component/support/mocks';
 import { IonAvatar } from '@ionic/vue';
 import WorkspaceCard from '@/components/workspaces/WorkspaceCard.vue';
+import { WorkspaceRole } from '@/parsec';
 
 mockI18n();
 

--- a/client/tests/component/specs/testWorkspaceListItem.spec.ts
+++ b/client/tests/component/specs/testWorkspaceListItem.spec.ts
@@ -1,11 +1,12 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { MockWorkspace, WorkspaceRole } from '@/common/mocks';
+import { MockWorkspace } from '@/common/mocks';
 import { mount, VueWrapper } from '@vue/test-utils';
 import { DateTime } from 'luxon';
 import { mockI18n, getDefaultProvideConfig } from 'tests/component/support/mocks';
 import { IonAvatar } from '@ionic/vue';
 import WorkspaceListItem from '@/components/workspaces/WorkspaceListItem.vue';
+import { WorkspaceRole } from '@/parsec';
 
 mockI18n();
 

--- a/client/tests/component/specs/testWorkspaceTagRole.spec.ts
+++ b/client/tests/component/specs/testWorkspaceTagRole.spec.ts
@@ -5,7 +5,7 @@ import { mockI18n, getDefaultProvideConfig } from 'tests/component/support/mocks
 mockI18n();
 
 import WorkspaceTagRole from '@/components/workspaces/WorkspaceTagRole.vue';
-import { WorkspaceRole } from '@/common/mocks';
+import { WorkspaceRole } from '@/parsec';
 import { mount } from '@vue/test-utils';
 
 describe('User Avatar', () => {

--- a/client/tests/e2e/specs/test_workspace_sharing_modal.ts
+++ b/client/tests/e2e/specs/test_workspace_sharing_modal.ts
@@ -41,7 +41,7 @@ describe('Check workspace sharing modal', () => {
     cy.get('.popover-viewport').find('ion-item').eq(0).click();
     cy.get('ion-list').find('.content').eq(4).find('.filter-button').contains('Reader');
     // cspell:disable-next-line
-    cy.get('@consoleLog').should('have.been.calledWith', 'Update user Cernd role to reader');
+    cy.get('@consoleLog').should('have.been.calledWith', 'Update user Cernd role to RealmRoleReader');
   });
 
   it('Filter users', () => {


### PR DESCRIPTION
Cleaning up the mocks a bit.