### PR TITLE
[MS] Navigate to the folder of an imported file

### DIFF
--- a/client/src/components/files/FileUploadItem.vue
+++ b/client/src/components/files/FileUploadItem.vue
@@ -10,7 +10,10 @@
       failed: state === ImportState.CreateFailed,
     }"
   >
-    <ion-item class="element ion-no-padding">
+    <ion-item
+      class="element ion-no-padding"
+      @click="onImportClick"
+    >
       <div class="element-type">
         <div class="element-type__icon">
           <ms-image
@@ -95,6 +98,7 @@
 import { formatFileSize, getFileIcon, shortenFileName } from '@/common/file';
 import { MsImage } from '@/components/core/ms-image';
 import MsInformationTooltip from '@/components/core/ms-tooltip/MsInformationTooltip.vue';
+import { navigateToWorkspace } from '@/router';
 import { ImportData, ImportState } from '@/services/importManager';
 import { IonButton, IonIcon, IonItem, IonLabel, IonProgressBar, IonText } from '@ionic/vue';
 import { arrowForward, checkmark, close } from 'ionicons/icons';
@@ -116,6 +120,13 @@ defineExpose({
 const emits = defineEmits<{
   (event: 'importCancel', id: string): void;
 }>();
+
+async function onImportClick(): Promise<void> {
+  if (props.state !== ImportState.FileImported) {
+    return;
+  }
+  await navigateToWorkspace(props.importData.workspaceId, props.importData.path);
+}
 
 function onCancelClick(): void {
   emits('importCancel', props.importData.id);

--- a/client/src/views/files/FileUploadModal.vue
+++ b/client/src/views/files/FileUploadModal.vue
@@ -48,7 +48,7 @@ async function uploadFileEntry(currentPath: string, fsEntry: FileSystemEntry): P
     });
   } else {
     (fsEntry as FileSystemFileEntry).file(async (file) => {
-      importManager.importFile(props.workspaceHandle, props.workspaceId, file, parsecPath);
+      importManager.importFile(props.workspaceHandle, props.workspaceId, file, currentPath);
     });
   }
 }
@@ -61,7 +61,7 @@ async function onFilesDrop(entries: FileSystemEntry[]): Promise<void> {
 
 async function onFilesImport(files: File[]): Promise<void> {
   for (const file of files) {
-    importManager.importFile(props.workspaceHandle, props.workspaceId, file, await Path.join(props.currentPath, file.name));
+    importManager.importFile(props.workspaceHandle, props.workspaceId, file, props.currentPath);
   }
 }
 </script>


### PR DESCRIPTION
Closes #6192 

Once a file has been imported, can click on it to navigate to its folder.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description