### PR TITLE
[MS] Fixed bugs for file FileListDisplay

### DIFF
--- a/client/src/components/files/FileListDisplay.vue
+++ b/client/src/components/files/FileListDisplay.vue
@@ -64,7 +64,7 @@ import FileListItemImporting from '@/components/files/FileListItemImporting.vue'
 import { EntryCollection, EntryModel, FileImportProgress, FileModel, FolderModel } from '@/components/files/types';
 import { Groups, HotkeyManager, HotkeyManagerKey, Hotkeys, Modifiers, Platforms } from '@/services/hotkeyManager';
 import { IonCheckbox, IonLabel, IonList, IonListHeader } from '@ionic/vue';
-import { computed, inject, onMounted, onUnmounted, ref } from 'vue';
+import { computed, inject, onMounted, onUnmounted } from 'vue';
 
 const hotkeyManager: HotkeyManager = inject(HotkeyManagerKey)!;
 
@@ -81,8 +81,6 @@ defineEmits<{
   (e: 'menuClick', event: Event, entry: EntryModel, onFinished: () => void): void;
 }>();
 
-const selectedCount = ref(0);
-
 onMounted(async () => {
   hotkeys = hotkeyManager.newHotkeys(Groups.Workspaces);
   hotkeys.add('a', Modifiers.Ctrl, Platforms.Desktop | Platforms.Web, async () => await selectAll(true));
@@ -95,25 +93,19 @@ onUnmounted(async () => {
 });
 
 const allSelected = computed(() => {
-  return selectedCount.value === props.files.getEntries().length + props.folders.getEntries().length;
+  const selectedCount = props.files.selectedCount() + props.folders.selectedCount();
+  return selectedCount > 0 && selectedCount === props.files.entriesCount() + props.folders.entriesCount();
 });
 
 const someSelected = computed(() => {
-  return selectedCount.value > 0;
+  return props.files.selectedCount() + props.folders.selectedCount() > 0;
 });
 
-async function onSelectedChange(_entry: EntryModel, _checked: boolean): Promise<void> {
-  selectedCount.value = props.files.getSelectedEntries().length + props.folders.getSelectedEntries().length;
-}
+async function onSelectedChange(_entry: EntryModel, _checked: boolean): Promise<void> {}
 
 async function selectAll(selected: boolean): Promise<void> {
   props.files.selectAll(selected);
   props.folders.selectAll(selected);
-  if (selected) {
-    selectedCount.value = props.files.getEntries().length + props.folders.getEntries().length;
-  } else {
-    selectedCount.value = 0;
-  }
 }
 </script>
 

--- a/client/src/parsec/file.ts
+++ b/client/src/parsec/file.ts
@@ -92,8 +92,8 @@ export async function entryStat(path: FsPath): Promise<Result<EntryStat, Workspa
   }
 
   function generateChildren(): Array<[string, string]> {
-    const fileCount = Math.floor(Math.random() * 15) + 1;
-    const folderCount = Math.floor(Math.random() * 15) + 1;
+    const fileCount = Math.floor(Math.random() * 1) + 2;
+    const folderCount = Math.floor(Math.random() * 1) + 2;
 
     const result: Array<[string, string]> = [];
     for (let i = 0; i < fileCount + folderCount; i++) {

--- a/client/src/views/files/FileContextMenu.vue
+++ b/client/src/views/files/FileContextMenu.vue
@@ -58,6 +58,7 @@
 
         <ion-item
           button
+          v-show="isDesktop()"
           @click="onClick(FileAction.Open)"
           class="ion-no-padding list-group-item"
         >
@@ -69,6 +70,7 @@
 
         <ion-item
           button
+          v-show="false"
           @click="onClick(FileAction.ShowHistory)"
           class="ion-no-padding list-group-item"
         >

--- a/client/src/views/header/HeaderPage.vue
+++ b/client/src/views/header/HeaderPage.vue
@@ -212,7 +212,7 @@ async function updateRoute(): Promise<void> {
       id: 1,
       display: workspaceName.value,
       name: Routes.Documents,
-      query: { documentPath: '/' },
+      query: { documentPath: '/', workspaceId: workspaceId },
       params: getCurrentRouteParams(),
     });
     for (let i = 0; i < workspacePath.length; i++) {
@@ -221,7 +221,7 @@ async function updateRoute(): Promise<void> {
         id: i + 2,
         display: workspacePath[i],
         name: Routes.Documents,
-        query: { documentPath: `/${rebuildPath.join('/')}` },
+        query: { documentPath: `/${rebuildPath.join('/')}`, workspaceId: workspaceId },
         params: getCurrentRouteParams(),
       });
     }

--- a/client/tests/e2e/specs/test_folders_page.ts
+++ b/client/tests/e2e/specs/test_folders_page.ts
@@ -173,7 +173,7 @@ describe('Check folders page', () => {
   });
 
   it('Tests delete multiple files', () => {
-    cy.get('.folder-list-header').find('ion-checkbox').invoke('show').click();
+    cy.get('.folder-list-header').find('ion-checkbox').click();
     cy.get('#button-delete').contains('Delete').click();
     cy.get('.question-modal').find('.ms-modal-header__title').contains('Delete multiple items');
     cy.get('.question-modal')


### PR DESCRIPTION
1. incorrect selection being kept when changing folder
2. missing workspaceId when using the breadcrumb, resulting in incorrect workspace role
3. removed unused file actions
4. lowered the amount of files and folders to avoid overflowing on cy

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes

