### PR TITLE
Backport: Add Sentry as optional component and fix env variable in docs (#6297) to dev/v2

### DIFF
--- a/docs/adminguide/hosting/index.rst
+++ b/docs/adminguide/hosting/index.rst
@@ -42,11 +42,13 @@ The `Parsec`_ server depends on the following external components in order to wo
 
 - An `SMTP server`_ for sending emails.
 - A `TSL/SSL server certificate`_ for ``HTTPS`` communication with the clients.
+- (Optional) A `Sentry DSN` for telemetry report.
 
 .. _PostgreSQL: https://www.postgresql.org/
 .. _S3 object storage: https://aws.amazon.com/s3/
 .. _SMTP server: https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol
 .. _TSL/SSL server certificate: https://en.wikipedia.org/wiki/Public_key_certificate#TLS/SSL_server_certificate
+.. _Sentry DSN: https://docs.sentry.io/product/sentry-basics/concepts/dsn-explainer/
 
 .. warning::
 

--- a/docs/adminguide/hosting/parsec.env
+++ b/docs/adminguide/hosting/parsec.env
@@ -27,8 +27,8 @@ PARSEC_SPONTANEOUS_ORGANIZATION_BOOTSTRAP=false
 # Keep SSE connection open by sending keepalive messages to client (pass <=0 to disable).
 PARSEC_SSE_KEEPALIVE=30
 
-# Sentry URL for telemetry report.
-# PARSEC_SENTRY_DNS
+# Sentry Data Source Name for telemetry report.
+# PARSEC_SENTRY_DSN
 
-# Environment name for sentry's telemetry reports.
+# Sentry environment for telemetry report.
 PARSEC_SENTRY_ENVIRONMENT=production

--- a/packaging/server/template-prod.env.list
+++ b/packaging/server/template-prod.env.list
@@ -58,8 +58,8 @@ PARSEC_ORGANIZATION_BOOTSTRAP_WEBHOOK
 # Keep SSE connection open by sending keepalive messages to client (pass <=0 to disable).
 PARSEC_SSE_KEEPALICE=30
 
-# Sentry URL for telemetry report.
-# PARSEC_SENTRY_DNS
+# Sentry Data Source Name for telemetry report.
+# PARSEC_SENTRY_DSN
 
-# Environment name for sentry's telemetry reports.
+# Sentry environment for telemetry report.
 PARSEC_SENTRY_ENVIRONMENT=production


### PR DESCRIPTION
Backport https://github.com/Scille/parsec-cloud/pull/6297/commits/405e887e40318da0bec3f463da7ff7f863782a8b from #6297 to `dev/v2`

Related to #6172 