### PR TITLE
Prevent concurrent run of `publish` workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,13 @@ on:
       - published
       - edited
 
+# We set `concurrency` to prevent having this workflow being run on code that is not up-to-date on a PR (a user make multiple push in a quick manner).
+# But on the main branch, we don't want that behavior.
+# Having the workflow run on each merge commit is something we would like, that could help us where a regression was made and missed by previous checks.
+concurrency:
+  group: publish-package-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
When publishing a release (publish a release that was on draft), that raise 2 events `published` & `edited`.

We configured the workflow to run when one of those is received but since publishing a release raise those 2 events, that make the workflow run 2 time instead of one.

By adding the `concurrent` settings, we prevent the workflow to run on the same `ref`.
