### PR TITLE
[MS] Moved devices functions to their own file

### DIFF
--- a/client/src/parsec/device.ts
+++ b/client/src/parsec/device.ts
@@ -1,8 +1,13 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { Result } from '@/parsec/types';
+import { Result, OwnDeviceInfo, ClientListUserDevicesError, UserID, ClientListUserDevicesErrorTag, DeviceInfo } from '@/parsec/types';
 import { getParsecHandle } from '@/parsec/routing';
 import { needsMocks } from '@/parsec/environment';
+import { getClientInfo } from '@/parsec/login';
+import { DateTime } from 'luxon';
+import { libparsec } from '@/plugins/libparsec';
+
+const RECOVERY_DEVICE_PREFIX = 'recovery';
 
 export interface RecoveryDeviceData {
   code: string;
@@ -44,6 +49,104 @@ export async function exportRecoveryDevice(_password: string): Promise<Result<Re
         code: 'ABCDEF',
         file: 'Q2lnYXJlQU1vdXN0YWNoZQ==',
       },
+    };
+  }
+}
+
+export async function hasRecoveryDevice(): Promise<boolean> {
+  const result = await listOwnDevices();
+  if (!result.ok) {
+    return false;
+  }
+  return result.value.some((deviceInfo: OwnDeviceInfo) => deviceInfo.id.startsWith(RECOVERY_DEVICE_PREFIX));
+}
+
+export async function listOwnDevices(): Promise<Result<Array<OwnDeviceInfo>, ClientListUserDevicesError>> {
+  const handle = getParsecHandle();
+
+  if (handle !== null && !needsMocks()) {
+    const clientResult = await getClientInfo();
+
+    if (clientResult.ok) {
+      const result = await listUserDevices(clientResult.value.userId);
+      if (result.ok) {
+        result.value.map((device) => {
+          (device as OwnDeviceInfo).isCurrent = device.id === clientResult.value.deviceId;
+          return device;
+        });
+      }
+      return result as Result<Array<OwnDeviceInfo>, ClientListUserDevicesError>;
+    } else {
+      return {
+        ok: false,
+        error: { tag: ClientListUserDevicesErrorTag.Internal, error: '' },
+      };
+    }
+  } else {
+    return {
+      ok: true,
+      value: [
+        {
+          id: 'device1',
+          deviceLabel: 'My First Device',
+          createdOn: DateTime.now(),
+          createdBy: 'some_device',
+          isCurrent: true,
+        },
+        {
+          id: 'device2',
+          deviceLabel: 'My Second Device',
+          createdOn: DateTime.now(),
+          createdBy: 'device1',
+          isCurrent: false,
+        },
+        {
+          id: `${RECOVERY_DEVICE_PREFIX}_device1`,
+          deviceLabel: 'Recovery First Device',
+          createdOn: DateTime.now(),
+          createdBy: 'device1',
+          isCurrent: false,
+        },
+      ],
+    };
+  }
+}
+
+export async function listUserDevices(user: UserID): Promise<Result<Array<DeviceInfo>, ClientListUserDevicesError>> {
+  const handle = getParsecHandle();
+
+  if (handle !== null && !needsMocks()) {
+    const result = await libparsec.clientListUserDevices(handle, user);
+    if (result.ok) {
+      result.value.map((item) => {
+        item.createdOn = DateTime.fromSeconds(item.createdOn as any as number);
+        return item;
+      });
+    }
+    return result as any as Promise<Result<Array<DeviceInfo>, ClientListUserDevicesError>>;
+  } else {
+    return {
+      ok: true,
+      value: [
+        {
+          id: 'device1',
+          deviceLabel: 'My First Device',
+          createdOn: DateTime.now(),
+          createdBy: 'some_device',
+        },
+        {
+          id: 'device2',
+          deviceLabel: 'My Second Device',
+          createdOn: DateTime.now(),
+          createdBy: 'device1',
+        },
+        {
+          id: `${RECOVERY_DEVICE_PREFIX}_device1`,
+          deviceLabel: 'Recovery First Device',
+          createdOn: DateTime.now(),
+          createdBy: 'device1',
+        },
+      ],
     };
   }
 }

--- a/client/src/parsec/login.ts
+++ b/client/src/parsec/login.ts
@@ -20,15 +20,10 @@ import {
   ClientInfo,
   ClientInfoError,
   UserProfile,
-  ClientListUserDevicesError,
-  ClientListUserDevicesErrorTag,
-  OwnDeviceInfo,
 } from '@/parsec/types';
 import { getParsecHandle } from '@/parsec/routing';
 import { DEFAULT_HANDLE, getClientConfig } from '@/parsec/internals';
 import { needsMocks } from '@/parsec/environment';
