### PR TITLE
Add `spawn_local` to spawn a future on the current thread

### DIFF
--- a/libparsec/crates/platform_async/src/lib.rs
+++ b/libparsec/crates/platform_async/src/lib.rs
@@ -57,7 +57,7 @@ macro_rules! select2 {
 
 // Platform specific stuff
 
-pub use platform::{oneshot, sleep, spawn, watch, JoinHandle};
+pub use platform::{oneshot, sleep, spawn, spawn_local, watch, JoinHandle};
 pub use std::time::Duration; // Re-exposed to simplify use of `sleep`
 
 #[cfg(target_arch = "wasm32")]

--- a/libparsec/crates/platform_async/src/native/mod.rs
+++ b/libparsec/crates/platform_async/src/native/mod.rs
@@ -22,9 +22,9 @@ pub fn sleep(duration: std::time::Duration) -> impl crate::future::Future<Output
 }
 
 #[derive(Debug)]
-pub struct JoinHandle<T>(tokio::task::JoinHandle<T>);
+pub struct JoinHandle<F>(tokio::task::JoinHandle<F>);
 
-impl<T> JoinHandle<T> {
+impl<F> JoinHandle<F> {
     #[inline(always)]
     pub fn abort(&self) {
         self.0.abort()
@@ -35,8 +35,8 @@ impl<T> JoinHandle<T> {
     }
 }
 
-impl<T> crate::future::Future for JoinHandle<T> {
-    type Output = std::result::Result<T, tokio::task::JoinError>;
+impl<F> crate::future::Future for JoinHandle<F> {
+    type Output = std::result::Result<F, tokio::task::JoinError>;
 
     #[inline(always)]
     fn poll(
@@ -49,10 +49,18 @@ impl<T> crate::future::Future for JoinHandle<T> {
 }
 
 #[inline(always)]
-pub fn spawn<T>(future: T) -> JoinHandle<T::Output>
+pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
 where
-    T: crate::future::Future + Send + 'static,
-    T::Output: Send + 'static,
+    F: crate::future::Future + Send + 'static,
+    F::Output: Send + 'static,
 {
-    JoinHandle(tokio::spawn(future))
+    JoinHandle(tokio::task::spawn(future))
+}
+
+pub fn spawn_local<F>(future: F) -> JoinHandle<F::Output>
+where
+    F: crate::future::Future + 'static,
+    F::Output: 'static,
+{
+    JoinHandle(tokio::task::spawn_local(future))
 }

--- a/libparsec/crates/platform_async/src/web/mod.rs
+++ b/libparsec/crates/platform_async/src/web/mod.rs
@@ -9,11 +9,11 @@ pub async fn sleep(duration: std::time::Duration) {
 }
 
 #[derive(Debug)]
-pub struct JoinHandle<T> {
-    phantom: std::marker::PhantomData<T>,
+pub struct JoinHandle<F> {
+    phantom: std::marker::PhantomData<F>,
 }
 
-impl<T> JoinHandle<T> {
+impl<F> JoinHandle<F> {
     #[inline(always)]
     pub fn abort(&self) {
         todo!()
@@ -42,8 +42,8 @@ impl JoinError {
     }
 }
 
-impl<T> crate::future::Future for JoinHandle<T> {
-    type Output = std::result::Result<T, JoinError>;
+impl<F> crate::future::Future for JoinHandle<F> {
+    type Output = std::result::Result<F, JoinError>;
 
     #[inline(always)]
     fn poll(
@@ -55,9 +55,16 @@ impl<T> crate::future::Future for JoinHandle<T> {
 }
 
 #[inline(always)]
-pub fn spawn<T>(_future: T) -> JoinHandle<T::Output>
+pub fn spawn<F>(_future: F) -> JoinHandle<F::Output>
 where
-    T: crate::future::Future,
+    F: crate::future::Future,
+{
+    todo!()
+}
+
+pub fn spawn_local<F>(_future: F) -> JoinHandle<F::Output>
+where
+    F: crate::future::Future,
 {
     todo!()
 }


### PR DESCRIPTION
Having `spawn_local` is useful when you have a future that doesn't implement `Send`