### PR TITLE
[MS] MsDropdown appearance

### DIFF
--- a/client/src/components/core/ms-dropdown/MsDropdown.vue
+++ b/client/src/components/core/ms-dropdown/MsDropdown.vue
@@ -1,37 +1,47 @@
 <!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
 
 <template>
-  <ion-button
-    fill="clear"
-    @click="openPopover($event)"
-    id="dropdown-popover-button"
-    class="filter-button button-medium"
-    :disabled="disabled"
-  >
-    <ion-icon
-      :class="{ 'popover-is-open': isPopoverOpen }"
-      class="ms-dropdown-icon"
-      slot="end"
-      :icon="caretDown"
-    />
-    {{ labelRef }}
-  </ion-button>
+  <div class="dropdown-container">
+    <ion-text
+      class="form-label"
+      v-if="title && appearanceRef === MsAppearance.Outline"
+    >
+      {{ title }}
+    </ion-text>
+    <ion-button
+      :fill="appearanceRef"
+      @click="openPopover($event)"
+      id="dropdown-popover-button"
+      class="filter-button button-medium"
+      :disabled="disabled"
+    >
+      <ion-icon
+        :class="{ 'popover-is-open': isPopoverOpen }"
+        class="ms-dropdown-icon"
+        slot="end"
+        :icon="getIcon()"
+      />
+      {{ labelRef }}
+    </ion-button>
+  </div>
 </template>
 
 <script setup lang="ts">
 import { defineProps, defineEmits, Ref, ref } from 'vue';
-import { IonButton, IonIcon, popoverController } from '@ionic/vue';
-import { caretDown } from 'ionicons/icons';
+import { IonText, IonButton, IonIcon, popoverController } from '@ionic/vue';
+import { caretDown, chevronDown } from 'ionicons/icons';
 import MsDropdownPopover from '@/components/core/ms-dropdown/MsDropdownPopover.vue';
