### PR TITLE
[MS] Exclude files currently being imported from the list

### DIFF
--- a/client/src/views/files/FoldersPage.vue
+++ b/client/src/views/files/FoldersPage.vue
@@ -296,10 +296,13 @@ async function listFolder(): Promise<void> {
     children.value = [];
     allFilesSelected.value = false;
     for (const childName of (result.value as parsec.EntryStatFolder).children) {
-      const childPath = await parsec.Path.join(currentPath.value, childName);
-      const fileResult = await parsec.entryStat(childPath);
-      if (fileResult.ok) {
-        children.value.push(fileResult.value);
+      // Excluding files currently being imported
+      if (fileImports.value.find((imp) => imp.data.file.name === childName) === undefined) {
+        const childPath = await parsec.Path.join(currentPath.value, childName);
+        const fileResult = await parsec.entryStat(childPath);
+        if (fileResult.ok) {
+          children.value.push(fileResult.value);
+        }
       }
     }
   } else {


### PR DESCRIPTION
Files currently being imported could be displayed twice, because the import first creates the file, which means that the file appeared with a size of 0, and appeared again as being currently imported.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
