### PR TITLE
[MS] Added the option to redownload recovery files

### DIFF
--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -574,6 +574,7 @@
         "actions": {
             "understand": "I understand",
             "download": "Download",
+            "downloadAgain": "Download again",
             "backToDevices": "Back to my devices"
         },
         "toasts": {

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -574,6 +574,7 @@
         "actions": {
             "understand": "J'ai compris",
             "download": "Télécharger",
+            "downloadAgain": "Télécharger à nouveau",
             "backToDevices": "Retourner à mes appareils"
         },
         "toasts": {

--- a/client/src/views/devices/ExportRecoveryDevicePage.vue
+++ b/client/src/views/devices/ExportRecoveryDevicePage.vue
@@ -57,21 +57,10 @@
                 <ion-icon :icon="document" />
                 {{ $t('ExportRecoveryDevicePage.titles.recoveryFile') }}
               </div>
-              <ion-text class="file-item__description body">
-                {{ $t('ExportRecoveryDevicePage.subtitles.fileExplanation') }}
-              </ion-text>
-              <div
-                class="file-item__button"
-                v-show="!recoveryFileDownloaded"
-              >
-                <ion-button
-                  @click="downloadRecoveryFile()"
-                  id="downloadButton"
-                  size="default"
-                >
-                  <ion-icon :icon="download" />
-                  {{ $t('ExportRecoveryDevicePage.actions.download') }}
-                </ion-button>
+              <div class="file-item__subtitle">
+                <ion-text class="file-item__description body">
+                  {{ $t('ExportRecoveryDevicePage.subtitles.fileExplanation') }}
+                </ion-text>
               </div>
               <div
                 class="file-item__downloaded body"
@@ -83,27 +72,31 @@
                 />
                 {{ $t('ExportRecoveryDevicePage.subtitles.fileDownloaded') }}
               </div>
+              <div class="file-item__button">
+                <ion-button
+                  @click="downloadRecoveryFile()"
+                  id="downloadButton"
+                  size="default"
+                  :fill="recoveryFileDownloaded ? 'outline' : 'solid'"
+                >
+                  <ion-icon :icon="recoveryFileDownloaded ? reload : download" />
+                  {{
+                    recoveryFileDownloaded
+                      ? $t('ExportRecoveryDevicePage.actions.downloadAgain')
+                      : $t('ExportRecoveryDevicePage.actions.download')
+                  }}
+                </ion-button>
+              </div>
             </div>
             <div class="file-item">
               <div class="file-item__title subtitles-normal">
                 <ion-icon :icon="key" />
                 {{ $t('ExportRecoveryDevicePage.titles.recoveryKey') }}
               </div>
-              <ion-text class="file-item__description body">
-                {{ $t('ExportRecoveryDevicePage.subtitles.keyExplanation') }}
-              </ion-text>
-              <div
-                v-show="!recoveryKeyDownloaded"
-                class="file-item__button"
-              >
-                <ion-button
-                  @click="downloadRecoveryKey()"
-                  id="downloadButton"
-                  size="default"
-                >
-                  <ion-icon :icon="download" />
-                  {{ $t('ExportRecoveryDevicePage.actions.download') }}
-                </ion-button>
+              <div class="file-item__subtitle">
+                <ion-text class="file-item__description body">
+                  {{ $t('ExportRecoveryDevicePage.subtitles.keyExplanation') }}
+                </ion-text>
               </div>
               <div
                 class="file-item__downloaded body"
@@ -114,6 +107,21 @@
                   class="checked"
                 />
                 {{ $t('ExportRecoveryDevicePage.subtitles.fileDownloaded') }}
+              </div>
+              <div class="file-item__button">
+                <ion-button
+                  @click="downloadRecoveryKey()"
+                  id="downloadButton"
+                  size="default"
+                  :fill="recoveryKeyDownloaded ? 'outline' : 'solid'"
+                >
+                  <ion-icon :icon="recoveryKeyDownloaded ? reload : download" />
+                  {{
+                    recoveryKeyDownloaded
+                      ? $t('ExportRecoveryDevicePage.actions.downloadAgain')
+                      : $t('ExportRecoveryDevicePage.actions.download')
+                  }}
+                </ion-button>
               </div>
             </div>
           </div>
@@ -151,7 +159,7 @@ import { exportRecoveryDevice, RecoveryDeviceErrorTag } from '@/parsec';
 import { getClientInfo } from '@/parsec/login';
 import { NotificationManager, Notification, NotificationKey, NotificationLevel } from '@/services/notificationManager';
 import { routerNavigateTo } from '@/router';
-import { home, checkmarkCircle, document, key, download } from 'ionicons/icons';
+import { home, checkmarkCircle, document, key, download, reload } from 'ionicons/icons';
 
 const { t } = useI18n();
 
@@ -204,24 +212,28 @@ async function exportDevice(): Promise<void> {
 
 async function downloadRecoveryKey(): Promise<void> {
   fileDownload(code, t('ExportRecoveryDevicePage.filenames.recoveryKey', { org: orgId.value }));
-  recoveryKeyDownloaded.value = true;
-  notificationManager.showToast(
-    new Notification({
-      message: t('ExportRecoveryDevicePage.toasts.keyDownloadOk'),
-      level: NotificationLevel.Success,
-    }),
-  );
+  setTimeout(() => {
+    recoveryKeyDownloaded.value = true;
+    notificationManager.showToast(
+      new Notification({
+        message: t('ExportRecoveryDevicePage.toasts.keyDownloadOk'),
+        level: NotificationLevel.Success,
+      }),
+    );
+  }, 500);
 }
 
 async function downloadRecoveryFile(): Promise<void> {
   fileDownload(file, t('ExportRecoveryDevicePage.filenames.recoveryFile', { org: orgId.value }));
-  recoveryFileDownloaded.value = true;
-  notificationManager.showToast(
-    new Notification({
-      message: t('ExportRecoveryDevicePage.toasts.fileDownloadOk'),
-      level: NotificationLevel.Success,
-    }),
-  );
+  setTimeout(() => {
+    recoveryFileDownloaded.value = true;
+    notificationManager.showToast(
+      new Notification({
+        message: t('ExportRecoveryDevicePage.toasts.fileDownloadOk'),
+        level: NotificationLevel.Success,
+      }),
+    );
+  }, 500);
 }
 
 async function fileDownload(data: string, fileName: string): Promise<void> {
@@ -278,12 +290,16 @@ function onBackToDevicesClick(): void {
         }
       }
 
+      &__subtitle {
+        margin-bottom: 1.5rem;
+      }
+
       &__description {
         color: var(--parsec-color-light-secondary-grey);
       }
 
       &__button {
-        margin-top: 2rem;
+        margin-top: 0.5rem;
         display: flex;
         align-items: center;
         gap: 0.5rem;
@@ -307,7 +323,7 @@ function onBackToDevicesClick(): void {
       &__downloaded {
         display: flex;
         align-items: center;
-        margin-top: 2rem;
+        margin-top: 0.5rem;
         padding: 0.375rem 0;
         gap: 0.5rem;
         color: var(--parsec-color-light-secondary-grey);

--- a/client/tests/e2e/specs/test_export_recovery_device_page.ts
+++ b/client/tests/e2e/specs/test_export_recovery_device_page.ts
@@ -39,12 +39,16 @@ describe('Display export recovery device page', () => {
     cy.get('@thirdItem').contains('File downloaded').should('not.be.visible');
     cy.get('@fourthItem').contains('File downloaded').should('not.be.visible');
     cy.get('@fileDownloadButton').click();
+    cy.wait(500);
     cy.checkToastMessage('The recovery file was successfully downloaded');
-    cy.get('@thirdItem').find('#downloadButton').should('not.be.visible');
+    cy.get('@thirdItem').find('#downloadButton').should('be.visible');
+    cy.get('@thirdItem').find('#downloadButton').contains('Download again');
     cy.get('@thirdItem').contains('File downloaded').should('be.visible');
     cy.get('@keyDownloadButton').click();
+    cy.wait(500);
     cy.checkToastMessage('The secret key was successfully downloaded');
-    cy.get('@fourthItem').find('#downloadButton').should('not.be.visible');
+    cy.get('@fourthItem').find('#downloadButton').should('be.visible');
+    cy.get('@fourthItem').find('#downloadButton').contains('Download again');
     cy.get('.recovery-container').find('#back-to-devices-button').as('returnButton').should('be.visible');
     cy.get('@fourthItem').contains('File downloaded').should('be.visible');
     cy.get('@returnButton').should('not.have.class', 'button-disabled').click();


### PR DESCRIPTION
Closes #5912

1. Keep the download button visible, but adds the label `File downloaded` if the button has been clicked
2. Since there's no way to know when the file has been downloaded, I added a small timeout so that it takes a few ms to display the label

- [X] Keep changes in the pull request as small as possible
   <!-- Move unrelated changes to a new pull request -->
- [X] Ensure the commit history is sanitized
   <!-- Commits should have a meaningful title and contain a coherent set of changes
        Squash commits that are only relevant to the branch context -->
- [X] Give a meaningful title to your PR
- [X] Describe your changes
   <!-- Give some context about the changes
        Draw attention to the details that should not be overlooked -->
- [X] Link any related issue in the description