### PR TITLE
[MS] Fixed eslint warnings

### DIFF
--- a/client/.eslintignore
+++ b/client/.eslintignore
@@ -9,5 +9,5 @@ electron/app
 electron/src/
 electron/dist
 electron/node_modules
-src/views/TestPage.vue
+src/views/testing/TestPage.vue
 bindings

--- a/client/src/components/core/ms-action-bar/MsActionBarButton.vue
+++ b/client/src/components/core/ms-action-bar/MsActionBarButton.vue
@@ -45,8 +45,4 @@ defineProps<{
     margin-right: 0.375rem;
   }
 }
-
-.danger:hover {
-  color: var(--parsec-color-light-danger-700);
-}
 </style>

--- a/client/src/components/core/ms-modal/MsTextInputModal.vue
+++ b/client/src/components/core/ms-modal/MsTextInputModal.vue
@@ -63,7 +63,4 @@ function cancel(): Promise<boolean> {
 }
 </script>
 
-<style scoped lang="scss">
-.text-input-modal {
-}
-</style>
+<style scoped lang="scss"></style>

--- a/client/src/components/core/ms-toggle/MsGridListToggle.vue
+++ b/client/src/components/core/ms-toggle/MsGridListToggle.vue
@@ -82,6 +82,7 @@ defineExpose({
   }
 }
 
