### PR TITLE
[MS] Fix an error that can happen when selecting a file

### DIFF
--- a/client/src/components/files/FileCard.vue
+++ b/client/src/components/files/FileCard.vue
@@ -11,7 +11,7 @@
     <div class="card-checkbox">
       <!-- eslint-disable vue/no-mutating-props -->
       <ion-checkbox
-        aria-label=""
+        aria-label="''"
         class="checkbox"
         v-model="entry.isSelected"
         v-show="entry.isSelected || isHovered || showCheckbox"

--- a/client/src/components/files/FileListItem.vue
+++ b/client/src/components/files/FileListItem.vue
@@ -14,7 +14,7 @@
       <div class="file-selected">
         <!-- eslint-disable vue/no-mutating-props -->
         <ion-checkbox
-          aria-label=""
+          aria-label="''"
           class="checkbox"
           v-model="entry.isSelected"
           v-show="entry.isSelected || isHovered || showCheckbox"


### PR DESCRIPTION
Small bug that can happen when selecting a file where the checkbox goes into legacy mode because the label was not properly set.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
