### PR TITLE
Configure nextest timeout for slow tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,14 @@
+[profile.default]
+# https://nexte.st/book/slow-tests.html
+slow-timeout = { period = "10s", terminate-after = 3 } # Timeout a test after 30s (3 * 10s)
+
+[profile.ci]
+slow-timeout = { period = "10s", terminate-after = 5 } # Timeout a test after 50s (5 * 10s)
+# https://nexte.st/book/other-options.html#--success-output-and---failure-output
+status-level = "all"
+# Show output failures as soon as they happen and at the end of the test run.
+# This option work well when `fail-fast` is disabled.
+# https://nexte.st/book/other-options.html#--success-output-and---failure-output
+failure-output = "immediate-final"
+# Continue even if a test fail.
+fail-fast = false

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -27,7 +27,7 @@ concurrency:
 
 env:
   CARGO_CI_FLAGS: --locked --profile ci-rust
-  CARGO_NEXTEST_CI_FLAGS: --locked --cargo-profile ci-rust
+  CARGO_NEXTEST_CI_FLAGS: --profile=ci --locked --cargo-profile ci-rust
   WINFSP_VERSION: 2.0.23075
   WINFSP_TEST_EXE: C:/Program Files (x86)/WinFsp/bin/winfsp-tests-x64.exe
 


### PR DESCRIPTION
Add nextest configuration:

- Change the default configuration for `slow-timeout`

  The default display a message `SLOW {TEST}` every `60s` without terminating it.
  Now the message is displayed every `10s` and stoppind the test at the
  3rd warning.

- Add profile `ci` to be used in the CI:
  - Laxer `slow-timeout`

    Stop the test after 5 slow message (instead of 3).

  - Show test failure outputs immediatly and at the end of the run
    (default to `immediate` which work well when `fail-fast` is enabled).
  - Disable fail fast (enabled in `default` profile).

Full nextest configuration options can be found here: <https://nexte.st/book/configuration.html>
