### PR TITLE
[MS] Fix all existing popover placement

### DIFF
--- a/client/src/components/core/ms-dropdown/MsDropdown.vue
+++ b/client/src/components/core/ms-dropdown/MsDropdown.vue
@@ -43,14 +43,16 @@ const selectedOption: Ref<MsDropdownOption | undefined> = ref(
 const labelRef = ref(selectedOption.value?.label || props.label);
 const isPopoverOpen = ref(false);
 
-async function openPopover(ev: Event): Promise<void> {
+async function openPopover(event: Event): Promise<void> {
   const popover = await popoverController.create({
     component: MsDropdownPopover,
+    cssClass: 'dropdown-popover',
     componentProps: {
       options: props.options,
       defaultOption: selectedOption.value?.key,
     },
-    event: ev,
+    event: event,
+    alignment: 'end',
     showBackdrop: false,
   });
   isPopoverOpen.value = true;

--- a/client/src/components/core/ms-dropdown/MsDropdownPopover.vue
+++ b/client/src/components/core/ms-dropdown/MsDropdownPopover.vue
@@ -117,6 +117,7 @@ function openTooltip(event: Event, text: string): void {
 
   .icon {
     margin: 0;
+    margin-left: 1em;
   }
 
   &.selected {

--- a/client/src/components/core/ms-sorter/MsSorter.vue
+++ b/client/src/components/core/ms-sorter/MsSorter.vue
@@ -42,16 +42,18 @@ const selectedOption: Ref<MsSorterOption | undefined> = ref(
 const sortByAsc: Ref<boolean> = ref(true);
 const labelRef = ref(selectedOption.value?.label || props.label);
 
-async function openPopover(ev: Event): Promise<void> {
+async function openPopover(event: Event): Promise<void> {
   const popover = await popoverController.create({
     component: MsSorterPopover,
+    cssClass: 'sorter-popover',
     componentProps: {
       options: props.options,
       defaultOption: selectedOption.value?.key,
       sorterLabels: props.sorterLabels,
       sortByAsc: sortByAsc.value,
     },
-    event: ev,
+    event: event,
+    alignment: 'end',
     showBackdrop: false,
   });
   await popover.present();

--- a/client/src/components/core/ms-sorter/MsSorterPopover.vue
+++ b/client/src/components/core/ms-sorter/MsSorterPopover.vue
@@ -79,6 +79,10 @@ function onOptionClick(option?: MsSorterOption): void {
   .checked.selected {
     color: var(--parsec-color-light-primary-700);
   }
+
+  ion-icon {
+    margin-left: 1em;
+  }
 }
 #sort-order-button {
   --background: var(--parsec-color-light-secondary-medium);
@@ -98,4 +102,3 @@ function onOptionClick(option?: MsSorterOption): void {
   }
 }
 </style>
-@/components/core/ms-sort/MsSorterOption

--- a/client/src/theme/components/popovers.scss
+++ b/client/src/theme/components/popovers.scss
@@ -1,58 +1,41 @@
 /* Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS */
 
 /* **** Parsec popover **** */
-
-ion-popover {
-  --width: 300px;
+:root {
+  --popover-border-radius: var(--parsec-radius-8);
+  --popover-default-width: 20rem;
+  --popover-option-width: 18rem;
 }
 
-.popover-side-bottom:not(.tooltip-popover) {
-  --width: 250px;
-  --offset-x: -3em;
-  --offset-y: 0.5em;
+// Global popover style
+ion-popover {
+  --width: var(--popover-default-width);
+  --box-shadow: var(--parsec-shadow-strong);
 
+  &::part(content) {
+    border-radius: var(--popover-border-radius);
+    border: none;
+  }
+}
+
+.popover-side-bottom {
   .popover-viewport {
-    border: var(--parsec-color-light-secondary-disabled) 1.5px solid;
-    border-radius: var(--parsec-radius-8);
+    border: none;
+    border-radius: var(--popover-border-radius);
     overflow: hidden;
   }
 }
 
-ion-popover::part(content) {
-  border-radius: var(--parsec-radius-8);
-}
-
-/* --- Option file popover --- */
-
-/* handle the popover option menu on file item (list or grid) */
-.file-context-menu {
-  --width: 20rem;
-}
-
+// Custom popover style
 /* --- homepage popover --- */
 .homepage-popover {
-  --width: 350px;
-  --offset-x: -6.8rem;
   --offset-y: 0.5em;
-}
-
-.homepage-popover .item-native {
-  padding-inline-start: 0;
 }
 
 /* --- profil popover --- */
 .profile-header-popover {
-  --offset-x: -2em;
-  --offset-y: 1em;
-
-  .popover-viewport {
-    border: none;
-    border-radius: var(--parsec-radius-8);
-  }
-}
-
-.profile-header-popover::part(content) {
-  background: none;
+  --offset-x: -1em;
+  --offset-y: 0.5em;
 }
 
 /* --- tooltip popover --- */
@@ -60,9 +43,17 @@ ion-popover::part(content) {
   --background: none;
   --box-shadow: none;
   --width: fit-content;
+}
 
-  .popover-viewport {
-    border: none;
-    overflow: hidden;
-  }
+/* --- sorter, dropdown popover --- */
+.sorter-popover,
+.dropdown-popover {
+  --width: fit-content;
+}
+
+/* --- dropdown option popover --- */
+.workspace-context-menu,
+.file-context-menu,
+.user-context-menu {
+  --width: var(--popover-option-width);
 }

--- a/client/src/views/files/FoldersPage.vue
+++ b/client/src/views/files/FoldersPage.vue
@@ -660,7 +660,7 @@ async function openFileContextMenu(event: Event, file: parsec.EntryStat, onFinis
     translucent: true,
     showBackdrop: false,
     dismissOnSelect: true,
-    reference: 'event',
+    alignment: 'end',
   });
   await popover.present();
 

--- a/client/src/views/header/ProfileHeader.vue
+++ b/client/src/views/header/ProfileHeader.vue
@@ -5,10 +5,7 @@
     button
     id="click-trigger"
     class="container"
-    @click="
-      isPopoverOpen = !isPopoverOpen;
-      openPopover($event);
-    "
+    @click="openPopover($event)"
   >
     <ion-avatar
       slot="start"
@@ -52,15 +49,17 @@ const props = defineProps<{
   name: string;
 }>();
 
-async function openPopover(ev: Event): Promise<void> {
+async function openPopover(event: Event): Promise<void> {
+  isPopoverOpen.value = !isPopoverOpen.value;
   const popover = await popoverController.create({
     component: ProfileHeaderPopover,
+    cssClass: 'profile-header-popover',
     componentProps: {
       name: props.name,
     },
-    cssClass: 'profile-header-popover',
-    event: ev,
+    event: event,
     showBackdrop: false,
+    alignment: 'end',
   });
   await popover.present();
 
@@ -109,6 +108,9 @@ async function openPopover(ev: Event): Promise<void> {
   cursor: pointer;
   &:hover {
     --background-hover: none;
+  }
+  & * {
+    pointer-events: none;
   }
 }
 

--- a/client/src/views/header/ProfileHeaderPopover.vue
+++ b/client/src/views/header/ProfileHeaderPopover.vue
@@ -104,10 +104,7 @@ function onOptionClick(option: ProfilePopoverOption): void {
 
 <style lang="scss" scoped>
 .container {
-  border-radius: var(--parsec-radius-8);
   padding: 0;
-  overflow: hidden;
-  border: 1px solid var(--parsec-color-light-secondary-medium);
 }
 
 .profile-email {

--- a/client/src/views/home/HomePage.vue
+++ b/client/src/views/home/HomePage.vue
@@ -473,12 +473,13 @@ async function openAboutModal(): Promise<void> {
   await modal.onWillDismiss();
 }
 
-async function openPopover(ev: Event): Promise<void> {
+async function openPopover(event: Event): Promise<void> {
   const popover = await popoverController.create({
     component: HomePagePopover,
     cssClass: 'homepage-popover',
-    event: ev,
+    event: event,
     showBackdrop: false,
+    alignment: 'end',
   });
   await popover.present();
   const result = await popover.onWillDismiss();

--- a/client/src/views/home/HomePagePopover.vue
+++ b/client/src/views/home/HomePagePopover.vue
@@ -59,9 +59,8 @@ async function onClick(action: HomePageAction): Promise<boolean> {
 <style lang="scss" scoped>
 .container {
   padding: 0.5rem;
-  border-radius: 0.5rem;
-  overflow: hidden;
 }
+
 .container__item {
   --background: none;
   width: 100%;

--- a/client/src/views/users/ActiveUsersPage.vue
+++ b/client/src/views/users/ActiveUsersPage.vue
@@ -368,7 +368,7 @@ async function openUserContextMenu(event: Event, user: UserInfo, onFinished?: ()
     translucent: true,
     showBackdrop: false,
     dismissOnSelect: true,
-    reference: 'event',
+    alignment: 'end',
     componentProps: {
       isRevoked: user.isRevoked(),
     },

--- a/client/src/views/users/RevokedUsersPage.vue
+++ b/client/src/views/users/RevokedUsersPage.vue
@@ -210,7 +210,7 @@ async function openUserContextMenu(event: Event, user: UserInfo, onFinished?: ()
     translucent: true,
     showBackdrop: false,
     dismissOnSelect: true,
-    reference: 'event',
+    alignment: 'end',
     componentProps: {
       isRevoked: user.isRevoked(),
     },

--- a/client/src/views/workspaces/WorkspacesPage.vue
+++ b/client/src/views/workspaces/WorkspacesPage.vue
@@ -253,11 +253,12 @@ async function onWorkspaceShareClick(_: Event, workspace: WorkspaceInfo): Promis
 async function openWorkspaceContextMenu(event: Event, workspace: WorkspaceInfo): Promise<void> {
   const popover = await popoverController.create({
     component: WorkspaceContextMenu,
+    cssClass: 'workspace-context-menu',
     event: event,
     translucent: true,
     showBackdrop: false,
     dismissOnSelect: true,
-    reference: 'event',
+    alignment: 'end',
   });
   await popover.present();
 


### PR DESCRIPTION
closes #5890 
@fabienSvtr please take a look at the last commit, we have CSS managing border, border radius and overflow on this class: `popover-side-bottom`. This is causing a lot of problems like you can see, I've used a lot of :not to clean the placement mess due to this global override.
The CSS here is not meant to remain like this, but I would like your opinion on the subject, do we remove this override? Do we prefer case by case? or override on ion-popover maybe?
On another note, I must specify that I like the popovers without the border as much (maybe even more) as they are supposed to be, it is another subject, but maybe we could keep them like they are in the PR.