### PR TITLE
[MS] Added deeplinking for parsec3 protocol

### DIFF
--- a/client/electron/capacitor.config.ts
+++ b/client/electron/capacitor.config.ts
@@ -19,6 +19,8 @@ const config: CapacitorElectronConfig = {
   electron: {
     trayIconAndMenuEnabled: true,
     splashScreenEnabled: true,
+    deepLinkingEnabled: true,
+    deepLinkingCustomProtocol: 'parsec3',
   },
 };
 

--- a/client/electron/src/index.ts
+++ b/client/electron/src/index.ts
@@ -29,7 +29,7 @@ const myCapacitorApp = new ElectronCapacitorApp(capacitorFileConfig, appMenuBarM
 // If deep linking is enabled then we will set it up here.
 if (capacitorFileConfig.electron?.deepLinkingEnabled) {
   setupElectronDeepLinking(myCapacitorApp, {
-    customProtocol: capacitorFileConfig.electron.deepLinkingCustomProtocol ?? 'mycapacitorapp',
+    customProtocol: capacitorFileConfig.electron.deepLinkingCustomProtocol ?? 'parsec3',
   });
 }
 
@@ -65,7 +65,7 @@ if (!lock) {
     if (commandLine.length > 0) {
       const lastArg = commandLine.at(-1);
       // We're only interested in potential Parsec links
-      if (lastArg.startsWith('parsec://')) {
+      if (lastArg.startsWith('parsec3://')) {
         myCapacitorApp.getMainWindow().webContents.send('open-link', lastArg);
       }
     }


### PR DESCRIPTION
Closes #6536 

Capacitor-community/electron handles this natively (https://capacitor-community.github.io/electron/docs/deeplinking) so it wasn't too hard. The link is passed as an argument, and links as arguments are already handled.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
 