### PR TITLE
[MS] Refactored folders page

### DIFF
--- a/client/src/components/files/FileCard.vue
+++ b/client/src/components/files/FileCard.vue
@@ -3,20 +3,21 @@
 <template>
   <ion-item
     class="file-card-item ion-no-padding"
-    :class="{ selected: isSelected }"
-    @click="$emit('click', $event, file)"
+    :class="{ selected: entry.isSelected }"
+    @click="$emit('click', $event, entry)"
     @mouseenter="isHovered = true"
     @mouseleave="isHovered = false"
   >
     <div class="card-checkbox">
+      <!-- eslint-disable vue/no-mutating-props -->
       <ion-checkbox
         aria-label=""
         class="checkbox"
-        v-model="isSelected"
-        v-show="isSelected || isHovered || showCheckbox"
+        v-model="entry.isSelected"
+        v-show="entry.isSelected || isHovered || showCheckbox"
         @click.stop
-        @ion-change="$emit('select', file, isSelected)"
       />
+      <!-- eslint-enable vue/no-mutating-props -->
     </div>
     <div
       class="card-option"
@@ -28,7 +29,7 @@
     <div class="card-content">
       <div class="card-content-icons">
         <ms-image
-          :image="file.isFile() ? getFileIcon(props.file.name) : Folder"
+          :image="entry.isFile() ? getFileIcon(entry.name) : Folder"
           class="file-icon"
         />
         <ion-icon
@@ -39,12 +40,12 @@
       </div>
 
       <ion-title class="card-content__title body">
-        {{ file.name }}
+        {{ entry.name }}
       </ion-title>
 
       <ion-text class="card-content-last-update caption-caption">
         <span>{{ $t('FoldersPage.File.lastUpdate') }}</span>
-        <span>{{ formatTimeSince(file.updated, '--', 'short') }}</span>
+        <span>{{ formatTimeSince(entry.updated, '--', 'short') }}</span>
       </ion-text>
     </div>
   </ion-item>
@@ -54,38 +55,35 @@
 import { formatTimeSince } from '@/common/date';
 import { getFileIcon } from '@/common/file';
 import { Folder, MsImage } from '@/components/core/ms-image';
-import { EntryStat } from '@/parsec';
+import { EntryModel } from '@/components/files/types';
 import { IonCheckbox, IonIcon, IonItem, IonText, IonTitle } from '@ionic/vue';
 import { cloudDone, cloudOffline, ellipsisHorizontal } from 'ionicons/icons';
 import { ref } from 'vue';
 
 const isHovered = ref(false);
 const menuOpened = ref(false);
