### PR TITLE
[MS] Fixed homepage with no devices/one device

### DIFF
--- a/client/src/views/home/HomePageButtons.vue
+++ b/client/src/views/home/HomePageButtons.vue
@@ -4,7 +4,7 @@
   <ion-list class="container">
     <ion-item
       class="container__item"
-      @click="onClick(HomePageAction.CreateOrganization)"
+      @click="clicked(HomePageAction.CreateOrganization)"
     >
       <ion-icon
         :icon="addCircle"
@@ -21,7 +21,7 @@
     </ion-item>
     <ion-item
       class="container__item"
-      @click="onClick(HomePageAction.JoinOrganization)"
+      @click="clicked(HomePageAction.JoinOrganization)"
     >
       <ion-icon
         :icon="mail"
@@ -47,12 +47,23 @@ export enum HomePageAction {
 </script>
 
 <script setup lang="ts">
-import { MsModalResult } from '@/components/core';
-import { IonIcon, IonItem, IonLabel, IonList, IonText, popoverController } from '@ionic/vue';
+import { IonIcon, IonItem, IonLabel, IonList, IonText } from '@ionic/vue';
 import { addCircle, mail } from 'ionicons/icons';
 
-async function onClick(action: HomePageAction): Promise<boolean> {
-  return await popoverController.dismiss({ action: action }, MsModalResult.Confirm);
+const emits = defineEmits<{
+  (e: 'click', action: HomePageAction): void;
+}>();
+
+const props = defineProps<{
+  replaceEmit?: (action: HomePageAction) => Promise<void>;
+}>();
+
+async function clicked(action: HomePageAction): Promise<void> {
+  if (props.replaceEmit) {
+    await props.replaceEmit(action);
+  } else {
+    emits('click', action);
+  }
 }
 </script>
 


### PR DESCRIPTION
Closes #6170 

This fixes multiple issues on the home page:
1. Create/join buttons when there are no devices work properly
2. Made it possible to create/join an org with only one device
3. Displays the create/join button in all cases

To test, in `OrganizationListPage` in the `refreshDeviceList`, you can add after the `deviceList.value = await listAvailableDevices();`:

`deviceList.value = [];` to check with no devices
`deviceList.value = [deviceList.value[0]];` to check with one device

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description