### PR TITLE
Further fix to `check_newsfragments` script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
           && steps.newsfragment-have-changed.outputs.newsfragments == 'true'
         run: |
           whereis git
-          git fetch origin master
+          git fetch origin ${{ github.base_ref }}
           python .github/scripts/check_newsfragments.py --base=${{ github.base_ref }}
         timeout-minutes: 5
 


### PR DESCRIPTION
- Improve logging of newsfragment (display the `git log` command that will be executed).
- Prefix `base` argument with `origin/`.
- Use repeat on base argument to prevent iterating over each char of the string.
- Allow closed issue/PR.
- Fetch `base_ref` before executing the script.