-import { listUserDevices } from '@/parsec/user';
-import { DateTime } from 'luxon';
 
 export async function listAvailableDevices(): Promise<Array<AvailableDevice>> {
   return await libparsec.listAvailableDevices(window.getConfigDir());
@@ -114,58 +109,6 @@ export async function isOutsider(): Promise<boolean> {
   return (await getClientProfile()) === UserProfile.Outsider;
 }
 
-// TODO move devices function to another file
-export async function listOwnDevices(): Promise<Result<Array<OwnDeviceInfo>, ClientListUserDevicesError>> {
-  const handle = getParsecHandle();
-
-  if (handle !== null && !needsMocks()) {
-    const clientResult = await getClientInfo();
-
-    if (clientResult.ok) {
-      const result = await listUserDevices(clientResult.value.userId);
-      if (result.ok) {
-        result.value.map((device) => {
-          (device as OwnDeviceInfo).isCurrent = device.id === clientResult.value.deviceId;
-          return device;
-        });
-      }
-      return result as Result<Array<OwnDeviceInfo>, ClientListUserDevicesError>;
-    } else {
-      return {
-        ok: false,
-        error: { tag: ClientListUserDevicesErrorTag.Internal, error: '' },
-      };
-    }
-  } else {
-    return {
-      ok: true,
-      value: [
-        {
-          id: 'device1',
-          deviceLabel: 'My First Device',
-          createdOn: DateTime.now(),
-          createdBy: 'some_device',
-          isCurrent: true,
-        },
-        {
-          id: 'device2',
-          deviceLabel: 'My Second Device',
-          createdOn: DateTime.now(),
-          createdBy: 'device1',
-          isCurrent: false,
-        },
-        {
-          id: 'recovery_device1',
-          deviceLabel: 'Recovery First Device',
-          createdOn: DateTime.now(),
-          createdBy: 'device1',
-          isCurrent: false,
-        },
-      ],
-    };
-  }
-}
-
 export interface CurrentAvailableDeviceError {
   tag: 'NotFound';
 }
@@ -238,8 +181,4 @@ export async function changePassword(
       password: newPassword,
     },
   );
-}
-
-export async function hasRecoveryDevice(devicesInfo: Array<OwnDeviceInfo>): Promise<boolean> {
-  return devicesInfo.some((deviceInfo: OwnDeviceInfo) => deviceInfo.id.startsWith('recovery_'));
 }

--- a/client/src/parsec/user.ts
+++ b/client/src/parsec/user.ts
@@ -87,45 +87,6 @@ export async function listRevokedUsers(): Promise<Result<Array<UserInfo>, Client
   return result;
 }
 
-export async function listUserDevices(user: UserID): Promise<Result<Array<DeviceInfo>, ClientListUserDevicesError>> {
-  const handle = getParsecHandle();
-
-  if (handle !== null && !needsMocks()) {
-    const result = await libparsec.clientListUserDevices(handle, user);
-    if (result.ok) {
-      result.value.map((item) => {
-        item.createdOn = DateTime.fromSeconds(item.createdOn as any as number);
-        return item;
-      });
-    }
-    return result as any as Promise<Result<Array<DeviceInfo>, ClientListUserDevicesError>>;
-  } else {
-    return {
-      ok: true,
-      value: [
-        {
-          id: 'device1',
-          deviceLabel: 'My First Device',
-          createdOn: DateTime.now(),
-          createdBy: 'some_device',
-        },
-        {
-          id: 'device2',
-          deviceLabel: 'My Second Device',
-          createdOn: DateTime.now(),
-          createdBy: 'device1',
-        },
-        {
-          id: 'recovery_device1',
-          deviceLabel: 'Recovery First Device',
-          createdOn: DateTime.now(),
-          createdBy: 'device1',
-        },
-      ],
-    };
-  }
-}
-
 export enum RevokeUserTag {
   Internal = 'Internal',
 }

--- a/client/src/views/devices/DevicesPage.vue
+++ b/client/src/views/devices/DevicesPage.vue
@@ -161,7 +161,7 @@ async function refreshDevicesList(): Promise<void> {
   const result = await listOwnDevices();
   if (result.ok) {
     devices.value = result.value;
-    if (await hasRecoveryDevice(devices.value)) {
+    if (await hasRecoveryDevice()) {
       passwordSaved.value = true;
     }
   } else {


### PR DESCRIPTION
Not much, just moved functions around.

The only real change is that `hasRecoveryDevice` does not take a parameter anymore.

- [x] Keep changes in the pull request as small as possible
- [x] Ensure the commit history is sanitized
- [x] Give a meaningful title to your PR
- [x] Describe your changes