### PR TITLE
Harden notary script

### DIFF
--- a/.github/scripts/notary/lib.sh
+++ b/.github/scripts/notary/lib.sh
@@ -1,6 +1,6 @@
-#!bash
-
-QUERY_FOLDER=.github/scripts/notary/graphql
+#!/usr/bin/env bash
+SCRIPTDIR=${SCRIPTDIR:="$(dirname $(realpath -s "$0"))"}
+QUERY_FOLDER=$SCRIPTDIR/graphql
 
 # List project fields like `status`, `tag`, `labels` and other
 function list_project_fields() {


### PR DESCRIPTION
- Set and use `SCRIPTDIR` to be agnostic of the current working directory (i.e.: being able to execute it outside of `parsec-cloud` repo)
- Rework `Debug tool version` block to oneline tools' version instead of relying on debug output (`set -x`).

  This allow to run the script with `-x` without it being disable by the `set +x`.
- Allow to provide additional args to `Github-CLI` via the optional var `GH_ADDITIONAL_ARGS` (useful to set `--repo=<Owner>/<Repo>`)