### PR TITLE
[fix #6589]: Change the default track for the snap to `nightly/stable`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload Snap
         if: false
-        run: snapcraft upload --release=edge snap/parsec_v${{ steps.version.outputs.full }}_*.snap
+        run: snapcraft upload --release=nightly/stable snap/parsec_v${{ steps.version.outputs.full }}_*.snap
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_CREDENTIALS }}
         timeout-minutes: 2


### PR DESCRIPTION
I directly push to `stable` for the nightly track because we wont a validation process for those versions.