### PR TITLE
[MS] Fix config save/load

### DIFF
--- a/client/src/services/storageManager.ts
+++ b/client/src/services/storageManager.ts
@@ -21,14 +21,16 @@ export class StorageManager {
   static STORED_CONFIG_KEY = 'config';
 
   // TODO: CHANGE BACK THEME TO SYSTEM WHEN DARK MODE WILL BE HERE: https://github.com/Scille/parsec-cloud/issues/5427
-  static DEFAULT_CONFIG: Config = {
-    locale: '',
-    theme: 'light',
-    enableTelemetry: true,
-    minimizeToTray: true,
-    meteredConnection: false,
-    unsyncFiles: false,
-  };
+  static get DEFAULT_CONFIG(): Config {
+    return {
+      locale: '',
+      theme: 'light',
+      enableTelemetry: true,
+      minimizeToTray: true,
+      meteredConnection: false,
+      unsyncFiles: false,
+    };
+  }
 
   internalStore: Storage;
 


### PR DESCRIPTION
For some reason that I can't explain, `StorageManager.DEFAULT_CONFIG` was updated when the config changed (meaning we didn't go into the if, meaning the config was never stored). I have no idea why, as I specifically added a call to `structuredClone` when I wrote this code to prevent this from happening. Anyway, it's fixed using a getter, making sure that the DEFAULT_CONFIG is read only, which is simply better anyway.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes