### PR TITLE
[Backport] Add workflow to build the parsec server's docker image

### DIFF
--- a/.github/workflows/docker-server.yml
+++ b/.github/workflows/docker-server.yml
@@ -1,0 +1,75 @@
+name: Build & Publish Parsec Server Docker Image
+
+# cspell:words buildx
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - server/packaging/server/**
+      - .github/workflows/docker-server.yml
+  # Only run on pushed tag because we don't want this workflow to run everytime we push something to the main branch.
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+*
+
+permissions:
+  contents: write
+  packages: write
+
+# We set `concurrency` to prevent having this workflow being run on code that is not up-to-date on a PR (a user make multiple push in a quick manner).
+# But outside of a PR, we want to have only 1 workflow to be run at the same time on a given git ref
+concurrency:
+  group: docker-server-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker-server:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin v4.1.1
+        timeout-minutes: 3
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      - name: Log in to the Github Container registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get current version
+        id: version
+        run: |
+          sed -n 's/^.*Tool.Parsec: "\(.*\)",$/current=\1/p' misc/version_updater.py | tee $GITHUB_OUTPUT
+
+      - name: Generate build metadata
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        id: metadata
+        with:
+          images:
+            ghcr.io/scille/parsec-cloud/parsec-server
+          tags: |
+            type=semver,pattern={{ version }}
+            type=semver,pattern={{ major }}.{{ minor }}
+            type=raw,value=${{ steps.version.outputs.current }}+{{ date 'YYYYMMDD' }}.sha.{{ sha }}
+          flavor: |
+            latest=${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+
+      - name: Image to be published
+        run: echo ${{ steps.metadata.outputs.tags }}
+
+      - name: Build and publish
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        id: build
+        with:
+          context: .
+          file: packaging/server/server.dockerfile
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          push: ${{ (github.event_name == 'push' && github.ref_type == 'tag') || github.event_name == 'workflow_dispatch' }}

--- a/packaging/server/build.sh
+++ b/packaging/server/build.sh
@@ -13,6 +13,7 @@ CURRENT_COMMIT_SHA=$(git rev-parse --short HEAD)
 UNIQ_TAG="$CURRENT_DATE-$CURRENT_VERSION-$CURRENT_COMMIT_SHA"
 # We use Github package repository to store our docker's container.
 PREFIX=ghcr.io/scille/parsec-cloud
+IMAGE_NAME=parsec-server
 
 echo "Will create an image \`parsec-backend-server\` with the following tags:"
 echo "- \`latest\`"
@@ -23,8 +24,8 @@ echo
 
 DOCKER_BUILDKIT=1 docker build \
     -f $SCRIPTDIR/server.dockerfile \
-    -t $PREFIX/parsec-backend-server:latest \
-    -t $PREFIX/parsec-backend-server:$UNIQ_TAG \
+    -t $PREFIX/$IMAGE_NAME:latest \
+    -t $PREFIX/$IMAGE_NAME:$UNIQ_TAG \
     $ROOTDIR $@
 
 echo


### PR DESCRIPTION
The image will be build on tag push or by manual trigger with `workflow_dispatch`.

The image would have the following tags used:

- `VERSION+{{ date 'YYYYMMDD' }}.sha.{{ short-sha }}`
- `MAJOR.minor.patch`
- `MAJOR.minor`