### PR TITLE
Fixed #5594, #5595 and #5596

### DIFF
--- a/client/electron/package-lock.json
+++ b/client/electron/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "parsec",
+    "name": "parsec-v3-alpha",
     "version": "3.0.0a",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "parsec",
+            "name": "parsec-v3-alpha",
             "version": "3.0.0a",
             "license": "BUSL-1.1",
             "dependencies": {

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -343,9 +343,12 @@
             "folderLabel": "Folder name",
             "folderPlaceholder": "My folder"
         },
-        "deleteOneFileQuestion": "Are you sure you want to delete the file `{name}`?",
-        "deleteOneFolderQuestion": "Are you sure you want to delete the folder `{name}`?",
-        "deleteMultipleQuestion": "Are you sure you want to delete these {count} elements?",
+        "deleteOneFileQuestionTitle": "Delete one file",
+        "deleteOneFileQuestionSubtitle": "Are you sure you want to delete the file `{name}`?",
+        "deleteOneFolderQuestionTitle": "Delete one folder?",
+        "deleteOneFolderQuestionSubtitle": "Are you sure you want to delete the folder `{name}`?",
+        "deleteMultipleQuestionTitle": "Delete multiple elements",
+        "deleteMultipleQuestionSubtitle": "Are you sure you want to delete these {count} elements?",
         "linkNotCopiedToClipboard":"Could not copy the link to the clipboard.",
         "linkCopiedToClipboard":"The link has been copied to the clipboard.",
         "getLinkError":"Could not get a link to the workspace (reason: {reason})."

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -343,9 +343,12 @@
             "folderLabel": "Nom du dossier",
             "folderPlaceholder": "Mon dossier"
         },
-        "deleteOneFileQuestion": "Êtes-vous sûr(e) de vouloir supprimer le fichier `{name}` ?",
-        "deleteOneFolderQuestion": "Êtes-vous sûr(e) de vouloir supprimer le dossier `{name}` ?",
-        "deleteMultipleQuestion": "Êtes-vous sûr(e) de vouloir supprimer ces {count} éléments ?",
+        "deleteOneFileQuestionTitle": "Suppression d'un fichier",
+        "deleteOneFileQuestionSubtitle": "Êtes-vous sûr(e) de vouloir supprimer le fichier `{name}` ?",
+        "deleteOneFolderQuestionTitle": "Suppression d'un dossier",
+        "deleteOneFolderQuestionSubtitle": "Êtes-vous sûr(e) de vouloir supprimer le dossier `{name}` ?",
+        "deleteMultipleQuestionTitle": "Suppression de plusieurs éléments",
+        "deleteMultipleQuestionSubtitle": "Êtes-vous sûr(e) de vouloir supprimer ces {count} éléments ?",
         "linkNotCopiedToClipboard":"Impossible de copier le lien dans le presse-papier.",
         "linkCopiedToClipboard":"Le lien a été copié dans le presse-papier.",
         "getLinkError":"Impossible de récupérer un lien vers l'espace de travail (raison: {reason})."

--- a/client/src/parsec/user.ts
+++ b/client/src/parsec/user.ts
@@ -82,6 +82,15 @@ export async function listUsers(skipRevoked = true): Promise<Result<Array<UserIn
   }
 }
 
