### PR TITLE
[MS] Added a few application shortcuts

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -16,6 +16,10 @@ appendleft
 aqtbot
 aread
 armv
+arrowleft
+arrowup
+arrowdown
+arrowright
 arwx
 Asas
 asend

--- a/client/src/components/core/ms-input/MsPasswordInput.vue
+++ b/client/src/components/core/ms-input/MsPasswordInput.vue
@@ -21,6 +21,8 @@
             @keyup.enter="onEnterPress()"
             id="ms-password-input"
             :clear-on-edit="false"
+            @ion-focus="hasFocus = true"
+            @ion-blur="hasFocus = false"
           />
           <div
             class="input-icon"
@@ -38,11 +40,16 @@
 </template>
 
 <script setup lang="ts">
+import { Groups, HotkeyManager, HotkeyManagerKey, Hotkeys, Modifiers, Platforms } from '@/services/hotkeyManager';
 import { IonCol, IonGrid, IonIcon, IonInput, IonItem, IonRow, IonText } from '@ionic/vue';
 import { eye, eyeOff } from 'ionicons/icons';
-import { ref } from 'vue';
+import { inject, onMounted, onUnmounted, ref } from 'vue';
 
+const hotkeyManager: HotkeyManager = inject(HotkeyManagerKey)!;
 const inputRef = ref();
