### PR TITLE
[MS] Add validity state to inputs

### DIFF
--- a/client/src/common/validators.ts
+++ b/client/src/common/validators.ts
@@ -10,6 +10,7 @@ import {
   parseBackendAddr,
 } from '@/parsec';
 import { ParsedBackendAddrTag } from '@/plugins/libparsec';
+import { getI18n } from '@/services/translation';
 
 export enum Validity {
   Invalid = 0,
@@ -17,139 +18,194 @@ export enum Validity {
   Valid = 2,
 }
 
-export interface IValidator {
-  (value: string): Promise<Validity>;
+export interface ValidationResult {
+  validity: Validity;
+  reason?: string;
 }
 
-// Validators in this file are meant to be later replaced by using
-// calls to the bindings.
+export interface IValidator {
+  (value: string): Promise<ValidationResult>;
+}
+
+function translate(key: string): string {
+  const { t } = getI18n().global;
+  return t(key);
+}
 
 export const emailValidator: IValidator = async function (value: string) {
   value = value.trim();
   if (!value.includes('@') || value.length === 0) {
-    return Validity.Intermediate;
+    return { validity: Validity.Intermediate };
   }
-  return (await isValidEmail(value)) ? Validity.Valid : Validity.Invalid;
+  return (await isValidEmail(value)) ? { validity: Validity.Valid } : { validity: Validity.Invalid };
 };
 
 export const deviceNameValidator: IValidator = async function (value: string) {
   value = value.trim();
   if (value.length === 0) {
-    return Validity.Intermediate;
+    return { validity: Validity.Intermediate };
   }
-  return (await isValidDeviceName(value)) ? Validity.Valid : Validity.Invalid;
+  return (await isValidDeviceName(value)) ? { validity: Validity.Valid } : { validity: Validity.Invalid };
 };
 
 export const userNameValidator: IValidator = async function (value: string) {
   value = value.trim();
   if (value.length === 0) {
-    return Validity.Intermediate;
+    return { validity: Validity.Intermediate };
   }
-  return (await isValidUserName(value)) ? Validity.Valid : Validity.Invalid;
+  return (await isValidUserName(value)) ? { validity: Validity.Valid } : { validity: Validity.Invalid };
 };
 
 export const workspaceNameValidator: IValidator = async function (value: string) {
   value = value.trim();
   if (value.length === 0) {
-    return Validity.Intermediate;
+    return { validity: Validity.Intermediate };
   }
-  return (await isValidWorkspaceName(value)) ? Validity.Valid : Validity.Invalid;
+  return (await isValidWorkspaceName(value)) ? { validity: Validity.Valid } : { validity: Validity.Invalid };
 };
 
 export const entryNameValidator: IValidator = async function (value: string) {
   value = value.trim();
   if (value.length === 0) {
-    return Validity.Intermediate;
+    return { validity: Validity.Intermediate };
   }
-  return (await isValidEntryName(value)) ? Validity.Valid : Validity.Invalid;
+  return (await isValidEntryName(value)) ? { validity: Validity.Valid } : { validity: Validity.Invalid };
 };
 
 export const backendAddrValidator: IValidator = async function (value: string) {
   value = value.trim();
   if (value.length === 0) {
-    return Validity.Intermediate;
+    return { validity: Validity.Intermediate };
   }
   const result = await parseBackendAddr(value);
   if (result.ok) {
-    return result.value.tag === ParsedBackendAddrTag.Server ? Validity.Valid : Validity.Invalid;
+    return result.value.tag === ParsedBackendAddrTag.Server ? { validity: Validity.Valid } : { validity: Validity.Invalid };
   }
-  return Validity.Invalid;
+  return { validity: Validity.Invalid };
 };
 
 export const backendOrganizationAddrValidator: IValidator = async function (value: string) {
   value = value.trim();
   if (value.length === 0) {
-    return Validity.Intermediate;
+    return { validity: Validity.Intermediate };
   }
   const result = await parseBackendAddr(value);
   if (result.ok) {
-    return result.value.tag === ParsedBackendAddrTag.Organization ? Validity.Valid : Validity.Invalid;
+    return result.value.tag === ParsedBackendAddrTag.Organization ? { validity: Validity.Valid } : { validity: Validity.Invalid };
   }
-  return Validity.Invalid;
+  return { validity: Validity.Invalid };
 };
 
 export const organizationValidator: IValidator = async function (value: string) {
   value = value.trim();
   if (value.length === 0) {
-    return Validity.Intermediate;
+    return { validity: Validity.Intermediate };
   }
-  return (await isValidOrganizationName(value)) ? Validity.Valid : Validity.Invalid;
+  if (await isValidOrganizationName(value)) {
+    return { validity: Validity.Valid };
+  }
+  let reason = '';
+  if (value.length > 32) {
+    reason = 'validators.organizationName.tooLong';
+  } else if (new RegExp(/^[\w_-]+$/u).test(value) === false) {
+    reason = 'validators.organizationName.forbiddenCharacters';
+  }
+  return { validity: Validity.Invalid, reason: reason ? translate(reason) : '' };
 };
 
 export const claimLinkValidator: IValidator = async function (value: string) {
   value = value.trim();
   if (value.length === 0) {
-    return Validity.Intermediate;
+    return { validity: Validity.Intermediate };
   }
   const result = await parseBackendAddr(value);
   if (result.ok) {
-    return result.value.tag === ParsedBackendAddrTag.InvitationUser || result.value.tag === ParsedBackendAddrTag.InvitationDevice
-      ? Validity.Valid
-      : Validity.Invalid;
+    if (result.value.tag === ParsedBackendAddrTag.InvitationUser || result.value.tag === ParsedBackendAddrTag.InvitationDevice) {
+      return { validity: Validity.Valid };
+    } else {
+      return { validity: Validity.Invalid, reason: translate('validators.claimLink.invalidAction') };
+    }
   }
-  return Validity.Invalid;
+  let reason = '';
+  if (!value.startsWith('parsec://')) {
+    reason = 'validators.claimLink.invalidProtocol';
+  } else if (!value.includes('action=')) {
+    reason = 'validators.claimLink.missingAction';
+  } else if (value.includes('action=') && !value.includes('action=claim_user') && !value.includes('action=claim_device')) {
+    reason = 'validators.claimLink.invalidAction';
+  } else if (!value.includes('token=')) {
+    reason = 'validators.claimLink.missingToken';
+  } else if (!/^.+token=[a-f90-9]{32}&?$/.test(value)) {
+    reason = 'validators.claimLink.invalidToken';
+  }
+  console.log(reason);
+  return { validity: Validity.Invalid, reason: reason ? translate(reason) : '' };
 };
 
 export const fileLinkValidator: IValidator = async function (value: string) {
   value = value.trim();
   if (value.length === 0) {
-    return Validity.Intermediate;
+    return { validity: Validity.Intermediate };
   }
   const result = await parseBackendAddr(value);
   if (result.ok) {
-    return result.value.tag === ParsedBackendAddrTag.OrganizationFileLink ? Validity.Valid : Validity.Invalid;
+    return result.value.tag === ParsedBackendAddrTag.OrganizationFileLink ? { validity: Validity.Valid } : { validity: Validity.Invalid };
   }
-  return Validity.Invalid;
+  return { validity: Validity.Invalid };
 };
 
 export const claimUserLinkValidator: IValidator = async function (value: string) {
   value = value.trim();
   if (value.length === 0) {
-    return Validity.Intermediate;
+    return { validity: Validity.Intermediate };
   }
   const result = await parseBackendAddr(value);
   if (result.ok) {
-    return result.value.tag === ParsedBackendAddrTag.InvitationUser ? Validity.Valid : Validity.Invalid;
+    return result.value.tag === ParsedBackendAddrTag.InvitationUser ? { validity: Validity.Valid } : { validity: Validity.Invalid };
   }
-  return Validity.Invalid;
+  let reason = '';
+  if (!value.startsWith('parsec://')) {
+    reason = 'validators.claimUserLink.invalidProtocol';
+  } else if (!value.includes('action=')) {
+    reason = 'validators.claimUserLink.missingAction';
+  } else if (value.includes('action=') && !value.includes('action=claim_user')) {
+    reason = 'validators.claimUserLink.invalidAction';
+  } else if (!value.includes('token=')) {
+    reason = 'validators.claimUserLink.missingToken';
+  } else if (!/^.+token=[a-f90-9]{32}&?$/.test(value)) {
+    reason = 'validators.claimUserLink.invalidToken';
+  }
+  return { validity: Validity.Invalid, reason: reason ? translate(reason) : '' };
 };
 
 export const claimDeviceLinkValidator: IValidator = async function (value: string) {
   value = value.trim();
   if (value.length === 0) {
-    return Validity.Intermediate;
+    return { validity: Validity.Intermediate };
   }
   const result = await parseBackendAddr(value);
   if (result.ok) {
-    return result.value.tag === ParsedBackendAddrTag.InvitationDevice ? Validity.Valid : Validity.Invalid;
+    return result.value.tag === ParsedBackendAddrTag.InvitationDevice ? { validity: Validity.Valid } : { validity: Validity.Invalid };
   }
-  return Validity.Invalid;
+  let reason = '';
+  if (!value.startsWith('parsec://')) {
+    reason = 'validators.claimDeviceLink.invalidProtocol';
+  } else if (!value.includes('action=')) {
+    reason = 'validators.claimDeviceLink.missingAction';
+  } else if (value.includes('action=') && !value.includes('action=claim_device')) {
+    reason = 'validators.claimDeviceLink.invalidAction';
+  } else if (!value.includes('token=')) {
+    reason = 'validators.claimDeviceLink.missingToken';
+  } else if (!/^.+token=[a-f90-9]{32}&?$/.test(value)) {
+    reason = 'validators.claimDeviceLink.invalidToken';
+  }
+  return { validity: Validity.Invalid, reason: reason ? translate(reason) : '' };
 };
 
 export const secretKeyValidator: IValidator = async function (value: string) {
   value = value.trim();
   if (value.length === 0) {
-    return Validity.Intermediate;
+    return { validity: Validity.Intermediate };
   }
-  return /^([A-Z0-9]{4}-){12}[A-Z0-9]{4}$/.test(value) ? Validity.Valid : Validity.Invalid;
+  return { validity: /^([A-Z0-9]{4}-){12}[A-Z0-9]{4}$/.test(value) ? Validity.Valid : Validity.Invalid };
 };

--- a/client/src/components/core/ms-input/MsInput.vue
+++ b/client/src/components/core/ms-input/MsInput.vue
@@ -11,51 +11,68 @@
 
     <ion-item
       class="input"
-      :class="{ 'form-input-disabled': $props.disabled }"
+      :class="{
+        'form-input-disabled': $props.disabled,
+        'input-valid': validity === Validity.Valid,
+        'input-invalid': validity === Validity.Invalid,
+        'input-default': validity === Validity.Intermediate,
+      }"
     >
       <ion-input
         class="form-input"
         :autofocus="true"
         :placeholder="$props.placeholder"
         :value="modelValue"
-        @ion-input="
-          $emit('update:modelValue', $event.detail.value || '');
-          $emit('change', $event.detail.value || '');
-        "
+        @ion-input="onChange($event.detail.value || '')"
         @keyup.enter="$emit('onEnterKeyup', $event.target.value)"
         :disabled="$props.disabled"
       />
     </ion-item>
-    <!-- We need to had a info informative text for the custom input issue-->
-    <!-- <span
+    <span
+      v-show="errorMessage !== ''"
       class="form-error caption-caption"
     >
       <ion-icon
         class="form-error-icon"
-        :icon="errorIcon"
+        :icon="warning"
       />
       {{ errorMessage }}
-    </span> -->
+    </span>
   </div>
 </template>
 
 <script setup lang="ts">
-import { IonInput, IonItem } from '@ionic/vue';
+import { IValidator, Validity } from '@/common/validators';
+import { IonIcon, IonInput, IonItem } from '@ionic/vue';
+import { warning } from 'ionicons/icons';
+import { ref } from 'vue';
 
-defineProps<{
+const props = defineProps<{
   label?: string;
   placeholder?: string;
-  errorMessage?: string;
-  errorIcon?: string;
   modelValue?: string;
   disabled?: boolean;
+  validator?: IValidator;
 }>();
 
-defineEmits<{
+const errorMessage = ref('');
+const validity = ref(Validity.Intermediate);
+
+const emits = defineEmits<{
   (e: 'update:modelValue', value: string): void;
   (e: 'change', value: string): void;
   (e: 'onEnterKeyup', value: string): void;
 }>();
+
+async function onChange(value: string): Promise<void> {
+  emits('update:modelValue', value);
+  emits('change', value);
+  if (props.validator) {
+    const result = await props.validator(value);
+    validity.value = result.validity;
+    errorMessage.value = result.reason || '';
+  }
+}
 </script>
 
 <style lang="scss" scoped>
@@ -72,15 +89,9 @@ defineEmits<{
   }
 
   .input {
-    border: 1px solid var(--parsec-color-light-primary-300);
     border-radius: var(--parsec-radius-6);
     overflow: hidden;
     color: var(--parsec-color-light-primary-800);
-
-    &:focus-within {
-      --background: var(--parsec-color-light-secondary-background);
-      outline: var(--offset) solid var(--parsec-color-light-primary-300);
-    }
   }
 
   .form-input-disabled {
@@ -88,5 +99,40 @@ defineEmits<{
     background: var(--parsec-color-light-secondary-disabled);
     border: var(--parsec-color-light-secondary-disabled);
   }
+}
+
+.input-default {
+  border: 1px solid var(--parsec-color-light-primary-300);
+
+  &:focus-within {
+    --background: var(--parsec-color-light-secondary-background);
+    outline: var(--offset) solid var(--parsec-color-light-primary-300);
+  }
+}
+
+.input-valid {
+  border: 1px solid var(--parsec-color-light-primary-300);
+
+  &:not(:focus-within) {
+    --background: var(--parsec-color-light-secondary-background);
+    outline: var(--offset) solid var(--parsec-color-light-success-500);
+    border: 1px solid var(--parsec-color-light-success-500);
+  }
+}
+
+.input-invalid {
+  border: 1px solid var(--parsec-color-light-danger-500);
+
+  &:focus-within {
+    --background: var(--parsec-color-light-secondary-background);
+    outline: var(--offset) solid var(--parsec-color-light-danger-500);
+  }
+}
+
+.form-error {
+  color: var(--parsec-color-light-danger-500);
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
 }
 </style>

--- a/client/src/components/core/ms-modal/MsTextInputModal.vue
+++ b/client/src/components/core/ms-modal/MsTextInputModal.vue
@@ -21,6 +21,7 @@
       :placeholder="placeholder || ''"
       v-model="text"
       @on-enter-keyup="confirm()"
+      :validator="validator"
     />
   </ms-modal>
 </template>
@@ -38,7 +39,7 @@ const props = defineProps<GetTextOptions>();
 
 const text = ref(props.defaultValue || '');
 const textIsValid = asyncComputed(async () => {
-  return text.value && (!props.validator || (props.validator && (await props.validator(text.value)) === Validity.Valid));
+  return text.value && (!props.validator || (props.validator && (await props.validator(text.value)).validity === Validity.Valid));
 });
 
 async function confirm(): Promise<boolean> {

--- a/client/src/components/organizations/ChooseServer.vue
+++ b/client/src/components/organizations/ChooseServer.vue
@@ -93,7 +93,7 @@ defineEmits<{
 async function areFieldsCorrect(): Promise<boolean> {
   return (
     mode.value === ServerMode.SaaS ||
-    (mode.value === ServerMode.Custom && (await backendAddrValidator(backendAddr.value)) === Validity.Valid)
+    (mode.value === ServerMode.Custom && (await backendAddrValidator(backendAddr.value)).validity === Validity.Valid)
   );
 }
 </script>

--- a/client/src/components/users/UserInformation.vue
+++ b/client/src/components/users/UserInformation.vue
@@ -9,6 +9,7 @@
     :disabled="!$props.nameEnabled"
     @change="$emit('fieldUpdate')"
     @on-enter-keyup="$emit('onEnterKeyup', fullName)"
+    :validator="userNameValidator"
   />
   <ms-input
     :label="$t('CreateOrganization.email')"
@@ -18,6 +19,7 @@
     :disabled="!$props.emailEnabled"
     @change="$emit('fieldUpdate')"
     @on-enter-keyup="$emit('onEnterKeyup', email)"
+    :validator="emailValidator"
   />
   <ms-input
     :label="$t('CreateOrganization.deviceNameInputLabel')"
@@ -27,6 +29,7 @@
     :disabled="!$props.deviceEnabled"
     @change="$emit('fieldUpdate')"
     @on-enter-keyup="$emit('onEnterKeyup', deviceName)"
+    :validator="deviceNameValidator"
   />
 </template>
 
@@ -84,9 +87,9 @@ defineExpose({
 
 async function areFieldsCorrect(): Promise<boolean> {
   return (
-    (await emailValidator(email.value)) === Validity.Valid &&
-    (await userNameValidator(fullName.value)) === Validity.Valid &&
-    (await deviceNameValidator(deviceName.value)) === Validity.Valid
+    (await emailValidator(email.value)).validity === Validity.Valid &&
+    (await userNameValidator(fullName.value)).validity === Validity.Valid &&
+    (await deviceNameValidator(deviceName.value)).validity === Validity.Valid
   );
 }
 </script>

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -1118,5 +1118,32 @@
                 "message": "Please make sure you're connected to the internet."
             }
         }
+    },
+    "validators": {
+        "organizationName": {
+            "tooLong": "Name is too long, limit is 32 characters.",
+            "forbiddenCharacters": "Only letters, digits, underscores and hyphens. No spaces."
+        },
+        "claimLink": {
+            "invalidProtocol": "Link should start with 'parsec://'.",
+            "missingAction": "Link doesn't include an action.",
+            "invalidAction": "Link contains an invalid action.",
+            "missingToken": "Link doesn't include a token.",
+            "invalidToken": "Link contains an invalid token."
+        },
+        "claimUserLink": {
+            "invalidProtocol": "Link should start with 'parsec://'.",
+            "missingAction": "Link doesn't include an action.",
+            "invalidAction": "Link contains an invalid action.",
+            "missingToken": "Link doesn't include a token.",
+            "invalidToken": "Link contains an invalid token."
+        },
+        "claimDeviceLink": {
+            "invalidProtocol": "Link should start with 'parsec://'.",
+            "missingAction": "Link doesn't include an action.",
+            "invalidAction": "Link contains an invalid action.",
+            "missingToken": "Link doesn't include a token.",
+            "invalidToken": "Link contains an invalid token."
+        }
     }
 }

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -1118,5 +1118,32 @@
                 "message": "Veuillez vérifier que vous êtes bien connecté(e) à Internet."
             }
         }
+    },
+    "validators": {
+        "organizationName": {
+            "tooLong": "Le nom est trop long, la limite est de 32 symboles.",
+            "forbiddenCharacters": "Lettres, chiffres, tirets et tirets bas seulement. Aucun espace. Limité à 32 symboles."
+        },
+        "claimLink": {
+            "invalidProtocol": "Le lien doit commencer par 'parsec://'.",
+            "missingAction": "Le lien n'inclut pas d'action.",
+            "invalidAction": "Le lien contient une action invalide.",
+            "missingToken": "Le lien n'inclut pas de jeton.",
+            "invalidToken": "Le lien contient un jeton invalide."
+        },
+        "claimUserLink": {
+            "invalidProtocol": "Le lien doit commencer par 'parsec://'.",
+            "missingAction": "Le lien n'inclut pas d'action.",
+            "invalidAction": "Le lien contient une action invalide.",
+            "missingToken": "Le lien n'inclut pas de jeton.",
+            "invalidToken": "Le lien contient un jeton invalide."
+        },
+        "claimDeviceLink": {
+            "invalidProtocol": "Le lien doit commencer par 'parsec://'.",
+            "missingAction": "Le lien n'inclut pas d'action.",
+            "invalidAction": "Le lien contient une action invalide.",
+            "missingToken": "Le lien n'inclut pas de jeton.",
+            "invalidToken": "Le lien contient un jeton invalide."
+        }
     }
 }

