### PR TITLE
Link `parsec_cli` in dockerfile

### DIFF
--- a/server/packaging/server/server.dockerfile
+++ b/server/packaging/server/server.dockerfile
@@ -22,6 +22,7 @@ ADD --link \
 ADD --link libparsec/ libparsec/
 ADD --link server/ server/
 ADD --link bindings/ bindings/
+ADD --link cli/ cli/
 
 RUN bash in-docker-build.sh
 

--- a/server/packaging/testbed-server/testbed-server.dockerfile
+++ b/server/packaging/testbed-server/testbed-server.dockerfile
@@ -22,6 +22,7 @@ ADD --link \
 ADD --link libparsec/ libparsec/
 ADD --link server/ server/
 ADD --link bindings/ bindings/
+ADD --link cli/ cli/
 
 RUN bash in-docker-build.sh
 


### PR DESCRIPTION
The path `parsec_cli` is required because the root manifest search for
it (The bin crate `parsec_cli`)