-const isSelected = ref(false);
 
 const props = defineProps<{
-  file: EntryStat;
+  entry: EntryModel;
   showCheckbox: boolean;
 }>();
 
 const emits = defineEmits<{
-  (e: 'click', event: Event, file: EntryStat): void;
-  (e: 'menuClick', event: Event, file: EntryStat, onFinished: () => void): void;
-  (e: 'select', file: EntryStat, selected: boolean): void;
+  (e: 'click', event: Event, entry: EntryModel): void;
+  (e: 'menuClick', event: Event, entry: EntryModel, onFinished: () => void): void;
 }>();
 
 defineExpose({
-  isSelected,
   props,
 });
 
 function isFileSynced(): boolean {
-  return !props.file.needSync;
+  return !props.entry.needSync;
 }
 
 async function onOptionsClick(event: Event): Promise<void> {
   menuOpened.value = true;
-  emits('menuClick', event, props.file, () => {
+  emits('menuClick', event, props.entry, () => {
     menuOpened.value = false;
   });
 }

--- a/client/src/components/files/FileGridDisplay.vue
+++ b/client/src/components/files/FileGridDisplay.vue
@@ -1,0 +1,61 @@
+<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+
+<template>
+  <div class="folders-container-grid">
+    <file-card
+      class="folder-grid-item"
+      v-for="folder in folders.getEntries()"
+      :key="folder.id"
+      :entry="folder"
+      :show-checkbox="hasSelected()"
+      @click="$emit('click', folder, $event)"
+      @menu-click="$emit('menuClick', folder, $event)"
+    />
+    <file-card
+      class="folder-grid-item"
+      v-for="file in files.getEntries()"
+      :key="file.id"
+      :entry="file"
+      :show-checkbox="hasSelected()"
+      @click="$emit('click', file, $event)"
+      @menu-click="$emit('menuClick', file, $event)"
+    />
+
+    <file-card-importing
+      v-for="fileImport in importing"
+      :key="fileImport.data.id"
+      :data="fileImport.data"
+      :progress="fileImport.progress"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import FileCard from '@/components/files/FileCard.vue';
+import FileCardImporting from '@/components/files/FileCardImporting.vue';
+import { EntryCollection, EntryModel, FileImportProgress, FileModel, FolderModel } from '@/components/files/types';
+
+const props = defineProps<{
+  importing: Array<FileImportProgress>;
+  files: EntryCollection<FileModel>;
+  folders: EntryCollection<FolderModel>;
+}>();
+
+defineEmits<{
+  (e: 'click', entry: EntryModel, event: Event): void;
+  (e: 'menuClick', entry: EntryModel, event: Event): void;
+}>();
+
+function hasSelected(): boolean {
+  return props.files.hasSelected() || props.folders.hasSelected();
+}
+</script>
+
+<style scoped lang="scss">
+.folders-container-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5em;
+  overflow-y: auto;
+}
+</style>

--- a/client/src/components/files/FileImport.vue
+++ b/client/src/components/files/FileImport.vue
@@ -3,7 +3,7 @@
 <template>
   <div class="container">
     <div class="import-drag-drop">
-      <ms-image :image="FileImport" />
+      <ms-image :image="FileImportImage" />
       <ion-text class="import-drag-drop__title title-h3">
         {{ $t('FoldersPage.importModal.dragAndDrop') }}
       </ion-text>
@@ -37,7 +37,7 @@
 </template>
 
 <script setup lang="ts">
-import { FileImport, MsImage } from '@/components/core';
+import { FileImport as FileImportImage, MsImage } from '@/components/core';
 import { IonButton, IonIcon, IonText } from '@ionic/vue';
 import { ellipsisHorizontalCircle } from 'ionicons/icons';
 import { onMounted, onUnmounted, ref } from 'vue';

--- a/client/src/components/files/FileListDisplay.vue
+++ b/client/src/components/files/FileListDisplay.vue
@@ -1,0 +1,120 @@
+<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+
+<template>
+  <div>
+    <ion-list class="list">
+      <ion-list-header
+        class="folder-list-header"
+        lines="full"
+      >
+        <ion-label class="folder-list-header__label ion-text-nowrap label-selected">
+          <ion-checkbox
+            aria-label=""
+            class="checkbox"
+            @ion-change="selectAll($event.detail.checked)"
+            :value="allSelected"
+            :indeterminate="someSelected && !allSelected"
+          />
+        </ion-label>
+        <ion-label class="folder-list-header__label cell-title ion-text-nowrap label-name">
+          {{ $t('FoldersPage.listDisplayTitles.name') }}
+        </ion-label>
+        <ion-label class="folder-list-header__label cell-title ion-text-nowrap label-updatedBy">
+          {{ $t('FoldersPage.listDisplayTitles.updatedBy') }}
+        </ion-label>
+        <ion-label class="folder-list-header__label cell-title ion-text-nowrap label-lastUpdate">
+          {{ $t('FoldersPage.listDisplayTitles.lastUpdate') }}
+        </ion-label>
+        <ion-label class="folder-list-header__label cell-title ion-text-nowrap label-size">
+          {{ $t('FoldersPage.listDisplayTitles.size') }}
+        </ion-label>
+        <ion-label class="folder-list-header__label cell-title ion-text-nowrap label-space" />
+      </ion-list-header>
+      <file-list-item
+        v-for="folder in folders.getEntries()"
+        :key="folder.id"
+        :entry="folder"
+        :show-checkbox="someSelected"
+        @click="$emit('click', folder, $event)"
+        @menu-click="$emit('menuClick', folder, $event)"
+        @selected-change="onSelectedChange"
+      />
+      <file-list-item
+        v-for="file in files.getEntries()"
+        :key="file.id"
+        :entry="file"
+        :show-checkbox="someSelected"
+        @click="$emit('click', file, $event)"
+        @menu-click="$emit('menuClick', file, $event)"
+        @selected-change="onSelectedChange"
+      />
+      <file-list-item-importing
+        v-for="fileImport in importing"
+        :key="fileImport.data.id"
+        :data="fileImport.data"
+        :progress="fileImport.progress"
+      />
+    </ion-list>
+  </div>
+</template>
+
+<script setup lang="ts">
+import FileListItem from '@/components/files/FileListItem.vue';
+import FileListItemImporting from '@/components/files/FileListItemImporting.vue';
+import { EntryCollection, EntryModel, FileImportProgress, FileModel, FolderModel } from '@/components/files/types';
+import { IonCheckbox, IonLabel, IonList, IonListHeader } from '@ionic/vue';
+import { computed, ref } from 'vue';
+
+const props = defineProps<{
+  importing: Array<FileImportProgress>;
+  files: EntryCollection<FileModel>;
+  folders: EntryCollection<FolderModel>;
+}>();
+
+defineEmits<{
+  (e: 'click', entry: EntryModel, event: Event): void;
+  (e: 'menuClick', entry: EntryModel, event: Event): void;
+}>();
+
+const selectedCount = ref(0);
+
+const allSelected = computed(() => {
+  return selectedCount.value === props.files.getEntries().length + props.folders.getEntries().length;
+});
+
+const someSelected = computed(() => {
+  return selectedCount.value > 0;
+});
+
+async function onSelectedChange(_entry: EntryModel, _checked: boolean): Promise<void> {
+  selectedCount.value = props.files.getSelectedEntries().length + props.folders.getSelectedEntries().length;
+}
+
+async function selectAll(selected: boolean): Promise<void> {
+  props.files.selectAll(selected);
+  props.folders.selectAll(selected);
+  if (selected) {
+    selectedCount.value = props.files.getEntries().length + props.folders.getEntries().length;
+  } else {
+    selectedCount.value = 0;
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.folder-list-header {
+  &__label {
+    padding: 0.75rem 1rem;
+  }
+  .label-selected {
+    display: flex;
+    align-items: center;
+  }
+
+  .label-space {
+    min-width: 4rem;
+    flex-grow: 0;
+    margin-left: auto;
+  }
+}
+</style>

--- a/client/src/components/files/FileListItem.vue
+++ b/client/src/components/files/FileListItem.vue
@@ -5,30 +5,32 @@
     button
     lines="full"
     :detail="false"
-    :class="{ selected: isSelected }"
-    @click="$emit('click', $event, file)"
+    :class="{ selected: entry.isSelected }"
+    @click="$emit('click', $event, entry)"
     @mouseenter="isHovered = true"
     @mouseleave="isHovered = false"
   >
     <div class="file-list-item">
       <div class="file-selected">
+        <!-- eslint-disable vue/no-mutating-props -->
         <ion-checkbox
           aria-label=""
           class="checkbox"
-          v-model="isSelected"
-          v-show="isSelected || isHovered || showCheckbox"
+          v-model="entry.isSelected"
+          v-show="entry.isSelected || isHovered || showCheckbox"
+          @ion-change="$emit('selectedChange', entry, $event.detail.checked)"
           @click.stop
-          @ion-change="$emit('select', file, isSelected)"
         />
+        <!-- eslint-enable vue/no-mutating-props -->
       </div>
       <!-- file name -->
       <div class="file-name">
         <ms-image
-          :image="file.isFile() ? getFileIcon(props.file.name) : Folder"
+          :image="entry.isFile() ? getFileIcon(entry.name) : Folder"
           class="file-icon"
         />
         <ion-label class="file-name__label cell">
-          {{ file.name }}
+          {{ entry.name }}
         </ion-label>
         <ion-icon
           class="cloud-overlay"
@@ -44,25 +46,25 @@
         v-if="false"
       >
         <user-avatar-name
-          :user-avatar="file.id"
-          :user-name="file.id"
+          :user-avatar="entry.id"
+          :user-name="entry.id"
         />
       </div>
 
       <!-- last update -->
       <div class="file-lastUpdate">
         <ion-label class="label-last-update cell">
-          {{ formatTimeSince(file.updated, '--', 'short') }}
+          {{ formatTimeSince(entry.updated, '--', 'short') }}
         </ion-label>
       </div>
 
       <!-- file size -->
       <div class="file-size">
         <ion-label
-          v-show="file.isFile()"
+          v-show="entry.isFile()"
           class="label-size cell"
         >
-          {{ formatFileSize((file as EntryStatFile).size) }}
+          {{ formatFileSize((entry as FileModel).size) }}
         </ion-label>
       </div>
 
@@ -89,40 +91,38 @@
 import { formatTimeSince } from '@/common/date';
 import { formatFileSize, getFileIcon } from '@/common/file';
 import { Folder, MsImage } from '@/components/core/ms-image';
+import { EntryModel, FileModel } from '@/components/files/types';
 import UserAvatarName from '@/components/users/UserAvatarName.vue';
-import { EntryStat, EntryStatFile } from '@/parsec';
 import { IonButton, IonCheckbox, IonIcon, IonItem, IonLabel } from '@ionic/vue';
 import { cloudDone, cloudOffline, ellipsisHorizontal } from 'ionicons/icons';
 import { ref } from 'vue';
 
 const isHovered = ref(false);
 const menuOpened = ref(false);
-const isSelected = ref(false);
 
 const props = defineProps<{
-  file: EntryStat;
+  entry: EntryModel;
   showCheckbox: boolean;
 }>();
 
 const emits = defineEmits<{
-  (e: 'click', event: Event, file: EntryStat): void;
-  (e: 'menuClick', event: Event, file: EntryStat, onFinished: () => void): void;
-  (e: 'select', file: EntryStat, selected: boolean): void;
+  (e: 'click', event: Event, entry: EntryModel): void;
+  (e: 'menuClick', event: Event, entry: EntryModel, onFinished: () => void): void;
+  (e: 'selectedChange', entry: EntryModel, checked: boolean): void;
 }>();
 
 defineExpose({
   isHovered,
-  isSelected,
   props,
 });
 
 function isFileSynced(): boolean {
-  return !props.file.needSync;
+  return !props.entry.needSync;
 }
 
 async function onOptionsClick(event: Event): Promise<void> {
   menuOpened.value = true;
-  emits('menuClick', event, props.file, () => {
+  emits('menuClick', event, props.entry, () => {
     menuOpened.value = false;
   });
 }

--- a/client/src/components/files/index.ts
+++ b/client/src/components/files/index.ts
@@ -1,0 +1,25 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import FileCard from '@/components/files/FileCard.vue';
+import FileCardImporting from '@/components/files/FileCardImporting.vue';
+import FileDropZone from '@/components/files/FileDropZone.vue';
+import FileGridDisplay from '@/components/files/FileGridDisplay.vue';
+import FileImport from '@/components/files/FileImport.vue';
+import FileListDisplay from '@/components/files/FileListDisplay.vue';
+import FileListItem from '@/components/files/FileListItem.vue';
+import FileListItemImporting from '@/components/files/FileListItemImporting.vue';
+import FileUploadItem from '@/components/files/FileUploadItem.vue';
+
+export { EntryCollection, SortProperty } from '@/components/files/types';
+export type { EntryModel, FileImportProgress, FileModel, FolderModel } from '@/components/files/types';
+export {
+  FileCard,
+  FileCardImporting,
+  FileDropZone,
+  FileGridDisplay,
+  FileImport,
+  FileListDisplay,
+  FileListItem,
+  FileListItemImporting,
+  FileUploadItem,
+};

--- a/client/src/components/files/types.ts
+++ b/client/src/components/files/types.ts
@@ -1,0 +1,89 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { EntryStatFile, EntryStatFolder } from '@/parsec';
+import { ImportData } from '@/services/importManager';
+
+export enum SortProperty {
+  Name,
+  Size,
+  LastUpdate,
+}
+
+export interface FileImportProgress {
+  data: ImportData;
+  progress: number;
+}
+
+export interface FileModel extends EntryStatFile {
+  isSelected: boolean;
+}
+
+export interface FolderModel extends EntryStatFolder {
+  isSelected: boolean;
+}
+
+export type EntryModel = FileModel | FolderModel;
+
+export class EntryCollection<Model extends EntryModel> {
+  entries: Array<Model>;
+
+  constructor() {
+    this.entries = [];
+  }
+
+  hasSelected(): boolean {
+    return this.entries.find((entry) => entry.isSelected) !== undefined;
+  }
+
+  selectAll(selected: boolean): void {
+    for (const entry of this.entries) {
+      entry.isSelected = selected;
+    }
+  }
+
+  getEntries(): Array<Model> {
+    return this.entries;
+  }
+
+  entriesCount(): number {
+    return this.entries.length;
+  }
+
+  getSelectedEntries(): Array<Model> {
+    return this.entries.filter((entry) => entry.isSelected);
+  }
+
+  selectedCount(): number {
+    return this.entries.filter((entry) => entry.isSelected).length;
+  }
+
+  sort(property: SortProperty, ascending: boolean): void {
+    this.entries.sort((item1, item2) => {
+      // Because the difference between item1 and item2 will always be -1, 0 or 1, by setting
+      // a folder with a score of 3 by default, we're ensuring that it will always be on top
+      // of the list.
+      const item1Score = item1.isFile() ? 3 : 0;
+      const item2Score = item2.isFile() ? 3 : 0;
+      let diff = 0;
+
+      if (property === SortProperty.Name) {
+        diff = ascending ? item2.name.localeCompare(item1.name) : item1.name.localeCompare(item2.name);
+      } else if (property === SortProperty.LastUpdate) {
+        diff = ascending ? (item1.updated > item2.updated ? 1 : 0) : item2.updated > item1.updated ? 1 : 0;
+      } else if (property === SortProperty.Size) {
+        const size1 = item1.isFile() ? (item1 as FileModel).size : 0;
+        const size2 = item1.isFile() ? (item2 as FileModel).size : 0;
+        diff = ascending ? (size1 < size2 ? 1 : 0) : size2 < size1 ? 1 : 0;
+      }
+      return item1Score - item2Score - diff;
+    });
+  }
+
+  clear(): void {
+    this.entries = [];
+  }
+
+  append(entry: Model): void {
+    this.entries.push(entry);
+  }
+}

--- a/client/src/views/files/FileUploadMenu.vue
+++ b/client/src/views/files/FileUploadMenu.vue
@@ -122,7 +122,7 @@
 
 <script setup lang="ts">
 import { MsImage, NoImportDone, NoImportError, NoImportInProgress } from '@/components/core/ms-image';
-import FileUploadItem from '@/components/files/FileUploadItem.vue';
+import { FileUploadItem } from '@/components/files';
 import { navigateToWorkspace } from '@/router';
 import { FileProgressStateData, ImportData, ImportManager, ImportManagerKey, ImportState, StateData } from '@/services/importManager';
 import { IonIcon, IonItem, IonList, IonText } from '@ionic/vue';

--- a/client/src/views/files/FileUploadModal.vue
+++ b/client/src/views/files/FileUploadModal.vue
@@ -15,9 +15,8 @@
 
 <script setup lang="ts">
 import { MsModal } from '@/components/core';
-import FileDropZone from '@/components/files/FileDropZone.vue';
-import FileImport from '@/components/files/FileImport.vue';
-import { createFolder, Path, WorkspaceHandle, WorkspaceID } from '@/parsec';
+import { FileDropZone, FileImport } from '@/components/files';
+import { Path, WorkspaceHandle, WorkspaceID, createFolder } from '@/parsec';
 import { ImportManager, ImportManagerKey } from '@/services/importManager';
 import { inject } from 'vue';
 

--- a/client/tests/component/specs/testFileCard.spec.ts
+++ b/client/tests/component/specs/testFileCard.spec.ts
@@ -1,7 +1,8 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
+import { FileModel, FolderModel } from '@/components/files';
 import FileCard from '@/components/files/FileCard.vue';
-import { EntryStatFile, EntryStatFolder, FileType } from '@/parsec';
+import { FileType } from '@/parsec';
 import { getDefaultProvideConfig } from '@tests/component/support/mocks';
 import { mount } from '@vue/test-utils';
 import { DateTime } from 'luxon';
@@ -18,7 +19,7 @@ describe('File Card Item', () => {
   });
 
   it('Display item for file', () => {
-    const FILE: EntryStatFile = {
+    const FILE: FileModel = {
       tag: FileType.File,
       confinementPoint: null,
       id: '67',
@@ -30,13 +31,13 @@ describe('File Card Item', () => {
       size: 43_297_832_478,
       name: 'A File.txt',
       isFile: (): boolean => true,
+      isSelected: false,
     };
 
     const wrapper = mount(FileCard, {
       props: {
-        file: FILE,
+        entry: FILE,
         showCheckbox: true,
-        showOptions: true,
       },
       global: {
         provide: getDefaultProvideConfig(),
@@ -54,7 +55,7 @@ describe('File Card Item', () => {
   });
 
   it('Display item for folder', () => {
-    const FOLDER: EntryStatFolder = {
+    const FOLDER: FolderModel = {
       tag: FileType.Folder,
       confinementPoint: null,
       id: '67',
@@ -66,13 +67,13 @@ describe('File Card Item', () => {
       name: 'A Folder',
       isFile: (): boolean => false,
       children: ['A File.txt', 'Another File.png'],
+      isSelected: false,
     };
 
     const wrapper = mount(FileCard, {
       props: {
-        file: FOLDER,
+        entry: FOLDER,
         showCheckbox: true,
-        showOptions: true,
       },
       global: {
         provide: getDefaultProvideConfig(),

--- a/client/tests/component/specs/testFileListItem.spec.ts
+++ b/client/tests/component/specs/testFileListItem.spec.ts
@@ -1,7 +1,8 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
+import { FileModel, FolderModel } from '@/components/files';
 import FileListItem from '@/components/files/FileListItem.vue';
-import { EntryStatFile, EntryStatFolder, FileType } from '@/parsec';
+import { FileType } from '@/parsec';
 import { getDefaultProvideConfig } from '@tests/component/support/mocks';
 import { mount } from '@vue/test-utils';
 import { DateTime } from 'luxon';
@@ -18,7 +19,7 @@ describe('File List Item', () => {
   });
 
   it('Display item for file', () => {
-    const FILE: EntryStatFile = {
+    const FILE: FileModel = {
       tag: FileType.File,
       confinementPoint: null,
       id: '67',
@@ -30,11 +31,12 @@ describe('File List Item', () => {
       size: 43_297_832_478,
       name: 'A File.txt',
       isFile: (): boolean => true,
+      isSelected: false,
     };
 
     const wrapper = mount(FileListItem, {
       props: {
-        file: FILE,
+        entry: FILE,
         showCheckbox: false,
       },
       global: {
@@ -42,7 +44,6 @@ describe('File List Item', () => {
       },
     });
 
-    expect((wrapper.vm as any).isSelected).to.be.false;
     expect(wrapper.get('.file-name__label').text()).to.equal('A File.txt');
     expect(wrapper.get('.label-last-update').text()).to.equal('one second ago');
     expect(wrapper.get('.label-size').text()).to.equal('40.3 GB');
@@ -55,7 +56,7 @@ describe('File List Item', () => {
   });
 
   it('Display item for folder', () => {
-    const FOLDER: EntryStatFolder = {
+    const FOLDER: FolderModel = {
       tag: FileType.Folder,
       confinementPoint: null,
       id: '67',
@@ -67,11 +68,12 @@ describe('File List Item', () => {
       name: 'A Folder',
       isFile: (): boolean => false,
       children: ['A File.txt', 'Another File.png'],
+      isSelected: false,
     };
 
     const wrapper = mount(FileListItem, {
       props: {
-        file: FOLDER,
+        entry: FOLDER,
         showCheckbox: false,
       },
       global: {
@@ -79,7 +81,6 @@ describe('File List Item', () => {
       },
     });
 
-    expect((wrapper.vm as any).isSelected).to.be.false;
     expect(wrapper.get('.file-name__label').text()).to.equal('A Folder');
     expect(wrapper.get('.label-last-update').text()).to.equal('one second ago');
     // expect(wrapper.get('.label-size')).not.to.be.visible;

--- a/client/tests/e2e/specs/test_folders_page.ts
+++ b/client/tests/e2e/specs/test_folders_page.ts
@@ -114,28 +114,32 @@ describe('Check folders page', () => {
   });
 
   it('Tests select all files in list view', () => {
-    cy.get('.folder-list-header').realHover().find('ion-checkbox').invoke('show').should('not.have.class', 'checkbox-checked');
+    cy.get('.folder-list-header').should('not.have.class', 'checkbox-checked');
     // Select all
-    cy.get('.folder-list-header').find('ion-checkbox').invoke('show').click();
+    cy.get('.folder-list-header').find('ion-checkbox').click();
     cy.get('.folder-list-header').find('ion-checkbox').should('have.class', 'checkbox-checked');
     cy.get('.counter').contains(/^\d+ selected items$/);
-    cy.get('.file-list-item').eq(0).find('ion-checkbox').should('have.class', 'checkbox-checked');
-    cy.get('.file-list-item').eq(1).find('ion-checkbox').should('have.class', 'checkbox-checked');
+    cy.get('.file-list-item').first().find('ion-checkbox').should('have.class', 'checkbox-checked');
+    cy.get('.file-list-item').last().find('ion-checkbox').should('have.class', 'checkbox-checked');
     // Unselect all
-    cy.get('.folder-list-header').realHover().find('ion-checkbox').click();
+    cy.get('.folder-list-header').find('ion-checkbox').click();
     cy.get('.folder-list-header').find('ion-checkbox').should('not.have.class', 'checkbox-checked');
-    cy.get('.file-list-item').eq(0).find('ion-checkbox').should('not.be.visible');
-    cy.get('.file-list-item').eq(1).find('ion-checkbox').should('not.be.visible');
+    cy.get('.file-list-item').first().find('ion-checkbox').should('not.be.visible');
+    cy.get('.file-list-item').last().find('ion-checkbox').should('not.be.visible');
     cy.get('.counter').contains(/^\d+ items$/);
 
     // Select all, unselect first file
-    cy.get('.folder-list-header').realHover().find('ion-checkbox').invoke('show').click();
+    cy.get('.folder-list-header').find('ion-checkbox').click();
     cy.get('.folder-list-header').find('ion-checkbox').should('have.class', 'checkbox-checked');
     cy.get('.counter').contains(/^\d+ selected items$/);
-    cy.get('.file-list-item').eq(0).find('ion-checkbox').click();
-    cy.get('.folder-list-header').find('ion-checkbox').should('not.have.class', 'checkbox-checked');
-    cy.get('.file-list-item').eq(0).find('ion-checkbox').should('not.have.class', 'checkbox-checked');
+    cy.get('.file-list-item').first().find('ion-checkbox').click();
+    cy.get('.folder-list-header').find('ion-checkbox').should('have.class', 'checkbox-indeterminate');
+    cy.get('.file-list-item').first().find('ion-checkbox').should('not.have.class', 'checkbox-checked');
     cy.get('.counter').contains(/^\d+ selected items$/);
+
+    // Header checkbox should be selected if all files are selected
+    cy.get('.file-list-item').first().find('ion-checkbox').click();
+    cy.get('.folder-list-header').find('ion-checkbox').should('have.class', 'checkbox-checked');
   });
 
   it('Tests delete one file in list view', () => {
@@ -413,13 +417,13 @@ describe('Check folders page', () => {
 
   it('Check reader role', () => {
     cy.get('.list-workspaces').find('.list-workspaces__header').contains('All Workspaces').click();
-    cy.get('.workspaces-grid-item').eq(2).contains("Watcher's Keep").click();
+    cy.get('.workspaces-grid-item').eq(2).contains("Watcher's Keep").click({ force: true });
 
     cy.get('#folders-ms-action-bar').find('#button-new-folder').should('not.be.visible');
     cy.get('#folders-ms-action-bar').find('#button-import').should('not.be.visible');
 
     cy.get('.file-list-item').eq(0).trigger('mouseenter');
-    cy.get('.file-list-item').eq(0).find('ion-checkbox').click();
+    cy.get('.file-list-item').eq(0).realHover().find('ion-checkbox').click({ force: true });
 
     cy.get('#folders-ms-action-bar').find('#button-rename').should('not.be.visible');
     cy.get('#folders-ms-action-bar').find('#button-moveto').should('not.be.visible');


### PR DESCRIPTION
Refactored folders page.

1. Grid and list are in separated components, which mean they can also be reused (for example for a search feature)
2. FoldersPage has been cleaned quite a bit, a lot less logic to handle
3. The files and folders list are handled by a specific object, which means that they are shared between grid and list view (and thus keeping the selection status)
4. Selection is way clearer (no more refs on list of component)

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes