### PR TITLE
Bump rust to 1.74

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: ^misc/bench.py$
 
 default_language_version:
-  rust: 1.72.1
+  rust: 1.74.0
   node: 18.12.0
 
 repos:
@@ -170,8 +170,6 @@ repos:
             --exclude=libparsec_bindings_electron,
             --,
             --deny=warnings,
-            --deny=clippy::undocumented_unsafe_blocks,
-            --deny=clippy::unwrap_used
           ]
 
   ####

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,10 @@ license = "BUSL-1.1"
 version = "0.0.0"
 repository = "https://github.com/Scille/parsec-cloud"
 
+[workspace.lints.clippy]
+undocumented_unsafe_blocks = "deny"
+unwrap_used = "deny"
+
 # All dependencies should be specified here instead of just in the crate(s) requiring them:
 # - It ensures each given dependency version is consistent across all crates
 # - It simplifies updating dependency version (only a single place to update)

--- a/bindings/android/libparsec/rust/Cargo.toml
+++ b/bindings/android/libparsec/rust/Cargo.toml
@@ -11,6 +11,9 @@ repository.workspace = true
 [lib]
 crate-type = ["staticlib", "cdylib"]
 
+[lints]
+workspace = true
+
 [dependencies]
 libparsec = { workspace = true }
 lazy_static = { workspace = true }

--- a/bindings/electron/Cargo.toml
+++ b/bindings/electron/Cargo.toml
@@ -15,6 +15,9 @@ test-utils = ["libparsec/test-utils"]
 [lib]
 crate-type = ["cdylib"]
 
+[lints]
+workspace = true
+
 [dependencies]
 libparsec = { workspace = true }
 lazy_static = { workspace = true }

--- a/bindings/web/Cargo.toml
+++ b/bindings/web/Cargo.toml
@@ -15,6 +15,9 @@ test-utils = ["libparsec/test-utils"]
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[lints]
+workspace = true
+
 [dependencies]
 libparsec = { workspace = true }
 wasm-bindgen = { workspace = true, features = ["spans", "std"] }

--- a/libparsec/Cargo.toml
+++ b/libparsec/Cargo.toml
@@ -8,7 +8,8 @@ license.workspace = true
 version.workspace = true
 repository.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [features]
 # Remember kid: RustCrypto is used if `use-sodiumoxide` is not set !

--- a/libparsec/crates/client/Cargo.toml
+++ b/libparsec/crates/client/Cargo.toml
@@ -8,7 +8,8 @@ license.workspace = true
 version.workspace = true
 repository.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 libparsec_client_connection = { workspace = true }

