### PR TITLE
Add `show_envvar` to display env variables in help

### DIFF
--- a/docs/adminguide/hosting/index.rst
+++ b/docs/adminguide/hosting/index.rst
@@ -158,6 +158,21 @@ Create the file ``parsec.env`` with the following content to configure the ``par
   :language: ini
   :linenos:
 
+.. note::
+
+  To see the full list of environment variables that you can use to configure Parsec, you can run:
+
+  .. code-block:: bash
+
+    python -m parsec.cli backend run --help
+
+  Look for the sections ``[env var: VARIABLE]`` next to each configuration option. For example:
+
+  .. code-block:: bash
+
+    --administration-token TOKEN    Secret token to access the Administration API
+                                    [env var: PARSEC_ADMINISTRATION_TOKEN; required]
+
 The docker-compose file
 -----------------------
 

--- a/docs/adminguide/hosting/parsec.env
+++ b/docs/adminguide/hosting/parsec.env
@@ -3,26 +3,24 @@ PARSEC_HOST=0.0.0.0
 
 # The SSL key file.
 PARSEC_SSL_KEYFILE=/run/secrets/parsec-pem-key
+
 # The SSL certificate file.
 PARSEC_SSL_CERTFILE=/run/secrets/parsec-pem-crt
+
 # Enforce HTTPS by redirecting HTTP request.
 PARSEC_FORWARD_PROTO_ENFORCE_HTTPS=X-Forwarded-Proto:https
 
 # The granularity of Error log outputs.
 PARSEC_LOG_LEVEL=WARNING
+
 # The log formatting to use (`CONSOLE` or `JSON`).
 PARSEC_LOG_FORMAT=CONSOLE
+
 # The log file to write to (default to `stderr`).
 # PARSEC_LOG_FILE
 
-# The URL to reach Parsec server
+# The URL to reach Parsec server.
 PARSEC_BACKEND_ADDR=parsec://127.0.0.1:6777
-
-# Allow organization bootstrap without prior creation.
-PARSEC_SPONTANEOUS_ORGANIZATION_BOOTSTRAP=false
-
-# URL to notify a 3rd-party service when a new organization has been bootstrapped.
-# PARSEC_ORGANIZATION_BOOTSTRAP_WEBHOOK
 
 # Keep SSE connection open by sending keepalive messages to client (pass <=0 to disable).
 PARSEC_SSE_KEEPALIVE=30

--- a/server/parsec/backend/cli/migration.py
+++ b/server/parsec/backend/cli/migration.py
@@ -29,6 +29,7 @@ def _validate_postgres_db_url(ctx: Any, param: Any, value: str) -> str:
     required=True,
     callback=_validate_postgres_db_url,
     envvar="PARSEC_DB",
+    show_envvar=True,
     help="PostgreSQL database url",
 )
 @click.option("--dry-run", is_flag=True)

--- a/server/parsec/backend/cli/run.py
+++ b/server/parsec/backend/cli/run.py
@@ -94,6 +94,7 @@ For instance:
     default="127.0.0.1",
     show_default=True,
     envvar="PARSEC_HOST",
+    show_envvar=True,
     help="Host to listen on",
 )
 @click.option(
@@ -103,6 +104,7 @@ For instance:
     type=int,
     show_default=True,
     envvar="PARSEC_PORT",
+    show_envvar=True,
     help="Port to listen on",
 )
 @db_backend_options
@@ -111,6 +113,7 @@ For instance:
     default=10,
     show_default=True,
     envvar="PARSEC_MAXIMUM_DATABASE_CONNECTION_ATTEMPTS",
+    show_envvar=True,
     help="Maximum number of attempts at connecting to the database (0 means never retry)",
 )
 @click.option(
@@ -119,6 +122,7 @@ For instance:
     default=1.0,
     show_default=True,
     envvar="PARSEC_PAUSE_BEFORE_RETRY_DATABASE_CONNECTION",
+    show_envvar=True,
     help="Number of seconds before a new attempt at connecting to the database",
 )
 @blockstore_backend_options
@@ -126,12 +130,14 @@ For instance:
     "--administration-token",
     required=True,
     envvar="PARSEC_ADMINISTRATION_TOKEN",
