### PR TITLE
[MS] Better core components imports

### DIFF
--- a/client/src/components/core/index.ts
+++ b/client/src/components/core/index.ts
@@ -1,0 +1,34 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+// ** ms-types ** //
+export * from '@/components/core/ms-types';
+
+// ** ms-action-bar ** //
+export * from '@/components/core/ms-action-bar';
+
+// ** ms-dropdown ** //
+export * from '@/components/core/ms-dropdown';
+
+// ** ms-image ** //
+export * from '@/components/core/ms-image';
+
+// ** ms-input ** //
+export * from '@/components/core/ms-input';
+
+// ** ms-modal ** //
+export * from '@/components/core/ms-modal';
+
+// ** ms-sorter ** //
+export * from '@/components/core/ms-sorter';
+
+// ** ms-spinner ** //
+export * from '@/components/core/ms-spinner';
+
+// ** ms-stepper ** //
+export * from '@/components/core/ms-stepper';
+
+// ** ms-text ** //
+export * from '@/components/core/ms-text';
+
+// ** ms-toggle ** //
+export * from '@/components/core/ms-toggle';

--- a/client/src/components/core/ms-action-bar/index.ts
+++ b/client/src/components/core/ms-action-bar/index.ts
@@ -1,0 +1,5 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+import MsActionBar from '@/components/core/ms-action-bar/MsActionBar.vue';
+import MsActionBarButton from '@/components/core/ms-action-bar/MsActionBarButton.vue';
+
+export { MsActionBar, MsActionBarButton };

--- a/client/src/components/core/ms-dropdown/MsDropdown.vue
+++ b/client/src/components/core/ms-dropdown/MsDropdown.vue
@@ -23,13 +23,14 @@ import { defineProps, defineEmits, Ref, ref } from 'vue';
 import { IonButton, IonIcon, popoverController } from '@ionic/vue';
 import { caretDown } from 'ionicons/icons';
 import MsDropdownPopover from '@/components/core/ms-dropdown/MsDropdownPopover.vue';
-import { MsDropdownOption, MsDropdownChangeEvent, getMsOptionByKey } from '@/components/core/ms-types';
+import { MsOption, MsOptions } from '@/components/core/ms-types';
+import { MsDropdownChangeEvent } from '@/components/core/ms-dropdown/types';
 
 const props = defineProps<{
   defaultOption?: any;
   label?: string;
   description?: string;
-  options: MsDropdownOption[];
+  options: MsOptions;
   disabled?: boolean;
 }>();
 
@@ -37,9 +38,7 @@ const emits = defineEmits<{
   (e: 'change', value: MsDropdownChangeEvent): void;
 }>();
 
-const selectedOption: Ref<MsDropdownOption | undefined> = ref(
-  props.defaultOption ? getMsOptionByKey(props.options, props.defaultOption) : undefined,
-);
+const selectedOption: Ref<MsOption | undefined> = ref(props.defaultOption ? props.options.get(props.defaultOption) : undefined);
 const labelRef = ref(selectedOption.value?.label || props.label);
 const isPopoverOpen = ref(false);
 

--- a/client/src/components/core/ms-dropdown/MsDropdownPopover.vue
+++ b/client/src/components/core/ms-dropdown/MsDropdownPopover.vue
@@ -7,7 +7,7 @@
       :class="{ selected: selectedOption?.key === option.key, 'item-disabled': option.disabled }"
       button
       lines="none"
-      v-for="option in options"
+      v-for="option in options.set"
       :key="option.key"
       @click="onOptionClick(option)"
     >
@@ -42,17 +42,17 @@
 import { ref } from 'vue';
 import { IonList, IonItem, IonIcon, IonLabel, popoverController } from '@ionic/vue';
 import { checkmark, informationCircle } from 'ionicons/icons';
-import { MsDropdownOption, getMsOptionByKey } from '@/components/core/ms-types';
+import { MsOption, MsOptions } from '@/components/core/ms-types';
 import MsDropdownTooltip from '@/components/core/ms-dropdown/MsDropdownTooltip.vue';
 
 const props = defineProps<{
   defaultOption?: any;
-  options: MsDropdownOption[];
+  options: MsOptions;
 }>();
 
-const selectedOption = ref(props.defaultOption ? getMsOptionByKey(props.options, props.defaultOption) : props.options[0]);
+const selectedOption = ref(props.defaultOption ? props.options.get(props.defaultOption) : props.options.at(0));
 
