### PR TITLE
Update docs/Dockerfile to support Python 3.12

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,18 +1,14 @@
 # cspell:words inotify
 
-FROM ubuntu:22.04
+FROM python:3.12-slim
 
-ENV DEBIAN_FRONTEND=noninteractive
 SHELL [ "/bin/bash", "-c" ]
 
 RUN useradd --uid=1000 --user-group --home-dir=/home/parsec --create-home parsec
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     make \
-    python3 \
-    python3-venv \
-    python3-pip \
     # Install additional fonts for latex
     fonts-roboto \
     fonts-firacode \
@@ -25,21 +21,26 @@ RUN apt-get update \
     texlive-latex-base \
     texlive-latex-recommended \
     texlive-latex-extra \
-    # The pdf is build using latexmk
+    # The PDF is built using latexmk
     latexmk \
     ca-certificates \
     curl \
     git \
     gettext \
-    inotify-tools
+    inotify-tools \
+    # Remove unnecessary apt cache
+    && rm -rf /var/lib/apt/lists/*
 
 USER parsec:parsec
+
 WORKDIR /data/docs
 
 COPY poetry.lock pyproject.toml conf.py /data/docs/
 
-RUN python3 -m venv /home/parsec/poetry-venv && \
+RUN python -m venv /home/parsec/poetry-venv && \
     source /home/parsec/poetry-venv/bin/activate && \
     pip install poetry && \
     poetry install && \
     echo 'source /home/parsec/poetry-venv/bin/activate' >> /home/parsec/.bashrc
+
+CMD [ "/bin/bash" ]

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,26 +1,81 @@
 <!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
 
-# How to generate the documentation website
+# Parsec documentation
+
+This directory contains the sources for Parsec docs.
+
+## Introduction
+
+Parsec docs are written in [reStructuredText (.rst)](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html) format.
+
+[Sphinx](https://www.sphinx-doc.org/en/master/index.html) is used to build the docs in multiple output formats (such as HTML and PDF).
 
 ## Requirements
 
-Install dependencies with `poetry install --with docs`
+There are two ways to install dependencies:
 
-## Update translation
+- Using [Poetry](https://python-poetry.org/docs/#installation)
 
-see <http://www.sphinx-doc.org/en/master/usage/advanced/intl.html>
+  ```bash
+  poetry install
+  ```
 
-1. Extract text and create/update `.po` files
+> **Note**
+> You'll need extra dependencies to build PDF docs (via `latexmk`), see Dockerfile.
 
-    ```shell
+- Using [Docker](https://docs.docker.com/engine/install/)
+
+    1. Build Docker image:
+
+        ```bash
+        docker build -t parsec-docs .
+        ```
+
+    2. Run a container:
+
+        ```bash
+        docker run --rm -it -v $(pwd):/data parsec-docs
+        ```
+
+        > **Note**
+        > The current working directory must be the local path to parsec-cloud repo.
+        > It is mounted in `/data` in the container. This means that builds started from
+        > the container will be available in your local repo under `_build` directory.
+
+## Build docs
+
+Build HTML docs with:
+
+```bash
+make html
+```
+
+To see the list of available output formats:
+
+```bash
+make
+```
+
+## Translations
+
+Translations are based on [Sphinx Internationalization](http://www.sphinx-doc.org/en/master/usage/advanced/intl.html).
+
+1. Extract text from docs
+
+    ```bash
     make gettext
+    ```
+
+2. Create/update `.po` files for translation
+
+    ```bash
     sphinx-intl update -p _build/locale -l fr
     ```
 
-2. Translate `.po` files
+3. Translate `.po` files (manually or with a tool like [Poedit](https://poedit.net/))
 
-3. Build `.po -> .mo`
+4. Build docs `.po -> .mo`
 
-    ```shell
+    ```bash
     make -e SPHINXOPTS="-D language='fr'" html
     ```


### PR DESCRIPTION
Dockerfile was broken since the upgrade to Python 3.12.

Also, update README.md to add more details about how to build the docs with Docker.