+export async function listRevokedUsers(): Promise<Result<Array<UserInfo>, ClientListUsersError>> {
+  const result = await listUsers(false);
+
+  if (result.ok) {
+    result.value = result.value.filter((user) => user.isRevoked());
+  }
+  return result;
+}
+
 export async function listUserDevices(user: UserID): Promise<Result<Array<DeviceInfo>, ClientListUserDevicesError>> {
   const handle = getParsecHandle();
 

--- a/client/src/views/files/FoldersPage.vue
+++ b/client/src/views/files/FoldersPage.vue
@@ -360,11 +360,13 @@ async function deleteEntries(entries: parsec.EntryStat[]): Promise<void> {
     return;
   } else if (entries.length === 1) {
     const entry = entries[0];
-    const answer = await askQuestion(
-      entry.isFile() ?
-        t('FoldersPage.deleteOneFileQuestion', {name: entry.name}) :
-        t('FoldersPage.deleteOneFolderQuestion', {name: entry.name}),
-    );
+    const title = entry.isFile() ?
+      t('FoldersPage.deleteOneFileQuestionTitle') :
+      t('FoldersPage.deleteOneFolderQuestionTitle');
+    const subtitle = entry.isFile() ?
+      t('FoldersPage.deleteOneFileQuestionSubtitle', {name: entry.name}) :
+      t('FoldersPage.deleteOneFolderQuestionSubtitle', {name: entry.name});
+    const answer = await askQuestion(title, subtitle);
 
     if (answer === Answer.No) {
       return;
@@ -381,7 +383,8 @@ async function deleteEntries(entries: parsec.EntryStat[]): Promise<void> {
     }
   } else {
     const answer = await askQuestion(
-      t('FoldersPage.deleteMultipleQuestion', {count: entries.length}),
+      t('FoldersPage.deleteMultipleQuestionTitle'),
+      t('FoldersPage.deleteMultipleQuestionSubtitle', {count: entries.length}),
     );
     if (answer === Answer.No) {
       return;

--- a/client/src/views/home/HomePage.vue
+++ b/client/src/views/home/HomePage.vue
@@ -332,6 +332,10 @@ onUpdated(async () => {
 async function refreshDeviceList(): Promise<void> {
   deviceList.value = await parsecListAvailableDevices();
   storedDeviceDataDict.value = await storageManager.retrieveDevicesData();
+  if (deviceList.value.length === 1) {
+    showOrganizationList.value = false;
+    selectedDevice = deviceList.value[0];
+  }
 }
 
 function onMsSelectChange(event: MsSelectChangeEvent): void {

--- a/client/src/views/sidebar-menu/SidebarMenuPage.vue
+++ b/client/src/views/sidebar-menu/SidebarMenuPage.vue
@@ -34,8 +34,12 @@
                     </ion-card-title>
                   </div>
                 </div>
-                <!-- new icon to provide -->
-                <div class="organization-card__icon">
+                <!-- Keep it hidden for now since we have no way of switching org -->
+                <div
+                  class="organization-card__icon"
+                  v-show="false"
+                >
+                  <!-- new icon to provide -->
                   <svg
                     width="32"
                     height="32"

--- a/client/src/views/users/RevokedUsersPage.vue
+++ b/client/src/views/users/RevokedUsersPage.vue
@@ -26,7 +26,7 @@
       </ms-action-bar>
       <!-- users -->
       <div class="users-container">
-        <div v-if="filteredUsers.length === 0">
+        <div v-if="userList.length === 0">
           {{ $t('UsersPage.revokedEmptyList') }}
         </div>
         <div v-else>
@@ -60,7 +60,7 @@
                 <ion-label class="user-list-header__label cell-title label-space" />
               </ion-list-header>
               <user-list-item
-                v-for="user in filteredUsers"
+                v-for="user in userList"
                 :key="user.id"
                 :user="user"
                 :show-checkbox="selectedUsersCount > 0 || allUsersSelected"
@@ -76,7 +76,7 @@
           >
             <ion-item
               class="users-grid-item"
-              v-for="user in filteredUsers"
+              v-for="user in userList"
               :key="user.id"
             >
               <user-card
@@ -146,7 +146,7 @@ import { DisplayState } from '@/components/core/ms-toggle/MsGridListToggle.vue';
 import UserContextMenu from '@/views/users/UserContextMenu.vue';
 import { UserAction } from '@/views/users/UserContextMenu.vue';
 import MsActionBar from '@/components/core/ms-action-bar/MsActionBar.vue';
-import { UserInfo, listUsers as parsecListUsers } from '@/parsec';
+import { UserInfo, listRevokedUsers as parsecListRevokedUsers } from '@/parsec';
 import { NotificationCenter, NotificationKey, NotificationLevel, Notification } from '@/services/notificationCenter';
 import { useI18n } from 'vue-i18n';
 
@@ -166,13 +166,6 @@ const allUsersSelected = computed({
 const indeterminateState = computed({
   get: (): boolean => selectedUsersCount.value > 0 && selectedUsersCount.value < userList.value.length,
   set: (_val) => _val,
-});
-
-const filteredUsers = computed(() => {
-  const revokedUsers = userList.value.filter((user) => {
-    return user.isRevoked();
-  });
-  return revokedUsers;
 });
 
 const selectedUsersCount = computed(() => {
@@ -256,7 +249,7 @@ function resetSelection(): void {
 }
 
 async function refreshUserList(): Promise<void> {
-  const result = await parsecListUsers(false);
+  const result = await parsecListRevokedUsers();
   if (result.ok) {
     userList.value = result.value;
   } else {

--- a/client/tests/e2e/specs/test_folders_page.ts
+++ b/client/tests/e2e/specs/test_folders_page.ts
@@ -119,7 +119,9 @@ describe('Check folders page', () => {
   it('Tests delete one file', () => {
     cy.get('.file-list-item').first().find('.options-button').click();
     cy.get('#file-context-menu').find('ion-item').eq(4).contains('Delete').click();
-    cy.get('.question-modal').find('ion-title').contains('Are you sure you want to delete the file `File1.txt`?');
+    cy.get('.question-modal').find('.ms-modal-header__title').contains('Delete one file');
+    cy.get('.question-modal').find('.ms-alert-modal-header__text').contains('Are you sure you want to delete the file `File1.txt`?');
+
     cy.get('.question-modal').find('#next-button').click();
     cy.get('.question-modal').should('not.exist');
     cy.get('@consoleLog').should('have.been.called.with', 'File File1.txt deleted');
@@ -128,7 +130,8 @@ describe('Check folders page', () => {
   it('Tests delete multiple files', () => {
     cy.get('.folder-list-header').find('ion-checkbox').click();
     cy.get('#button-delete').contains('Delete').click();
-    cy.get('.question-modal').find('ion-title').contains('Are you sure you want to delete these 3 elements?');
+    cy.get('.question-modal').find('.ms-modal-header__title').contains('Delete multiple elements');
+    cy.get('.question-modal').find('.ms-alert-modal-header__text').contains('Are you sure you want to delete these 3 elements?');
     cy.get('.question-modal').find('#next-button').contains('Yes').click();
     cy.get('.question-modal').should('not.exist');
 


### PR DESCRIPTION
Closes #5594 
Closes #5595 
Closes #5596 

Didn't want to create multiple PRs for so small changes.

For the revoked user page, I added a function to only retrieve the revoked users. It will make it a bit easier and less confusing if we also want to filter on the revoked users later on.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