--- a/libparsec/crates/client/src/certificates_ops/poll.rs
+++ b/libparsec/crates/client/src/certificates_ops/poll.rs
@@ -105,7 +105,11 @@ pub(super) async fn poll_server_for_new_certificates(
 
         let certificates = match offset.cmp(&new_offset) {
             // Certificates hasn't changed while we were requesting the server
-            std::cmp::Ordering::Equal => certificates.into_iter().skip(0),
+            std::cmp::Ordering::Equal => {
+                // We need to return the same value as other branch so `skip(0)` it is.
+                #[allow(clippy::iter_skip_zero)]
+                certificates.into_iter().skip(0)
+            }
             // New certificates has been added while we were requesting the server
             std::cmp::Ordering::Less => {
                 let to_skip = (new_offset - offset) as usize;

--- a/libparsec/crates/client_connection/Cargo.toml
+++ b/libparsec/crates/client_connection/Cargo.toml
@@ -8,12 +8,13 @@ license.workspace = true
 version.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 test-with-testbed = [
     "libparsec_testbed",
 ]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 libparsec_crypto = { workspace = true }

--- a/libparsec/crates/crypto/Cargo.toml
+++ b/libparsec/crates/crypto/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 version.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 test-unsecure-but-fast-secretkey-from-password = []
 vendored-openssl = ["openssl/vendored"]

--- a/libparsec/crates/crypto/src/rustcrypto/sequester.rs
+++ b/libparsec/crates/crypto/src/rustcrypto/sequester.rs
@@ -40,7 +40,7 @@ impl TryFrom<&[u8]> for SequesterPrivateKeyDer {
 }
 
 impl SequesterPrivateKeyDer {
-    const ALGORITHM: &str = "RSAES-OAEP-XSALSA20-POLY1305";
+    const ALGORITHM: &'static str = "RSAES-OAEP-XSALSA20-POLY1305";
 
     pub fn generate_pair(size_in_bits: SequesterKeySize) -> (Self, SequesterPublicKeyDer) {
         let priv_key = RsaPrivateKey::new(&mut rand_08::thread_rng(), size_in_bits as usize)
@@ -124,7 +124,7 @@ impl Serialize for SequesterPublicKeyDer {
 }
 
 impl SequesterPublicKeyDer {
-    const ALGORITHM: &str = "RSAES-OAEP-XSALSA20-POLY1305";
+    const ALGORITHM: &'static str = "RSAES-OAEP-XSALSA20-POLY1305";
 
     pub fn size_in_bytes(&self) -> usize {
         self.0.n().bits() / 8
@@ -199,7 +199,7 @@ impl TryFrom<&[u8]> for SequesterSigningKeyDer {
 }
 
 impl SequesterSigningKeyDer {
-    const ALGORITHM: &str = "RSASSA-PSS-SHA256";
+    const ALGORITHM: &'static str = "RSASSA-PSS-SHA256";
 
     pub fn generate_pair(size_in_bits: SequesterKeySize) -> (Self, SequesterVerifyKeyDer) {
         let (priv_key, pub_key) = SequesterPrivateKeyDer::generate_pair(size_in_bits);
@@ -291,7 +291,7 @@ impl Serialize for SequesterVerifyKeyDer {
 }
 
 impl SequesterVerifyKeyDer {
-    const ALGORITHM: &str = "RSASSA-PSS-SHA256";
+    const ALGORITHM: &'static str = "RSASSA-PSS-SHA256";
 
     pub fn size_in_bytes(&self) -> usize {
         self.0.as_ref().n().bits() / 8

--- a/libparsec/crates/crypto/src/sodiumoxide/sequester.rs
+++ b/libparsec/crates/crypto/src/sodiumoxide/sequester.rs
@@ -52,7 +52,7 @@ impl TryFrom<&[u8]> for SequesterPrivateKeyDer {
 }
 
 impl SequesterPrivateKeyDer {
-    const ALGORITHM: &str = "RSAES-OAEP-XSALSA20-POLY1305";
+    const ALGORITHM: &'static str = "RSAES-OAEP-XSALSA20-POLY1305";
 
     pub fn generate_pair(size_in_bits: SequesterKeySize) -> (Self, SequesterPublicKeyDer) {
         let priv_key = Rsa::generate(size_in_bits as u32).expect("Cannot generate the RSA key");
@@ -158,7 +158,7 @@ impl Serialize for SequesterPublicKeyDer {
 }
 
 impl SequesterPublicKeyDer {
-    const ALGORITHM: &str = "RSAES-OAEP-XSALSA20-POLY1305";
+    const ALGORITHM: &'static str = "RSAES-OAEP-XSALSA20-POLY1305";
 
     pub fn size_in_bytes(&self) -> usize {
         self.0.size() as usize
@@ -243,7 +243,7 @@ impl TryFrom<&[u8]> for SequesterSigningKeyDer {
 }
 
 impl SequesterSigningKeyDer {
-    const ALGORITHM: &str = "RSASSA-PSS-SHA256";
+    const ALGORITHM: &'static str = "RSASSA-PSS-SHA256";
 
     pub fn generate_pair(size_in_bits: SequesterKeySize) -> (Self, SequesterVerifyKeyDer) {
         let (priv_key, pub_key) = SequesterPrivateKeyDer::generate_pair(size_in_bits);
@@ -351,7 +351,7 @@ impl Serialize for SequesterVerifyKeyDer {
 }
 
 impl SequesterVerifyKeyDer {
-    const ALGORITHM: &str = "RSASSA-PSS-SHA256";
+    const ALGORITHM: &'static str = "RSASSA-PSS-SHA256";
 
     pub fn size_in_bytes(&self) -> usize {
         self.0.bits() as usize / 8

--- a/libparsec/crates/platform_async/Cargo.toml
+++ b/libparsec/crates/platform_async/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 version.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 async-lock = { workspace = true }
 async-broadcast = { workspace = true }

--- a/libparsec/crates/platform_device_loader/Cargo.toml
+++ b/libparsec/crates/platform_device_loader/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 version.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 test-with-testbed = ["libparsec_testbed"]
 

--- a/libparsec/crates/platform_device_loader/src/native/mod.rs
+++ b/libparsec/crates/platform_device_loader/src/native/mod.rs
@@ -25,7 +25,7 @@ fn find_device_files(path: PathBuf) -> Vec<PathBuf> {
 
     // `fs::read_dir` fails if path doesn't exists, is not a folder or is not
     // accessible... In any case, there is not much we can do but to ignore it.
-    if let Ok(children) = std::fs::read_dir(&path) {
+    if let Ok(children) = std::fs::read_dir(path) {
         for child_dir in children.filter_map(|entry| entry.ok()) {
             let path = child_dir.path();
             if path.extension() == Some(OsStr::new(DEVICE_FILE_EXT)) {

--- a/libparsec/crates/platform_http_proxy/Cargo.toml
+++ b/libparsec/crates/platform_http_proxy/Cargo.toml
@@ -8,7 +8,8 @@ license.workspace = true
 version.workspace = true
 repository.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 libparsec_types = { workspace = true }

--- a/libparsec/crates/platform_mountpoint/Cargo.toml
+++ b/libparsec/crates/platform_mountpoint/Cargo.toml
@@ -8,7 +8,8 @@ license.workspace = true
 version.workspace = true
 repository.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winfsp_wrs = { workspace = true }

--- a/libparsec/crates/platform_mountpoint/examples/memfs.rs
+++ b/libparsec/crates/platform_mountpoint/examples/memfs.rs
@@ -1,4 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+#![allow(clippy::unwrap_used)]
 
 fn main() {
     #[cfg(not(target_os = "macos"))]

--- a/libparsec/crates/platform_storage/Cargo.toml
+++ b/libparsec/crates/platform_storage/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 version.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 test-with-testbed = ["libparsec_testbed"]
 

--- a/libparsec/crates/protocol/Cargo.toml
+++ b/libparsec/crates/protocol/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 version.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 libparsec_types = { workspace = true }
 libparsec_serialization_format = { workspace = true }

--- a/libparsec/crates/serialization_format/Cargo.toml
+++ b/libparsec/crates/serialization_format/Cargo.toml
@@ -11,6 +11,9 @@ repository.workspace = true
 [lib]
 proc-macro = true
 
+[lints]
+workspace = true
+
 [features]
 python-bindings-support = []
 

--- a/libparsec/crates/testbed/Cargo.toml
+++ b/libparsec/crates/testbed/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 version.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 libparsec_types = { workspace = true }
 

--- a/libparsec/crates/testbed/src/env.rs
+++ b/libparsec/crates/testbed/src/env.rs
@@ -561,11 +561,9 @@ where
             })
         };
 
-        let downcasted = component_store.downcast::<T>().unwrap_or_else(|_| {
+        component_store.downcast::<T>().unwrap_or_else(|_| {
             panic!("Unexpected component storage type for `{}`", component_key);
-        });
-
-        downcasted
+        })
     })
 }
 

--- a/libparsec/crates/tests_fixtures/Cargo.toml
+++ b/libparsec/crates/tests_fixtures/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 version.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = [
     "test-with-client-connection-testbed",

--- a/libparsec/crates/tests_lite/Cargo.toml
+++ b/libparsec/crates/tests_lite/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 version.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 # crates depending directly on use most likely doesn't need this `parsec_test`
 # (they directly uses `test`/`rstest` instead).

--- a/libparsec/crates/tests_macros/Cargo.toml
+++ b/libparsec/crates/tests_macros/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 version.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/libparsec/crates/types/Cargo.toml
+++ b/libparsec/crates/types/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 version.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 test-mock-time = []
 test-fixtures = ["dep:hex-literal", "dep:rstest"]

--- a/libparsec/crates/types/src/pki.rs
+++ b/libparsec/crates/types/src/pki.rs
@@ -167,7 +167,7 @@ pub struct LocalPendingEnrollment {
 }
 
 impl LocalPendingEnrollment {
-    const DIRECTORY_NAME: &str = "enrollment_requests";
+    const DIRECTORY_NAME: &'static str = "enrollment_requests";
 
     fn path_from_enrollment_id(config_dir: &Path, enrollment_id: EnrollmentID) -> PathBuf {
         config_dir

--- a/libparsec/crates/types/tests/manifest.rs
+++ b/libparsec/crates/types/tests/manifest.rs
@@ -483,8 +483,6 @@ fn file_manifest_verify(
         .map(|author| DeviceID::from_str(author).expect("Invalid raw DeviceID"))
         .unwrap_or_else(|| alice.device_id.to_owned());
     let expected_timestamp = expected_timestamp.unwrap_or(now);
-    let expected_id = expected_id;
-    let expected_version = expected_version;
 
     let manifest = FileManifest {
         author: alice.device_id.to_owned(),

--- a/misc/version_updater.py
+++ b/misc/version_updater.py
@@ -65,7 +65,7 @@ class Tool(enum.Enum):
 
 
 TOOLS_VERSION: Dict[Tool, str] = {
-    Tool.Rust: "1.72.1",
+    Tool.Rust: "1.74.0",
     Tool.Python: "3.9.10",
     Tool.Poetry: "1.5.1",
     Tool.Node: "18.12.0",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.72.1"
+channel = "1.74.0"
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 # https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 version.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 name = "parsec"
 crate-type = ["cdylib"]


### PR DESCRIPTION
- Use new `lint` table.

  https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-lints-section
  https://doc.rust-lang.org/stable/cargo/reference/workspaces.html#the-lints-table

- Fix const ref without an explicit static lifetime.
- Remove unnecessary `let` binding for downcast.
- Fix the borrowed expression implements the required traits for `std::fs::read_dir(path)`.
- Fix redundant redifinition of a binding.
- Ignore warning about usage of `skip(0)`.
- Ignore unwrap used in example `memfs`.