+let hotkeys: Hotkeys | null = null;
+const passwordVisible = ref(false);
+const hasFocus = ref(false);
 
 const props = defineProps<{
   label: string;
@@ -55,10 +62,24 @@ const emits = defineEmits<{
   (e: 'update:modelValue', value: string): void;
 }>();
 
-const passwordVisible = ref(false);
-
 defineExpose({
   setFocus,
+});
+
+onMounted(async () => {
+  hotkeys = hotkeyManager.newHotkeys(Groups.Unique);
+
+  hotkeys.add('/', Modifiers.Ctrl, Platforms.Desktop, async () => {
+    if (hasFocus.value) {
+      passwordVisible.value = !passwordVisible.value;
+    }
+  });
+});
+
+onUnmounted(async () => {
+  if (hotkeys) {
+    hotkeyManager.unregister(hotkeys);
+  }
 });
 
 function setFocus(): void {

--- a/client/src/components/files/FileGridDisplay.vue
+++ b/client/src/components/files/FileGridDisplay.vue
@@ -34,6 +34,26 @@
 import FileCard from '@/components/files/FileCard.vue';
 import FileCardImporting from '@/components/files/FileCardImporting.vue';
 import { EntryCollection, EntryModel, FileImportProgress, FileModel, FolderModel } from '@/components/files/types';
+import { Groups, HotkeyManager, HotkeyManagerKey, Hotkeys, Modifiers, Platforms } from '@/services/hotkeyManager';
+import { inject, onMounted, onUnmounted } from 'vue';
+
+const hotkeyManager: HotkeyManager = inject(HotkeyManagerKey)!;
+
+let hotkeys: Hotkeys | null = null;
+
+onMounted(async () => {
+  hotkeys = hotkeyManager.newHotkeys(Groups.Workspaces);
+  hotkeys.add('a', Modifiers.Ctrl, Platforms.Desktop | Platforms.Web, async () => {
+    props.files.selectAll(true);
+    props.folders.selectAll(true);
+  });
+});
+
+onUnmounted(async () => {
+  if (hotkeys) {
+    hotkeyManager.unregister(hotkeys);
+  }
+});
 
 const props = defineProps<{
   importing: Array<FileImportProgress>;

--- a/client/src/components/files/FileListDisplay.vue
+++ b/client/src/components/files/FileListDisplay.vue
@@ -12,7 +12,7 @@
             aria-label=""
             class="checkbox"
             @ion-change="selectAll($event.detail.checked)"
-            :value="allSelected"
+            :checked="allSelected"
             :indeterminate="someSelected && !allSelected"
           />
         </ion-label>
@@ -62,8 +62,13 @@
 import FileListItem from '@/components/files/FileListItem.vue';
 import FileListItemImporting from '@/components/files/FileListItemImporting.vue';
 import { EntryCollection, EntryModel, FileImportProgress, FileModel, FolderModel } from '@/components/files/types';
+import { Groups, HotkeyManager, HotkeyManagerKey, Hotkeys, Modifiers, Platforms } from '@/services/hotkeyManager';
 import { IonCheckbox, IonLabel, IonList, IonListHeader } from '@ionic/vue';
-import { computed, ref } from 'vue';
+import { computed, inject, onMounted, onUnmounted, ref } from 'vue';
+
+const hotkeyManager: HotkeyManager = inject(HotkeyManagerKey)!;
+
+let hotkeys: Hotkeys | null = null;
 
 const props = defineProps<{
   importing: Array<FileImportProgress>;
@@ -77,6 +82,17 @@ defineEmits<{
 }>();
 
 const selectedCount = ref(0);
+
+onMounted(async () => {
+  hotkeys = hotkeyManager.newHotkeys(Groups.Workspaces);
+  hotkeys.add('a', Modifiers.Ctrl, Platforms.Desktop | Platforms.Web, async () => await selectAll(true));
+});
+
+onUnmounted(async () => {
+  if (hotkeys) {
+    hotkeyManager.unregister(hotkeys);
+  }
+});
 
 const allSelected = computed(() => {
   return selectedCount.value === props.files.getEntries().length + props.folders.getEntries().length;

--- a/client/src/services/hotkeyManager.ts
+++ b/client/src/services/hotkeyManager.ts
@@ -151,6 +151,9 @@ export class HotkeyManager {
     if (['control', 'shift', 'alt'].includes(event.key.toLowerCase())) {
       return;
     }
+    if (event.repeat) {
+      return;
+    }
 
     if (!isDesktop() && !isWeb()) {
       return;
@@ -174,7 +177,7 @@ export class HotkeyManager {
   }
 
   private doModifiersMatch(event: KeyboardEvent, modifiers: number): boolean {
-    const ctrlKey = isMacOS() ? event.metaKey : isDesktop() ? event.ctrlKey : event.ctrlKey || event.metaKey;
+    const ctrlKey = event.ctrlKey || (isMacOS() && event.metaKey) || (isWeb() && event.metaKey);
     let eventMods = 0;
     eventMods |= ctrlKey ? Modifiers.Ctrl : Modifiers.None;
     eventMods |= event.altKey ? Modifiers.Alt : Modifiers.None;

--- a/client/tests/component/specs/testMsChoosePasswordInput.spec.ts
+++ b/client/tests/component/specs/testMsChoosePasswordInput.spec.ts
@@ -2,13 +2,18 @@
 
 import MsChoosePasswordInput from '@/components/core/ms-input/MsChoosePasswordInput.vue';
 import { IonInput } from '@ionic/vue';
+import { getDefaultProvideConfig } from '@tests/component/support/mocks';
 import { VueWrapper, mount } from '@vue/test-utils';
 
 describe('Choose password', () => {
   let wrapper: VueWrapper<any>;
 
   beforeEach(() => {
-    wrapper = mount(MsChoosePasswordInput, {});
+    wrapper = mount(MsChoosePasswordInput, {
+      global: {
+        provide: getDefaultProvideConfig(),
+      },
+    });
   });
 
   it('Validate the fields', async () => {

--- a/client/tests/component/specs/testPasswordInput.spec.ts
+++ b/client/tests/component/specs/testPasswordInput.spec.ts
@@ -2,6 +2,7 @@
 
 import MsPasswordInput from '@/components/core/ms-input/MsPasswordInput.vue';
 import { IonInput } from '@ionic/vue';
+import { getDefaultProvideConfig } from '@tests/component/support/mocks';
 import { VueWrapper, mount } from '@vue/test-utils';
 
 describe('Password Input', () => {
@@ -11,6 +12,9 @@ describe('Password Input', () => {
       props: {
         label: 'A Label',
         modelValue: '',
+      },
+      global: {
+        provide: getDefaultProvideConfig(),
       },
     });
   });

--- a/client/tests/component/support/mocks.ts
+++ b/client/tests/component/support/mocks.ts
@@ -1,5 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
+import { HotkeyManagerKey } from '@/services/hotkeyManager';
 import { InformationKey } from '@/services/informationManager';
 import { translate } from '@/services/translation';
 import { config } from '@vue/test-utils';
@@ -9,11 +10,29 @@ async function mockShowToast(_notif: Notification): Promise<void> {
   // Do nothing
 }
 
+class MockHotKeys {
+  add(_key: string, _modifiers: number, _platforms: number, _callback: () => Promise<void>): void {}
+}
+
+function mockNewHotKeys(_group: number): MockHotKeys {
+  return new MockHotKeys();
+}
+
+function mockUnregister(_hotkeys: MockHotKeys): void {}
+
+function mockGroupEnableDisable(_group: number): void {}
+
 function getDefaultProvideConfig(showToast = mockShowToast): any {
   const provide: any = {};
 
   provide[InformationKey] = {
     showToast: showToast,
+  };
+  provide[HotkeyManagerKey] = {
+    newHotkeys: mockNewHotKeys,
+    unregister: mockUnregister,
+    disableGroup: mockGroupEnableDisable,
+    enableGroup: mockGroupEnableDisable,
   };
 
   return provide;


### PR DESCRIPTION
A piece of #6183 

Search for the device list, settings, go back, display/hide password, new workspace, import files,  switch list/grid for workspaces and files, display notification center, select all files, delete/show info/rename file, ...

A few things to note:
1. I'm not completely satisfied with how shortcuts can be turned off/on
2. For testing purposes, I'm adding the `web` platforms automatically to all shortcuts if `needsMock` returns true
3. Haven't done the user page since it's meant to change
4. It fixes a bug with the files list display checkbox

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
