### PR TITLE
[MS] Updated how workspace navigation is done

### DIFF
--- a/client/src/components/core/ms-modal/FolderSelectionModal.vue
+++ b/client/src/components/core/ms-modal/FolderSelectionModal.vue
@@ -78,7 +78,7 @@ import { Folder, MsImage } from '@/components/core/ms-image';
 import MsModal from '@/components/core/ms-modal/MsModal.vue';
 import { FolderSelectionOptions, MsModalResult } from '@/components/core/ms-modal/types';
 import HeaderBreadcrumbs, { RouterPathNode } from '@/components/header/HeaderBreadcrumbs.vue';
-import { EntryStat, EntryStatFolder, FsPath, Path, entryStat, getWorkspaceName } from '@/parsec';
+import { EntryStat, EntryStatFolder, FsPath, Path, StartedWorkspaceInfo, entryStat, getWorkspaceInfo } from '@/parsec';
 import { getWorkspaceHandle } from '@/router';
 import { IonButton, IonButtons, IonIcon, IonItem, IonLabel, IonList, modalController } from '@ionic/vue';
 import { chevronBack, chevronForward } from 'ionicons/icons';
@@ -88,15 +88,14 @@ const props = defineProps<FolderSelectionOptions>();
 const selectedPath: Ref<FsPath> = ref(props.startingPath);
 const headerPath: Ref<RouterPathNode[]> = ref([]);
 const currentEntries: Ref<EntryStat[]> = ref([]);
-let workspaceName = '';
+const workspaceInfo: Ref<StartedWorkspaceInfo | null> = ref(null);
 const backStack: FsPath[] = [];
 const forwardStack: FsPath[] = [];
 
 onMounted(async () => {
-  // get workspace name only once
-  const result = await getWorkspaceName(props.workspaceId);
+  const result = await getWorkspaceInfo(props.workspaceHandle);
   if (result.ok) {
-    workspaceName = result.value;
+    workspaceInfo.value = result.value;
   }
   await update();
 });