-import { MsOption, MsOptions } from '@/components/core/ms-types';
+import { MsOption, MsOptions, MsAppearance } from '@/components/core/ms-types';
 import { MsDropdownChangeEvent } from '@/components/core/ms-dropdown/types';
 
 const props = defineProps<{
   defaultOption?: any;
   label?: string;
+  title?: string;
   description?: string;
   options: MsOptions;
   disabled?: boolean;
+  appearance?: MsAppearance;
 }>();
 
 const emits = defineEmits<{
@@ -41,6 +51,7 @@ const emits = defineEmits<{
 const selectedOption: Ref<MsOption | undefined> = ref(props.defaultOption ? props.options.get(props.defaultOption) : undefined);
 const labelRef = ref(selectedOption.value?.label || props.label);
 const isPopoverOpen = ref(false);
+const appearanceRef = ref(props.appearance ?? MsAppearance.Outline);
 
 async function openPopover(event: Event): Promise<void> {
   const popover = await popoverController.create({
@@ -71,12 +82,23 @@ async function onDidDismissPopover(popover: any): Promise<void> {
     });
   }
 }
+
+function getIcon(): string {
+  switch (appearanceRef.value) {
+    case MsAppearance.Outline:
+      return chevronDown;
+    case MsAppearance.Clear:
+      return caretDown;
+  }
+}
 </script>
 
 <style lang="scss" scoped>
 .filter-button {
   background: none;
   color: var(--parsec-color-light-primary-700);
+  margin: 0;
+  height: 100%;
 }
 
 .option {
@@ -86,6 +108,20 @@ async function onDidDismissPopover(popover: any): Promise<void> {
   &.selected {
     color: var(--parsec-color-light-primary-700);
     font-weight: bold;
+  }
+}
+
+.dropdown-container {
+  // offset necessary to simulate border 3px on focus with outline (outline 2px + border 1px)
+  --offset: 2px;
+  --min-height: 3rem;
+  padding: var(--offset);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  .form-label {
+    color: var(--parsec-color-light-primary-700);
   }
 }
 

--- a/client/src/components/core/ms-types.ts
+++ b/client/src/components/core/ms-types.ts
@@ -7,6 +7,11 @@ export enum MsReportTheme {
   Error = 'ms-error',
 }
 
+export enum MsAppearance {
+  Outline = 'outline',
+  Clear = 'clear',
+}
+
 export interface MsOption {
   label: string;
   description?: string;

--- a/client/src/components/workspaces/WorkspaceUserRole.vue
+++ b/client/src/components/workspaces/WorkspaceUserRole.vue
@@ -13,6 +13,7 @@
       :options="options"
       :disabled="disabled"
       :default-option="role || NOT_SHARED_KEY"
+      :appearance="MsAppearance.Clear"
       @change="$emit('roleUpdate', user, getRoleFromString($event.option.key))"
     />
   </div>
@@ -21,7 +22,7 @@
 <script setup lang="ts">
 import { defineProps, defineEmits, computed } from 'vue';
 import { UserProfile, WorkspaceRole, canChangeRole } from '@/parsec';
-import { MsDropdown, MsOptions } from '@/components/core';
+import { MsAppearance, MsDropdown, MsOptions } from '@/components/core';
 import { useI18n } from 'vue-i18n';
 import UserAvatarName from '@/components/users/UserAvatarName.vue';
 import { UserTuple } from '@/parsec';

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -703,7 +703,8 @@
                 "finish": "Finish",
                 "approve": "Approve"
             },
-            "profilePlaceholder": "Choose a profile",
+            "profileDropdownPlaceholder": "Choose a profile",
+            "profileDropdownTitle": "Profile",
             "errors": {
                 "noneCodeSelected": "If you didn't see the correct code, it could be a security concern. Please restart the process.",
                 "invalidCodeSelected": "You didn't select the correct code. Please restart the process.",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -703,7 +703,8 @@
                 "finish": "Terminer",
                 "approve": "Approuver"
             },
-            "profilePlaceholder": "Choisissez un profil",
+            "profileDropdownPlaceholder": "Choisissez un profil",
+            "profileDropdownTitle": "Profil",
             "errors": {
                 "noneCodeSelected": "Si aucun des codes proposés n'était le bon, il peut s'agir d'un souci de sécurité. Veuillez redémarrer le processus.",
                 "invalidCodeSelected": "Vous n'avez pas sélectionné le bon code. Veuillez redémarrer le processus.",

--- a/client/src/theme/components/modals.scss
+++ b/client/src/theme/components/modals.scss
@@ -222,6 +222,10 @@ ion-modal.join-by-link-modal::part(content) {
         margin: auto;
       }
     }
+
+    .dropdown-container {
+      width: calc(50% - 0.75rem);
+    }
   }
 }
 

--- a/client/src/views/users/GreetUserModal.vue
+++ b/client/src/views/users/GreetUserModal.vue
@@ -91,7 +91,8 @@
           />
           <ms-dropdown
             class="dropdown"
-            :label="t('UsersPage.greet.profilePlaceholder')"
+            :title="t('UsersPage.greet.profileDropdownTitle')"
+            :label="t('UsersPage.greet.profileDropdownPlaceholder')"
             :options="profileOptions"
             @change="setUserProfile($event.option.key)"
           />


### PR DESCRIPTION
closes #5884 
- Add appearance choice for ms-dropdown
- Put Outline as default value
- Update ms-dropdown use cases with appropriate values
- Add a title for Outline appearance

Results:
1. **dropdown clear apperance**
![dropdown-clear](https://github.com/Scille/parsec-cloud/assets/19772607/c7ea8935-d1ec-40bd-adce-27fa3b2fb597)

2. **dropdown outline apperance**
![dropdown-outline](https://github.com/Scille/parsec-cloud/assets/19772607/2ee2f336-468b-4ade-a16a-0882907eaa3d)

3. **dropdown outline apperance with title**
![dropdown-outline-with-title](https://github.com/Scille/parsec-cloud/assets/19772607/75945a90-59cf-4bdd-9299-7394a40a1d35)

@fabienSvtr as you can see on the last screenshot, the dropdown outline appearance style needs some little adjustments (label and icon placement), I'll leave it up to you to decide whether you want to continue on this branch or open a new issue to do it later.