--- a/client/src/services/translation.ts
+++ b/client/src/services/translation.ts
@@ -1,0 +1,65 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import enUS from '@/locales/en-US.json';
+import frFR from '@/locales/fr-FR.json';
+import { createI18n } from 'vue-i18n';
+
+let i18n: any | null = null;
+
+export function initTranslations(locale: string): void {
+  /* I18n variables */
+  // Type-define 'fr-FR' as the master schema for the resource
+  type MessageSchema = typeof frFR;
+  const supportedLocales: { [key: string]: string } = {
+    fr: 'fr-FR',
+    en: 'en-US',
+    'fr-FR': 'fr-FR',
+    'en-US': 'en-US',
+  };
+  const defaultLocale = 'fr-FR';
+  i18n = createI18n<[MessageSchema], 'fr-FR' | 'en-US'>({
+    legacy: false,
+    globalInjection: true,
+    locale: locale || supportedLocales[window.navigator.language] || defaultLocale,
+    messages: {
+      'fr-FR': frFR,
+      'en-US': enUS,
+    },
+    datetimeFormats: {
+      'en-US': {
+        short: {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+        },
+        long: {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+          weekday: 'long',
+          hour: 'numeric',
+          minute: 'numeric',
+        },
+      },
+      'fr-FR': {
+        short: {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+        },
+        long: {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+          weekday: 'long',
+          hour: 'numeric',
+          minute: 'numeric',
+        },
+      },
+    },
+  });
+}
+
+export function getI18n(): any {
+  return i18n;
+}

