### PR TITLE
[MS] Refactoring of HomePage

### DIFF
--- a/client/src/components/header/HomePageHeader.vue
+++ b/client/src/components/header/HomePageHeader.vue
@@ -2,46 +2,48 @@
 
 <template>
   <ion-card-content class="topbar">
-    <ion-card-title
-      color="tertiary"
-      v-if="showBackButton"
-    >
-      <ion-button
-        fill="clear"
-        @click="$emit('backClick')"
-        id="back-to-list-button"
+    <div class="topbar-content">
+      <ion-card-title
+        color="tertiary"
+        v-if="showBackButton"
       >
-        <ion-icon
-          slot="start"
-          :icon="chevronBack"
-        />
-        {{ $t('HomePage.organizationLogin.backToList') }}
+        <ion-button
+          fill="clear"
+          @click="$emit('backClick')"
+          id="back-to-list-button"
+        >
+          <ion-icon
+            slot="start"
+            :icon="chevronBack"
+          />
+          {{ $t('HomePage.organizationLogin.backToList') }}
+        </ion-button>
+      </ion-card-title>
+      <ion-button
+        @click="togglePopover"
+        size="large"
+        id="create-organization-button"
+        class="button-default"
+      >
+        {{ $t('HomePage.noExistingOrganization.createOrJoin') }}
       </ion-button>
-    </ion-card-title>
-    <ion-button
-      @click="togglePopover"
-      size="large"
-      id="create-organization-button"
-      class="button-default"
-    >
-      {{ $t('HomePage.noExistingOrganization.createOrJoin') }}
-    </ion-button>
-    <ion-buttons
-      slot="primary"
-      class="topbar-icon__settings"
-    >
-      <ion-button
-        slot="icon-only"
-        id="trigger-settings-button"
-        class="topbar-button__item"
-        @click="$emit('settingsClick')"
+      <ion-buttons
+        slot="primary"
+        class="topbar-icon__settings"
       >
-        <ion-icon
+        <ion-button
           slot="icon-only"
-          :icon="cog"
-        />
-      </ion-button>
-    </ion-buttons>
+          id="trigger-settings-button"
+          class="topbar-button__item"
+          @click="$emit('settingsClick')"
+        >
+          <ion-icon
+            slot="icon-only"
+            :icon="cog"
+          />
+        </ion-button>
+      </ion-buttons>
+    </div>
   </ion-card-content>
 </template>
 