+    show_envvar=True,
     metavar="TOKEN",
-    help="Secret token to access the administration api",
+    help="Secret token to access the Administration API",
 )
 @click.option(
     "--spontaneous-organization-bootstrap",
     envvar="PARSEC_SPONTANEOUS_ORGANIZATION_BOOTSTRAP",
+    show_envvar=True,
     is_flag=True,
     help="""Allow organization bootstrap without prior creation.
 
@@ -147,6 +153,7 @@ reservation and change the bootstrap token)
 @click.option(
     "--organization-bootstrap-webhook",
     envvar="PARSEC_ORGANIZATION_BOOTSTRAP_WEBHOOK",
+    show_envvar=True,
     metavar="URL",
     help="""URL to notify 3rd party service that a new organization has been bootstrapped.
 
@@ -158,12 +165,14 @@ organization_id, device_id, device_label (can be null), human_email (can be null
 @click.option(
     "--organization-initial-active-users-limit",
     envvar="PARSEC_ORGANIZATION_INITIAL_ACTIVE_USERS_LIMIT",
+    show_envvar=True,
     help="Non-revoked users limit used to configure newly created organizations (default: no limit)",
     type=int,
 )
 @click.option(
     "--organization-initial-user-profile-outsider-allowed",
     envvar="PARSEC_ORGANIZATION_INITIAL_USER_PROFILE_OUTSIDER_ALLOWED",
+    show_envvar=True,
     help="Allow the outsider profiles for the newly created organizations (default: True)",
     default=True,
     type=bool,
@@ -171,6 +180,7 @@ organization_id, device_id, device_label (can be null), human_email (can be null
 @click.option(
     "--backend-addr",
     envvar="PARSEC_BACKEND_ADDR",
+    show_envvar=True,
     required=True,
     metavar="URL",
     type=BackendAddr.from_url,
@@ -179,12 +189,14 @@ organization_id, device_id, device_label (can be null), human_email (can be null
 @click.option(
     "--email-host",
     envvar="PARSEC_EMAIL_HOST",
+    show_envvar=True,
     required=True,
     help="The host to use for sending email, set to `MOCKED` to output emails to temporary file",
 )
 @click.option(
     "--email-port",
     envvar="PARSEC_EMAIL_PORT",
+    show_envvar=True,
     type=int,
     default=25,
     show_default=True,
@@ -198,6 +210,7 @@ organization_id, device_id, device_label (can be null), human_email (can be null
 @click.option(
     "--email-host-password",
     envvar="PARSEC_EMAIL_HOST_PASSWORD",
+    show_envvar=True,
     help=(
         "Password to use for the SMTP server defined in EMAIL_HOST."
         " This setting is used in conjunction with EMAIL_HOST_USER when authenticating to the SMTP server."
@@ -206,6 +219,7 @@ organization_id, device_id, device_label (can be null), human_email (can be null
 @click.option(
     "--email-use-ssl",
     envvar="PARSEC_EMAIL_USE_SSL",
+    show_envvar=True,
     is_flag=True,
     help=(
         "Whether to use a TLS (secure) connection when talking to the SMTP server."
@@ -215,6 +229,7 @@ organization_id, device_id, device_label (can be null), human_email (can be null
 @click.option(
     "--email-use-tls",
     envvar="PARSEC_EMAIL_USE_TLS",
+    show_envvar=True,
     is_flag=True,
     help=(
         "Whether to use an implicit TLS (secure) connection when talking to the SMTP server."
@@ -227,6 +242,7 @@ organization_id, device_id, device_label (can be null), human_email (can be null
 @click.option(
     "--email-sender",
     envvar="PARSEC_EMAIL_SENDER",
+    show_envvar=True,
     metavar="EMAIL",
     help="Sender address used in sent emails",
 )
@@ -237,6 +253,7 @@ organization_id, device_id, device_label (can be null), human_email (can be null
     default=None,
     callback=lambda ctx, param, value: _parse_forward_proto_enforce_https_check_param(value),
     envvar="PARSEC_FORWARD_PROTO_ENFORCE_HTTPS",
+    show_envvar=True,
     help=(
         "Enforce HTTPS by redirecting incoming request that do not comply with the provided header."
         " This is useful when running Parsec behind a forward proxy handing the SSL layer."
@@ -249,12 +266,14 @@ organization_id, device_id, device_label (can be null), human_email (can be null
     "--ssl-keyfile",
     type=click.Path(exists=True, dir_okay=False),
     envvar="PARSEC_SSL_KEYFILE",
+    show_envvar=True,
     help="SSL key file. This setting enables serving Parsec over SSL.",
 )
 @click.option(
     "--ssl-certfile",
     type=click.Path(exists=True, dir_okay=False),
     envvar="PARSEC_SSL_CERTFILE",
+    show_envvar=True,
     help="SSL certificate file. This setting enables serving Parsec over SSL.",
 )
 # Add --log-level/--log-format/--log-file
@@ -280,6 +299,7 @@ organization_id, device_id, device_label (can be null), human_email (can be null
     type=float,
     callback=lambda ctx, param, value: math.inf if value is None or value <= 0 else value,
     envvar="PARSEC_SSE_KEEPALIVE",
+    show_envvar=True,
     help="Keep SSE connection open by sending keepalive messages to client (pass <= 0 to disable)",
 )
 # Add --debug

--- a/server/parsec/backend/cli/utils.py
+++ b/server/parsec/backend/cli/utils.py
@@ -29,6 +29,7 @@ def db_backend_options(fn: Callable[P, T]) -> Callable[P, T]:
             "--db",
             required=True,
             envvar="PARSEC_DB",
+            show_envvar=True,
             metavar="URL",
             help="""Database configuration.
 Allowed values:
@@ -43,6 +44,7 @@ Allowed values:
             default=5,
             show_default=True,
             envvar="PARSEC_DB_MIN_CONNECTIONS",
+            show_envvar=True,
             help="Minimal number of connections to the database if using PostgreSQL",
         ),
         click.option(
@@ -50,6 +52,7 @@ Allowed values:
             default=7,
             show_default=True,
             envvar="PARSEC_DB_MAX_CONNECTIONS",
+            show_envvar=True,
             help="Maximum number of connections to the database if using PostgreSQL",
         ),
     ]
@@ -207,6 +210,7 @@ def blockstore_backend_options(fn: Callable[P, T]) -> Callable[P, T]:
             multiple=True,
             callback=lambda ctx, param, value: _parse_blockstore_params(value),
             envvar="PARSEC_BLOCKSTORE",
+            show_envvar=True,
             metavar="CONFIG",
             help="""Blockstore configuration.
 Allowed values:

--- a/server/parsec/cli_utils.py
+++ b/server/parsec/cli_utils.py
@@ -194,6 +194,7 @@ def logging_config_options(
             default=default_log_level,
             show_default=True,
             envvar="PARSEC_LOG_LEVEL",
+            show_envvar=True,
         )
         @click.option(
             "--log-format",
@@ -202,9 +203,15 @@ def logging_config_options(
             default="CONSOLE",
             show_default=True,
             envvar="PARSEC_LOG_FORMAT",
+            show_envvar=True,
         )
         @click.option(
-            "--log-file", "-o", default=None, envvar="PARSEC_LOG_FILE", help="[default: stderr]"
+            "--log-file",
+            "-o",
+            default=None,
+            envvar="PARSEC_LOG_FILE",
+            show_envvar=True,
+            help="[default: stderr]",
         )
         @wraps(fn)
         def wrapper(
@@ -255,12 +262,14 @@ def sentry_config_options(
             "--sentry-dsn",
             metavar="URL",
             envvar="PARSEC_SENTRY_DSN",
+            show_envvar=True,
             help="Sentry Data Source Name for telemetry report",
         )
         @click.option(
             "--sentry-environment",
             metavar="NAME",
             envvar="PARSEC_SENTRY_ENVIRONMENT",
+            show_envvar=True,
             default="production",
             show_default=True,
             help="Sentry environment for telemetry report",


### PR DESCRIPTION
Also, update Administrator Guide:
- Remove `PARSEC_SPONTANEOUS_ORGANIZATION_BOOTSTRAP` from docs since it has the expected default value (False)
- Add note explaining how to get the full list of available env var

Closes #6173 