### PR TITLE
Rename `get_last_realm_certificate_index`

### DIFF
--- a/libparsec/crates/client/tests/unit/workspace_ops/inbound_sync_folder.rs
+++ b/libparsec/crates/client/tests/unit/workspace_ops/inbound_sync_folder.rs
@@ -232,7 +232,7 @@ async fn non_placeholder(
             p_assert_eq!(req.timestamp, None);
             authenticated_cmds::latest::vlob_read::Rep::Ok {
                 author: "alice@dev2".parse().unwrap(),
-                certificate_index: env.get_last_realm_certificate_index(),
+                certificate_index: env.get_last_certificate_index(),
                 timestamp: wksp1_foo_last_remote_manifest.timestamp,
                 version: wksp1_foo_last_remote_manifest.version,
                 blob: wksp1_foo_last_encrypted,

--- a/libparsec/crates/client/tests/unit/workspace_ops/inbound_sync_root.rs
+++ b/libparsec/crates/client/tests/unit/workspace_ops/inbound_sync_root.rs
@@ -203,7 +203,7 @@ async fn non_placeholder(
             p_assert_eq!(req.timestamp, None);
             authenticated_cmds::latest::vlob_read::Rep::Ok {
                 author: "alice@dev2".parse().unwrap(),
-                certificate_index: env.get_last_realm_certificate_index(),
+                certificate_index: env.get_last_certificate_index(),
                 timestamp: wksp1_last_remote_manifest.timestamp,
                 version: wksp1_last_remote_manifest.version,
                 blob: wksp1_last_encrypted,
@@ -369,7 +369,7 @@ async fn placeholder(
             p_assert_eq!(req.timestamp, None);
             authenticated_cmds::latest::vlob_read::Rep::Ok {
                 author: "alice@dev2".parse().unwrap(),
-                certificate_index: env.get_last_realm_certificate_index(),
+                certificate_index: env.get_last_certificate_index(),
                 timestamp: wksp1_last_remote_manifest.timestamp,
                 version: wksp1_last_remote_manifest.version,
                 blob: wksp1_last_encrypted,

--- a/libparsec/crates/client/tests/unit/workspace_ops/outbound_sync_root.rs
+++ b/libparsec/crates/client/tests/unit/workspace_ops/outbound_sync_root.rs
@@ -168,7 +168,7 @@ async fn non_placeholder(
                         p_assert_eq!(req.timestamp, None);
                         authenticated_cmds::latest::vlob_read::Rep::Ok {
                             author: "alice@dev2".parse().unwrap(),
-                            certificate_index: env.get_last_realm_certificate_index(),
+                            certificate_index: env.get_last_certificate_index(),
                             timestamp: wksp1_last_remote_manifest.timestamp,
                             version: wksp1_last_remote_manifest.version,
                             blob: wksp1_last_encrypted,

--- a/libparsec/crates/testbed/src/env.rs
+++ b/libparsec/crates/testbed/src/env.rs
@@ -334,7 +334,7 @@ impl TestbedEnv {
             })
             .unwrap()
     }
-    pub fn get_last_realm_certificate_index(&self) -> IndexInt {
+    pub fn get_last_certificate_index(&self) -> IndexInt {
         self.template
             .certificates_rev()
             .map(|x| x.certificate_index)


### PR DESCRIPTION
The `realm` has no sense