+// eslint-disable-next-line vue-scoped-css/no-unused-selector
 .button-disabled {
   border: 1px solid var(--parsec-color-light-primary-700);
   background: var(--parsec-color-light-secondary-premiere);

--- a/client/src/components/core/ms-tooltip/MsTooltip.vue
+++ b/client/src/components/core/ms-tooltip/MsTooltip.vue
@@ -27,13 +27,13 @@ defineProps<{
   flex-direction: column;
   --fill-color: var(--parsec-color-light-primary-900);
 
-  &.bottom {
-    flex-direction: column-reverse;
+  // &.bottom {
+  //   flex-direction: column-reverse;
 
-    svg {
-      transform: rotate(180deg);
-    }
-  }
+  //   svg {
+  //     transform: rotate(180deg);
+  //   }
+  // }
 }
 
 .tooltip-content {

--- a/client/src/components/organizations/ChooseServer.vue
+++ b/client/src/components/organizations/ChooseServer.vue
@@ -112,6 +112,7 @@ async function areFieldsCorrect(): Promise<boolean> {
   flex-direction: column;
 }
 
+// eslint-disable-next-line vue-scoped-css/no-unused-selector
 .radio-list-item {
   display: flex;
   flex-direction: column;
@@ -171,6 +172,7 @@ async function areFieldsCorrect(): Promise<boolean> {
   }
 }
 
+// eslint-disable-next-line vue-scoped-css/no-unused-selector
 .item-radio.radio-checked {
   &::part(container) {
     border-color: var(--parsec-color-light-primary-600);

--- a/client/src/components/workspaces/WorkspaceListItem.vue
+++ b/client/src/components/workspaces/WorkspaceListItem.vue
@@ -196,7 +196,6 @@ defineEmits<{
 }
 
 .label-size,
-.label-shared-with,
 .label-last-update {
   color: var(--parsec-color-light-secondary-grey);
 }

--- a/client/src/parsec/device.ts
+++ b/client/src/parsec/device.ts
@@ -120,7 +120,7 @@ export async function importRecoveryDevice(
   }
 }
 
-export async function saveDevice(deviceInfo: DeviceInfo, password: string): Promise<Result<AvailableDevice, RecoveryImportError>> {
+export async function saveDevice(deviceInfo: DeviceInfo, _password: string): Promise<Result<AvailableDevice, RecoveryImportError>> {
   // const _saveStrategy: DeviceSaveStrategyPassword = { tag: DeviceSaveStrategyTag.Password, password: password };
   return {
     ok: true,
@@ -139,7 +139,7 @@ export async function saveDevice(deviceInfo: DeviceInfo, password: string): Prom
   };
 }
 
-export async function deleteDevice(device: AvailableDevice): Promise<Result<boolean>> {
+export async function deleteDevice(_device: AvailableDevice): Promise<Result<boolean>> {
   return { ok: true, value: true };
 }
 

--- a/client/src/parsec/file.ts
+++ b/client/src/parsec/file.ts
@@ -228,7 +228,7 @@ export interface FileLinkData {
   workspaceId: WorkspaceID;
 }
 
-export async function parseFileLink(link: string): Promise<Result<FileLinkData, ParseLinkError>> {
+export async function parseFileLink(_link: string): Promise<Result<FileLinkData, ParseLinkError>> {
   const clientHandle = getParsecHandle();
 
   if (clientHandle && !needsMocks()) {

--- a/client/src/parsec/user.ts
+++ b/client/src/parsec/user.ts
@@ -95,7 +95,7 @@ export interface RevokeUserError {
   tag: RevokeUserTag.Internal;
 }
 
-export async function revokeUser(userId: UserID): Promise<Result<null, RevokeUserError>> {
+export async function revokeUser(_userId: UserID): Promise<Result<null, RevokeUserError>> {
   const handle = getParsecHandle();
 
   if (handle !== null && !needsMocks()) {

--- a/client/src/views/devices/GreetDeviceModal.vue
+++ b/client/src/views/devices/GreetDeviceModal.vue
@@ -685,14 +685,5 @@ onMounted(async () => {
   border-radius: var(--parsec-radius-6);
   justify-content: space-between;
   color: var(--parsec-color-light-secondary-text);
-
-  &__icon {
-    font-size: 1.5rem;
-    color: var(--parsec-color-light-primary-500);
-  }
-
-  &__name {
-    font-weight: 500;
-  }
 }
 </style>

--- a/client/src/views/header/NotificationCenterPopover.vue
+++ b/client/src/views/header/NotificationCenterPopover.vue
@@ -14,7 +14,6 @@
           class="notification-center-header__toggle dark small body-sm"
           @ion-change="ReadOnlyToggle = !ReadOnlyToggle"
         >
-          {{ console.log(ReadOnlyToggle) }}
           {{ $t('notificationCenter.readOnly') }}
         </ion-toggle>
       </div>

--- a/client/src/views/settings/SettingsView.vue
+++ b/client/src/views/settings/SettingsView.vue
@@ -221,6 +221,7 @@ onUnmounted(async (): Promise<void> => {
     width: 100%;
     max-width: 11.25rem;
 
+    // eslint-disable-next-line vue-scoped-css/no-unused-selector
     &__item {
       color: var(--parsec-color-light-secondary-text);
       border-radius: 4px;

--- a/client/src/views/sidebar-menu/SidebarMenuPage.vue
+++ b/client/src/views/sidebar-menu/SidebarMenuPage.vue
@@ -529,6 +529,7 @@ async function openOrganizationChoice(event: Event): Promise<void> {
   }
 }
 
+// eslint-disable-next-line vue-scoped-css/no-unused-selector
 .list-md {
   background: none;
 }

--- a/client/src/views/users/MyContactDetailsPage.vue
+++ b/client/src/views/users/MyContactDetailsPage.vue
@@ -189,33 +189,33 @@ onMounted(async () => {
   }
 }
 
-.avatar {
-  // display: flex;
-  display: none;
-  flex-wrap: wrap;
-  margin-bottom: 1.5rem;
-  justify-content: space-between;
-  position: relative;
-  opacity: 0.5;
+// .avatar {
+//   // display: flex;
+//   display: none;
+//   flex-wrap: wrap;
+//   margin-bottom: 1.5rem;
+//   justify-content: space-between;
+//   position: relative;
+//   opacity: 0.5;
 
-  &-title {
-    flex-basis: 100%;
-  }
+//   &-title {
+//     flex-basis: 100%;
+//   }
 
-  &-image {
-    width: 200%;
-  }
+//   &-image {
+//     width: 200%;
+//   }
 
-  &-unavailable {
-    margin-left: auto;
-    position: absolute;
-    top: 40%;
-    right: 5%;
-  }
-}
+//   &-unavailable {
+//     margin-left: auto;
+//     position: absolute;
+//     top: 40%;
+//     right: 5%;
+//   }
+// }
 
-.password-change,
-.avatar {
+.password-change {
+  // .avatar {
   background-color: var(--parsec-color-light-secondary-background);
   border-radius: var(--parsec-radius-8);
   padding: 1.5em;

--- a/client/src/views/users/RevokedUsersPage.vue
+++ b/client/src/views/users/RevokedUsersPage.vue
@@ -341,13 +341,6 @@ onMounted(async (): Promise<void> => {
   overflow-y: auto;
 }
 
-.users-toolbar {
-  padding: 1em 2em;
-  height: 6em;
-  background-color: var(--parsec-color-light-secondary-background);
-  border-top: 1px solid var(--parsec-color-light-secondary-light);
-}
-
 .users-grid-item {
   --inner-padding-end: 0px;
   --inner-padding-start: 0px;


### PR DESCRIPTION
Clean a bit of code, mostly CSS, to remove eslint's warnings. In the case of unused CSS selectors, I've tried to be as careful as possible and either remove it if the warning was legitimate, or disable the warning if the rule was actually used.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
