### PR TITLE
Fix `check_newsfragments` should compare against base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,10 +150,9 @@ jobs:
 
       - name: Check News fragments
         if: |
-          startsWith(github.ref, 'refs/pull/')
+          github.event_name == 'pull_request'
           && !(
-            startsWith(github.head_ref, 'yolo')
-            || startsWith(github.head_ref, 'release')
+            startsWith(github.head_ref, 'releases/')
             || startsWith(github.head_ref, 'revert')
             || startsWith(github.head_ref, 'acknowledge')
             )
@@ -161,7 +160,7 @@ jobs:
         run: |
           whereis git
           git fetch origin master
-          python .github/scripts/check_newsfragments.py ${{ github.head_ref }}
+          python .github/scripts/check_newsfragments.py --base=${{ github.base_ref }}
         timeout-minutes: 5
 
       - name: Patch pre-commit for line-ending


### PR DESCRIPTION
The script `check_newsfragments` use `origin/master` as the base target (where the pull is targeted) but `origin/master` is not always our target.

For example, if we work on a release branch or on the current `dev/v2` branch, that check don't work if `origin/master` already has the same newsfragment

Other Changes
-------------

- The script no longuer check if it need to check if it's on a branch that should be skipped (e.g.: `master`)

  The check is redundant with github actions and require to maintain 2 source of truth.

- Simplify the condition to run the `check_newsfragments`:

  - Use `event_name == 'pull_request'` instead of looking for the prefix `ref/pull`.
  - Remove the exception for `yolo` prefixed branch as we are no longer required to add a newsfragment.