### PR TITLE
[MS] Fix electron tray icon size

### DIFF
--- a/client/electron/src/setup.ts
+++ b/client/electron/src/setup.ts
@@ -200,7 +200,7 @@ export class ElectronCapacitorApp {
 
     // When the tray icon is enabled, setup the options.
     if (this.CapacitorFileConfig.electron?.trayIconAndMenuEnabled) {
-      this.TrayIcon = new Tray(icon);
+      this.TrayIcon = new Tray(icon.resize({ width: 16, height: 16 }));
 
       const trayToggleVisibility = () => {
         if (this.isMainWindowVisible()) {


### PR DESCRIPTION
## Before
<img width="1387" alt="Screenshot 2024-01-17 at 10 32 31" src="https://github.com/Scille/parsec-cloud/assets/41511029/549b8e43-da24-47c7-a6d2-23b07ed46230">

## After
<img width="400" alt="Screenshot 2024-01-17 at 10 33 14" src="https://github.com/Scille/parsec-cloud/assets/41511029/0c28d877-99c3-4a70-be60-7c8a238b8bb4">
