### PR TITLE
[MS] Changed `electron-is-dev` back to version 2.0.0

### DIFF
--- a/client/electron/package-lock.json
+++ b/client/electron/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@capacitor-community/electron": "^5.0.1",
                 "chokidar": "~3.5.2",
-                "electron-is-dev": "~3.0.1",
+                "electron-is-dev": "~2.0.0",
                 "electron-serve": "~1.2.0",
                 "electron-unhandled": "~4.0.1",
                 "electron-updater": "~6.1.7",
@@ -38,14 +38,6 @@
                 "keyv": "^4.5.2",
                 "mime-types": "~2.1.35",
                 "ora": "^5.4.1"
-            }
-        },
-        "node_modules/@capacitor-community/electron/node_modules/electron-is-dev": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-2.0.0.tgz",
-            "integrity": "sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA==",
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@capacitor-community/electron/node_modules/fs-extra": {
@@ -1703,12 +1695,9 @@
             }
         },
         "node_modules/electron-is-dev": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-3.0.1.tgz",
-            "integrity": "sha512-8TjjAh8Ec51hUi3o4TaU0mD3GMTOESi866oRNavj9A3IQJ7pmv+MJVmdZBFGw4GFT36X7bkqnuDNYvkQgvyI8Q==",
-            "engines": {
-                "node": ">=18"
-            },
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-2.0.0.tgz",
+            "integrity": "sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA==",
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
@@ -1776,14 +1765,6 @@
                 "lodash.debounce": "^4.0.8",
                 "serialize-error": "^8.1.0"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/electron-unhandled/node_modules/electron-is-dev": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-2.0.0.tgz",
-            "integrity": "sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA==",
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
@@ -3818,11 +3799,6 @@
                 "ora": "^5.4.1"
             },
             "dependencies": {
-                "electron-is-dev": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-2.0.0.tgz",
-                    "integrity": "sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA=="
-                },
                 "fs-extra": {
                     "version": "11.1.1",
                     "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
@@ -5093,9 +5069,9 @@
             }
         },
         "electron-is-dev": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-3.0.1.tgz",
-            "integrity": "sha512-8TjjAh8Ec51hUi3o4TaU0mD3GMTOESi866oRNavj9A3IQJ7pmv+MJVmdZBFGw4GFT36X7bkqnuDNYvkQgvyI8Q=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-2.0.0.tgz",
+            "integrity": "sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA=="
         },
         "electron-publish": {
             "version": "24.8.1",
@@ -5152,11 +5128,6 @@
                 "serialize-error": "^8.1.0"
             },
             "dependencies": {
-                "electron-is-dev": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-2.0.0.tgz",
-                    "integrity": "sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA=="
-                },
                 "serialize-error": {
                     "version": "8.1.0",
                     "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",

--- a/client/electron/package.json
+++ b/client/electron/package.json
@@ -22,7 +22,7 @@
     "dependencies": {
         "@capacitor-community/electron": "^5.0.1",
         "chokidar": "~3.5.2",
-        "electron-is-dev": "~3.0.1",
+        "electron-is-dev": "~2.0.0",
         "electron-serve": "~1.2.0",
         "electron-unhandled": "~4.0.1",
         "electron-updater": "~6.1.7",


### PR DESCRIPTION
`electron-is-dev` version 3.0.X causes bugs when starting electron (see https://github.com/sindresorhus/electron-is-dev/releases/tag/v3.0.0).

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
