### PR TITLE
[MS] Fixes animation for toast progress bar

### DIFF
--- a/client/src/theme/components/toasts.scss
+++ b/client/src/theme/components/toasts.scss
@@ -85,7 +85,7 @@ ion-toast.notification-toast {
     &::part(container) {
       &::after {
         width: 0%;
-        transition: width 5s ease-in-out;
+        transition: width var(--ms-toast-duration) ease-in-out;
       }
     }
   }


### PR DESCRIPTION
Closes #6163 

It would probably be easier if toast where our own component, we could probably just bind the duration with Vue. Sadly, they're created by the toastController.

The idea behind this fix is to assigned a unique id to each toast, and dynamically add a `<style>` tag in the `<head>` of the page that contains the CSS with the appropriate duration. The style is removed once the toast is closed.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
