### PR TITLE
Add `Delay` struct that is generated by `sleep`

### DIFF
--- a/libparsec/crates/platform_async/src/lib.rs
+++ b/libparsec/crates/platform_async/src/lib.rs
@@ -57,7 +57,7 @@ macro_rules! select2 {
 
 // Platform specific stuff
 
-pub use platform::{oneshot, sleep, spawn, watch, JoinHandle};
+pub use platform::{oneshot, sleep, spawn, watch, Delay, JoinHandle};
 pub use std::time::Duration; // Re-exposed to simplify use of `sleep`
 
 #[cfg(target_arch = "wasm32")]

--- a/libparsec/crates/platform_async/src/web/mod.rs
+++ b/libparsec/crates/platform_async/src/web/mod.rs
@@ -3,9 +3,28 @@
 pub mod oneshot;
 pub mod watch;
 
+use std::pin::Pin;
+
+pub struct Delay {
+    sleep: Pin<Box<gloo_timers::future::TimeoutFuture>>,
+}
+
+impl std::future::Future for Delay {
+    type Output = ();
+
+    fn poll(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        self.sleep.as_mut().poll(cx)
+    }
+}
+
 #[inline(always)]
-pub async fn sleep(duration: std::time::Duration) {
-    gloo_timers::future::sleep(duration).await;
+pub fn sleep(duration: std::time::Duration) -> Delay {
+    Delay {
+        sleep: Box::pin(gloo_timers::future::sleep(duration)),
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
That still allow to use sleep in the old fashion way:

```rust
sleep(ONE_SECOND).await;
```

But now that it return an object, it allow something like:

```rust
let delay = sleep(ONE_SECOND).await;

// Other stuff

delay.await
```