--- a/client/src/views/devices/ImportRecoveryDevicePage.vue
+++ b/client/src/views/devices/ImportRecoveryDevicePage.vue
@@ -171,7 +171,7 @@ async function importButtonClick(): Promise<void> {
 }
 
 async function checkSecretKeyValidity(): Promise<void> {
-  isSecretKeyValid.value = (await secretKeyValidator(secretKey.value)) === Validity.Valid;
+  isSecretKeyValid.value = (await secretKeyValidator(secretKey.value)).validity === Validity.Valid;
 }
 
 async function goToPasswordChange(): Promise<void> {

--- a/client/src/views/home/CreateOrganizationModal.vue
+++ b/client/src/views/home/CreateOrganizationModal.vue
@@ -48,6 +48,7 @@
             id="org-name-input"
             v-model="orgName"
             @on-enter-keyup="nextStep()"
+            :validator="organizationValidator"
           />
 
           <ion-text class="subtitles-sm org-name-criteria">
@@ -303,7 +304,7 @@ const canGoForward = asyncComputed(async () => {
   if (pageStep.value === CreateOrganizationStep.FinishStep || pageStep.value === CreateOrganizationStep.SpinnerStep) {
     return true;
   } else if (pageStep.value === CreateOrganizationStep.OrgNameStep) {
-    return (await organizationValidator(orgName.value)) === Validity.Valid;
+    return (await organizationValidator(orgName.value)).validity === Validity.Valid;
   } else if (
     pageStep.value === CreateOrganizationStep.PasswordStep ||
     pageStep.value === CreateOrganizationStep.ServerStep ||

--- a/client/src/views/home/DeviceJoinOrganizationModal.vue
+++ b/client/src/views/home/DeviceJoinOrganizationModal.vue
@@ -90,6 +90,7 @@
             v-model="deviceName"
             name="deviceName"
             @on-enter-keyup="nextStep()"
+            :validator="deviceNameValidator"
           />
         </div>
         <!-- part 5 (finish the process)-->
@@ -281,7 +282,7 @@ const nextButtonIsVisible = computed(() => {
 const canGoForward = asyncComputed(async () => {
   if (pageStep.value === DeviceJoinOrganizationStep.Password) {
     const validDeviceName = await deviceNameValidator(deviceName.value);
-    return (await passwordPage.value.areFieldsCorrect()) && validDeviceName === Validity.Valid;
+    return (await passwordPage.value.areFieldsCorrect()) && validDeviceName.validity === Validity.Valid;
   }
   return true;
 });

--- a/client/src/views/home/HomePage.vue
+++ b/client/src/views/home/HomePage.vue
@@ -108,6 +108,7 @@ async function openCreateOrganizationModal(): Promise<void> {
     component: CreateOrganizationModal,
     canDismiss: true,
     cssClass: 'create-organization-modal',
+    backdropDismiss: false,
   });
   await modal.present();
   const { data, role } = await modal.onWillDismiss();
@@ -121,9 +122,9 @@ async function openCreateOrganizationModal(): Promise<void> {
 async function openJoinByLinkModal(link: string): Promise<void> {
   let component = null;
 
-  if ((await claimUserLinkValidator(link)) === Validity.Valid) {
+  if ((await claimUserLinkValidator(link)).validity === Validity.Valid) {
     component = UserJoinOrganizationModal;
-  } else if ((await claimDeviceLinkValidator(link)) === Validity.Valid) {
+  } else if ((await claimDeviceLinkValidator(link)).validity === Validity.Valid) {
     component = DeviceJoinOrganizationModal;
   }
 
@@ -134,6 +135,7 @@ async function openJoinByLinkModal(link: string): Promise<void> {
   const modal = await modalController.create({
     component: component,
     canDismiss: true,
+    backdropDismiss: false,
     cssClass: 'join-organization-modal',
     componentProps: {
       invitationLink: link,

--- a/client/tests/e2e/specs/test_create_org_modal.ts
+++ b/client/tests/e2e/specs/test_create_org_modal.ts
@@ -20,6 +20,30 @@ describe('Create a new organization', () => {
     cy.get('.create-organization-modal').find('.modal-header__title').contains('Create an organization');
   });
 
+  it('Test org name validation', () => {
+    cy.get('#create-organization-button').click();
+    cy.get('.popover-viewport').find('ion-item').first().click();
+    cy.get('.create-organization-modal').find('.org-name').find('.input').as('input').should('have.class', 'input-default');
+    cy.get('.create-organization-modal').find('#next-button').as('okButton').should('have.class', 'button-disabled');
+    cy.get('.create-organization-modal').find('.org-name').find('.form-error').as('error').should('not.be.visible');
+
+    cy.get('@input').find('input').type('Org#');
+    cy.get('@input').should('have.class', 'input-invalid');
+    cy.get('@error').should('be.visible');
+    cy.get('@error').contains('Only letters, digits, underscores and hyphens. No spaces.');
+    cy.get('@okButton').should('have.class', 'button-disabled');
+
+    cy.get('@input').find('input').clear();
+    cy.get('@input').should('have.class', 'input-default');
+    cy.get('@error').should('not.be.visible');
+    cy.get('@okButton').should('have.class', 'button-disabled');
+
+    cy.get('@input').find('input').type('MyOrg');
+    cy.get('@input').should('have.class', 'input-valid');
+    cy.get('@error').should('not.be.visible');
+    cy.get('@okButton').should('not.have.class', 'button-disabled');
+  });
+
   it('Go through the org creation process', () => {
     cy.get('#create-organization-button').click();
     cy.get('.popover-viewport').find('ion-item').first().click();

--- a/client/tests/e2e/specs/test_home_page.ts
+++ b/client/tests/e2e/specs/test_home_page.ts
@@ -81,6 +81,48 @@ describe('Check organization list', () => {
     cy.get('.popover-viewport').contains('I received an invitation to join an organization');
   });
 
+  it('Test join org link validation', () => {
+    cy.get('#create-organization-button').click();
+    cy.get('.popover-viewport').find('ion-item').eq(1).click();
+    cy.get('.text-input-modal').find('.input').as('input').should('have.class', 'input-default');
+    cy.get('.text-input-modal').find('#next-button').as('okButton').should('have.class', 'button-disabled');
+    cy.get('.text-input-modal').find('.form-error').as('error').should('not.be.visible');
+
+    cy.get('@input').find('input').type('http://parsec.cloud/Test?action=claim_user&token=47265123969c4d6584c2bc15960cf212');
+    cy.get('@okButton').should('have.class', 'button-disabled');
+    cy.get('@error').should('be.visible');
+    cy.get('@error').contains("Link should start with 'parsec://'");
+
+    cy.get('@input').find('input').clear();
+    cy.get('@input').find('input').type('parsec://parsec.cloud/Test?token=47265123969c4d6584c2bc15960cf212');
+    cy.get('@okButton').should('have.class', 'button-disabled');
+    cy.get('@error').should('be.visible');
+    cy.get('@error').contains("Link doesn't include an action");
+
+    cy.get('@input').find('input').clear();
+    cy.get('@input').find('input').type('parsec://parsec.cloud/Test?action=bootstrap_organization&token=47265123969c4d6584c2bc15960cf212');
+    cy.get('@okButton').should('have.class', 'button-disabled');
+    cy.get('@error').should('be.visible');
+    cy.get('@error').contains('Link contains an invalid action');
+
+    cy.get('@input').find('input').clear();
+    cy.get('@input').find('input').type('parsec://parsec.cloud/Test?action=claim_user');
+    cy.get('@okButton').should('have.class', 'button-disabled');
+    cy.get('@error').should('be.visible');
+    cy.get('@error').contains("Link doesn't include a token");
+
+    cy.get('@input').find('input').clear();
+    cy.get('@input').find('input').type('parsec://parsec.cloud/Test?action=claim_user&token=abcde');
+    cy.get('@okButton').should('have.class', 'button-disabled');
+    cy.get('@error').should('be.visible');
+    cy.get('@error').contains('Link contains an invalid token');
+
+    cy.get('@input').find('input').clear();
+    cy.get('@input').find('input').type('parsec://parsec.cloud/Test?action=claim_user&token=47265123969c4d6584c2bc15960cf212');
+    cy.get('@okButton').should('not.have.class', 'button-disabled');
+    cy.get('@error').should('not.be.visible');
+  });
+
   it('Log into organization with command', () => {
     // Uses Cypress command to simplify the log in part
     cy.login('Boby', 'P@ssw0rd.');

--- a/client/tests/unit/specs/testValidators.spec.ts
+++ b/client/tests/unit/specs/testValidators.spec.ts
@@ -1,0 +1,88 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { claimDeviceLinkValidator, claimLinkValidator, claimUserLinkValidator, organizationValidator } from '@/common/validators';
+import { vi } from 'vitest';
+
+const VALID_TOKEN = 'a'.repeat(32);
+
+describe('Validators', () => {
+  beforeEach(async () => {
+    vi.mock('@/services/translation', () => {
+      return {
+        getI18n: (): any => {
+          return { global: { t: (key: string) => key } };
+        },
+      };
+    });
+
+    vi.mock('@/parsec', () => {
+      return {
+        isValidOrganizationName: async (_value: string): Promise<boolean> => {
+          return false;
+        },
+        parseBackendAddr: async (_value: string): Promise<any> => {
+          return { ok: false, error: 'error' };
+        },
+      };
+    });
+  });
+
+  it('Validates organization name', async () => {
+    const invalidNameResult = await organizationValidator('Org#');
+    expect(invalidNameResult.reason).to.equal('validators.organizationName.forbiddenCharacters');
+
+    const nameTooLongResult = await organizationValidator('a'.repeat(33));
+    expect(nameTooLongResult.reason).to.equal('validators.organizationName.tooLong');
+  });
+
+  it('Validates claim link', async () => {
+    const invalidProtocolResult = await claimLinkValidator(`http://host/org?action=claim_user&token=${VALID_TOKEN}`);
+    expect(invalidProtocolResult.reason).to.equal('validators.claimLink.invalidProtocol');
+
+    const missingActionResult = await claimLinkValidator(`parsec://host/org?token=${VALID_TOKEN}`);
+    expect(missingActionResult.reason).to.equal('validators.claimLink.missingAction');
+
+    const invalidActionResult = await claimLinkValidator(`parsec://host/org?action=bootstrap_organization&token=${VALID_TOKEN}`);
+    expect(invalidActionResult.reason).to.equal('validators.claimLink.invalidAction');
+
+    const missingTokenResult = await claimLinkValidator('parsec://host/org?action=claim_user');
+    expect(missingTokenResult.reason).to.equal('validators.claimLink.missingToken');
+
+    const invalidTokenResult = await claimLinkValidator('parsec://host/org?action=claim_user&token=abcdefg');
+    expect(invalidTokenResult.reason).to.equal('validators.claimLink.invalidToken');
+  });
+
+  it('Validates claim user', async () => {
+    const invalidProtocolResult = await claimUserLinkValidator(`http://host/org?action=claim_user&token=${VALID_TOKEN}`);
+    expect(invalidProtocolResult.reason).to.equal('validators.claimUserLink.invalidProtocol');
+
+    const missingActionResult = await claimUserLinkValidator(`parsec://host/org?token=${VALID_TOKEN}`);
+    expect(missingActionResult.reason).to.equal('validators.claimUserLink.missingAction');
+
+    const invalidActionResult = await claimUserLinkValidator(`parsec://host/org?action=claim_device&token=${VALID_TOKEN}`);
+    expect(invalidActionResult.reason).to.equal('validators.claimUserLink.invalidAction');
+
+    const missingTokenResult = await claimUserLinkValidator('parsec://host/org?action=claim_user');
+    expect(missingTokenResult.reason).to.equal('validators.claimUserLink.missingToken');
+
+    const invalidTokenResult = await claimUserLinkValidator('parsec://host/org?action=claim_user&token=abcdefg');
+    expect(invalidTokenResult.reason).to.equal('validators.claimUserLink.invalidToken');
+  });
+
+  it('Validates claim device', async () => {
+    const invalidProtocolResult = await claimDeviceLinkValidator(`http://host/org?action=claim_device&token=${VALID_TOKEN}`);
+    expect(invalidProtocolResult.reason).to.equal('validators.claimDeviceLink.invalidProtocol');
+
+    const missingActionResult = await claimDeviceLinkValidator(`parsec://host/org?token=${VALID_TOKEN}`);
+    expect(missingActionResult.reason).to.equal('validators.claimDeviceLink.missingAction');
+
+    const invalidActionResult = await claimDeviceLinkValidator(`parsec://host/org?action=claim_user&token=${VALID_TOKEN}`);
+    expect(invalidActionResult.reason).to.equal('validators.claimDeviceLink.invalidAction');
+
+    const missingTokenResult = await claimDeviceLinkValidator('parsec://host/org?action=claim_device');
+    expect(missingTokenResult.reason).to.equal('validators.claimDeviceLink.missingToken');
+
+    const invalidTokenResult = await claimDeviceLinkValidator('parsec://host/org?action=claim_device&token=abcdefg');
+    expect(invalidTokenResult.reason).to.equal('validators.claimDeviceLink.invalidToken');
+  });
+});


### PR DESCRIPTION
Closes #4988 

The idea is to add helper messages to inputs. This is done by:
1. Adding a validator to inputs.
2. Validators return a string giving details on what is invalid
3. Change the input class according to the validity

Since validators are not components but need to get translated strings, I extracted the functions linked to translation to their own file so that it can be used outsider of components. It also cleans the app initialization a bit.

![input-validation](https://github.com/Scille/parsec-cloud/assets/18075498/2389d71e-f26f-48f7-8eb4-f57e0bd225de)

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
