### PR TITLE
Refactor run-testenv

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -100,17 +100,6 @@ jobs:
         with:
           tool: nextest@0.9.54, wasm-pack@0.11.0, cargo-deny@0.14.3
 
-      - uses: ./.github/actions/setup-python-poetry
-        id: setup-python
-        with:
-          poetry-version: ${{ env.poetry-version }}
-          project-path: ./server
-        timeout-minutes: 10
-
-      - name: Install python dependencies
-        run: python make.py python-dev-install
-        timeout-minutes: 10
-
       - name: Build CLI binary
         run: cargo build ${{ env.CARGO_CI_FLAGS }} --package parsec_cli --features testenv
         timeout-minutes: 5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2342,6 +2348,7 @@ dependencies = [
  "serde_json",
  "terminal-spinners",
  "tokio",
+ "url",
  "uuid",
 ]
 
@@ -3684,6 +3691,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
+ "atomic",
  "getrandom 0.2.10",
  "rand",
  "serde",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-testenv = []
+testenv = ["dep:url"]
 
 [dependencies]
 libparsec = { workspace = true }
@@ -25,6 +25,7 @@ serde_json = { workspace = true }
 terminal-spinners = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 uuid = { workspace = true }
+url = { workspace = true, optional = true}
 
 [dev-dependencies]
 libparsec = { workspace = true, features = ["cli-tests"] }
@@ -32,3 +33,4 @@ libparsec = { workspace = true, features = ["cli-tests"] }
 assert_cmd = { workspace = true }
 predicates = { workspace = true, features = ["regex"] }
 rstest = { workspace = true }
+uuid = { workspace = true, features = ["v6", "std", "rng"] }


### PR DESCRIPTION
- Split `run_testenv` function into smaller functions.
- Add logic to skip starting the testbed server if the `TESTBED_SERVER` environment variable is set using that URL instead.
- CI: Don't install python dependencies on the rust workflow

Closes #6034
