### PR TITLE
Rfc nightly build

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -379,6 +379,7 @@ napi
 newsfragment
 newsfragments
 nextest
+nigthly
 Niño
 nlookup
 nmspc

--- a/docs/rfcs/0000-how-to-write-rfcs.md
+++ b/docs/rfcs/0000-how-to-write-rfcs.md
@@ -2,31 +2,30 @@
 
 # How to write RFCs
 
-This document indicate the `do` & `don't` when writing an RFC file.
+This document indicates the `do` & `don't` when writing an RFC file.
 
-- [How to write RFCs](#how-to-write-rfcs)
-  - [How to name the rfc file](#how-to-name-the-rfc-file)
-  - [How to write markdown](#how-to-write-markdown)
-  - [Link a RFC in another RFC](#link-a-rfc-in-another-rfc)
-  - [Link a github issue or pull request](#link-a-github-issue-or-pull-request)
-  - [Suggested vscode extensions](#suggested-vscode-extensions)
+- [How to name the RFC file](#how-to-name-the-rfc-file)
+- [How to write markdown](#how-to-write-markdown)
+- [Link an RFC in another RFC](#link-an-rfc-in-another-rfc)
+- [Link a GitHub issue or pull request](#link-a-github-issue-or-pull-request)
+- [Suggested vscode extensions](#suggested-vscode-extensions)
 
-## How to name the rfc file
+## How to name the RFC file
 
 We use a specific filename format for RFC files: `<id:04d>-<title:s>.md`
 
-- Where `id` is a serial number, it should be greater than the previous ids used
-  > If the greater previous id used is `42` the next id should be `43`.
+- Where `id` is a serial number, it should be greater than the previous IDs used
+  > If the greater previous ID used is `42` the next ID should be `43`.
 - Where `title` should be the title used in the document
   - The title could change a little
   - Use the `kebab-case`
-  - only use alpha numeric character `[0-9a-zA-Z]`
+  - only use alphanumeric character `[0-9a-zA-Z]`
 
 ## How to write markdown
 
-If you never written `markdown`, take a look at <https://www.markdownguide.org/basic-syntax/>
+If you have never written `markdown`, take a look at <https://www.markdownguide.org/basic-syntax/>
 
-## Link a RFC in another RFC
+## Link an RFC in another RFC
 
 To link another RFC in another RFC
 
@@ -34,9 +33,9 @@ To link another RFC in another RFC
 [RFC-NNNN](<RFC-FILENAME>)
 ```
 
-> Where `<RFC-FILENAME>` is the filename of the linked rfc, relative to the rfc.
+> Where `<RFC-FILENAME>` is the filename of the linked RFC, relative to the RFC.
 
-## Link a github issue or pull request
+## Link a GitHub issue or pull request
 
 If you want to link an issue or a pull request in the RFC use the following format:
 
@@ -54,8 +53,8 @@ If you want to link an issue or a pull request in the RFC use the following form
 
 ## Suggested vscode extensions
 
-I recommend using these vscode extensions:
+I recommend using these VS-Code extensions:
 
-- `yzhang.markdown-all-in-one`: Provide completion, some shortcut & command to simplify writing markdown.
+- `yzhang.markdown-all-in-one`: Provide completion, some shortcut & command to simplify writing Markdown.
 - `DavidAnson.vscode-markdownlint`: Add a markdown linter to provide a base style when writing markdown file.
 - `bierner.markdown-footnotes`: Allow to render the `footnotes` on the preview.

--- a/docs/rfcs/1008-nightly-build.md
+++ b/docs/rfcs/1008-nightly-build.md
@@ -1,0 +1,160 @@
+<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+
+# Nightly build
+
+This RFC proposes adding nightly builds to Parsec.
+
+- [Goals](#goals)
+- [What we already have](#what-we-already-have)
+- [What is missing](#what-is-missing)
+  - [For the client part](#for-the-client-part)
+    - [Missing version argument in the workflow `package-ionic-app.yml`](#missing-version-argument-in-the-workflow-package-ionic-appyml)
+    - [Include the client part in the releaser workflow](#include-the-client-part-in-the-releaser-workflow)
+  - [Overwriting nightly release \& automatic release](#overwriting-nightly-release--automatic-release)
+  - [Snapcraft channel with tracks](#snapcraft-channel-with-tracks)
+  - [Schedule the workflow](#schedule-the-workflow)
+  - [Slack notification (optional)](#slack-notification-optional)
+  - [Improve the unique dev format](#improve-the-unique-dev-format)
+- [F.A.Q](#faq)
+  - [Why do we need to release the nightly build? Or why we can't directly use the artifact link of a workflow?](#why-do-we-need-to-release-the-nightly-build-or-why-we-cant-directly-use-the-artifact-link-of-a-workflow)
+  - [Why do we use the `dev` identifier for a nightly build ?](#why-do-we-use-the-dev-identifier-for-a-nightly-build-)
+
+## Goals
+
+- Periodically test the release pipeline.
+- Have a recent build software at the ready (client and server).
+
+## What we already have
+
+We already have a workflow to create a release and build its artifacts[^releaser-workflow]. It is triggered by pushing a tag with the format `v[0-9]+.[0-9]+.[0-9]+*`.
+
+Currently, the workflow builds the server's Python wheel for Linux, Windows & macOS.
+
+[^releaser-workflow]: https://github.com/Scille/parsec-cloud/blob/05e4deba964c6b68b6fcbca4d458c235c43f6cff/.github/workflows/releaser.yml
+
+The script `releaser.py` can generate unique version that can be used for versioning and tagging nightly build.
+
+## What is missing
+
+### Client packaging
+
+The following changes are required for the [`package-ionic-app.yml`] workflow:
+
+- it needs to take a version argument (like [`package-server.yml`]).
+- it needs to be added to the [`releaser.yml`] workflow.
+
+[`package-server.yml`]: https://github.com/Scille/parsec-cloud/blob/05e4deba964c6b68b6fcbca4d458c235c43f6cff/.github/workflows/package-server.yml
+[`package-ionic-app.yml`]: https://github.com/Scille/parsec-cloud/blob/05e4deba964c6b68b6fcbca4d458c235c43f6cff/.github/workflows/package-server.yml
+[`releaser.yml`]: https://github.com/Scille/parsec-cloud/blob/05e4deba964c6b68b6fcbca4d458c235c43f6cff/.github/workflows/releaser.yml
+
+### Overwriting nightly release & automatic release
+
+The [`releaser.yml`] workflow creates a [GitHub release] in draft mode. Creating a `draft-release` for _every_ nightly build (everyday so) is problematic because we might be overwhelmed by the number of draft releases.
+
+We could [override the assets] of the previous nightly release (instead of recreating a new one). The problem with this approach is that GitHub sort the releases by creation date: nightly release will be put behind newer releases.
+
+So the idea is to _remove_ the previous nigthly release and recreate a new one. In order to do so, the API to [delete a release] requires a `release_id`.
+
+[override the assets]: https://stackoverflow.com/questions/62934246/github-update-overwrite-existing-asset-of-a-release
+[GitHub release]: https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases
+
+[delete a release]: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#delete-a-release
+
+The `release_id` could be obtained by [getting a release using its tag name] but a `draft-release` isn't identified by a tag name (the more you know).
+
+[getting a release using its tag name]: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-a-release-by-tag-name
+
+Another possibility is to [list all releases] to find the one to be removed. This would allow to update the workflow in order to directly create the release (see [Why do we need to release the nightly build?](#why-do-we-need-to-release-the-nightly-build-or-why-we-cant-directly-use-the-artifact-link-of-a-workflow)).
+
+[list all releases]: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases
+
+### Snapcraft channel with tracks
+
+Currently we only use the `stable` & `edge` from the default `latest` track. We could introduce a new [track] in order to include nightly builds, for example:
+
+- `latest`: We already have this one since it's the default track (when no track is specified)
+- `v{MAJOR}`: A track per major version (in the case we need to maintain multiple version at the same time)
+- `nightly`: A track for the nightly builds
+
+  > The name `nightly` (Firefox style) was chosen by the parsec-dev team based on a poll. Alternatives that were considered:
+  > - `canary` (Chrome style)
+  > - `insider` (VS-Code style)
+
+[track]: https://snapcraft.io/docs/channels#heading--tracks
+
+That would translate to the following usage:
+
+```shell
+snap install parsec # This will use `latest/stable`
+snap install parsec --channel=latest # will use `latest/stable`
+snap install parsec --channel=latest/beta # will use `latest/beta`
+snap install parsec --channel=v3 # will use `v3/stable`
+snap install parsec --channel=nightly # will use `nightly/stable`
+```
+
+We could simply put the versions that contain a `dev` part into the `insider` track.
+
+### Schedule the workflow
+
+
+We need to have a workflow that schedule the nightly build at a specific interval (every day at 22H30 for example).
+GitHub already allow to [trigger a workflow on a schedule].
+
+[trigger a workflow on a schedule]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+
+> [!CAUTION]
+> Event triggered by a GitHub actions don't trigger a workflow. So everything should be done in a single workflow.
+
+### Slack notification (optional)
+
+We could send a Slack notification when a nightly build finished (successfully or not)
+With the link to download the generated build.
+
+Slack provide GitHub action for that: <https://github.com/slackapi/slack-github-action>
+
+### Fix the unique dev format
+
+Currently, `releaser.py` generates a dev version by appending the `dev` part at the end of the current version before the local part.
+
+The dev part is formatted `dev.{number}` where `{number}` is calculated with the following formula:
+
+$f(year, month, day) = year * 366 + month * 31 + day$
+
+The constant $366$ is wrong, the value $372$ ($12 * 31 = 372$) should have been used instead.
+
+For the date `2024-02-27 15:50:28+01:00` that gives `dev.740873`:
+
+$$f(2024, 2, 27) = 2024 * 366 + 2 * 31 + 27$$
+$$f(2024, 2, 27) = 740873$$
+
+Considering the previous example date, the formula could be changed to:
+
+- A _timestamp_: `dev.1709045428`
+- A _timestamp_ without the time info ($floor(timestamp / 24 * 3600)$) : `dev.19780`
+- The current formula with fixed value ($year * 372 + month * 31 + day$): `dev.753017`
+- A date format (`dev.YYYYMMDD`): `dev.20240227`
+
+## F.A.Q
+
+### Why do we need to release the nightly build? Or why we can't directly use the artifact link of a workflow?
+
+When a workflow generate artifacts, those artifacts could be directly downloaded from the workflow summary.
+
+But that has some limitations:
+
+- Those artifacts expire after a configured period (default to 90days).
+- The artifacts are wrapped in a zip file, so you need to extract them before using them.
+- You could not easily know if the workflow summary you're using is the latest available.
+- The artifacts may contain data that is not useful for you.
+
+### Why do we use the `dev` identifier for a nightly build ?
+
+We need to have a version that is compatible with [semver] and [pep440], that indicate that it's a nightly build.
+
+On [semver], we could use any verb like `nightly`, so the choice come from [pep440].
+
+Pep440 only allows the verb `dev` at the end of the version before the local identifiers ([Specify a development release in pep440])
+
+[semver]: https://semver.org/
+[pep440]: https://peps.python.org/pep-0440/
+[Specify a development release in pep440]: https://peps.python.org/pep-0440/#developmental-releases


### PR DESCRIPTION
## Describe your changes

Add RFC to discuss then implement nightly build into parsec.

The rendered file can be viewed here: <https://github.com/Scille/parsec-cloud/blob/rfc-nightly-build/docs/rfcs/1008-nightly-build.md>

The way it's written allows to implement it in part independently

Related to #6546