### PR TITLE
[MS] Fixed rmdir and mkdir, add a message for empty folders

### DIFF
--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -282,6 +282,7 @@
         "import": "Import",
         "itemCount": "No items | 1 item | {count} items",
         "itemSelectedCount": "No selected items | 1 selected item | {count} selected items",
+        "emptyFolder": "This folder is empty.",
         "listDisplayTitles": {
             "name": "Name",
             "updatedBy": "Updated By",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -282,6 +282,7 @@
         "import": "Import",
         "itemCount": "Aucun élément | U1n élément | {count} éléments",
         "itemSelectedCount": "Aucun élément sélectionné | 1 élément sélectionné | {count} éléments sélectionnés",
+        "emptyFolder": "Ce dossier est vide.",
         "listDisplayTitles": {
             "name": "Nom",
             "updatedBy": "Modifié par",

--- a/client/src/parsec/file.ts
+++ b/client/src/parsec/file.ts
@@ -33,7 +33,7 @@ export async function createFolder(path: FsPath): Promise<Result<FileID, Workspa
   const workspaceHandle = getWorkspaceHandle();
 
   if (clientHandle && workspaceHandle && window.isDesktop()) {
-    return await libparsec.workspaceCreateFolderAll(workspaceHandle, path);
+    return await libparsec.workspaceCreateFolder(workspaceHandle, path);
   } else {
     return {ok: true, value: '7'};
   }
@@ -55,7 +55,7 @@ export async function deleteFolder(path: FsPath): Promise<Result<null, Workspace
   const workspaceHandle = getWorkspaceHandle();
 
   if (clientHandle && workspaceHandle && window.isDesktop()) {
-    return await libparsec.workspaceRemoveFolderAll(workspaceHandle, path);
+    return await libparsec.workspaceRemoveFolder(workspaceHandle, path);
   } else {
     return {ok: true, value: null};
   }

--- a/client/src/views/files/FoldersPage.vue
+++ b/client/src/views/files/FoldersPage.vue
@@ -80,7 +80,11 @@
         </div>
       </ms-action-bar>
       <div class="folder-container">
-        <div v-if="displayView === DisplayState.List">
+        <div v-if="children.length === 0">
+          {{ $t('FoldersPage.emptyFolder') }}
+        </div>
+
+        <div v-if="children.length && displayView === DisplayState.List">
           <ion-list>
             <ion-list-header
               class="folder-list-header"
@@ -120,7 +124,7 @@
           </ion-list>
         </div>
         <div
-          v-else
+          v-if="children.length && displayView === DisplayState.Grid"
           class="folders-container-grid"
         >
           <ion-item
@@ -398,7 +402,7 @@ async function deleteFile(file: parsec.EntryStat): Promise<void> {
     return;
   }
   const filePath = pathJoin(currentPath.value, file.name);
-  const result = await parsec.deleteFile(filePath);
+  const result = file.isFile() ? await parsec.deleteFile(filePath) : await parsec.deleteFolder(filePath);
   if (!result.ok) {
     notificationCenter.showToast(new Notification({
       message: t('FoldersPage.errors.deleteFailed', {name: file.name}),


### PR DESCRIPTION
`libparsec.workspaceCreateFolder` and `libparsec.workspaceRemoveFolder` are not implemented yet.

Also added a message for folders that are empty.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
