### PR TITLE
[Backport] Fix `check_newsfragments` should compare against base

### DIFF
--- a/.github/scripts/check_newsfragments.py
+++ b/.github/scripts/check_newsfragments.py
@@ -6,30 +6,23 @@ PRs must contain a newsfragment that reference an opened issue
 
 import argparse
 import json
-import re
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from subprocess import run
 from typing import Optional
 from urllib.request import HTTPError, Request, urlopen
 
-# If file never existed in master, consider as a new newsfragment
-# Cannot just git diff against master branch here given newsfragments
-# removed in master will be considered as new items in our branch
-# --exit-code makes the command exit with 0 if there are changes
-BASE_CMD = "git log origin/master --exit-code --".split()
-
-# Ignore master given we compare against it !
-# Also ignore release branch (e.g. `2.11`) that don't have to create newsfragments
-IGNORED_BRANCHES_PATTERN = r"(master|[0-9]+\.[0-9]+)"
-
 # This list should be keep up to date with `misc/releaser.py::FRAGMENT_TYPES.keys()`
 VALID_TYPE = ["feature", "bugfix", "doc", "removal", "api", "misc", "empty"]
 
 
-def check_newsfragment(fragment: Path) -> Optional[bool]:
+def check_newsfragment(fragment: Path, base: str) -> Optional[bool]:
     fragment_name = fragment.name
-    cmd_args = [*BASE_CMD, str(fragment)]
+    # If file never existed in `base`, consider as a new newsfragment
+    # Cannot just git diff against `base` branch here given newsfragments
+    # removed in master will be considered as new items in our branch
+    # --exit-code makes the command exit with 0 if there are changes
+    cmd_args = ["git", "log", base, "--exit-code", "--", str(fragment)]
     ret = run(cmd_args, capture_output=True)
 
     if ret.returncode == 0:
@@ -71,18 +64,16 @@ def check_newsfragment(fragment: Path) -> Optional[bool]:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("branch_name", help="current branch name", type=str)
+    parser.add_argument(
+        "--base", help="The base branch to compare to", default="origin/master", type=str
+    )
     args = parser.parse_args()
-
-    if re.match(IGNORED_BRANCHES_PATTERN, args.branch_name):
-        print("Release branch detected, ignoring newsfragment checks")
-        raise SystemExit(0)
 
     with ThreadPoolExecutor() as pool:
         ret = list(
             filter(
                 lambda value: value is not None,
-                pool.map(check_newsfragment, Path("newsfragments").glob("*.rst")),
+                pool.map(check_newsfragment, Path("newsfragments").glob("*.rst"), args.base),
             )
         )
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,10 +142,9 @@ jobs:
 
       - name: Check News fragments
         if: |
-          startsWith(github.ref, 'refs/pull/')
+          github.event_name == 'pull_request'
           && !(
-            startsWith(github.head_ref, 'yolo')
-            || startsWith(github.head_ref, 'release')
+            startsWith(github.head_ref, 'releases/')
             || startsWith(github.head_ref, 'revert')
             || startsWith(github.head_ref, 'acknowledge')
             )
@@ -153,7 +152,7 @@ jobs:
         run: |
           whereis git
           git fetch origin master
-          python .github/scripts/check_newsfragments.py ${{ github.head_ref }}
+          python .github/scripts/check_newsfragments.py --base=${{ github.base_ref }}
         timeout-minutes: 5
 
       - name: Patch pre-commit for line-ending


### PR DESCRIPTION
The script `check_newsfragments` use `origin/master` as the base target (where the pull is targeted) but `origin/master` is not always our target.

For example, if we work on a release branch or on the current `dev/v2` branch, that check don't work if `origin/master` already has the same newsfragment

Other Changes
-------------

- The script no longuer check if it need to check if it's on a branch that should be skipped (e.g.: `master`)

  The check is redundant with github actions and require to maintain 2 source of truth.

- Simplify the condition to run the `check_newsfragments`:

  - Use `event_name == 'pull_request'` instead of looking for the prefix `ref/pull`.
  - Remove the exception for `yolo` prefixed branch as we are no longer required to add a newsfragment.