@@ -125,7 +124,7 @@ async function update(): Promise<void> {
   headerPath.value = [];
   headerPath.value.push({
     id: 0,
-    display: workspaceName,
+    display: workspaceInfo.value ? workspaceInfo.value.currentName : '',
     name: '',
     query: { documentPath: path },
   });

--- a/client/src/components/core/ms-modal/types.ts
+++ b/client/src/components/core/ms-modal/types.ts
@@ -2,8 +2,7 @@
 
 import { IValidator } from '@/common/validators';
 import { MsReportTheme } from '@/components/core/ms-types';
-import { FsPath } from '@/parsec';
-import { WorkspaceID } from '@/parsec/types';
+import { FsPath, WorkspaceHandle } from '@/parsec';
 
 export enum Answer {
   No = 0,
@@ -14,7 +13,7 @@ export interface FolderSelectionOptions {
   title: string;
   subtitle?: string;
   startingPath: FsPath;
-  workspaceId: WorkspaceID;
+  workspaceHandle: WorkspaceHandle;
 }
 
 export interface GetTextOptions {

--- a/client/src/components/files/FileUploadItem.vue
+++ b/client/src/components/files/FileUploadItem.vue
@@ -31,9 +31,9 @@
           <span class="default-state">{{ formatFileSize(fileCache.size) }}</span>
           <span
             class="default-state"
-            v-show="workspaceName !== ''"
+            v-if="workspaceInfo"
           >
-            &bull; {{ workspaceName }}
+            &bull; {{ workspaceInfo.currentName }}
           </span>
           <span
             class="hover-state"
@@ -128,11 +128,11 @@
 import { formatFileSize, getFileIcon, shortenFileName } from '@/common/file';
 import { MsImage } from '@/components/core/ms-image';
 import MsInformationTooltip from '@/components/core/ms-tooltip/MsInformationTooltip.vue';
-import { getWorkspaceName } from '@/parsec';
+import { StartedWorkspaceInfo, getWorkspaceInfo } from '@/parsec';
 import { ImportData, ImportState } from '@/services/importManager';
 import { IonButton, IonIcon, IonItem, IonLabel, IonProgressBar, IonText } from '@ionic/vue';
 import { arrowForward, checkmark, close } from 'ionicons/icons';
-import { onMounted, ref } from 'vue';
+import { Ref, onMounted, ref } from 'vue';
 
 const props = defineProps<{
   importData: ImportData;
@@ -144,16 +144,16 @@ const props = defineProps<{
 // will never change, so we cache them.
 const fileCache = structuredClone(props.importData.file);
 
-const workspaceName = ref('');
+const workspaceInfo: Ref<StartedWorkspaceInfo | null> = ref(null);
 
 defineExpose({
   props,
 });
 
 onMounted(async () => {
-  const result = await getWorkspaceName(props.importData.workspaceId);
+  const result = await getWorkspaceInfo(props.importData.workspaceHandle);
   if (result.ok) {
-    workspaceName.value = result.value;
+    workspaceInfo.value = result.value;
   }
 });
 

--- a/client/src/components/notifications/MultipleUsersJoinWorkspaceNotification.vue
+++ b/client/src/components/notifications/MultipleUsersJoinWorkspaceNotification.vue
@@ -18,7 +18,7 @@
             <strong> {{ notificationData.roles.length }} {{ $t('notification.users') }} </strong>
           </template>
           <template #workspace>
-            <strong>{{ workspaceName }}</strong>
+            <strong>{{ workspaceInfo ? workspaceInfo.currentName : '' }}</strong>
           </template>
         </i18n-t>
       </ion-text>
@@ -39,22 +39,23 @@
 import { formatTimeSince } from '@/common/date';
 import MultipleUsersJoinPopover from '@/components/notifications/MultipleUsersJoinPopover.vue';
 import NotificationItem from '@/components/notifications/NotificationItem.vue';
-import { getWorkspaceName } from '@/parsec';
+import { getWorkspaceInfo, StartedWorkspaceInfo } from '@/parsec';
 import { MultipleUsersJoinWorkspaceData } from '@/services/informationManager';
 import { Notification } from '@/services/notificationManager';
 import { IonIcon, IonText, popoverController } from '@ionic/vue';
 import { people } from 'ionicons/icons';
-import { onMounted, ref } from 'vue';
+import { onMounted, ref, Ref } from 'vue';
 
-const workspaceName = ref('');
+const workspaceInfo: Ref<StartedWorkspaceInfo | null> = ref(null);
+
 const props = defineProps<{
   notification: Notification;
 }>();
 
 onMounted(async () => {
-  const result = await getWorkspaceName(notificationData.workspaceId);
+  const result = await getWorkspaceInfo(notificationData.workspaceHandle);
   if (result.ok) {
-    workspaceName.value = result.value;
+    workspaceInfo.value = result.value;
   }
 });
 

--- a/client/src/components/notifications/UserJoinWorkspaceNotification.vue
+++ b/client/src/components/notifications/UserJoinWorkspaceNotification.vue
@@ -16,7 +16,7 @@
             <strong>{{ userInfo ? userInfo.humanHandle.label : '' }}</strong>
           </template>
           <template #workspace>
-            <strong>{{ workspaceName }}</strong>
+            <strong>{{ workspaceInfo ? workspaceInfo.currentName : '' }}</strong>
           </template>
         </i18n-t>
       </ion-text>
@@ -31,24 +31,25 @@
 import { formatTimeSince } from '@/common/date';
 import NotificationItem from '@/components/notifications/NotificationItem.vue';
 import UserAvatarName from '@/components/users/UserAvatarName.vue';
-import { UserInfo, getUserInfo, getWorkspaceName } from '@/parsec';
+import { StartedWorkspaceInfo, UserInfo, getUserInfo, getWorkspaceInfo } from '@/parsec';
 import { UserJoinWorkspaceData } from '@/services/informationManager';
 import { Notification } from '@/services/notificationManager';
 import { IonText } from '@ionic/vue';
 import { Ref, onMounted, ref } from 'vue';
 
 const userInfo: Ref<UserInfo | null> = ref(null);
-const workspaceName = ref('');
+const workspaceInfo: Ref<StartedWorkspaceInfo | null> = ref(null);
+
 const props = defineProps<{
   notification: Notification;
 }>();
 
 onMounted(async () => {
-  const resultWorkspace = await getWorkspaceName(notificationData.workspaceId);
+  const resultWorkspace = await getWorkspaceInfo(notificationData.workspaceHandle);
   const resultUser = await getUserInfo(notificationData.userId);
 
   if (resultWorkspace.ok) {
-    workspaceName.value = resultWorkspace.value;
+    workspaceInfo.value = resultWorkspace.value;
   }
 
   if (resultUser.ok) {

--- a/client/src/components/notifications/UserSharedDocumentNotification.vue
+++ b/client/src/components/notifications/UserSharedDocumentNotification.vue
@@ -55,7 +55,7 @@ import { formatFileSize, getFileIcon } from '@/common/file';
 import { Folder, MsImage } from '@/components/core/ms-image';
 import NotificationItem from '@/components/notifications/NotificationItem.vue';
 import UserAvatarName from '@/components/users/UserAvatarName.vue';
-import { UserInfo, getUserInfo, getWorkspaceName } from '@/parsec';
+import { StartedWorkspaceInfo, UserInfo, getUserInfo, getWorkspaceInfo } from '@/parsec';
 import { navigateToWorkspace } from '@/router';
 import { UserSharedDocumentData } from '@/services/informationManager';
 import { Notification } from '@/services/notificationManager';
@@ -63,17 +63,18 @@ import { IonText, popoverController } from '@ionic/vue';
 import { Ref, onMounted, ref } from 'vue';
 
 const userInfo: Ref<UserInfo | null> = ref(null);
-const workspaceName = ref('');
+const workspaceInfo: Ref<StartedWorkspaceInfo | null> = ref(null);
+
 const props = defineProps<{
   notification: Notification;
 }>();
 
 onMounted(async () => {
-  const resultWorkspace = await getWorkspaceName(notificationData.workspaceId);
+  const resultWorkspace = await getWorkspaceInfo(notificationData.workspaceHandle);
   const resultUser = await getUserInfo(notificationData.userId);
 
   if (resultWorkspace.ok) {
-    workspaceName.value = resultWorkspace.value;
+    workspaceInfo.value = resultWorkspace.value;
   }
 
   if (resultUser.ok) {
@@ -83,7 +84,7 @@ onMounted(async () => {
 
 async function goToEnclosingFolder(): Promise<void> {
   await popoverController.dismiss();
-  await navigateToWorkspace(notificationData.workspaceId, notificationData.filePath);
+  await navigateToWorkspace(notificationData.workspaceHandle, notificationData.filePath);
 }
 
 const notificationData = props.notification.getData<UserSharedDocumentData>();

--- a/client/src/components/notifications/WorkspaceAccessNotification.vue
+++ b/client/src/components/notifications/WorkspaceAccessNotification.vue
@@ -15,7 +15,7 @@
           scope="global"
         >
           <template #workspace>
-            <strong>{{ workspaceName }}</strong>
+            <strong>{{ workspaceInfo ? workspaceInfo.currentName : '' }}</strong>
           </template>
         </i18n-t>
       </ion-text>
@@ -39,30 +39,31 @@
 <script setup lang="ts">
 import { formatTimeSince } from '@/common/date';
 import NotificationItem from '@/components/notifications/NotificationItem.vue';
-import { getWorkspaceName } from '@/parsec';
+import { getWorkspaceInfo, StartedWorkspaceInfo } from '@/parsec';
 import { currentRouteIsWorkspaceRoute, navigateToWorkspace } from '@/router';
 import { NewWorkspaceAccessData } from '@/services/informationManager';
 import { Notification } from '@/services/notificationManager';
 import { IonIcon, IonText, popoverController } from '@ionic/vue';
 import { arrowForward, business } from 'ionicons/icons';
-import { onMounted, ref } from 'vue';
+import { onMounted, ref, Ref } from 'vue';
 
-const workspaceName = ref('');
+const workspaceInfo: Ref<StartedWorkspaceInfo | null> = ref(null);
+
 const props = defineProps<{
   notification: Notification;
 }>();
 
 onMounted(async () => {
-  const result = await getWorkspaceName(notificationData.workspaceId);
+  const result = await getWorkspaceInfo(notificationData.workspaceHandle);
   if (result.ok) {
-    workspaceName.value = result.value;
+    workspaceInfo.value = result.value;
   }
 });
 
 async function navigateToNewWorkspace(): Promise<void> {
   await popoverController.dismiss();
-  if (!currentRouteIsWorkspaceRoute(notificationData.workspaceId)) {
-    await navigateToWorkspace(notificationData.workspaceId);
+  if (!currentRouteIsWorkspaceRoute(notificationData.workspaceHandle)) {
+    await navigateToWorkspace(notificationData.workspaceHandle);
   }
 }
 

--- a/client/src/components/notifications/WorkspaceRoleChangedNotification.vue
+++ b/client/src/components/notifications/WorkspaceRoleChangedNotification.vue
@@ -19,7 +19,7 @@
             <strong>{{ translateWorkspaceRole(notificationData.newRole).label }}</strong>
           </template>
           <template #workspace>
-            <strong>{{ workspaceName }}</strong>
+            <strong>{{ workspaceInfo ? workspaceInfo.currentName : '' }}</strong>
           </template>
         </i18n-t>
       </ion-text>
@@ -34,22 +34,23 @@
 import { formatTimeSince } from '@/common/date';
 import { LogoIconGradient, MsImage } from '@/components/core/ms-image';
 import NotificationItem from '@/components/notifications/NotificationItem.vue';
-import { getWorkspaceName } from '@/parsec';
+import { StartedWorkspaceInfo, getWorkspaceInfo } from '@/parsec';
 import { WorkspaceRoleChangedData } from '@/services/informationManager';
 import { Notification } from '@/services/notificationManager';
 import { translateWorkspaceRole } from '@/services/translation';
 import { IonText } from '@ionic/vue';
-import { onMounted, ref } from 'vue';
+import { Ref, onMounted, ref } from 'vue';
 
-const workspaceName = ref('');
+const workspaceInfo: Ref<StartedWorkspaceInfo | null> = ref(null);
+
 const props = defineProps<{
   notification: Notification;
 }>();
 
 onMounted(async () => {
-  const result = await getWorkspaceName(notificationData.workspaceId);
+  const result = await getWorkspaceInfo(notificationData.workspaceHandle);
   if (result.ok) {
-    workspaceName.value = result.value;
+    workspaceInfo.value = result.value;
   }
 });
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -29,7 +29,7 @@ import { isPlatform } from '@ionic/vue';
 /* Theme variables */
 import { Validity, claimLinkValidator, fileLinkValidator } from '@/common/validators';
 import { Answer, askQuestion } from '@/components/core';
-import { getOrganizationHandles, isElectron, listAvailableDevices, parseFileLink } from '@/parsec';
+import { getOrganizationHandles, initializeWorkspace, isElectron, listAvailableDevices, parseFileLink } from '@/parsec';
 import { Platform, libparsec } from '@/plugins/libparsec';
 import { HotkeyManager, HotkeyManagerKey } from '@/services/hotkeyManager';
 import { ImportManager, ImportManagerKey } from '@/services/importManager';
@@ -204,7 +204,10 @@ async function handleFileLink(link: string, informationManager: InformationManag
       // Switch to the organization first
       await switchOrganization(handles[0], true);
     }
-    await navigateToWorkspace(linkData.workspaceId, linkData.path);
+    const initResult = await initializeWorkspace(linkData.workspaceId, handles[0]);
+    if (initResult.ok) {
+      await navigateToWorkspace(initResult.value.handle, linkData.path);
+    }
   } else {
     // Check if we have a device with the org
     const devices = await listAvailableDevices();

--- a/client/src/parsec/file.ts
+++ b/client/src/parsec/file.ts
@@ -248,7 +248,7 @@ export async function parseFileLink(_link: string): Promise<Result<FileLinkData,
       value: {
         organizationId: 'MyOrg',
         path: '/Dir/file.txt',
-        workspaceId: 'abcd',
+        workspaceId: '1234',
       },
     };
   } else {
@@ -257,7 +257,7 @@ export async function parseFileLink(_link: string): Promise<Result<FileLinkData,
       value: {
         organizationId: 'MyOrg',
         path: '/Dir/file.txt',
-        workspaceId: 'abcd',
+        workspaceId: '1234',
       },
     };
   }

--- a/client/src/parsec/login.ts
+++ b/client/src/parsec/login.ts
@@ -176,7 +176,7 @@ export async function getCurrentAvailableDevice(): Promise<Result<AvailableDevic
   // clientInfo are not real on web right now
   // const currentAvailableDevice = availableDevices.find((device) => device.deviceId === clientResult.value.deviceId);
 
-  if (!needsMocks) {
+  if (!needsMocks()) {
     const currentAvailableDevice = availableDevices.find((device) => device.deviceId === clientResult.value.deviceId);
     if (!currentAvailableDevice) {
       return { ok: false, error: { tag: 'NotFound' } };

--- a/client/src/parsec/types.ts
+++ b/client/src/parsec/types.ts
@@ -36,6 +36,8 @@ export {
   WorkspaceCreateFolderErrorTag,
   WorkspaceFdCloseErrorTag,
   WorkspaceFdWriteErrorTag,
+  WorkspaceInfoErrorTag,
+  WorkspaceMountErrorTag,
   WorkspaceOpenFileErrorTag,
   WorkspaceRemoveEntryErrorTag,
   WorkspaceRenameEntryErrorTag,
@@ -122,6 +124,8 @@ export type {
   WorkspaceFdResizeError,
   WorkspaceFdWriteError,
   VlobID as WorkspaceID,
+  WorkspaceInfoError,
+  WorkspaceMountError,
   WorkspaceOpenFileError,
   WorkspaceRemoveEntryError,
   WorkspaceRenameEntryError,
@@ -137,8 +141,10 @@ import type {
   HumanHandle,
   EntryStatFile as ParsecEntryStatFile,
   EntryStatFolder as ParsecEntryStatFolder,
+  StartedWorkspaceInfo as ParsecStartedWorkspaceInfo,
   UserInfo as ParsecUserInfo,
   WorkspaceInfo as ParsecWorkspaceInfo,
+  Path,
   UserID,
   UserProfile,
   VlobID,
@@ -150,6 +156,8 @@ type WorkspaceHandle = Handle;
 type EntryID = VlobID;
 type WorkspaceName = EntryName;
 type ConnectionHandle = Handle;
+type MountpointHandle = Handle;
+type SystemPath = Path;
 
 interface UserInfo extends ParsecUserInfo {
   isRevoked: () => boolean;
@@ -227,6 +235,13 @@ interface WorkspaceInfo extends ParsecWorkspaceInfo {
   size: number;
   lastUpdated: DateTime;
   availableOffline: boolean;
+  handle: WorkspaceHandle;
+  mountpointHandle: MountpointHandle;
+  mountpointPath: SystemPath;
+}
+
+interface StartedWorkspaceInfo extends ParsecStartedWorkspaceInfo {
+  handle: WorkspaceHandle;
 }
 
 enum OrganizationInfoErrorTag {
@@ -274,11 +289,14 @@ export {
   GetWorkspaceNameError,
   GetWorkspaceNameErrorTag,
   HumanHandle,
+  MountpointHandle,
   OpenOptions,
   OrganizationInfo,
   OrganizationInfoError,
   OrganizationInfoErrorTag,
   OwnDeviceInfo,
+  StartedWorkspaceInfo,
+  SystemPath,
   UserID,
   UserInfo,
   UserTuple,

--- a/client/src/parsec/types.ts
+++ b/client/src/parsec/types.ts
@@ -236,8 +236,7 @@ interface WorkspaceInfo extends ParsecWorkspaceInfo {
   lastUpdated: DateTime;
   availableOffline: boolean;
   handle: WorkspaceHandle;
-  mountpointHandle: MountpointHandle;
-  mountpointPath: SystemPath;
+  mountpoints: [MountpointHandle, SystemPath][];
 }
 
 interface StartedWorkspaceInfo extends ParsecStartedWorkspaceInfo {

--- a/client/src/router/checks.ts
+++ b/client/src/router/checks.ts
@@ -1,7 +1,7 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { WorkspaceID } from '@/parsec';
-import { getConnectionHandle, getCurrentRouteQuery } from '@/router/params';
+import { WorkspaceHandle } from '@/parsec';
+import { getConnectionHandle, getWorkspaceHandle } from '@/router/params';
 import { Routes, getRouter } from '@/router/types';
 
 export function isLoggedIn(): boolean {
@@ -40,9 +40,8 @@ export function currentRouteIsOneOf(routes: Routes[]): boolean {
   return (routes as string[]).includes(currentRouteName as string);
 }
 
-export function currentRouteIsWorkspaceRoute(workspaceId: WorkspaceID): boolean {
-  const query = getCurrentRouteQuery();
-  return currentRouteIs(Routes.Documents) && query.workspaceId === workspaceId;
+export function currentRouteIsWorkspaceRoute(workspaceHandle: WorkspaceHandle): boolean {
+  return currentRouteIs(Routes.Documents) && getWorkspaceHandle() === workspaceHandle;
 }
 
 export function currentRouteIsUserRoute(): boolean {

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -10,7 +10,6 @@ export {
   getDocumentPath,
   getRoutePath,
   getWorkspaceHandle,
-  getWorkspaceId,
 } from '@/router/params';
 export * from '@/router/types';
 export { watchOrganizationSwitch, watchRoute } from '@/router/watchers';

--- a/client/src/router/navigation.ts
+++ b/client/src/router/navigation.ts
@@ -1,8 +1,8 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { ConnectionHandle, EntryName, startWorkspace, WorkspaceID } from '@/parsec';
+import { ConnectionHandle, EntryName, WorkspaceHandle } from '@/parsec';
 import { getConnectionHandle } from '@/router/params';
-import { getCurrentRoute, getRouter, Query, Routes } from '@/router/types';
+import { Query, Routes, getCurrentRoute, getRouter } from '@/router/types';
 import { organizationKey } from '@/router/watchers';
 import { LocationQueryRaw, RouteParamsRaw } from 'vue-router';
 
@@ -38,16 +38,10 @@ export async function navigateTo(routeName: Routes, options?: NavigationOptions)
   }
 }
 
-export async function navigateToWorkspace(workspaceId: WorkspaceID, path = '/', selectFile?: EntryName): Promise<void> {
-  startWorkspace(workspaceId).then(async (result) => {
-    if (result.ok) {
-      await navigateTo(Routes.Documents, {
-        params: { workspaceHandle: result.value },
-        query: { documentPath: path, workspaceId: workspaceId, selectFile: selectFile },
-      });
-    } else {
-      console.error(`Failed to navigate to workspace: ${result.error.tag}`);
-    }
+export async function navigateToWorkspace(workspaceHandle: WorkspaceHandle, path = '/', selectFile?: EntryName): Promise<void> {
+  await navigateTo(Routes.Documents, {
+    params: { workspaceHandle: workspaceHandle },
+    query: { documentPath: path, selectFile: selectFile },
   });
 }
 

--- a/client/src/router/params.ts
+++ b/client/src/router/params.ts
@@ -1,6 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { ConnectionHandle, FsPath, WorkspaceHandle, WorkspaceID } from '@/parsec';
+import { ConnectionHandle, FsPath, WorkspaceHandle } from '@/parsec';
 import { Query, Routes, getRouter } from '@/router/types';
 
 export function getConnectionHandle(): ConnectionHandle | null {
@@ -21,15 +21,6 @@ export function getWorkspaceHandle(): WorkspaceHandle | undefined {
     return parseInt(currentRoute.params.workspaceHandle as string) as WorkspaceHandle;
   }
   return undefined;
-}
-
-export function getWorkspaceId(): WorkspaceID {
-  const query = getCurrentRouteQuery();
-
-  if (getCurrentRouteName() === Routes.Documents && query.workspaceId) {
-    return query.workspaceId;
-  }
-  return '';
 }
 
 export function getRoutePath(): string {

--- a/client/src/router/types.ts
+++ b/client/src/router/types.ts
@@ -1,6 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { AvailableDevice, EntryName, FileLinkData, FsPath, WorkspaceID, WorkspaceName } from '@/parsec';
+import { AvailableDevice, FileLinkData, FsPath, WorkspaceName } from '@/parsec';
 import { createRouter, createWebHistory } from '@ionic/vue-router';
 import { Ref } from 'vue';
 import { RouteLocationNormalizedLoaded, RouteRecordRaw, Router } from 'vue-router';
@@ -127,7 +127,6 @@ export function getCurrentRoute(): Ref<RouteLocationNormalizedLoaded> {
 export interface Query {
   documentPath?: FsPath;
   device?: AvailableDevice;
-  workspaceId?: WorkspaceID;
   claimLink?: string;
   fileLink?: FileLinkData;
   openInvite?: true;

--- a/client/src/router/types.ts
+++ b/client/src/router/types.ts
@@ -1,6 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { AvailableDevice, FileLinkData, FsPath, WorkspaceName } from '@/parsec';
+import { AvailableDevice, EntryName, FileLinkData, FsPath, WorkspaceName } from '@/parsec';
 import { createRouter, createWebHistory } from '@ionic/vue-router';
 import { Ref } from 'vue';
 import { RouteLocationNormalizedLoaded, RouteRecordRaw, Router } from 'vue-router';

--- a/client/src/services/informationManager.ts
+++ b/client/src/services/informationManager.ts
@@ -1,7 +1,7 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 import { MsAlertModal, MsAlertModalConfig, MsReportTheme } from '@/components/core';
-import { EntryName, FsPath, SizeInt, UserID, WorkspaceID, WorkspaceRole } from '@/parsec';
+import { EntryName, FsPath, SizeInt, UserID, WorkspaceHandle, WorkspaceRole } from '@/parsec';
 import { NotificationManager } from '@/services/notificationManager';
 import { ToastManager } from '@/services/toastManager';
 import { modalController } from '@ionic/vue';
@@ -25,7 +25,7 @@ export interface AbstractInformationData {
 
 export interface WorkspaceRoleChangedData extends AbstractInformationData {
   type: InformationDataType.WorkspaceRoleChanged;
-  workspaceId: WorkspaceID;
+  workspaceHandle: WorkspaceHandle;
   oldRole: WorkspaceRole;
   newRole: WorkspaceRole;
 }
@@ -33,14 +33,14 @@ export interface WorkspaceRoleChangedData extends AbstractInformationData {
 // The account owner has been granted access to a workspace
 export interface NewWorkspaceAccessData extends AbstractInformationData {
   type: InformationDataType.NewWorkspaceAccess;
-  workspaceId: WorkspaceID;
+  workspaceHandle: WorkspaceHandle;
   role: WorkspaceRole;
 }
 
 // A user has been granted access to a workspace
 export interface UserJoinWorkspaceData extends AbstractInformationData {
   type: InformationDataType.UserJoinWorkspace;
-  workspaceId: WorkspaceID;
+  workspaceHandle: WorkspaceHandle;
   role: WorkspaceRole;
   userId: UserID;
 }
@@ -48,7 +48,7 @@ export interface UserJoinWorkspaceData extends AbstractInformationData {
 // Multiple users have been granted access to a workspace
 export interface MultipleUsersJoinWorkspaceData extends AbstractInformationData {
   type: InformationDataType.MultipleUsersJoinWorkspace;
-  workspaceId: WorkspaceID;
+  workspaceHandle: WorkspaceHandle;
   roles: {
     userId: UserID;
     role: WorkspaceRole;
@@ -58,7 +58,7 @@ export interface MultipleUsersJoinWorkspaceData extends AbstractInformationData 
 // A user has shared a document in a workspace
 export interface UserSharedDocumentData extends AbstractInformationData {
   type: InformationDataType.UserSharedDocument;
-  workspaceId: WorkspaceID;
+  workspaceHandle: WorkspaceHandle;
   userId: UserID;
   fileName: EntryName;
   filePath: FsPath;

--- a/client/src/views/files/FileUploadMenu.vue
+++ b/client/src/views/files/FileUploadMenu.vue
@@ -194,7 +194,7 @@ async function onImportFinishedClick(importData: ImportData, state: ImportState)
   if (state !== ImportState.FileImported) {
     return;
   }
-  await navigateToWorkspace(importData.workspaceId, importData.path, importData.file.name);
+  await navigateToWorkspace(importData.workspaceHandle, importData.path, importData.file.name);
   menu.minimize();
 }
 

--- a/client/src/views/header/HeaderPage.vue
+++ b/client/src/views/header/HeaderPage.vue
@@ -187,11 +187,14 @@ async function updateRoute(): Promise<void> {
       },
     ];
   } else if (currentRouteIs(Routes.Documents)) {
-    const result = await getWorkspaceInfo(getWorkspaceHandle());
-    if (result.ok) {
-      workspaceInfo.value = result.value;
-    } else {
-      console.warn('Could not get workspace info', result.error);
+    const workspaceHandle = getWorkspaceHandle();
+    if (workspaceHandle) {
+      const result = await getWorkspaceInfo(workspaceHandle);
+      if (result.ok) {
+        workspaceInfo.value = result.value;
+      } else {
+        console.warn('Could not get workspace info', result.error);
+      }
     }
 
     const finalPath: RouterPathNode[] = [];

--- a/client/src/views/header/NotificationCenterPopover.vue
+++ b/client/src/views/header/NotificationCenterPopover.vue
@@ -144,7 +144,7 @@ onMounted(() => {
           workspaceHandle: 3,
           userId: 'id1',
           fileName: 'Encrypted-file.txt',
-          filePath: '',
+          filePath: '/',
           fileSize: 1024,
         },
       });

--- a/client/src/views/header/NotificationCenterPopover.vue
+++ b/client/src/views/header/NotificationCenterPopover.vue
@@ -75,7 +75,7 @@ onMounted(() => {
         level: InformationLevel.Info,
         data: {
           type: InformationDataType.WorkspaceRoleChanged,
-          workspaceId: '1337',
+          workspaceHandle: 2,
           oldRole: WorkspaceRole.Contributor,
           newRole: WorkspaceRole.Manager,
         },
@@ -87,7 +87,7 @@ onMounted(() => {
         level: InformationLevel.Info,
         data: {
           type: InformationDataType.NewWorkspaceAccess,
-          workspaceId: '1337',
+          workspaceHandle: 1,
           role: WorkspaceRole.Manager,
         },
       });
@@ -98,7 +98,7 @@ onMounted(() => {
         level: InformationLevel.Info,
         data: {
           type: InformationDataType.NewWorkspaceAccess,
-          workspaceId: '1337',
+          workspaceHandle: 3,
           role: WorkspaceRole.Manager,
         },
       });
@@ -109,7 +109,7 @@ onMounted(() => {
         level: InformationLevel.Info,
         data: {
           type: InformationDataType.UserJoinWorkspace,
-          workspaceId: '1337',
+          workspaceHandle: 1,
           role: WorkspaceRole.Manager,
           userId: 'id1',
         },
@@ -121,7 +121,7 @@ onMounted(() => {
         level: InformationLevel.Info,
         data: {
           type: InformationDataType.MultipleUsersJoinWorkspace,
-          workspaceId: '1337',
+          workspaceHandle: 1,
           roles: [
             {
               userId: 'id1',
@@ -141,7 +141,7 @@ onMounted(() => {
         level: InformationLevel.Info,
         data: {
           type: InformationDataType.UserSharedDocument,
-          workspaceId: '1337',
+          workspaceHandle: 3,
           userId: 'id1',
           fileName: 'Encrypted-file.txt',
           filePath: '',

--- a/client/src/views/home/HomePage.vue
+++ b/client/src/views/home/HomePage.vue
@@ -58,8 +58,8 @@
 <script setup lang="ts">
 import { Validity, claimDeviceLinkValidator, claimLinkValidator, claimUserLinkValidator } from '@/common/validators';
 import { MsModalResult, getTextInputFromUser } from '@/components/core';
-import { AvailableDevice, getDeviceHandle, isDeviceLoggedIn, login as parsecLogin, startWorkspace } from '@/parsec';
-import { NavigationOptions, Routes, getCurrentRouteQuery, navigateTo, switchOrganization, watchRoute } from '@/router';
+import { AvailableDevice, getDeviceHandle, initializeWorkspace, isDeviceLoggedIn, login as parsecLogin } from '@/parsec';
+import { NavigationOptions, Routes, getCurrentRouteQuery, navigateTo, navigateToWorkspace, switchOrganization, watchRoute } from '@/router';
 import { Groups, HotkeyManager, HotkeyManagerKey, Hotkeys, Modifiers, Platforms } from '@/services/hotkeyManager';
 import { StorageManager, StorageManagerKey, StoredDeviceData } from '@/services/storageManager';
 import { translate } from '@/services/translation';
@@ -198,17 +198,10 @@ async function login(device: AvailableDevice, password: string): Promise<void> {
     const query = getCurrentRouteQuery();
     if (query.fileLink) {
       const linkData = query.fileLink;
-      startWorkspace(linkData.workspaceId).then(async (wkResult) => {
-        if (wkResult.ok) {
-          await navigateTo(Routes.Documents, {
-            params: { handle: result.value, workspaceHandle: wkResult.value },
-            query: { documentPath: linkData.path, workspaceId: linkData.workspaceId },
-            replace: true,
-          });
-        } else {
-          console.log('Failed to start the workspace for file link');
-        }
-      });
+      const initResult = await initializeWorkspace(linkData.workspaceId, result.value);
+      if (initResult.ok) {
+        await navigateToWorkspace(initResult.value.handle, linkData.path);
+      }
     } else {
       const options: NavigationOptions = { params: { handle: result.value }, replace: true };
       await navigateTo(Routes.Workspaces, options);

--- a/client/src/views/sidebar-menu/SidebarMenuPage.vue
+++ b/client/src/views/sidebar-menu/SidebarMenuPage.vue
@@ -120,9 +120,9 @@
                 lines="none"
                 button
                 v-for="workspace in workspaces"
-                :key="workspace.id"
-                @click="goToWorkspace(workspace.id)"
-                :class="currentRouteIsWorkspaceRoute(workspace.id) ? 'item-selected' : 'item-not-selected'"
+                :key="workspace.handle"
+                @click="goToWorkspace(workspace.handle)"
+                :class="currentRouteIsWorkspaceRoute(workspace.handle) ? 'item-selected' : 'item-not-selected'"
                 class="sidebar-item"
               >
                 <ion-icon
@@ -202,6 +202,7 @@ import OrganizationSwitchPopover from '@/components/organizations/OrganizationSw
 import {
   ClientInfo,
   UserProfile,
+  WorkspaceHandle,
   WorkspaceInfo,
   isDesktop,
   getClientInfo as parsecGetClientInfo,
@@ -260,8 +261,8 @@ const resetWatchCancel: WatchStopHandle = watch(wasReset, (value) => {
   }
 });
 
-async function goToWorkspace(workspaceId: string): Promise<void> {
-  await navigateToWorkspace(workspaceId);
+async function goToWorkspace(workspaceHandle: WorkspaceHandle): Promise<void> {
+  await navigateToWorkspace(workspaceHandle);
   await menuController.close();
 }
 

--- a/client/src/views/workspaces/WorkspacesPage.vue
+++ b/client/src/views/workspaces/WorkspacesPage.vue
@@ -239,7 +239,7 @@ async function onDisplayStateChange(): Promise<void> {
 }
 
 async function refreshWorkspacesList(): Promise<void> {
-  const result = await parsecListWorkspaces();
+  const result = await parsecListWorkspaces(true);
   if (result.ok) {
     workspaceList.value = result.value;
   } else {

--- a/client/src/views/workspaces/WorkspacesPage.vue
+++ b/client/src/views/workspaces/WorkspacesPage.vue
@@ -320,7 +320,7 @@ async function openCreateWorkspaceModal(): Promise<void> {
 }
 
 async function onWorkspaceClick(_event: Event, workspace: WorkspaceInfo): Promise<void> {
-  await navigateToWorkspace(workspace.id);
+  await navigateToWorkspace(workspace.handle);
 }
 
 async function onWorkspaceShareClick(_: Event, workspace: WorkspaceInfo): Promise<void> {
@@ -363,7 +363,7 @@ async function openWorkspaceContextMenu(event: Event, workspace: WorkspaceInfo):
 }
 
 async function copyLinkToClipboard(workspace: WorkspaceInfo): Promise<void> {
-  const result = await parsecGetPathLink(workspace.id, '/');
+  const result = await parsecGetPathLink(workspace.handle, '/');
 
   if (result.ok) {
     if (!(await writeTextToClipboard(result.value))) {

--- a/client/tests/component/specs/testWorkspaceCard.spec.ts
+++ b/client/tests/component/specs/testWorkspaceCard.spec.ts
@@ -61,8 +61,7 @@ describe('Workspace Card', () => {
     lastUpdated: DateTime.fromISO('2023-05-08T12:00:00'),
     isStarted: false,
     isBootstrapped: true,
-    mountpointHandle: 42,
-    mountpointPath: '/',
+    mountpoints: [[42, '/']],
     handle: 1,
   };
 

--- a/client/tests/component/specs/testWorkspaceCard.spec.ts
+++ b/client/tests/component/specs/testWorkspaceCard.spec.ts
@@ -61,6 +61,9 @@ describe('Workspace Card', () => {
     lastUpdated: DateTime.fromISO('2023-05-08T12:00:00'),
     isStarted: false,
     isBootstrapped: true,
+    mountpointHandle: 42,
+    mountpointPath: '/',
+    handle: 1,
   };
 
   beforeEach(() => {

--- a/client/tests/component/specs/testWorkspaceListItem.spec.ts
+++ b/client/tests/component/specs/testWorkspaceListItem.spec.ts
@@ -61,6 +61,9 @@ describe('Workspace List Item', () => {
     lastUpdated: DateTime.fromISO('2023-05-08T12:00:00'),
     isStarted: false,
     isBootstrapped: true,
+    mountpointHandle: 42,
+    mountpointPath: '/',
+    handle: 1,
   };
 
   beforeEach(() => {

--- a/client/tests/component/specs/testWorkspaceListItem.spec.ts
+++ b/client/tests/component/specs/testWorkspaceListItem.spec.ts
@@ -61,8 +61,7 @@ describe('Workspace List Item', () => {
     lastUpdated: DateTime.fromISO('2023-05-08T12:00:00'),
     isStarted: false,
     isBootstrapped: true,
-    mountpointHandle: 42,
-    mountpointPath: '/',
+    mountpoints: [[42, '/']],
     handle: 1,
   };
 

--- a/client/tests/unit/specs/testInformationManager.spec.ts
+++ b/client/tests/unit/specs/testInformationManager.spec.ts
@@ -48,7 +48,7 @@ describe('Information Manager', () => {
         level: InformationLevel.Warning,
         data: {
           type: InformationDataType.WorkspaceRoleChanged,
-          workspaceId: 'workspaceId',
+          workspaceHandle: 42,
           oldRole: WorkspaceRole.Reader,
           newRole: WorkspaceRole.Contributor,
         },
@@ -89,7 +89,7 @@ describe('Information Manager', () => {
     expect(informationWithSomeData).to.exist;
     expect(informationWithSomeData.data).to.deep.equal({
       type: InformationDataType.WorkspaceRoleChanged,
-      workspaceId: 'workspaceId',
+      workspaceHandle: 42,
       oldRole: WorkspaceRole.Reader,
       newRole: WorkspaceRole.Contributor,
     });

--- a/client/tests/unit/specs/testNotificationManager.spec.ts
+++ b/client/tests/unit/specs/testNotificationManager.spec.ts
@@ -33,7 +33,7 @@ describe('Notification Manager', () => {
         theme: MsReportTheme.Info,
         data: {
           type: InformationDataType.WorkspaceRoleChanged,
-          workspaceId: 'workspaceId',
+          workspaceHandle: 42,
           oldRole: WorkspaceRole.Reader,
           newRole: WorkspaceRole.Contributor,
         },


### PR DESCRIPTION
Changed how workspaces are being accessed. We use the `workspaceHandle` as our selector to get information on the workspace, and workspaces are now always started and mounted.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
