### PR TITLE
Manage FSLocalStorageError in the mountpoint operation error handlers

### DIFF
--- a/parsec/core/fs/__init__.py
+++ b/parsec/core/fs/__init__.py
@@ -2,14 +2,12 @@
 from __future__ import annotations
 
 from parsec.core.fs.exceptions import (
-    # Remote operation errors
     FSBackendOfflineError,
     FSBadEncryptionRevision,
     FSCrossDeviceError,
     FSDeviceNotFoundError,
     FSDirectoryNotEmptyError,
     FSEndOfFileError,
-    # Generic classes
     FSError,
     FSFileExistsError,
     FSFileNotFoundError,
@@ -18,11 +16,13 @@ from parsec.core.fs.exceptions import (
     FSInvalidTrustchainError,
     FSIsADirectoryError,
     FSLocalOperationError,
+    FSLocalStorageClosedError,
+    FSLocalStorageError,
+    FSLocalStorageOperationalError,
     FSNameTooLongError,
     FSNoAccessError,
     FSNotADirectoryError,
     FSOperationError,
-    # Local operation errors
     FSPermissionError,
     FSReadOnlyError,
     FSRemoteBlockNotFound,
@@ -37,7 +37,6 @@ from parsec.core.fs.exceptions import (
     FSWorkspaceInMaintenance,
     FSWorkspaceNoAccess,
     FSWorkspaceNoReadAccess,
-    # Misc errors
     FSWorkspaceNotFoundError,
     FSWorkspaceNotInMaintenance,
     FSWorkspaceNoWriteAccess,
@@ -71,6 +70,10 @@ __all__ = (
     # Misc errors
     "FSWorkspaceNotFoundError",
     "FSWorkspaceTimestampedTooEarly",
+    # Local storage errors
+    "FSLocalStorageError",
+    "FSLocalStorageOperationalError",
+    "FSLocalStorageClosedError",
     # Local operation errors
     "FSPermissionError",
     "FSNoAccessError",

--- a/parsec/core/fs/exceptions.py
+++ b/parsec/core/fs/exceptions.py
@@ -7,6 +7,7 @@ Define all the FSError classes, using the following hierarchy:
     FSInternalError (Exception)
     FSError (Exception)
     +-- FSMiscError
+    +-- FSLocalStorageError
     +-- FSOperationError (OSError)
         +-- FSLocalOperationError
         +-- FSRemoteOperationError
@@ -152,14 +153,18 @@ class FSNoSynchronizationRequired(FSInternalError):
     pass
 
 
-class FSLocalStorageClosedError(FSInternalError):
-    pass
-
-
 # Local storage errors
 
 
-class FSLocalStorageOperationalError(FSError):
+class FSLocalStorageError(FSError):
+    pass
+
+
+class FSLocalStorageClosedError(FSLocalStorageError):
+    pass
+
+
+class FSLocalStorageOperationalError(FSLocalStorageError):
     pass
 
 


### PR DESCRIPTION
Make tests more robusts by not logging local storage errors e.g.:
https://github.com/Scille/parsec-cloud/actions/runs/6535280644/job/17744372411#step:23:355