### PR TITLE
Use `BigInt` for 64-bits integer

### DIFF
--- a/bindings/electron/src/index.d.ts
+++ b/bindings/electron/src/index.d.ts
@@ -633,7 +633,7 @@ export interface EntryInfoFile {
     base_version: number
     is_placeholder: boolean
     need_sync: boolean
-    size: number
+    size: BigInt
 }
 export interface EntryInfoFolder {
     tag: "Folder"

--- a/bindings/electron/src/meths.rs
+++ b/bindings/electron/src/meths.rs
@@ -2658,7 +2658,7 @@ fn variant_entry_info_js_to_rs<'a>(
                 js_val.value(cx)
             };
             let size = {
-                let js_val: Handle<JsNumber> = obj.get(cx, "size")?;
+                let js_val: Handle<BigInt> = obj.get(cx, "size")?;
                 {
                     let v = js_val.value(cx);
                     if v < (u64::MIN as f64) || (u64::MAX as f64) < v {

--- a/bindings/generator/templates/binding_electron_index.d.ts.j2
+++ b/bindings/generator/templates/binding_electron_index.d.ts.j2
@@ -22,8 +22,10 @@ Array<{{ render_type(t.elem) }}>
 null
 {%- elif t.kind == "bool" -%}
 boolean
-{%- elif t.kind in ("i32_based", "u32_based", "i64_based", "u64_based", "f64_based", "float") -%}
+{%- elif t.kind in ("i32_based", "u32_based", "f64_based", "float") -%}
 number
+{%- elif t.kind in ("i64_based", "u64_based") -%}
+BigInt
 {%- elif t.kind in ("str", "str_based") -%}
 string
 {%- elif t.kind in ("bytes", "bytes_based") -%}

--- a/bindings/generator/templates/binding_electron_meths.rs.j2
+++ b/bindings/generator/templates/binding_electron_meths.rs.j2
@@ -19,8 +19,10 @@ JsValue
 JsNull
 {%- elif type.kind == "bool" -%}
 JsBoolean
-{%- elif type.kind in ("i32_based", "u32_based", "i64_based", "u64_based", "f64_based", "float") -%}
+{%- elif type.kind in ("i32_based", "u32_based", "f64_based", "float") -%}
 JsNumber
+{%- elif type.kind in ("i64_based", "u64_based") -%}
+BigInt
 {%- elif type.kind in ("str", "str_based") -%}
 JsString
 {%- elif type.kind in ("bytes", "bytes_based") -%}

--- a/bindings/generator/templates/binding_web_meths.rs.j2
+++ b/bindings/generator/templates/binding_web_meths.rs.j2
@@ -169,22 +169,12 @@ if {{ js_val }}.is_null() {
     }
     v as u32
 }
-{%- elif type.kind == "i64_based" -%}
-{
-    let v = {{ js_val }}.dyn_into::<Number>().map_err(|_| TypeError::new("Not a number"))?.value_of();
-    if v < (i64::MIN as f64) || (i64::MAX as f64) < v {
-        return Err(JsValue::from(TypeError::new("Not an i64 number")));
-    }
-    v as i64
-}
-{%- elif type.kind == "u64_based" -%}
-{
-    let v = {{ js_val }}.dyn_into::<Number>().map_err(|_| TypeError::new("Not a number"))?.value_of();
-    if v < (u64::MIN as f64) || (u64::MAX as f64) < v {
-        return Err(JsValue::from(TypeError::new("Not an u64 number")));
-    }
-    v as u64
-}
+{%- elif type.kind in ("i64_based", "u64_based") -%}
+{% set rs_type = "i64" if type.kind == "i64_based" else "u64" %}
+{{ js_val }}
+    .dyn_into::<BigInt>()
+    .map_err(|_| TypeError::new("Not a number"))
+    .and_then(|v| {{ rs_type }}::try_from(v).map_err(|_| TypeError::new("Not an {{ rs_type }} number")))?
 {%- elif type.kind == "f64_based" -%}
 {
     let v = {{ js_val }}.dyn_into::<Number>()?.value_of();

--- a/bindings/generator/templates/client_plugin_definitions.ts.j2
+++ b/bindings/generator/templates/client_plugin_definitions.ts.j2
@@ -78,11 +78,18 @@ export type {{ type.name }} = Uint8Array
 {% endif %}
 {% endfor %}
 {# Number-based types #}
-{% for type in api.i32_based_types + api.u32_based_types + api.i64_based_types + api.u64_based_types + api.f64_based_types %}
+{% for type in api.i32_based_types + api.u32_based_types + api.f64_based_types %}
 {% if type.custom_ts_type_declaration %}
 {{ type.custom_ts_type_declaration }}
 {% else %}
 export type {{ type.name }} = number
+{% endif %}
+{% endfor %}
+{% for type in api.i64_based_types + api.u64_based_types %}
+{% if type.custom_ts_type_declaration %}
+{{ type.custom_ts_type_declaration }}
+{% else %}
+export type {{ type.name }} = bigint
 {% endif %}
 {% endfor %}
 {# Structures #}

--- a/bindings/web/src/meths.rs
+++ b/bindings/web/src/meths.rs
@@ -2682,16 +2682,12 @@ fn variant_entry_info_js_to_rs(obj: JsValue) -> Result<libparsec::EntryInfo, JsV
             };
             let size = {
                 let js_val = Reflect::get(&obj, &"size".into())?;
-                {
-                    let v = js_val
-                        .dyn_into::<Number>()
-                        .map_err(|_| TypeError::new("Not a number"))?
-                        .value_of();
-                    if v < (u64::MIN as f64) || (u64::MAX as f64) < v {
-                        return Err(JsValue::from(TypeError::new("Not an u64 number")));
-                    }
-                    v as u64
-                }
+                js_val
+                    .dyn_into::<BigInt>()
+                    .map_err(|_| TypeError::new("Not a number"))
+                    .and_then(|v| {
+                        u64::try_from(v).map_err(|_| TypeError::new("Not an u64 number"))
+                    })?
             };
             Ok(libparsec::EntryInfo::File {
                 confinement_point,

--- a/client/src/plugins/libparsec/definitions.ts
+++ b/client/src/plugins/libparsec/definitions.ts
@@ -67,11 +67,11 @@ export type CacheSize = number
 export type Handle = number
 export type U32 = number
 export type VersionInt = number
-export type I64 = number
-export type IndexInt = number
-export type SizeInt = number
-export type U64 = number
 export type { DateTime } from 'luxon'; import type { DateTime } from 'luxon';
+export type I64 = bigint
+export type IndexInt = bigint
+export type SizeInt = bigint
+export type U64 = bigint
 
 export interface AvailableDevice {
     keyFilePath: Path


### PR DESCRIPTION
To support 64-bits integer in the Javascript binding, I discover that we need to convert the rust type `i64` & `u64` to `BigInt` to not lose information.

Blocked by:

- [x] #5379