-function onOptionClick(option?: MsDropdownOption): void {
+function onOptionClick(option?: MsOption): void {
   if (option) {
     selectedOption.value = option;
   }

--- a/client/src/components/core/ms-dropdown/index.ts
+++ b/client/src/components/core/ms-dropdown/index.ts
@@ -1,0 +1,5 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+import MsDropdown from '@/components/core/ms-dropdown/MsDropdown.vue';
+
+export * from '@/components/core/ms-dropdown/types';
+export { MsDropdown };

--- a/client/src/components/core/ms-dropdown/types.ts
+++ b/client/src/components/core/ms-dropdown/types.ts
@@ -1,0 +1,7 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { MsOption } from '@/components/core/ms-types';
+
+export interface MsDropdownChangeEvent {
+  option: MsOption;
+}

--- a/client/src/components/core/ms-input/index.ts
+++ b/client/src/components/core/ms-input/index.ts
@@ -1,0 +1,7 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+import MsInput from '@/components/core/ms-input/MsInput.vue';
+import MsChoosePasswordInput from '@/components/core/ms-input/MsChoosePasswordInput.vue';
+import MsPasswordInput from '@/components/core/ms-input/MsPasswordInput.vue';
+import MsSearchInput from '@/components/core/ms-input/MsSearchInput.vue';
+
+export { MsChoosePasswordInput, MsInput, MsPasswordInput, MsSearchInput };

--- a/client/src/components/core/ms-modal/FolderSelectionModal.vue
+++ b/client/src/components/core/ms-modal/FolderSelectionModal.vue
@@ -65,9 +65,8 @@ import { modalController, IonList, IonItem, IonLabel, IonIcon, IonListHeader } f
 import { ref, Ref, onMounted } from 'vue';
 import MsModal from '@/components/core/ms-modal/MsModal.vue';
 import { entryStat } from '@/parsec';
-import { MsModalResult } from '@/components/core/ms-types';
 import { Path } from '@/parsec';
-import { FolderSelectionOptions } from '@/components/core/ms-utils';
+import { FolderSelectionOptions, MsModalResult } from '@/components/core/ms-modal/types';
 
 const props = defineProps<FolderSelectionOptions>();
 const selectedPath = ref(props.startingPath);

--- a/client/src/components/core/ms-modal/MsAlertModal.vue
+++ b/client/src/components/core/ms-modal/MsAlertModal.vue
@@ -15,18 +15,10 @@
   />
 </template>
 
-<script lang="ts">
-export interface MsAlertModalConfig {
-  title?: string;
-  theme: MsReportTheme;
-  message: string;
-}
-</script>
-
 <script setup lang="ts">
 import MsModal from '@/components/core/ms-modal/MsModal.vue';
 import { modalController } from '@ionic/vue';
-import { MsReportTheme, MsModalResult } from '@/components/core/ms-types';
+import { MsAlertModalConfig, MsModalResult } from '@/components/core/ms-modal/types';
 
 defineProps<MsAlertModalConfig>();
 

--- a/client/src/components/core/ms-modal/MsModal.vue
+++ b/client/src/components/core/ms-modal/MsModal.vue
@@ -94,34 +94,12 @@
   </ion-page>
 </template>
 
-<script lang="ts">
-export interface MsModalConfig {
-  title?: string;
-  theme?: MsReportTheme;
-  subtitle?: string;
-  closeButton?: {
-    visible: boolean;
-    onClick?: () => Promise<boolean>;
-  };
-  cancelButton?: {
-    disabled: boolean;
-    label: string;
-    onClick?: () => Promise<boolean>;
-  };
-  confirmButton?: {
-    disabled: boolean;
-    label: string;
-    onClick?: () => Promise<boolean>;
-  };
-}
-</script>
-
 <script setup lang="ts">
 import { IonText, IonPage, IonHeader, IonTitle, IonToolbar, IonButtons, IonButton, modalController, IonFooter, IonIcon } from '@ionic/vue';
 import { close } from 'ionicons/icons';
 import { onMounted, ref, Ref } from 'vue';
-import { MsReportTheme, MsModalResult } from '@/components/core/ms-types';
-import MsReportText from '@/components/core/ms-text/MsReportText.vue';
+import { MsReportText } from '@/components/core/ms-text';
+import { MsModalConfig, MsModalResult } from '@/components/core/ms-modal/types';
 
 const modal: Ref<HTMLDivElement | null> = ref(null);
 defineProps<MsModalConfig>();

--- a/client/src/components/core/ms-modal/MsPasswordInputModal.vue
+++ b/client/src/components/core/ms-modal/MsPasswordInputModal.vue
@@ -23,9 +23,8 @@
 import { modalController } from '@ionic/vue';
 import { ref } from 'vue';
 import MsModal from '@/components/core/ms-modal/MsModal.vue';
-import MsPasswordInput from '@/components/core/ms-input/MsPasswordInput.vue';
-import { MsModalResult } from '@/components/core/ms-types';
-import { GetPasswordOptions } from '@/components/core/ms-utils';
+import { MsPasswordInput } from '@/components/core/ms-input';
+import { GetPasswordOptions, MsModalResult } from '@/components/core/ms-modal/types';
 
 defineProps<GetPasswordOptions>();
 

--- a/client/src/components/core/ms-modal/MsQuestionModal.vue
+++ b/client/src/components/core/ms-modal/MsQuestionModal.vue
@@ -22,7 +22,7 @@
 <script setup lang="ts">
 import MsModal from '@/components/core/ms-modal/MsModal.vue';
 import { modalController } from '@ionic/vue';
-import { MsModalResult } from '@/components/core/ms-types';
+import { MsModalResult } from '@/components/core/ms-modal/types';
 
 defineProps<{
   title: string;

--- a/client/src/components/core/ms-modal/MsTextInputModal.vue
+++ b/client/src/components/core/ms-modal/MsTextInputModal.vue
@@ -29,11 +29,10 @@
 import { modalController } from '@ionic/vue';
 import { ref } from 'vue';
 import MsModal from '@/components/core/ms-modal/MsModal.vue';
-import MsInput from '@/components/core/ms-input/MsInput.vue';
-import { MsModalResult } from '@/components/core/ms-types';
+import { MsInput } from '@/components/core/ms-input';
 import { Validity } from '@/common/validators';
 import { asyncComputed } from '@/common/asyncComputed';
-import { GetTextOptions } from '@/components/core/ms-utils';
+import { GetTextOptions, MsModalResult } from '@/components/core/ms-modal/types';
 
 const props = defineProps<GetTextOptions>();
 

--- a/client/src/components/core/ms-modal/index.ts
+++ b/client/src/components/core/ms-modal/index.ts
@@ -1,0 +1,7 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+import MsModal from '@/components/core/ms-modal/MsModal.vue';
+import MsAlertModal from '@/components/core/ms-modal/MsAlertModal.vue';
+
+export * from '@/components/core/ms-modal/utils';
+export * from '@/components/core/ms-modal/types';
+export { MsModal, MsAlertModal };

--- a/client/src/components/core/ms-modal/types.ts
+++ b/client/src/components/core/ms-modal/types.ts
@@ -1,0 +1,65 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { IValidator } from '@/common/validators';
+import { FsPath } from '@/parsec';
+import { MsReportTheme } from '@/components/core/ms-types';
+
+export enum Answer {
+  No = 0,
+  Yes = 1,
+}
+
+export interface FolderSelectionOptions {
+  title: string;
+  subtitle?: string;
+  startingPath: FsPath;
+}
+
+export interface GetTextOptions {
+  title: string;
+  subtitle?: string;
+  trim?: boolean;
+  validator?: IValidator;
+  inputLabel?: string;
+  placeholder?: string;
+  okButtonText?: string;
+  defaultValue?: string;
+}
+
+export interface GetPasswordOptions {
+  title: string;
+  subtitle?: string;
+  inputLabel?: string;
+  okButtonText?: string;
+}
+
+export interface MsAlertModalConfig {
+  title?: string;
+  theme: MsReportTheme;
+  message: string;
+}
+
+export interface MsModalConfig {
+  title?: string;
+  theme?: MsReportTheme;
+  subtitle?: string;
+  closeButton?: {
+    visible: boolean;
+    onClick?: () => Promise<boolean>;
+  };
+  cancelButton?: {
+    disabled: boolean;
+    label: string;
+    onClick?: () => Promise<boolean>;
+  };
+  confirmButton?: {
+    disabled: boolean;
+    label: string;
+    onClick?: () => Promise<boolean>;
+  };
+}
+
+export enum MsModalResult {
+  Cancel = 'cancel',
+  Confirm = 'confirm',
+}

--- a/client/src/components/core/ms-modal/utils.ts
+++ b/client/src/components/core/ms-modal/utils.ts
@@ -1,18 +1,12 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 import { modalController } from '@ionic/vue';
-import { MsModalResult } from '@/components/core/ms-types';
 import MsQuestionModal from '@/components/core/ms-modal/MsQuestionModal.vue';
 import MsPasswordInputModal from '@/components/core/ms-modal/MsPasswordInputModal.vue';
 import MsTextInputModal from '@/components/core/ms-modal/MsTextInputModal.vue';
-import { IValidator } from '@/common/validators';
 import FolderSelectionModal from '@/components/core/ms-modal/FolderSelectionModal.vue';
 import { FsPath } from '@/parsec';
-
-export enum Answer {
-  No = 0,
-  Yes = 1,
-}
+import { FolderSelectionOptions, GetPasswordOptions, GetTextOptions, Answer, MsModalResult } from '@/components/core/ms-modal/types';
 
 export async function askQuestion(title: string, subtitle?: string, redisplayMainModalOnYes = true): Promise<Answer> {
   const top = await modalController.getTop();
@@ -50,13 +44,6 @@ export async function askQuestion(title: string, subtitle?: string, redisplayMai
   return answer;
 }
 
-export interface GetPasswordOptions {
-  title: string;
-  subtitle?: string;
-  inputLabel?: string;
-  okButtonText?: string;
-}
-
 export async function getPasswordFromUser(options: GetPasswordOptions): Promise<string | null> {
   const modal = await modalController.create({
     component: MsPasswordInputModal,
@@ -68,17 +55,6 @@ export async function getPasswordFromUser(options: GetPasswordOptions): Promise<
   const result = await modal.onWillDismiss();
   await modal.dismiss();
   return result.role === MsModalResult.Confirm ? result.data : null;
-}
-
-export interface GetTextOptions {
-  title: string;
-  subtitle?: string;
-  trim?: boolean;
-  validator?: IValidator;
-  inputLabel?: string;
-  placeholder?: string;
-  okButtonText?: string;
-  defaultValue?: string;
 }
 
 export async function getTextInputFromUser(options: GetTextOptions): Promise<string | null> {
@@ -101,12 +77,6 @@ export async function getTextInputFromUser(options: GetTextOptions): Promise<str
   const result = await modal.onWillDismiss();
   await modal.dismiss();
   return result.role === MsModalResult.Confirm ? result.data : null;
-}
-
-export interface FolderSelectionOptions {
-  title: string;
-  subtitle?: string;
-  startingPath: FsPath;
 }
 
 export async function selectFolder(options: FolderSelectionOptions): Promise<FsPath | null> {

--- a/client/src/components/core/ms-sorter/MsSorter.vue
+++ b/client/src/components/core/ms-sorter/MsSorter.vue
@@ -22,12 +22,13 @@ import { defineProps, defineEmits, Ref, ref } from 'vue';
 import { IonButton, IonIcon, popoverController } from '@ionic/vue';
 import { swapVertical } from 'ionicons/icons';
 import MsSorterPopover from '@/components/core/ms-sorter/MsSorterPopover.vue';
-import { MsSorterOption, MsSorterLabels, MsSorterChangeEvent, getMsOptionByKey } from '@/components/core/ms-types';
+import { MsSorterChangeEvent, MsSorterLabels } from '@/components/core/ms-sorter/types';
+import { MsOption, MsOptions } from '@/components/core/ms-types';
 
 const props = defineProps<{
   defaultOption: any;
   label?: string;
-  options: MsSorterOption[];
+  options: MsOptions;
   sorterLabels?: MsSorterLabels;
   disabled?: boolean;
 }>();
@@ -36,9 +37,7 @@ const emits = defineEmits<{
   (e: 'change', value: MsSorterChangeEvent): void;
 }>();
 
-const selectedOption: Ref<MsSorterOption | undefined> = ref(
-  props.defaultOption ? getMsOptionByKey(props.options, props.defaultOption) : undefined,
-);
+const selectedOption: Ref<MsOption | undefined> = ref(props.defaultOption ? props.options.get(props.defaultOption) : undefined);
 const sortByAsc: Ref<boolean> = ref(true);
 const labelRef = ref(selectedOption.value?.label || props.label);
 

--- a/client/src/components/core/ms-sorter/MsSorterPopover.vue
+++ b/client/src/components/core/ms-sorter/MsSorterPopover.vue
@@ -21,7 +21,7 @@
       :disabled="option.disabled"
       button
       lines="none"
-      v-for="option in options"
+      v-for="option in options.set"
       :key="option.key"
       @click="onOptionClick(option)"
     >
@@ -41,19 +41,20 @@
 import { ref, Ref } from 'vue';
 import { IonList, IonItem, IonIcon, popoverController } from '@ionic/vue';
 import { arrowUp, arrowDown, checkmark } from 'ionicons/icons';
-import { MsSorterOption, MsSorterLabels, getMsOptionByKey } from '@/components/core/ms-types';
+import { MsOption, MsOptions } from '@/components/core/ms-types';
+import { MsSorterLabels } from '@/components/core/ms-sorter/types';
 
 const props = defineProps<{
   defaultOption?: any;
-  options: MsSorterOption[];
+  options: MsOptions;
   sorterLabels?: MsSorterLabels;
   sortByAsc: boolean;
 }>();
 
 const sortByAsc: Ref<boolean> = ref(props.sortByAsc);
-const selectedOption = ref(props.defaultOption ? getMsOptionByKey(props.options, props.defaultOption) : props.options[0]);
+const selectedOption = ref(props.defaultOption ? props.options.get(props.defaultOption) : props.options.at(0));
 
-function onOptionClick(option?: MsSorterOption): void {
+function onOptionClick(option?: MsOption): void {
   if (option) {
     selectedOption.value = option;
   } else {

--- a/client/src/components/core/ms-sorter/index.ts
+++ b/client/src/components/core/ms-sorter/index.ts
@@ -1,0 +1,5 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+import MsSorter from '@/components/core/ms-sorter/MsSorter.vue';
+
+export * from '@/components/core/ms-sorter/types';
+export { MsSorter };

--- a/client/src/components/core/ms-sorter/types.ts
+++ b/client/src/components/core/ms-sorter/types.ts
@@ -1,0 +1,13 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { MsOption } from '@/components/core/ms-types';
+
+export interface MsSorterLabels {
+  asc: string;
+  desc: string;
+}
+
+export interface MsSorterChangeEvent {
+  option: MsOption;
+  sortByAsc: boolean;
+}

--- a/client/src/components/core/ms-spinner/index.ts
+++ b/client/src/components/core/ms-spinner/index.ts
@@ -1,0 +1,4 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+import MsSpinner from '@/components/core/ms-spinner/MsSpinner.vue';
+
+export { MsSpinner };

--- a/client/src/components/core/ms-stepper/MsWizardStepper.vue
+++ b/client/src/components/core/ms-stepper/MsWizardStepper.vue
@@ -22,8 +22,9 @@
 
 <script setup lang="ts">
 import { IonText } from '@ionic/vue';
-import MsWizardStepperStep, { MsStepStatus } from '@/components/core/ms-stepper/MsWizardStepperStep.vue';
+import MsWizardStepperStep from '@/components/core/ms-stepper/MsWizardStepperStep.vue';
 import { defineProps } from 'vue';
+import { MsStepStatus } from '@/components/core/ms-stepper/types';
 
 defineProps<{
   titles: string[];

--- a/client/src/components/core/ms-stepper/MsWizardStepperStep.vue
+++ b/client/src/components/core/ms-stepper/MsWizardStepperStep.vue
@@ -29,18 +29,11 @@
   </div>
 </template>
 
-<script lang="ts">
-export enum MsStepStatus {
-  DEFAULT = 'default',
-  DONE = 'done',
-  ACTIVE = 'active',
-}
-</script>
-
 <script setup lang="ts">
 import { IonIcon } from '@ionic/vue';
 import { checkmark } from 'ionicons/icons';
 import { defineProps } from 'vue';
+import { MsStepStatus } from '@/components/core/ms-stepper/types';
 
 defineProps<{
   status: MsStepStatus;

--- a/client/src/components/core/ms-stepper/index.ts
+++ b/client/src/components/core/ms-stepper/index.ts
@@ -1,0 +1,5 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+import MsWizardStepper from '@/components/core/ms-stepper/MsWizardStepper.vue';
+
+export * from '@/components/core/ms-stepper/types';
+export { MsWizardStepper };

--- a/client/src/components/core/ms-stepper/types.ts
+++ b/client/src/components/core/ms-stepper/types.ts
@@ -1,0 +1,7 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+export enum MsStepStatus {
+  DEFAULT = 'default',
+  DONE = 'done',
+  ACTIVE = 'active',
+}

--- a/client/src/components/core/ms-text/index.ts
+++ b/client/src/components/core/ms-text/index.ts
@@ -1,0 +1,5 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+import MsInformativeText from '@/components/core/ms-text/MsInformativeText.vue';
+import MsReportText from '@/components/core/ms-text/MsReportText.vue';
+
+export { MsInformativeText, MsReportText };

--- a/client/src/components/core/ms-toggle/MsGridListToggle.vue
+++ b/client/src/components/core/ms-toggle/MsGridListToggle.vue
@@ -31,17 +31,11 @@
   </div>
 </template>
 
-<script lang="ts">
-export enum DisplayState {
-  List = 0,
-  Grid = 1,
-}
-</script>
-
 <script setup lang="ts">
 import { IonButton, IonIcon } from '@ionic/vue';
 import { defineEmits } from 'vue';
 import { grid, list } from 'ionicons/icons';
+import { DisplayState } from '@/components/core/ms-toggle/types';
 
 defineProps<{
   modelValue: DisplayState;

--- a/client/src/components/core/ms-toggle/index.ts
+++ b/client/src/components/core/ms-toggle/index.ts
@@ -1,0 +1,5 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+import MsGridListToggle from '@/components/core/ms-toggle/MsGridListToggle.vue';
+
+export * from '@/components/core/ms-toggle/types';
+export { MsGridListToggle };

--- a/client/src/components/core/ms-toggle/types.ts
+++ b/client/src/components/core/ms-toggle/types.ts
@@ -1,0 +1,6 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+export enum DisplayState {
+  List = 0,
+  Grid = 1,
+}

--- a/client/src/components/core/ms-types.ts
+++ b/client/src/components/core/ms-types.ts
@@ -7,36 +7,27 @@ export enum MsReportTheme {
   Error = 'ms-error',
 }
 
-export enum MsModalResult {
-  Cancel = 'cancel',
-  Confirm = 'confirm',
-}
-
-interface MsOption {
+export interface MsOption {
   label: string;
   description?: string;
   key: any;
   disabled?: boolean;
 }
 
-export function getMsOptionByKey(options: MsOption[], key: any): MsOption | undefined {
-  return options.find((option) => {
-    return option.key === key;
-  });
-}
+export class MsOptions {
+  set: MsOption[];
 
-export type MsDropdownOption = MsOption;
-export type MsSorterOption = MsOption;
+  constructor(options: MsOption[]) {
+    this.set = options;
+  }
 
-export interface MsSorterLabels {
-  asc: string;
-  desc: string;
-}
-export interface MsDropdownChangeEvent {
-  option: MsDropdownOption;
-}
+  at(index: number): MsOption | undefined {
+    return this.set.at(index);
+  }
 
-export interface MsSorterChangeEvent {
-  option: MsSorterOption;
-  sortByAsc: boolean;
+  get(key: any): MsOption | undefined {
+    return this.set.find((option) => {
+      return option.key === key;
+    });
+  }
 }

--- a/client/src/components/files/FileImport.vue
+++ b/client/src/components/files/FileImport.vue
@@ -37,11 +37,10 @@
 </template>
 
 <script setup lang="ts">
-import { MsImage, FileImport } from '@/components/core/ms-image';
+import { FileImport, MsImage } from '@/components/core';
 import { IonButton, IonIcon, IonText } from '@ionic/vue';
 import { ellipsisHorizontalCircle } from 'ionicons/icons';
 import { onMounted, onUnmounted, ref } from 'vue';
-
 const emits = defineEmits<{
   (e: 'filesImport', entries: File[]): void;
 }>();

--- a/client/src/components/organizations/ChooseServer.vue
+++ b/client/src/components/organizations/ChooseServer.vue
@@ -73,7 +73,7 @@ export enum ServerMode {
 <script setup lang="ts">
 import { IonList, IonRadio, IonRadioGroup, IonText } from '@ionic/vue';
 import { ref } from 'vue';
-import MsInput from '@/components/core/ms-input/MsInput.vue';
+import { MsInput } from '@/components/core';
 import { backendAddrValidator, Validity } from '@/common/validators';
 
 const backendAddr = ref('');

--- a/client/src/components/users/UserInformation.vue
+++ b/client/src/components/users/UserInformation.vue
@@ -32,7 +32,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue';
-import MsInput from '@/components/core/ms-input/MsInput.vue';
+import { MsInput } from '@/components/core';
 import { Validity, userNameValidator, deviceNameValidator, emailValidator } from '@/common/validators';
 
 function getDefaultDeviceName(): string {

--- a/client/src/components/workspaces/WorkspaceUserRole.vue
+++ b/client/src/components/workspaces/WorkspaceUserRole.vue
@@ -21,8 +21,7 @@
 <script setup lang="ts">
 import { defineProps, defineEmits, computed } from 'vue';
 import { UserProfile, WorkspaceRole, canChangeRole } from '@/parsec';
-import MsDropdown from '@/components/core/ms-dropdown/MsDropdown.vue';
-import { MsDropdownOption } from '@/components/core/ms-types';
+import { MsDropdown, MsOptions } from '@/components/core';
 import { useI18n } from 'vue-i18n';
 import UserAvatarName from '@/components/users/UserAvatarName.vue';
 import { UserTuple } from '@/parsec';
@@ -44,8 +43,8 @@ defineEmits<{
 
 const NOT_SHARED_KEY = 'not_shared';
 
-const options = computed((): MsDropdownOption[] => {
-  return [
+const options = computed((): MsOptions => {
+  return new MsOptions([
     {
       key: WorkspaceRole.Reader,
       label: translateWorkspaceRole(t, WorkspaceRole.Reader),
@@ -71,7 +70,7 @@ const options = computed((): MsDropdownOption[] => {
       label: translateWorkspaceRole(t, null),
       disabled: !canChangeRole(props.clientProfile, props.user.profile, props.clientRole, props.role, null),
     },
-  ];
+  ]);
 });
 
 function getRoleFromString(role: string): WorkspaceRole | null {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -38,7 +38,7 @@ import { isPlatform } from '@ionic/vue';
 import '@/theme/global.scss';
 import { Platform, libparsec } from '@/plugins/libparsec';
 import { Notification, NotificationManager, NotificationLevel } from '@/services/notificationManager';
-import { Answer, askQuestion } from '@/components/core/ms-utils';
+import { Answer, askQuestion } from '@/components/core';
 import { isElectron, isHomeRoute } from '@/parsec';
 import { fileLinkValidator, claimLinkValidator, Validity } from '@/common/validators';
 import { ImportManager, ImportManagerKey } from '@/services/importManager';

--- a/client/src/services/notificationManager.ts
+++ b/client/src/services/notificationManager.ts
@@ -2,10 +2,9 @@
 
 import { DateTime } from 'luxon';
 import { v4 as uuid4 } from 'uuid';
-import MsAlertModal, { MsAlertModalConfig } from '@/components/core/ms-modal/MsAlertModal.vue';
 import { modalController } from '@ionic/vue';
 import { ComposerTranslation } from 'vue-i18n';
-import { MsModalResult, MsReportTheme } from '@/components/core/ms-types';
+import { MsAlertModal, MsModalResult, MsReportTheme, MsAlertModalConfig } from '@/components/core';
 import { ToastManager } from '@/services/toastManager';
 
 // Re-export so everything can be imported from this file

--- a/client/src/services/toastManager.ts
+++ b/client/src/services/toastManager.ts
@@ -1,7 +1,7 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 import { toastController } from '@ionic/vue';
-import { MsReportTheme } from '@/components/core/ms-types';
+import { MsReportTheme } from '@/components/core';
 import { informationCircle, checkmarkCircle, warning, closeCircle } from 'ionicons/icons';
 import { ComposerTranslation } from 'vue-i18n';
 

--- a/client/src/views/about/AboutModal.vue
+++ b/client/src/views/about/AboutModal.vue
@@ -11,7 +11,7 @@
 
 <script setup lang="ts">
 import AboutView from '@/views/about/AboutView.vue';
-import MsModal from '@/components/core/ms-modal/MsModal.vue';
+import { MsModal } from '@/components/core';
 </script>
 
 <style lang="scss" scoped></style>

--- a/client/src/views/about/ChangesModal.vue
+++ b/client/src/views/about/ChangesModal.vue
@@ -119,7 +119,7 @@ import { IonPage, IonIcon, IonList, IonItem, IonText } from '@ionic/vue';
 import { sparkles, construct, infinite } from 'ionicons/icons';
 import { onMounted, ref, Ref } from 'vue';
 import { getChanges, VersionChange } from '@/common/mocks';
-import MsModal from '@/components/core/ms-modal/MsModal.vue';
+import { MsModal } from '@/components/core';
 
 const changes: Ref<VersionChange[]> = ref([]);
 

--- a/client/src/views/devices/DevicesPage.vue
+++ b/client/src/views/devices/DevicesPage.vue
@@ -132,8 +132,7 @@
 
 <script setup lang="ts">
 import { NotificationKey } from '@/common/injectionKeys';
-import { MsImage, PasswordLock } from '@/components/core/ms-image';
-import { MsModalResult } from '@/components/core/ms-types';
+import { MsImage, MsModalResult, PasswordLock } from '@/components/core';
 import DeviceCard from '@/components/devices/DeviceCard.vue';
 import { OwnDeviceInfo, hasRecoveryDevice, listOwnDevices } from '@/parsec';
 import { routerNavigateTo } from '@/router';

--- a/client/src/views/devices/ExportRecoveryDevicePage.vue
+++ b/client/src/views/devices/ExportRecoveryDevicePage.vue
@@ -143,9 +143,8 @@
 
 <script setup lang="ts">
 import { IonPage, IonContent, IonButton, IonIcon, IonText } from '@ionic/vue';
-import MsInformativeText from '@/components/core/ms-text/MsInformativeText.vue';
 import { ref, inject, onMounted } from 'vue';
-import { getPasswordFromUser } from '@/components/core/ms-utils';
+import { getPasswordFromUser, MsInformativeText } from '@/components/core';
 import { useI18n } from 'vue-i18n';
 import { exportRecoveryDevice, RecoveryDeviceErrorTag } from '@/parsec';
 import { getClientInfo } from '@/parsec/login';

--- a/client/src/views/devices/GreetDeviceModal.vue
+++ b/client/src/views/devices/GreetDeviceModal.vue
@@ -150,11 +150,9 @@ import {
 import { close } from 'ionicons/icons';
 import { ref, computed, onMounted, inject } from 'vue';
 import { useI18n } from 'vue-i18n';
-import MsWizardStepper from '@/components/core/ms-stepper/MsWizardStepper.vue';
-import MsInformativeText from '@/components/core/ms-text/MsInformativeText.vue';
 import SasCodeProvide from '@/components/sas-code/SasCodeProvide.vue';
 import SasCodeChoice from '@/components/sas-code/SasCodeChoice.vue';
-import { MsModalResult } from '@/components/core/ms-types';
+import { MsWizardStepper, MsInformativeText, MsModalResult } from '@/components/core';
 import { DeviceGreet } from '@/parsec';
 import { NotificationManager, NotificationKey, Notification, NotificationLevel } from '@/services/notificationManager';
 

--- a/client/src/views/files/FileDetailsModal.vue
+++ b/client/src/views/files/FileDetailsModal.vue
@@ -90,7 +90,7 @@
 import { IonPage, IonLabel, IonItem, IonText } from '@ionic/vue';
 import {} from 'ionicons/icons';
 import { inject } from 'vue';
-import MsModal from '@/components/core/ms-modal/MsModal.vue';
+import { MsModal } from '@/components/core';
 import { EntryStat, EntryStatFile } from '@/parsec';
 import { FormattersKey, Formatters } from '@/common/injectionKeys';
 

--- a/client/src/views/files/FileUploadModal.vue
+++ b/client/src/views/files/FileUploadModal.vue
@@ -16,7 +16,7 @@
 <script setup lang="ts">
 import FileImport from '@/components/files/FileImport.vue';
 import FileDropZone from '@/components/files/FileDropZone.vue';
-import MsModal from '@/components/core/ms-modal/MsModal.vue';
+import { MsModal } from '@/components/core';
 import { Path } from '@/parsec';
 import { createFolder, WorkspaceHandle, WorkspaceID } from '@/parsec';
 import { inject } from 'vue';

--- a/client/src/views/files/FoldersPage.vue
+++ b/client/src/views/files/FoldersPage.vue
@@ -198,20 +198,25 @@ import {
 import { folderOpen, document, pencil, link, arrowRedo, trashBin, copy, informationCircle } from 'ionicons/icons';
 import { useRoute } from 'vue-router';
 import { computed, ref, Ref, inject, watch, onUnmounted, onMounted } from 'vue';
-import MsActionBarButton from '@/components/core/ms-action-bar/MsActionBarButton.vue';
-import MsGridListToggle from '@/components/core/ms-toggle/MsGridListToggle.vue';
-import { DisplayState } from '@/components/core/ms-toggle/MsGridListToggle.vue';
 import FileListItem from '@/components/files/FileListItem.vue';
 import FileCard from '@/components/files/FileCard.vue';
 import FileContextMenu from '@/views/files/FileContextMenu.vue';
 import { routerNavigateTo } from '@/router';
 import { FileAction } from '@/views/files/FileContextMenu.vue';
-import MsActionBar from '@/components/core/ms-action-bar/MsActionBar.vue';
 import FileUploadModal from '@/views/files/FileUploadModal.vue';
 import { NotificationManager, Notification, NotificationKey, NotificationLevel } from '@/services/notificationManager';
 import * as parsec from '@/parsec';
 import { useI18n } from 'vue-i18n';
-import { getTextInputFromUser, Answer, askQuestion, selectFolder } from '@/components/core/ms-utils';
+import {
+  MsActionBar,
+  MsGridListToggle,
+  MsActionBarButton,
+  DisplayState,
+  getTextInputFromUser,
+  Answer,
+  askQuestion,
+  selectFolder,
+} from '@/components/core';
 import { entryNameValidator } from '@/common/validators';
 import FileDetailsModal from '@/views/files/FileDetailsModal.vue';
 import { writeTextToClipboard } from '@/common/clipboard';

--- a/client/src/views/header/ProfileHeader.vue
+++ b/client/src/views/header/ProfileHeader.vue
@@ -36,7 +36,7 @@ import { useRouter } from 'vue-router';
 import { routerNavigateTo } from '@/router';
 import { useI18n } from 'vue-i18n';
 import { logout as parsecLogout } from '@/parsec';
-import { askQuestion, Answer } from '@/components/core/ms-utils';
+import { askQuestion, Answer } from '@/components/core';
 import { NotificationManager, Notification, NotificationKey, NotificationLevel } from '@/services/notificationManager';
 
 const isPopoverOpen = ref(false);

--- a/client/src/views/home/CreateOrganizationModal.vue
+++ b/client/src/views/home/CreateOrganizationModal.vue
@@ -177,21 +177,14 @@ import { IonTitle, IonText, IonPage, IonHeader, IonButton, IonButtons, IonFooter
 import { chevronForward, chevronBack, checkmarkDone, close } from 'ionicons/icons';
 import { ref, Ref, inject } from 'vue';
 import { useI18n } from 'vue-i18n';
-import MsInformativeText from '@/components/core/ms-text/MsInformativeText.vue';
-import MsChoosePasswordInput from '@/components/core/ms-input/MsChoosePasswordInput.vue';
 import UserInformation from '@/components/users/UserInformation.vue';
-import ChooseServer from '@/components/organizations/ChooseServer.vue';
-import { ServerMode } from '@/components/organizations/ChooseServer.vue';
-import SummaryStep from '@/views/home/SummaryStep.vue';
-import { OrgInfo } from '@/views/home/SummaryStep.vue';
-import MsSpinner from '@/components/core/ms-spinner/MsSpinner.vue';
-import MsInput from '@/components/core/ms-input/MsInput.vue';
+import ChooseServer, { ServerMode } from '@/components/organizations/ChooseServer.vue';
+import SummaryStep, { OrgInfo } from '@/views/home/SummaryStep.vue';
 import { AvailableDevice, createOrganization as parsecCreateOrganization, BootstrapOrganizationErrorTag } from '@/parsec';
-import { MsModalResult } from '@/components/core/ms-types';
 import { organizationValidator, Validity } from '@/common/validators';
 import { asyncComputed } from '@/common/asyncComputed';
 import { NotificationManager, Notification, NotificationLevel, NotificationKey } from '@/services/notificationManager';
-import { askQuestion, Answer } from '@/components/core/ms-utils';
+import { MsInformativeText, MsChoosePasswordInput, MsSpinner, MsInput, MsModalResult, askQuestion, Answer } from '@/components/core';
 
 enum CreateOrganizationStep {
   OrgNameStep = 1,

--- a/client/src/views/home/DeviceJoinOrganizationModal.vue
+++ b/client/src/views/home/DeviceJoinOrganizationModal.vue
@@ -156,20 +156,15 @@ import {
 import { close, checkmarkCircle } from 'ionicons/icons';
 import { ref, computed, onMounted, inject } from 'vue';
 import { useI18n } from 'vue-i18n';
-import MsWizardStepper from '@/components/core/ms-stepper/MsWizardStepper.vue';
 import SasCodeProvide from '@/components/sas-code/SasCodeProvide.vue';
 import SasCodeChoice from '@/components/sas-code/SasCodeChoice.vue';
 import InformationJoinDevice from '@/views/home/InformationJoinDeviceStep.vue';
-import MsInformativeText from '@/components/core/ms-text/MsInformativeText.vue';
-import { MsModalResult } from '@/components/core/ms-types';
-import MsInput from '@/components/core/ms-input/MsInput.vue';
-import MsChoosePasswordInput from '@/components/core/ms-input/MsChoosePasswordInput.vue';
 import { asyncComputed } from '@/common/asyncComputed';
 import { DeviceClaim, parseBackendAddr, ParsedBackendAddrInvitationDevice, ParsedBackendAddrTag } from '@/parsec';
 import { Notification, NotificationManager, NotificationLevel } from '@/services/notificationManager';
 import { NotificationKey } from '@/common/injectionKeys';
 import { Validity, deviceNameValidator } from '@/common/validators';
-import { askQuestion, Answer } from '@/components/core/ms-utils';
+import { MsWizardStepper, MsChoosePasswordInput, MsInformativeText, MsInput, MsModalResult, askQuestion, Answer } from '@/components/core';
 
 const notificationManager = inject(NotificationKey) as NotificationManager;
 

--- a/client/src/views/home/HomePage.vue
+++ b/client/src/views/home/HomePage.vue
@@ -229,12 +229,17 @@
 import { Formatters, FormattersKey, NotificationKey, StorageManagerKey } from '@/common/injectionKeys';
 import { getAppVersion } from '@/common/mocks';
 import { Validity, claimDeviceLinkValidator, claimLinkValidator, claimUserLinkValidator } from '@/common/validators';
-import { MsImage, LogoRowWhite } from '@/components/core/ms-image';
-import MsPasswordInput from '@/components/core/ms-input/MsPasswordInput.vue';
-import MsSearchInput from '@/components/core/ms-input/MsSearchInput.vue';
-import MsSorter from '@/components/core/ms-sorter/MsSorter.vue';
-import { MsModalResult, MsSorterChangeEvent, MsSorterOption } from '@/components/core/ms-types';
-import { getTextInputFromUser } from '@/components/core/ms-utils';
+import {
+  LogoRowWhite,
+  MsImage,
+  MsModalResult,
+  MsPasswordInput,
+  MsSearchInput,
+  MsSorter,
+  MsSorterChangeEvent,
+  MsOptions,
+  getTextInputFromUser,
+} from '@/components/core';
 import OrganizationCard from '@/components/organizations/OrganizationCard.vue';
 import { AvailableDevice, isLoggedIn, listAvailableDevices as parsecListAvailableDevices, login as parsecLogin } from '@/parsec';
 import { Notification, NotificationLevel, NotificationManager } from '@/services/notificationManager';
@@ -286,14 +291,14 @@ const storageManager: StorageManager = inject(StorageManagerKey)!;
 const notificationManager: NotificationManager = inject(NotificationKey)!;
 const isPopoverOpen = ref(false);
 
-const msSorterOptions: MsSorterOption[] = [
+const msSorterOptions: MsOptions = new MsOptions([
   {
     label: t('HomePage.organizationList.sortByOrganization'),
     key: 'organization',
   },
   { label: t('HomePage.organizationList.sortByUserName'), key: 'user_name' },
   { label: t('HomePage.organizationList.sortByLastLogin'), key: 'last_login' },
-];
+]);
 
 const msSorterLabels = {
   asc: t('HomePage.organizationList.sortOrderAsc'),
@@ -791,4 +796,3 @@ async function openSettingsModal(): Promise<void> {
   }
 }
 </style>
-@/components/core/ms-sort/MsSorterOption

--- a/client/src/views/home/HomePagePopover.vue
+++ b/client/src/views/home/HomePagePopover.vue
@@ -47,7 +47,7 @@ export enum HomePageAction {
 </script>
 
 <script setup lang="ts">
-import { MsModalResult } from '@/components/core/ms-types';
+import { MsModalResult } from '@/components/core';
 import { IonList, IonItem, IonIcon, IonLabel, IonText, popoverController } from '@ionic/vue';
 import { addCircle, mail } from 'ionicons/icons';
 

--- a/client/src/views/home/InformationJoinDeviceStep.vue
+++ b/client/src/views/home/InformationJoinDeviceStep.vue
@@ -36,8 +36,7 @@
 </template>
 
 <script setup lang="ts">
-import { MsImage, Device, SwapArrows } from '@/components/core/ms-image';
-import MsInformativeText from '@/components/core/ms-text/MsInformativeText.vue';
+import { Device, MsImage, MsInformativeText, SwapArrows } from '@/components/core';
 import { IonText } from '@ionic/vue';
 </script>
 

--- a/client/src/views/home/UserJoinOrganizationModal.vue
+++ b/client/src/views/home/UserJoinOrganizationModal.vue
@@ -187,17 +187,13 @@ import {
 import { close } from 'ionicons/icons';
 import { ref, computed, onMounted, inject } from 'vue';
 import { useI18n } from 'vue-i18n';
-import MsWizardStepper from '@/components/core/ms-stepper/MsWizardStepper.vue';
 import SasCodeProvide from '@/components/sas-code/SasCodeProvide.vue';
 import SasCodeChoice from '@/components/sas-code/SasCodeChoice.vue';
-import MsChoosePasswordInput from '@/components/core/ms-input/MsChoosePasswordInput.vue';
-import MsInformativeText from '@/components/core/ms-text/MsInformativeText.vue';
 import UserInformation from '@/components/users/UserInformation.vue';
-import { MsModalResult } from '@/components/core/ms-types';
+import { MsWizardStepper, MsChoosePasswordInput, MsInformativeText, MsModalResult, askQuestion, Answer } from '@/components/core';
 import { Notification, NotificationManager, NotificationLevel, NotificationKey } from '@/services/notificationManager';
 import { asyncComputed } from '@/common/asyncComputed';
 import { UserClaim } from '@/parsec';
-import { askQuestion, Answer } from '@/components/core/ms-utils';
 
 enum UserJoinOrganizationStep {
   WaitForHost = 1,

--- a/client/src/views/settings/SettingsModal.vue
+++ b/client/src/views/settings/SettingsModal.vue
@@ -11,7 +11,7 @@
 
 <script setup lang="ts">
 import SettingsView from '@/views/settings/SettingsView.vue';
-import MsModal from '@/components/core/ms-modal/MsModal.vue';
+import { MsModal } from '@/components/core';
 </script>
 
 <style lang="scss" scoped></style>

--- a/client/src/views/settings/SettingsView.vue
+++ b/client/src/views/settings/SettingsView.vue
@@ -126,8 +126,7 @@ import { toggleDarkMode } from '@/states/darkMode';
 import { Config, StorageManager } from '@/services/storageManager';
 import { StorageManagerKey } from '@/common/injectionKeys';
 import SettingsOption from '@/components/settings/SettingsOption.vue';
-import MsDropdown from '@/components/core/ms-dropdown/MsDropdown.vue';
-import { MsDropdownOption } from '@/components/core/ms-types';
+import { MsDropdown, MsOptions } from '@/components/core';
 
 const { t, locale } = useI18n();
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -135,7 +134,7 @@ const storageManager = inject(StorageManagerKey)! as StorageManager;
 const config = ref<Config>(structuredClone(StorageManager.DEFAULT_CONFIG));
 let justLoaded = false;
 
-const languageOptions: MsDropdownOption[] = [
+const languageOptions: MsOptions = new MsOptions([
   {
     key: 'en-US',
     label: t('SettingsPage.language.values.enUS'),
@@ -144,9 +143,9 @@ const languageOptions: MsDropdownOption[] = [
     key: 'fr-FR',
     label: t('SettingsPage.language.values.frFR'),
   },
-];
+]);
 
-const themeOptions: MsDropdownOption[] = [
+const themeOptions: MsOptions = new MsOptions([
   {
     key: 'dark',
     label: t('SettingsPage.theme.values.dark'),
@@ -159,7 +158,7 @@ const themeOptions: MsDropdownOption[] = [
     key: 'system',
     label: t('SettingsPage.theme.values.system'),
   },
-];
+]);
 
 enum SettingsTabs {
   General = 'General',

--- a/client/src/views/sidebar-menu/SidebarMenuPage.vue
+++ b/client/src/views/sidebar-menu/SidebarMenuPage.vue
@@ -209,7 +209,7 @@
 </template>
 
 <script setup lang="ts">
-import { MsImage, CaretExpand } from '@/components/core/ms-image';
+import { CaretExpand, MsImage } from '@/components/core';
 import {
   ClientInfo,
   UserProfile,

--- a/client/src/views/users/ActiveUsersPage.vue
+++ b/client/src/views/users/ActiveUsersPage.vue
@@ -170,12 +170,8 @@ import { IonContent, IonItem, IonList, IonPage, IonLabel, IonListHeader, IonChec
 import { personRemove, personAdd, eye } from 'ionicons/icons';
 import UserListItem from '@/components/users/UserListItem.vue';
 import UserCard from '@/components/users/UserCard.vue';
-import MsActionBarButton from '@/components/core/ms-action-bar/MsActionBarButton.vue';
-import MsGridListToggle from '@/components/core/ms-toggle/MsGridListToggle.vue';
-import { DisplayState } from '@/components/core/ms-toggle/MsGridListToggle.vue';
-import UserContextMenu from '@/views/users/UserContextMenu.vue';
-import { UserAction } from '@/views/users/UserContextMenu.vue';
-import MsActionBar from '@/components/core/ms-action-bar/MsActionBar.vue';
+import UserContextMenu, { UserAction } from '@/views/users/UserContextMenu.vue';
+import { DisplayState, Answer, askQuestion, MsActionBarButton, MsActionBar, MsGridListToggle } from '@/components/core';
 import { routerNavigateTo } from '@/router';
 import {
   listUsers as parsecListUsers,
@@ -189,7 +185,6 @@ import {
 import { NotificationManager, Notification, NotificationLevel, NotificationKey } from '@/services/notificationManager';
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
-import { Answer, askQuestion } from '@/components/core/ms-utils';
 
 const displayView = ref(DisplayState.List);
 const userList: Ref<UserInfo[]> = ref([]);

--- a/client/src/views/users/GreetUserModal.vue
+++ b/client/src/views/users/GreetUserModal.vue
@@ -171,18 +171,14 @@ import {
 import { close } from 'ionicons/icons';
 import { ref, Ref, computed, onMounted, inject, watch, onUnmounted } from 'vue';
 import { useI18n } from 'vue-i18n';
-import MsWizardStepper from '@/components/core/ms-stepper/MsWizardStepper.vue';
-import MsInformativeText from '@/components/core/ms-text/MsInformativeText.vue';
 import SasCodeProvide from '@/components/sas-code/SasCodeProvide.vue';
 import SasCodeChoice from '@/components/sas-code/SasCodeChoice.vue';
 import UserInformation from '@/components/users/UserInformation.vue';
 import TagProfile from '@/components/users/TagProfile.vue';
 import UserAvatarName from '@/components/users/UserAvatarName.vue';
-import { MsModalResult, MsDropdownOption } from '@/components/core/ms-types';
 import { UserInvitation, UserGreet, UserProfile } from '@/parsec';
 import { NotificationManager, NotificationKey, Notification, NotificationLevel } from '@/services/notificationManager';
-import { Answer, askQuestion } from '@/components/core/ms-utils';
-import MsDropdown from '@/components/core/ms-dropdown/MsDropdown.vue';
+import { MsInformativeText, MsWizardStepper, MsModalResult, Answer, askQuestion, MsDropdown, MsOptions } from '@/components/core';
 
 enum GreetUserStep {
   WaitForGuest = 1,
@@ -208,7 +204,7 @@ const greeter = ref(new UserGreet());
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const notificationManager: NotificationManager = inject(NotificationKey)!;
 
-const profileOptions: MsDropdownOption[] = [
+const profileOptions: MsOptions = new MsOptions([
   {
     key: UserProfile.Admin,
     label: t('UsersPage.profile.admin'),
@@ -221,7 +217,7 @@ const profileOptions: MsDropdownOption[] = [
     key: UserProfile.Outsider,
     label: t('UsersPage.profile.outsider'),
   },
-];
+]);
 
 function getTitleAndSubtitle(): [string, string] {
   if (pageStep.value === GreetUserStep.WaitForGuest) {

--- a/client/src/views/users/InvitationsPage.vue
+++ b/client/src/views/users/InvitationsPage.vue
@@ -76,12 +76,8 @@
 import { IonPage, IonContent, IonList, IonItem, IonListHeader, IonLabel, modalController } from '@ionic/vue';
 import { personAdd } from 'ionicons/icons';
 import { onUpdated, ref, Ref, onMounted, inject, watch, onUnmounted } from 'vue';
-import MsActionBar from '@/components/core/ms-action-bar/MsActionBar.vue';
-import MsActionBarButton from '@/components/core/ms-action-bar/MsActionBarButton.vue';
-import MsGridListToggle from '@/components/core/ms-toggle/MsGridListToggle.vue';
-import { DisplayState } from '@/components/core/ms-toggle/MsGridListToggle.vue';
+import { MsModalResult, DisplayState, getTextInputFromUser, MsActionBar, MsActionBarButton, MsGridListToggle } from '@/components/core';
 import { useI18n } from 'vue-i18n';
-import { MsModalResult } from '@/components/core/ms-types';
 import GreetUserModal from '@/views/users/GreetUserModal.vue';
 import InvitationCard from '@/components/users/InvitationCard.vue';
 import InvitationListItem from '@/components/users/InvitationListItem.vue';
@@ -99,7 +95,6 @@ import {
 import { NotificationManager, NotificationKey, NotificationLevel, Notification } from '@/services/notificationManager';
 import { useRoute } from 'vue-router';
 import { routerNavigateTo } from '@/router';
-import { getTextInputFromUser } from '@/components/core/ms-utils';
 import { emailValidator } from '@/common/validators';
 
 const invitations: Ref<UserInvitation[]> = ref([]);

--- a/client/src/views/users/MyContactDetailsPage.vue
+++ b/client/src/views/users/MyContactDetailsPage.vue
@@ -77,8 +77,7 @@ import {
 } from '@/parsec';
 import { IonPage, IonContent, IonText, IonChip, IonButton } from '@ionic/vue';
 import TagProfile from '@/components/users/TagProfile.vue';
-import MsChoosePasswordInput from '@/components/core/ms-input/MsChoosePasswordInput.vue';
-import MsPasswordInput from '@/components/core/ms-input/MsPasswordInput.vue';
+import { MsChoosePasswordInput, MsPasswordInput } from '@/components/core';
 import { Ref, ref, onMounted, inject } from 'vue';
 import { asyncComputed } from '@/common/asyncComputed';
 import { NotificationManager, NotificationKey, NotificationLevel, Notification } from '@/services/notificationManager';

--- a/client/src/views/users/RevokedUsersPage.vue
+++ b/client/src/views/users/RevokedUsersPage.vue
@@ -130,12 +130,8 @@ import { IonContent, IonItem, IonList, IonPage, IonLabel, IonListHeader, IonChec
 import { eye } from 'ionicons/icons';
 import UserListItem from '@/components/users/UserListItem.vue';
 import UserCard from '@/components/users/UserCard.vue';
-import MsActionBarButton from '@/components/core/ms-action-bar/MsActionBarButton.vue';
-import MsGridListToggle from '@/components/core/ms-toggle/MsGridListToggle.vue';
-import { DisplayState } from '@/components/core/ms-toggle/MsGridListToggle.vue';
-import UserContextMenu from '@/views/users/UserContextMenu.vue';
-import { UserAction } from '@/views/users/UserContextMenu.vue';
-import MsActionBar from '@/components/core/ms-action-bar/MsActionBar.vue';
+import { DisplayState, MsActionBarButton, MsGridListToggle, MsActionBar } from '@/components/core';
+import UserContextMenu, { UserAction } from '@/views/users/UserContextMenu.vue';
 import { UserInfo, listRevokedUsers as parsecListRevokedUsers } from '@/parsec';
 import { NotificationManager, NotificationKey, NotificationLevel, Notification } from '@/services/notificationManager';
 import { useI18n } from 'vue-i18n';

--- a/client/src/views/workspaces/WorkspaceSharingModal.vue
+++ b/client/src/views/workspaces/WorkspaceSharingModal.vue
@@ -45,17 +45,15 @@
 </template>
 
 <script setup lang="ts">
-import { IonPage, IonList, modalController } from '@ionic/vue';
-import { ref, Ref, watch, onUnmounted, onMounted, inject } from 'vue';
-import { MsModalResult } from '@/components/core/ms-types';
-import { WorkspaceID, WorkspaceRole, getWorkspaceSharing, UserTuple, shareWorkspace, UserProfile, getClientProfile } from '@/parsec';
 import { NotificationKey } from '@/common/injectionKeys';
-import { NotificationManager, Notification, NotificationLevel } from '@/services/notificationManager';
-import WorkspaceUserRole from '@/components/workspaces/WorkspaceUserRole.vue';
-import MsModal from '@/components/core/ms-modal/MsModal.vue';
-import MsInput from '@/components/core/ms-input/MsInput.vue';
-import { useI18n } from 'vue-i18n';
 import { translateWorkspaceRole } from '@/common/translations';
+import { MsInput, MsModal } from '@/components/core';
+import WorkspaceUserRole from '@/components/workspaces/WorkspaceUserRole.vue';
+import { UserProfile, UserTuple, WorkspaceID, WorkspaceRole, getClientProfile, getWorkspaceSharing, shareWorkspace } from '@/parsec';
+import { Notification, NotificationLevel, NotificationManager } from '@/services/notificationManager';
+import { IonList, IonPage } from '@ionic/vue';
+import { Ref, inject, onMounted, onUnmounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const notificationManager: NotificationManager = inject(NotificationKey)!;

--- a/client/src/views/workspaces/WorkspacesPage.vue
+++ b/client/src/views/workspaces/WorkspacesPage.vue
@@ -126,14 +126,20 @@ import WorkspaceListItem from '@/components/workspaces/WorkspaceListItem.vue';
 import WorkspaceContextMenu from '@/views/workspaces/WorkspaceContextMenu.vue';
 import { WorkspaceAction } from '@/views/workspaces/WorkspaceContextMenu.vue';
 import WorkspaceSharingModal from '@/views/workspaces/WorkspaceSharingModal.vue';
-import MsSorter from '@/components/core/ms-sorter/MsSorter.vue';
-import MsActionBarButton from '@/components/core/ms-action-bar/MsActionBarButton.vue';
-import { MsSorterChangeEvent, MsSorterOption } from '@/components/core/ms-types';
-import MsGridListToggle from '@/components/core/ms-toggle/MsGridListToggle.vue';
-import { DisplayState } from '@/components/core/ms-toggle/MsGridListToggle.vue';
 import { useI18n } from 'vue-i18n';
 import { ref, Ref, onMounted, computed, inject } from 'vue';
-import MsActionBar from '@/components/core/ms-action-bar/MsActionBar.vue';
+import { workspaceNameValidator } from '@/common/validators';
+import { writeTextToClipboard } from '@/common/clipboard';
+import {
+  MsSorter,
+  MsActionBarButton,
+  MsGridListToggle,
+  MsActionBar,
+  MsSorterChangeEvent,
+  MsOptions,
+  getTextInputFromUser,
+  DisplayState,
+} from '@/components/core';
 import { routerNavigateToWorkspace } from '@/router';
 import {
   WorkspaceInfo,
@@ -142,9 +148,6 @@ import {
   getPathLink as parsecGetPathLink,
 } from '@/parsec';
 import { NotificationManager, Notification, NotificationKey, NotificationLevel } from '@/services/notificationManager';
-import { getTextInputFromUser } from '@/components/core/ms-utils';
-import { workspaceNameValidator } from '@/common/validators';
-import { writeTextToClipboard } from '@/common/clipboard';
 
 const { t } = useI18n();
 const sortBy = ref('name');
@@ -189,11 +192,11 @@ const filteredWorkspaces = computed(() => {
   });
 });
 
-const msSorterOptions: MsSorterOption[] = [
+const msSorterOptions: MsOptions = new MsOptions([
   { label: t('WorkspacesPage.sort.sortByName'), key: 'name' },
   { label: t('WorkspacesPage.sort.sortBySize'), key: 'size' },
   { label: t('WorkspacesPage.sort.sortByLastUpdated'), key: 'lastUpdated' },
-];
+]);
 
 function onMsSorterChange(event: MsSorterChangeEvent): void {
   sortBy.value = event.option.key;
@@ -367,4 +370,3 @@ ion-item::part(native) {
   display: flex;
 }
 </style>
-@/components/core/ms-sort/MsSorterOption

--- a/client/tests/component/specs/testMsSorterPopover.spec.ts
+++ b/client/tests/component/specs/testMsSorterPopover.spec.ts
@@ -1,17 +1,17 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { MsSorterOption, MsSorterLabels } from '@/components/core/ms-types';
-import MsSorterPopover from '@/components/core/ms-sorter/MsSorterPopover.vue';
 import { VueWrapper, mount } from '@vue/test-utils';
+import { MsOptions, MsSorterLabels } from '@/components/core';
+import MsSorterPopover from '@/components/core/ms-sorter/MsSorterPopover.vue';
 
 describe('Select popover', () => {
   let wrapper: VueWrapper;
 
-  const defaultOptions: MsSorterOption[] = [
+  const defaultOptions: MsOptions = new MsOptions([
     { label: 'Label A', key: '1' },
     { label: 'Label B', key: '2' },
     { label: 'Label C', key: '3' },
-  ];
+  ]);
 
   const defaultSortLabels: MsSorterLabels = {
     asc: 'Asc',
@@ -33,7 +33,7 @@ describe('Select popover', () => {
     const items = wrapper.findAll('ion-item');
     expect(items.length).to.equal(4);
     // Use first option as default
-    expect((wrapper.vm as any).selectedOption).to.deep.equal(defaultOptions[0]);
+    expect((wrapper.vm as any).selectedOption).to.deep.equal(defaultOptions.at(0));
     expect((wrapper.vm as any).sortByAsc).to.be.true;
     expect(items.at(1)?.text()).to.equal('Label A');
     expect(items.at(2)?.text()).to.equal('Label B');


### PR DESCRIPTION
depends on #5975  (need to rebase after #5975  will be merged)
closes #5955 

## About exporting directly in the same file in another <script> block:

- Errors can be encountered due to how Vue and JavaScript handle module exports. In JavaScript, only values (like objects, functions, classes, etc.) can be exported and imported between modules.
- TypeScript interfaces, on the other hand, are not values and do not exist at runtime, so they cannot be exported or imported in the same way.
- Most of the time, it's working because TypeScript is able to find the interface in the global scope, not because it's being imported as a value from the `MsExample.vue` module.
- To ensure consistent behavior and avoid confusion, I would recommend moving our enums and interfaces to a separate TypeScript file and importing them from there.
- This way, we can be sure that the interfaces are always available when we need them, and we won't run into issues with the Vue `<script setup>` syntax.

## Benefits from exporting .vue components from index.ts:

- Avoid name confusion since we can name the import whatever we want
- Bring more control on what we want to use outside of components/core (ex: we don't export MsQuestionModal since we prefer to use askQuestion utils function)
- Improve significantly the readability of files that use these imports
- Make our imports very similar to ionic ones, easier to understand / read

## New usage:

- Outside of components/core:
    ```typescript
    import { ... } from '@components/core';
    ```

- Inside of components/core:
    ```typescript
    import { ... } from '@components/core/ms-utils';
    import { ... } from '@components/core/ms-types';
    import MsExample from '@components/core/ms-example/MsExample.vue';
    ```

- `ms-utils.ts` is meant for functions
- `ms-types.ts` is meant for enums, interfaces, maps (basically types and constants)