@@ -94,32 +96,15 @@ async function openPopover(event: Event): Promise<void> {
 
 <style lang="scss" scoped>
 .topbar {
-
-
-  background-color: #ffe700;
-  opacity: 0.8;
-  background-image: linear-gradient(30deg, #ffe700 12%, transparent 12.5%, transparent 87%, #ffe700 87.5%, #ffe700),
-    linear-gradient(150deg, #ffe700 12%, transparent 12.5%, transparent 87%, #ffe700 87.5%, #ffe700),
-    linear-gradient(30deg, #ffe700 12%, transparent 12.5%, transparent 87%, #ffe700 87.5%, #ffe700),
-    linear-gradient(150deg, #ffe700 12%, transparent 12.5%, transparent 87%, #ffe700 87.5%, #ffe700),
-    linear-gradient(60deg, #3e4616 25%, transparent 25.5%, transparent 75%, #3e4616 75%, #3e4616),
-    linear-gradient(60deg, #3e4616 25%, transparent 25.5%, transparent 75%, #3e4616 75%, #3e4616);
-  background-size: 20px 35px;
-  background-position:
-    0 0,
-    0 0,
-    10px 18px,
-    10px 18px,
-    0 0,
-    10px 18px;
-
-
-
-
   border-bottom: 1px solid var(--parsec-color-light-secondary-disabled);
-  padding: 3.5rem 3.5rem 1.5rem;
-  display: flex;
-  align-items: center;
+  padding: 0;
+
+  .topbar-content {
+    padding: 3.5rem 3.5rem 1.5rem;
+    max-width: var(--parsec-max-content-width);
+    display: flex;
+    align-items: center;
+  }
 
   #create-organization-button {
     margin-left: auto;

--- a/client/src/components/header/HomePageHeader.vue
+++ b/client/src/components/header/HomePageHeader.vue
@@ -1,0 +1,152 @@
+<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+
+<template>
+  <ion-card-content class="topbar">
+    <ion-card-title
+      color="tertiary"
+      v-if="showBackButton"
+    >
+      <ion-button
+        fill="clear"
+        @click="$emit('backClick')"
+        id="back-to-list-button"
+      >
+        <ion-icon
+          slot="start"
+          :icon="chevronBack"
+        />
+        {{ $t('HomePage.organizationLogin.backToList') }}
+      </ion-button>
+    </ion-card-title>
+    <ion-button
+      @click="togglePopover"
+      size="large"
+      id="create-organization-button"
+      class="button-default"
+    >
+      {{ $t('HomePage.noExistingOrganization.createOrJoin') }}
+    </ion-button>
+    <ion-buttons
+      slot="primary"
+      class="topbar-icon__settings"
+    >
+      <ion-button
+        slot="icon-only"
+        id="trigger-settings-button"
+        class="topbar-button__item"
+        @click="$emit('settingsClick')"
+      >
+        <ion-icon
+          slot="icon-only"
+          :icon="cog"
+        />
+      </ion-button>
+    </ion-buttons>
+  </ion-card-content>
+</template>
+
+<script setup lang="ts">
+import { popoverController, IonButtons, IonButton, IonIcon, IonCardTitle, IonCardContent } from '@ionic/vue';
+import { cog, chevronBack } from 'ionicons/icons';
+import { ref } from 'vue';
+import HomePagePopover, { HomePageAction } from '@/views/home/HomePagePopover.vue';
+import { MsModalResult } from '@/components/core';
+
+defineProps<{
+  showBackButton: boolean;
+}>();
+
+const emits = defineEmits<{
+  (e: 'createOrganizationClick'): void;
+  (e: 'joinOrganizationClick'): void;
+  (e: 'settingsClick'): void;
+  (e: 'backClick'): void;
+}>();
+
+const isPopoverOpen = ref(false);
+
+async function togglePopover(event: Event): Promise<void> {
+  isPopoverOpen.value = !isPopoverOpen.value;
+  openPopover(event);
+}
+
+async function openPopover(event: Event): Promise<void> {
+  const popover = await popoverController.create({
+    component: HomePagePopover,
+    cssClass: 'homepage-popover',
+    event: event,
+    showBackdrop: false,
+    alignment: 'end',
+  });
+  await popover.present();
+  const result = await popover.onWillDismiss();
+  await popover.dismiss();
+  if (result.role !== MsModalResult.Confirm) {
+    return;
+  }
+  if (result.data.action === HomePageAction.CreateOrganization) {
+    emits('createOrganizationClick');
+  } else if (result.data.action === HomePageAction.JoinOrganization) {
+    emits('joinOrganizationClick');
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.topbar {
+
+
+  background-color: #ffe700;
+  opacity: 0.8;
+  background-image: linear-gradient(30deg, #ffe700 12%, transparent 12.5%, transparent 87%, #ffe700 87.5%, #ffe700),
+    linear-gradient(150deg, #ffe700 12%, transparent 12.5%, transparent 87%, #ffe700 87.5%, #ffe700),
+    linear-gradient(30deg, #ffe700 12%, transparent 12.5%, transparent 87%, #ffe700 87.5%, #ffe700),
+    linear-gradient(150deg, #ffe700 12%, transparent 12.5%, transparent 87%, #ffe700 87.5%, #ffe700),
+    linear-gradient(60deg, #3e4616 25%, transparent 25.5%, transparent 75%, #3e4616 75%, #3e4616),
+    linear-gradient(60deg, #3e4616 25%, transparent 25.5%, transparent 75%, #3e4616 75%, #3e4616);
+  background-size: 20px 35px;
+  background-position:
+    0 0,
+    0 0,
+    10px 18px,
+    10px 18px,
+    0 0,
+    10px 18px;
+
+
+
+
+  border-bottom: 1px solid var(--parsec-color-light-secondary-disabled);
+  padding: 3.5rem 3.5rem 1.5rem;
+  display: flex;
+  align-items: center;
+
+  #create-organization-button {
+    margin-left: auto;
+    margin-right: 1.5rem;
+  }
+
+  .topbar-button__item,
+  .sc-ion-buttons-md-s .button {
+    border: 1px solid var(--parsec-color-light-secondary-light);
+    color: var(--parsec-color-light-primary-700);
+    border-radius: 50%;
+    --padding-top: 0;
+    --padding-end: 0;
+    --padding-bottom: 0;
+    --padding-start: 0;
+    width: 3em;
+    height: 3em;
+
+    &:hover {
+      --background-hover: var(--parsec-color-light-primary-50);
+      background: var(--parsec-color-light-primary-50);
+      border: var(--parsec-color-light-primary-50);
+    }
+
+    ion-icon {
+      font-size: 1.375rem;
+    }
+  }
+}
+</style>

--- a/client/src/components/header/HomePageSidebar.vue
+++ b/client/src/components/header/HomePageSidebar.vue
@@ -1,37 +1,35 @@
 <!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
 
 <template>
-  <div id="page">
-    <div class="sidebar">
-      <div class="sidebar-content">
-        <div class="sidebar-content__titles">
-          <h1 class="title-h1-lg">
-            {{ $t('HomePage.organizationList.title') }}
-          </h1>
-          <ion-text class="subtitles-normal">
-            {{ $t('HomePage.organizationList.subtitle') }}
-          </ion-text>
+  <div class="sidebar">
+    <div class="sidebar-content">
+      <div class="sidebar-content__titles">
+        <h1 class="title-h1-lg">
+          {{ $t('HomePage.organizationList.title') }}
+        </h1>
+        <ion-text class="subtitles-normal">
+          {{ $t('HomePage.organizationList.subtitle') }}
+        </ion-text>
+      </div>
+      <div class="sidebar-footer">
+        <div class="sidebar-footer__logo">
+          <ms-image
+            :image="LogoRowWhite"
+            class="logo-img"
+          />
         </div>
-        <div class="sidebar-footer">
-          <div class="sidebar-footer__logo">
-            <ms-image
-              :image="LogoRowWhite"
-              class="logo-img"
-            />
-          </div>
-          <div
-            class="sidebar-footer__version body"
-            @click="$emit('aboutClick')"
-          >
-            <ion-icon
-              slot="start"
-              :icon="informationCircle"
-              size="small"
-            />
-            <span class="version-text">
-              {{ getAppVersion() }}
-            </span>
-          </div>
+        <div
+          class="sidebar-footer__version body"
+          @click="$emit('aboutClick')"
+        >
+          <ion-icon
+            slot="start"
+            :icon="informationCircle"
+            size="small"
+          />
+          <span class="version-text">
+            {{ getAppVersion() }}
+          </span>
         </div>
       </div>
     </div>
@@ -85,6 +83,7 @@ defineEmits<{
       flex-grow: 2;
       max-width: var(--parsec-max-title-width);
       position: relative;
+      color: var(--parsec-color-light-secondary-premiere);
       gap: 1rem;
     }
   }

--- a/client/src/components/header/HomePageSidebar.vue
+++ b/client/src/components/header/HomePageSidebar.vue
@@ -1,0 +1,136 @@
+<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+
+<template>
+  <div id="page">
+    <div class="sidebar">
+      <div class="sidebar-content">
+        <div class="sidebar-content__titles">
+          <h1 class="title-h1-lg">
+            {{ $t('HomePage.organizationList.title') }}
+          </h1>
+          <ion-text class="subtitles-normal">
+            {{ $t('HomePage.organizationList.subtitle') }}
+          </ion-text>
+        </div>
+        <div class="sidebar-footer">
+          <div class="sidebar-footer__logo">
+            <ms-image
+              :image="LogoRowWhite"
+              class="logo-img"
+            />
+          </div>
+          <div
+            class="sidebar-footer__version body"
+            @click="$emit('aboutClick')"
+          >
+            <ion-icon
+              slot="start"
+              :icon="informationCircle"
+              size="small"
+            />
+            <span class="version-text">
+              {{ getAppVersion() }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { IonText, IonIcon } from '@ionic/vue';
+import { informationCircle } from 'ionicons/icons';
+import { getAppVersion } from '@/common/mocks';
+import { MsImage, LogoRowWhite } from '@/components/core';
+
+defineEmits<{
+  (e: 'aboutClick'): void;
+}>();
+</script>
+
+<style lang="scss" scoped>
+.sidebar {
+  display: flex;
+  height: 100vh;
+  width: 40vw;
+  padding: 2rem;
+  background: var(--parsec-color-light-gradient);
+  position: relative;
+  justify-content: flex-end;
+  z-index: -3;
+
+  &::before {
+    content: '';
+    position: absolute;
+    z-index: -2;
+    top: 0;
+    right: 0;
+    width: 100vw;
+    height: 100vh;
+    background: url('@/assets/images/background/homepage-rectangle.svg') repeat center;
+    background-size: cover;
+  }
+
+  .sidebar-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-left: 2rem;
+
+    &__titles {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      flex-grow: 2;
+      max-width: var(--parsec-max-title-width);
+      position: relative;
+      gap: 1rem;
+    }
+  }
+
+  .sidebar-footer {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+
+    &__logo {
+      display: flex;
+      width: 100%;
+
+      .logo-img {
+        max-height: 3em;
+        width: 30%;
+        height: 100%;
+      }
+    }
+
+    &__version {
+      cursor: pointer;
+      color: var(--parsec-color-light-secondary-premiere);
+      padding: 0.3rem 0.5rem;
+      border-radius: var(--parsec-radius-8);
+      background-color: var(--parsec-color-light-primary-30-opacity15);
+      border: 1px solid var(--parsec-color-light-primary-30-opacity15);
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      transition: all 150ms linear;
+
+      .version-text {
+        line-height: 0;
+        padding: 0.8rem 0;
+      }
+
+      ion-icon {
+        font-size: 1.375rem;
+        color: var(--parsec-color-light-primary-100);
+      }
+
+      &:hover {
+        border-color: var(--parsec-color-light-primary-100);
+      }
+    }
+  }
+}
+</style>

--- a/client/src/services/storageManager.ts
+++ b/client/src/services/storageManager.ts
@@ -4,6 +4,8 @@ import { isElectron } from '@/parsec';
 import { Storage } from '@ionic/storage';
 import { DateTime } from 'luxon';
 
+export { StorageManagerKey } from '@/common/injectionKeys';
+
 export interface StoredDeviceData {
   lastLogin: DateTime;
 }

--- a/client/src/theme/components/cards.scss
+++ b/client/src/theme/components/cards.scss
@@ -2,11 +2,6 @@
 
 /* **** Parsec cards **** */
 
-ion-card-title {
-  margin: 1em 0;
-  font-weight: bold;
-}
-
 ion-card {
   --box-shadow: none;
 }

--- a/client/src/theme/variables/width.scss
+++ b/client/src/theme/variables/width.scss
@@ -6,7 +6,7 @@
   --parsec-modal-width: 42rem;
   --parsec-min-content-width: 35rem;
   --parsec-max-content-width: 78rem;
-  --parsec-max-title-width: 20rem;
+  --parsec-max-title-width: 31.25rem;
   --parsec-sidebar-menu-width: 300px;
   --parsec-sidebar-menu-min-width: 0px;
   --parsec-sidebar-menu-max-width: 500px;

--- a/client/src/transitions/SlideHorizontal.vue
+++ b/client/src/transitions/SlideHorizontal.vue
@@ -1,8 +1,8 @@
 <!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
 <template>
-  <transition-group :name="!props.reverseDirection ? 'slide-left' : 'slide-right'">
+  <transition :name="!props.reverseDirection ? 'slide-left' : 'slide-right'">
     <slot />
-  </transition-group>
+  </transition>
 </template>
 
 <script setup lang="ts">

--- a/client/src/views/home/HomePage.vue
+++ b/client/src/views/home/HomePage.vue
@@ -4,7 +4,6 @@
   <ion-page>
     <ion-content
       :fullscreen="true"
-      color="secondary"
     >
       <div id="page">
         <home-page-sidebar @about-click="openAboutModal" />
@@ -229,14 +228,9 @@ async function onJoinOrganizationClicked(): Promise<void> {
 .right-side {
   height: 100vh;
   width: 60vw;
-  max-width: var(--parsec-max-content-width);
   background: var(--parsec-color-light-secondary-inversed-contrast);
   flex-direction: column;
   position: relative;
   z-index: -5;
-}
-
-.header {
-  z-index: 6;
 }
 </style>

--- a/client/src/views/home/HomePage.vue
+++ b/client/src/views/home/HomePage.vue
@@ -2,9 +2,7 @@
 
 <template>
   <ion-page>
-    <ion-content
-      :fullscreen="true"
-    >
+    <ion-content :fullscreen="true">
       <div id="page">
         <home-page-sidebar @about-click="openAboutModal" />
 
@@ -21,19 +19,19 @@
             :show-back-button="state !== HomePageState.OrganizationList"
           />
 
-          <slide-horizontal :reverse-direction="state === HomePageState.Login">
-            <template v-if="state === HomePageState.OrganizationList">
-              <organization-list-page @organization-select="onOrganizationSelected" />
-            </template>
-            <!-- after animation -->
-            <template v-if="state === HomePageState.Login && selectedDevice">
-              <login-page
-                :device="selectedDevice"
-                @login-click="login"
-                @forgotten-password-click="onForgottenPasswordClicked"
-              />
-            </template>
-          </slide-horizontal>
+          <!-- <slide-horizontal :reverse-direction="state === HomePageState.Login"> -->
+          <template v-if="state === HomePageState.OrganizationList">
+            <organization-list-page @organization-select="onOrganizationSelected" />
+          </template>
+          <!-- after animation -->
+          <template v-if="state === HomePageState.Login && selectedDevice">
+            <login-page
+              :device="selectedDevice"
+              @login-click="login"
+              @forgotten-password-click="onForgottenPasswordClicked"
+            />
+          </template>
+          <!-- </slide-horizontal> -->
         </div>
         <!-- end of organization -->
       </div>

--- a/client/src/views/home/LoginPage.vue
+++ b/client/src/views/home/LoginPage.vue
@@ -79,7 +79,6 @@ const password = ref('');
   align-items: center;
   flex-grow: 1;
   margin: 0;
-  max-height: 100%;
 
   .organization-container {
     max-width: 52.5rem;

--- a/client/src/views/home/LoginPage.vue
+++ b/client/src/views/home/LoginPage.vue
@@ -1,0 +1,201 @@
+<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+
+<template>
+  <ion-page>
+    <ion-content
+      :fullscreen="true"
+      color="secondary"
+    >
+      <ion-card class="login-popup">
+        <ion-card-content class="organization-container">
+          <ion-text class="title-h1">
+            {{ $t('HomePage.organizationLogin.login') }}
+          </ion-text>
+          <!-- login -->
+          <div id="login-container">
+            <ion-card class="login-card">
+              <ion-card-content class="login-card__content">
+                <ion-grid>
+                  <organization-card :device="device" />
+                  <ms-password-input
+                    :label="$t('HomePage.organizationLogin.passwordLabel')"
+                    v-model="password"
+                    @on-enter-keyup="onLoginClick()"
+                    id="ms-password-input"
+                  />
+                  <ion-button
+                    fill="clear"
+                    @click="$emit('forgottenPasswordClick', device)"
+                    id="forgotten-password-button"
+                  >
+                    {{ $t('HomePage.organizationLogin.forgottenPassword') }}
+                  </ion-button>
+                </ion-grid>
+              </ion-card-content>
+            </ion-card>
+            <div class="login-button-container">
+              <ion-button
+                @click="onLoginClick()"
+                size="large"
+                :disabled="password.length == 0"
+                class="login-button"
+              >
+                <ion-icon
+                  slot="start"
+                  :icon="logIn"
+                />
+                {{ $t('HomePage.organizationLogin.login') }}
+              </ion-button>
+            </div>
+          </div>
+          <!-- end of login -->
+        </ion-card-content>
+      </ion-card>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { IonButton, IonCard, IonCardContent, IonContent, IonPage, IonIcon, IonGrid, IonText } from '@ionic/vue';
+import { logIn } from 'ionicons/icons';
+import { AvailableDevice } from '@/parsec';
+import { ref } from 'vue';
+import OrganizationCard from '@/components/organizations/OrganizationCard.vue';
+import { MsPasswordInput } from '@/components/core';
+
+const props = defineProps<{
+  device: AvailableDevice;
+}>();
+
+const emits = defineEmits<{
+  (e: 'loginClick', device: AvailableDevice, password: string): void;
+  (e: 'forgottenPasswordClick', device: AvailableDevice): void;
+}>();
+
+async function onLoginClick(): Promise<void> {
+  emits('loginClick', props.device, password.value);
+}
+
+const password = ref('');
+</script>
+
+<style lang="scss" scoped>
+.login-popup {
+  box-shadow: none;
+  display: flex;
+  margin: auto 0;
+  align-items: center;
+  justify-content: center;
+  flex-grow: 1;
+  max-height: 80%;
+
+  .organization-container {
+    max-width: 62.5rem;
+    padding: 0 3.5rem 3.5rem;
+    flex-grow: 1;
+  }
+
+  .title-h1 {
+    color: var(--parsec-color-light-primary-700);
+  }
+
+  #login-container {
+    margin-top: 2.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .login-card {
+    background: var(--parsec-color-light-secondary-background);
+    border-radius: 8px;
+    padding: 2em;
+    box-shadow: none;
+    margin: 0;
+
+    &__content {
+      padding: 0;
+
+      #ms-password-input {
+        margin: 1.5rem 0 1rem;
+      }
+    }
+
+    .organization-card {
+      margin-bottom: 2em;
+      display: flex;
+
+      &__body {
+        padding: 0;
+      }
+    }
+  }
+
+  .login-button-container {
+    text-align: right;
+
+    .login-button {
+      margin: 0;
+    }
+  }
+}
+.login-popup {
+  box-shadow: none;
+  display: flex;
+  margin: auto 0;
+  align-items: center;
+  justify-content: center;
+  flex-grow: 1;
+  max-height: 80%;
+
+  .organization-container {
+    max-width: 62.5rem;
+    padding: 0 3.5rem 3.5rem;
+    flex-grow: 1;
+  }
+
+  .title-h1 {
+    color: var(--parsec-color-light-primary-700);
+  }
+
+  #login-container {
+    margin-top: 2.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .login-card {
+    background: var(--parsec-color-light-secondary-background);
+    border-radius: 8px;
+    padding: 2em;
+    box-shadow: none;
+    margin: 0;
+
+    &__content {
+      padding: 0;
+
+      #ms-password-input {
+        margin: 1.5rem 0 1rem;
+      }
+    }
+
+    .organization-card {
+      margin-bottom: 2em;
+      display: flex;
+
+      &__body {
+        padding: 0;
+      }
+    }
+  }
+
+  .login-button-container {
+    text-align: right;
+
+    .login-button {
+      margin: 0;
+    }
+  }
+}
+</style>

--- a/client/src/views/home/LoginPage.vue
+++ b/client/src/views/home/LoginPage.vue
@@ -1,62 +1,55 @@
 <!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
 
 <template>
-  <ion-page>
-    <ion-content
-      :fullscreen="true"
-      color="secondary"
-    >
-      <ion-card class="login-popup">
-        <ion-card-content class="organization-container">
-          <ion-text class="title-h1">
-            {{ $t('HomePage.organizationLogin.login') }}
-          </ion-text>
-          <!-- login -->
-          <div id="login-container">
-            <ion-card class="login-card">
-              <ion-card-content class="login-card__content">
-                <ion-grid>
-                  <organization-card :device="device" />
-                  <ms-password-input
-                    :label="$t('HomePage.organizationLogin.passwordLabel')"
-                    v-model="password"
-                    @on-enter-keyup="onLoginClick()"
-                    id="ms-password-input"
-                  />
-                  <ion-button
-                    fill="clear"
-                    @click="$emit('forgottenPasswordClick', device)"
-                    id="forgotten-password-button"
-                  >
-                    {{ $t('HomePage.organizationLogin.forgottenPassword') }}
-                  </ion-button>
-                </ion-grid>
-              </ion-card-content>
-            </ion-card>
-            <div class="login-button-container">
+  <ion-card class="login-popup">
+    <ion-card-content class="organization-container">
+      <ion-text class="title-h1">
+        {{ $t('HomePage.organizationLogin.login') }}
+      </ion-text>
+      <!-- login -->
+      <div id="login-container">
+        <ion-card class="login-card">
+          <ion-card-content class="login-card__content">
+            <ion-grid>
+              <organization-card :device="device" />
+              <ms-password-input
+                :label="$t('HomePage.organizationLogin.passwordLabel')"
+                v-model="password"
+                @on-enter-keyup="onLoginClick()"
+                id="ms-password-input"
+              />
               <ion-button
-                @click="onLoginClick()"
-                size="large"
-                :disabled="password.length == 0"
-                class="login-button"
+                fill="clear"
+                @click="$emit('forgottenPasswordClick', device)"
+                id="forgotten-password-button"
               >
-                <ion-icon
-                  slot="start"
-                  :icon="logIn"
-                />
-                {{ $t('HomePage.organizationLogin.login') }}
+                {{ $t('HomePage.organizationLogin.forgottenPassword') }}
               </ion-button>
-            </div>
-          </div>
-          <!-- end of login -->
-        </ion-card-content>
-      </ion-card>
-    </ion-content>
-  </ion-page>
+            </ion-grid>
+          </ion-card-content>
+        </ion-card>
+        <div class="login-button-container">
+          <ion-button
+            @click="onLoginClick()"
+            size="large"
+            :disabled="password.length == 0"
+            class="login-button"
+          >
+            <ion-icon
+              slot="start"
+              :icon="logIn"
+            />
+            {{ $t('HomePage.organizationLogin.login') }}
+          </ion-button>
+        </div>
+      </div>
+      <!-- end of login -->
+    </ion-card-content>
+  </ion-card>
 </template>
 
 <script setup lang="ts">
-import { IonButton, IonCard, IonCardContent, IonContent, IonPage, IonIcon, IonGrid, IonText } from '@ionic/vue';
+import { IonButton, IonCard, IonCardContent, IonIcon, IonGrid, IonText } from '@ionic/vue';
 import { logIn } from 'ionicons/icons';
 import { AvailableDevice } from '@/parsec';
 import { ref } from 'vue';
@@ -83,74 +76,14 @@ const password = ref('');
 .login-popup {
   box-shadow: none;
   display: flex;
-  margin: auto 0;
   align-items: center;
-  justify-content: center;
   flex-grow: 1;
-  max-height: 80%;
+  margin: 0;
+  max-height: 100%;
 
   .organization-container {
-    max-width: 62.5rem;
-    padding: 0 3.5rem 3.5rem;
-    flex-grow: 1;
-  }
-
-  .title-h1 {
-    color: var(--parsec-color-light-primary-700);
-  }
-
-  #login-container {
-    margin-top: 2.5rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-  }
-
-  .login-card {
-    background: var(--parsec-color-light-secondary-background);
-    border-radius: 8px;
-    padding: 2em;
-    box-shadow: none;
-    margin: 0;
-
-    &__content {
-      padding: 0;
-
-      #ms-password-input {
-        margin: 1.5rem 0 1rem;
-      }
-    }
-
-    .organization-card {
-      margin-bottom: 2em;
-      display: flex;
-
-      &__body {
-        padding: 0;
-      }
-    }
-  }
-
-  .login-button-container {
-    text-align: right;
-
-    .login-button {
-      margin: 0;
-    }
-  }
-}
-.login-popup {
-  box-shadow: none;
-  display: flex;
-  margin: auto 0;
-  align-items: center;
-  justify-content: center;
-  flex-grow: 1;
-  max-height: 80%;
-
-  .organization-container {
-    max-width: 62.5rem;
-    padding: 0 3.5rem 3.5rem;
+    max-width: 52.5rem;
+    padding: 0 3.5rem 8.5rem;
     flex-grow: 1;
   }
 

--- a/client/src/views/home/OrganizationListPage.vue
+++ b/client/src/views/home/OrganizationListPage.vue
@@ -55,9 +55,7 @@
                           {{ $t('HomePage.organizationList.lastLogin') }}
                         </p>
                         <p>
-                          {{
-                            device.slug in storedDeviceDataDict ? timeSince(storedDeviceDataDict[device.slug].lastLogin, '--') : '--'
-                          }}
+                          {{ device.slug in storedDeviceDataDict ? timeSince(storedDeviceDataDict[device.slug].lastLogin, '--') : '--' }}
                         </p>
                       </ion-col>
                     </ion-row>

--- a/client/src/views/home/OrganizationListPage.vue
+++ b/client/src/views/home/OrganizationListPage.vue
@@ -1,86 +1,79 @@
 <!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
 
 <template>
-  <ion-page>
-    <ion-content
-      :fullscreen="true"
-      color="secondary"
-    >
-      <ion-card class="right-side-container">
-        <template v-if="deviceList.length === 0">
-          <ion-card-content class="organization-container">
-            <ion-card-title>
-              {{ $t('HomePage.noDevices') }}
-            </ion-card-title>
-            {{ $t('HomePage.howToAddDevices') }}
-          </ion-card-content>
-        </template>
-        <template v-if="deviceList.length > 0">
-          <ion-card-content class="organization-container">
-            <ion-card-title class="organization-filter">
-              <ms-search-input
-                :label="$t('HomePage.organizationList.search')"
-                v-model="searchQuery"
-                id="ms-search-input"
-              />
-              <!-- No use in showing the sort/filter options for less than 2 devices -->
-              <template v-if="deviceList.length >= 2">
-                <ms-sorter
-                  id="organization-filter-select"
-                  label="t('HomePage.organizationList.labelSortBy')"
-                  :options="msSorterOptions"
-                  default-option="organization"
-                  :sorter-labels="msSorterLabels"
-                  @change="onMsSorterChange($event)"
-                />
-              </template>
-            </ion-card-title>
-            <ion-grid class="organization-list">
-              <ion-row class="organization-list-row">
-                <ion-col
-                  v-for="device in filteredDevices"
-                  :key="device.slug"
-                  class="organization-list-row__col"
-                  size="2"
-                >
-                  <ion-card
-                    button
-                    class="organization-card"
-                    @click="$emit('organizationSelect', device)"
-                  >
-                    <ion-card-content class="card-content">
-                      <ion-grid>
-                        <organization-card
-                          :device="device"
-                          class="card-content__body"
-                        />
-                        <ion-row class="card-content__footer">
-                          <ion-col size="auto">
-                            <p>
-                              {{ $t('HomePage.organizationList.lastLogin') }}
-                            </p>
-                            <p>
-                              {{
-                                device.slug in storedDeviceDataDict ? timeSince(storedDeviceDataDict[device.slug].lastLogin, '--') : '--'
-                              }}
-                            </p>
-                          </ion-col>
-                        </ion-row>
-                      </ion-grid>
-                    </ion-card-content>
-                  </ion-card>
-                </ion-col>
-              </ion-row>
-            </ion-grid>
-          </ion-card-content>
-        </template>
-      </ion-card>
-    </ion-content>
-  </ion-page>
+  <ion-card class="right-side-container">
+    <template v-if="deviceList.length === 0">
+      <ion-card-content class="organization-container">
+        <ion-card-title>
+          {{ $t('HomePage.noDevices') }}
+        </ion-card-title>
+        {{ $t('HomePage.howToAddDevices') }}
+      </ion-card-content>
+    </template>
+    <template v-if="deviceList.length > 0">
+      <ion-card-content class="organization-container">
+        <ion-card-title class="organization-filter">
+          <ms-search-input
+            :label="$t('HomePage.organizationList.search')"
+            v-model="searchQuery"
+            id="ms-search-input"
+          />
+          <!-- No use in showing the sort/filter options for less than 2 devices -->
+          <template v-if="deviceList.length >= 2">
+            <ms-sorter
+              id="organization-filter-select"
+              label="t('HomePage.organizationList.labelSortBy')"
+              :options="msSorterOptions"
+              default-option="organization"
+              :sorter-labels="msSorterLabels"
+              @change="onMsSorterChange($event)"
+            />
+          </template>
+        </ion-card-title>
+        <ion-grid class="organization-list">
+          <ion-row class="organization-list-row">
+            <ion-col
+              v-for="device in filteredDevices"
+              :key="device.slug"
+              class="organization-list-row__col"
+              size="2"
+            >
+              <ion-card
+                button
+                class="organization-card"
+                @click="$emit('organizationSelect', device)"
+              >
+                <ion-card-content class="card-content">
+                  <ion-grid>
+                    <organization-card
+                      :device="device"
+                      class="card-content__body"
+                    />
+                    <ion-row class="card-content__footer">
+                      <ion-col size="auto">
+                        <p>
+                          {{ $t('HomePage.organizationList.lastLogin') }}
+                        </p>
+                        <p>
+                          {{
+                            device.slug in storedDeviceDataDict ? timeSince(storedDeviceDataDict[device.slug].lastLogin, '--') : '--'
+                          }}
+                        </p>
+                      </ion-col>
+                    </ion-row>
+                  </ion-grid>
+                </ion-card-content>
+              </ion-card>
+            </ion-col>
+          </ion-row>
+        </ion-grid>
+      </ion-card-content>
+    </template>
+  </ion-card>
 </template>
 
 <script setup lang="ts">
-import { IonContent, IonPage, IonCardContent, IonGrid, IonRow, IonCol, IonCard, IonCardTitle } from '@ionic/vue';
+import { IonCardContent, IonGrid, IonRow, IonCol, IonCard, IonCardTitle } from '@ionic/vue';
 import { AvailableDevice, listAvailableDevices } from '@/parsec';
 import { ref, Ref, computed, onMounted, inject, onUpdated } from 'vue';
 import { StorageManager, StoredDeviceData, StorageManagerKey } from '@/services/storageManager';
@@ -185,37 +178,30 @@ const filteredDevices = computed(() => {
 <style lang="scss" scoped>
 .right-side-container {
   height: 100%;
-
-
-
-  background-color: #ff08fc;
-  opacity: 0.8;
-  background-image: repeating-radial-gradient(circle at 0 0, transparent 0, #15f4ee 20px), repeating-linear-gradient(#ff08fc, #ff08fc);
-
-
-
-
-  margin-inline: 0px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  border-radius: 0;
   box-shadow: none;
   flex-grow: 0;
   flex-shrink: 0;
+  margin: 0;
+  width: 60vw;
 }
 
 .organization-container {
-  padding: 1.5rem 3.5rem 0;
+  padding: 2rem 3.5rem 0;
   height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-width: var(--parsec-max-content-width);
 
   .organization-filter {
     display: flex;
-    margin: 0 0 0.5rem;
-    justify-content: flex-end;
+    justify-content: space-between;
+    margin: 0;
   }
 
   .organization-list {
     max-height: 80%;
+    margin: 0;
     overflow-y: auto;
     --ion-grid-columns: 6;
   }

--- a/client/src/views/home/OrganizationListPage.vue
+++ b/client/src/views/home/OrganizationListPage.vue
@@ -1,0 +1,271 @@
+<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+
+<template>
+  <ion-page>
+    <ion-content
+      :fullscreen="true"
+      color="secondary"
+    >
+      <ion-card class="right-side-container">
+        <template v-if="deviceList.length === 0">
+          <ion-card-content class="organization-container">
+            <ion-card-title>
+              {{ $t('HomePage.noDevices') }}
+            </ion-card-title>
+            {{ $t('HomePage.howToAddDevices') }}
+          </ion-card-content>
+        </template>
+        <template v-if="deviceList.length > 0">
+          <ion-card-content class="organization-container">
+            <ion-card-title class="organization-filter">
+              <ms-search-input
+                :label="$t('HomePage.organizationList.search')"
+                v-model="searchQuery"
+                id="ms-search-input"
+              />
+              <!-- No use in showing the sort/filter options for less than 2 devices -->
+              <template v-if="deviceList.length >= 2">
+                <ms-sorter
+                  id="organization-filter-select"
+                  label="t('HomePage.organizationList.labelSortBy')"
+                  :options="msSorterOptions"
+                  default-option="organization"
+                  :sorter-labels="msSorterLabels"
+                  @change="onMsSorterChange($event)"
+                />
+              </template>
+            </ion-card-title>
+            <ion-grid class="organization-list">
+              <ion-row class="organization-list-row">
+                <ion-col
+                  v-for="device in filteredDevices"
+                  :key="device.slug"
+                  class="organization-list-row__col"
+                  size="2"
+                >
+                  <ion-card
+                    button
+                    class="organization-card"
+                    @click="$emit('organizationSelect', device)"
+                  >
+                    <ion-card-content class="card-content">
+                      <ion-grid>
+                        <organization-card
+                          :device="device"
+                          class="card-content__body"
+                        />
+                        <ion-row class="card-content__footer">
+                          <ion-col size="auto">
+                            <p>
+                              {{ $t('HomePage.organizationList.lastLogin') }}
+                            </p>
+                            <p>
+                              {{
+                                device.slug in storedDeviceDataDict ? timeSince(storedDeviceDataDict[device.slug].lastLogin, '--') : '--'
+                              }}
+                            </p>
+                          </ion-col>
+                        </ion-row>
+                      </ion-grid>
+                    </ion-card-content>
+                  </ion-card>
+                </ion-col>
+              </ion-row>
+            </ion-grid>
+          </ion-card-content>
+        </template>
+      </ion-card>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { IonContent, IonPage, IonCardContent, IonGrid, IonRow, IonCol, IonCard, IonCardTitle } from '@ionic/vue';
+import { AvailableDevice, listAvailableDevices } from '@/parsec';
+import { ref, Ref, computed, onMounted, inject, onUpdated } from 'vue';
+import { StorageManager, StoredDeviceData, StorageManagerKey } from '@/services/storageManager';
+import { Formatters, FormattersKey } from '@/common/injectionKeys';
+import { DateTime } from 'luxon';
+import { MsOptions, MsSorterChangeEvent, MsSorter, MsSearchInput } from '@/components/core';
+import { useI18n } from 'vue-i18n';
+import OrganizationCard from '@/components/organizations/OrganizationCard.vue';
+
+const emits = defineEmits<{
+  (e: 'organizationSelect', device: AvailableDevice): void;
+}>();
+
+const { t } = useI18n();
+const deviceList: Ref<AvailableDevice[]> = ref([]);
+const storedDeviceDataDict = ref<{ [slug: string]: StoredDeviceData }>({});
+const storageManager: StorageManager = inject(StorageManagerKey)!;
+const { timeSince } = inject(FormattersKey)! as Formatters;
+const sortBy = ref('organization');
+const sortByAsc = ref(true);
+const searchQuery = ref('');
+
+const msSorterOptions: MsOptions = new MsOptions([
+  {
+    label: t('HomePage.organizationList.sortByOrganization'),
+    key: 'organization',
+  },
+  { label: t('HomePage.organizationList.sortByUserName'), key: 'user_name' },
+  { label: t('HomePage.organizationList.sortByLastLogin'), key: 'last_login' },
+]);
+
+const msSorterLabels = {
+  asc: t('HomePage.organizationList.sortOrderAsc'),
+  desc: t('HomePage.organizationList.sortOrderDesc'),
+};
+
+onMounted(async (): Promise<void> => {
+  storedDeviceDataDict.value = await storageManager.retrieveDevicesData();
+  await refreshDeviceList();
+});
+
+onUpdated(async (): Promise<void> => {
+  await refreshDeviceList();
+});
+
+async function refreshDeviceList(): Promise<void> {
+  deviceList.value = await listAvailableDevices();
+  if (deviceList.value.length === 1) {
+    emits('organizationSelect', deviceList.value[0]);
+  }
+}
+
+function onMsSorterChange(event: MsSorterChangeEvent): void {
+  sortBy.value = event.option.key;
+  sortByAsc.value = event.sortByAsc;
+}
+
+const filteredDevices = computed(() => {
+  return deviceList.value
+    .filter((item) => {
+      const lowerSearchString = searchQuery.value.toLocaleLowerCase();
+      return (
+        item.humanHandle.label.toLocaleLowerCase().includes(lowerSearchString) ||
+        item.organizationId.toLocaleLowerCase().includes(lowerSearchString)
+      );
+    })
+    .sort((a, b) => {
+      const aLabel = a.humanHandle.label;
+      const bLabel = b.humanHandle.label;
+      if (sortBy.value === 'organization') {
+        if (sortByAsc.value) {
+          return a.organizationId.localeCompare(b.organizationId);
+        } else {
+          return b.organizationId.localeCompare(a.organizationId);
+        }
+      } else if (sortBy.value === 'user_name' && aLabel && bLabel) {
+        if (sortByAsc.value) {
+          return aLabel?.localeCompare(bLabel ?? '');
+        } else {
+          return bLabel?.localeCompare(aLabel ?? '');
+        }
+      } else if (sortBy.value === 'last_login') {
+        const aLastLogin =
+          a.slug in storedDeviceDataDict.value && storedDeviceDataDict.value[a.slug].lastLogin !== undefined
+            ? storedDeviceDataDict.value[a.slug].lastLogin
+            : DateTime.fromMillis(0);
+        const bLastLogin =
+          b.slug in storedDeviceDataDict.value && storedDeviceDataDict.value[b.slug].lastLogin !== undefined
+            ? storedDeviceDataDict.value[b.slug].lastLogin
+            : DateTime.fromMillis(0);
+        if (sortByAsc.value) {
+          return bLastLogin.diff(aLastLogin).toObject().milliseconds!;
+        } else {
+          return aLastLogin.diff(bLastLogin).toObject().milliseconds!;
+        }
+      }
+      return 0;
+    });
+});
+</script>
+
+<style lang="scss" scoped>
+.right-side-container {
+  height: 100%;
+
+
+
+  background-color: #ff08fc;
+  opacity: 0.8;
+  background-image: repeating-radial-gradient(circle at 0 0, transparent 0, #15f4ee 20px), repeating-linear-gradient(#ff08fc, #ff08fc);
+
+
+
+
+  margin-inline: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  border-radius: 0;
+  box-shadow: none;
+  flex-grow: 0;
+  flex-shrink: 0;
+}
+
+.organization-container {
+  padding: 1.5rem 3.5rem 0;
+  height: 100%;
+
+  .organization-filter {
+    display: flex;
+    margin: 0 0 0.5rem;
+    justify-content: flex-end;
+  }
+
+  .organization-list {
+    max-height: 80%;
+    overflow-y: auto;
+    --ion-grid-columns: 6;
+  }
+
+  .organization-list-row {
+    &__col {
+      display: flex;
+      align-items: center;
+    }
+  }
+
+  .organization-card {
+    background: var(--parsec-color-light-secondary-background);
+    user-select: none;
+    transition: box-shadow 150ms linear;
+    box-shadow: none;
+    border-radius: 0.5em;
+    margin-inline: 0;
+    margin-top: 0;
+    margin-bottom: 0;
+    width: 100%;
+
+    &:hover {
+      box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.08);
+    }
+
+    .card-content {
+      padding-top: 0px;
+      padding-bottom: 0px;
+      padding-inline-end: 0px;
+      padding-inline-start: 0px;
+
+      &__footer {
+        padding: 0.5em 1em;
+        background: var(--parsec-color-light-secondary-medium);
+        border-top: 1px solid var(--parsec-color-light-secondary-disabled);
+        color: var(--parsec-color-light-secondary-grey);
+        height: 4.6em;
+      }
+
+      &:hover {
+        background: var(--parsec-color-light-primary-50);
+        cursor: pointer;
+
+        .card-content__footer {
+          background: var(--parsec-color-light-primary-50);
+          border-top: 1px solid var(--parsec-color-light-primary-100);
+        }
+      }
+    }
+  }
+}
+</style>

--- a/client/src/views/home/OrganizationListPage.vue
+++ b/client/src/views/home/OrganizationListPage.vue
@@ -2,7 +2,7 @@
 
 <template>
   <ion-card class="right-side-container">
-    <template v-if="deviceList.length === 0">
+    <template v-if="deviceList.length === 0 && !querying">
       <ion-card-content class="organization-container">
         <ion-card-title>
           {{ $t('HomePage.noDevices') }}
@@ -95,6 +95,7 @@ const { timeSince } = inject(FormattersKey)! as Formatters;
 const sortBy = ref('organization');
 const sortByAsc = ref(true);
 const searchQuery = ref('');
+const querying = ref(true);
 
 const msSorterOptions: MsOptions = new MsOptions([
   {
@@ -120,10 +121,12 @@ onUpdated(async (): Promise<void> => {
 });
 
 async function refreshDeviceList(): Promise<void> {
+  querying.value = true;
   deviceList.value = await listAvailableDevices();
   if (deviceList.value.length === 1) {
     emits('organizationSelect', deviceList.value[0]);
   }
+  querying.value = false;
 }
 
 function onMsSorterChange(event: MsSorterChangeEvent): void {

--- a/client/tests/e2e/specs/test_create_org_modal.ts
+++ b/client/tests/e2e/specs/test_create_org_modal.ts
@@ -6,6 +6,10 @@ describe('Create a new organization', () => {
     cy.contains('Your organizations');
   });
 
+  afterEach(() => {
+    cy.dropTestbed();
+  });
+
   it('Open org creation modal', () => {
     cy.get('.create-organization-modal').should('not.exist');
     cy.get('#create-organization-button').click();

--- a/client/tests/e2e/specs/test_invitations_page.ts
+++ b/client/tests/e2e/specs/test_invitations_page.ts
@@ -8,6 +8,10 @@ describe('Check invitations page', () => {
     cy.get('.user-menu__item').eq(2).click();
   });
 
+  afterEach(() => {
+    cy.dropTestbed();
+  });
+
   it('Check the initial state', () => {
     cy.get('.topbar-left__title').find('.title-h2').contains('Invitations');
     cy.get('.invitation-list').find('.invitation-list-item').as('invitations').should('have.length', 2);


### PR DESCRIPTION
Closes #5957 

Moved the search bar for devices on the login screen (makes it easier to implement, and it's also in line with the new mock-ups, two birds with one stone).

I tried using the routing instead (the actual page being a child of the sidebar and header), but ultimately decided against it as it made everything much more complex than it really needed to be. It makes sense in the logged in UI where a lot of pages use the same template, and the pages are not really linked together. In this case, the pages are more closely related and there's a low and finite number of them.

Animation is disabled, related issue is #6003 

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
