### PR TITLE
Run `cargo-deny` only when rust dependencies are modified

### DIFF
--- a/.github/filters/ci.yml
+++ b/.github/filters/ci.yml
@@ -6,6 +6,7 @@ rust-libparsec: &rust-libparsec libparsec/**
 
 rust-dependencies-workspace: &rust-dependencies-workspace
   - Cargo.toml
+  - "**/Cargo.toml"
   - Cargo.lock
 
 rust-toolchain: &rust-toolchain rust-toolchain.toml

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -8,10 +8,20 @@ on:
         required: true
         default: false
         type: boolean
+      check-cargo-deny:
+        description: Run cargo-deny
+        required: true
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       run-wasm-tests:
         description: Run wasm test
+        required: true
+        default: false
+        type: boolean
+      check-cargo-deny:
+        description: Run cargo-deny
         required: true
         default: false
         type: boolean
@@ -165,6 +175,7 @@ jobs:
         timeout-minutes: 2
 
       - name: Check restricted usage with cargo-deny
+        if: inputs.check-cargo-deny
         run: |
           echo "::add-matcher::.github/custom-problem-matchers/cargo-deny.json"
           # cargo-deny outputs the report on stderr and it needs to be redirected to stdout for the problem matcher to work.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       python: ${{ steps.need-check.outputs.python }}
       python-style-only: ${{ steps.need-check.outputs.python_style_only }}
       rust-platform-crates: ${{ steps.need-check.outputs.rust_platform_crates }}
+      rust-dependencies: ${{ steps.need-check.outputs.rust_dependencies }}
       web: ${{ steps.need-check.outputs.web }}
       docs: ${{ steps.need-check.outputs.docs }}
     steps:
@@ -61,6 +62,7 @@ jobs:
           # Thus don't require to run the python test.
           NEED_CHECK_python_style_only: ${{ steps.changes.outputs.python-jobs == 'false' && steps.changes.outputs.any-python-files == 'true' }}
           NEED_CHECK_rust_platform_crates: ${{ steps.changes.outputs.rust-platform-crates == 'true' }}
+          NEED_CHECK_rust_dependencies: ${{ steps.changes.outputs.rust-dependencies-workspace == 'true' }}
           NEED_CHECK_docs: ${{ steps.changes.outputs.docs-jobs == 'true' }}
 
   # Github PR merging is configured to only require this job to pass
@@ -194,7 +196,8 @@ jobs:
     if: needs.dispatch.outputs.rust == 'true'
     uses: ./.github/workflows/ci-rust.yml
     with:
-      run-wasm-tests: ${{ needs.dispatch.outputs.rust-platform-crates == 'true'}}
+      run-wasm-tests: ${{ needs.dispatch.outputs.rust-platform-crates == 'true' }}
+      check-cargo-deny: ${{ needs.dispatch.outputs.rust-dependencies == 'true' }}
 
   web:
     needs:


### PR DESCRIPTION
Closes #6026
