### PR TITLE
Event bindings

### DIFF
--- a/bindings/electron/src/index.d.ts
+++ b/bindings/electron/src/index.d.ts
@@ -79,6 +79,7 @@ export interface ClientInfo {
     deviceLabel: string
     humanHandle: HumanHandle
     currentProfile: UserProfile
+    serverConfig: ServerConfig
 }
 
 
@@ -161,6 +162,12 @@ export interface OpenOptions {
     truncate: boolean
     create: boolean
     createNew: boolean
+}
+
+
+export interface ServerConfig {
+    userProfileOutsiderAllowed: boolean
+    activeUsersLimit: ActiveUsersLimit
 }
 
 
@@ -252,6 +259,19 @@ export interface WorkspaceUserAccessInfo {
     currentProfile: UserProfile
     currentRole: RealmRole
 }
+
+
+// ActiveUsersLimit
+export interface ActiveUsersLimitLimitedTo {
+    tag: "LimitedTo"
+    x1: number
+}
+export interface ActiveUsersLimitNoLimit {
+    tag: "NoLimit"
+}
+export type ActiveUsersLimit =
+  | ActiveUsersLimitLimitedTo
+  | ActiveUsersLimitNoLimit
 
 
 // BootstrapOrganizationError
@@ -456,12 +476,43 @@ export type ClientCreateWorkspaceError =
 
 
 // ClientEvent
+export interface ClientEventIncompatibleServer {
+    tag: "IncompatibleServer"
+    detail: string
+}
+export interface ClientEventInvitationChanged {
+    tag: "InvitationChanged"
+    token: string
+    status: InvitationStatus
+}
+export interface ClientEventOffline {
+    tag: "Offline"
+}
+export interface ClientEventOnline {
+    tag: "Online"
+}
 export interface ClientEventPing {
     tag: "Ping"
     ping: string
 }
+export interface ClientEventServerConfigChanged {
+    tag: "ServerConfigChanged"
+}
+export interface ClientEventTooMuchDriftWithServerClock {
+    tag: "TooMuchDriftWithServerClock"
+    server_timestamp: number
+    client_timestamp: number
+    ballpark_client_early_offset: number
+    ballpark_client_late_offset: number
+}
 export type ClientEvent =
+  | ClientEventIncompatibleServer
+  | ClientEventInvitationChanged
+  | ClientEventOffline
+  | ClientEventOnline
   | ClientEventPing
+  | ClientEventServerConfigChanged
+  | ClientEventTooMuchDriftWithServerClock
 
 
 // ClientGetUserDeviceError

--- a/bindings/generator/api/client.py
+++ b/bindings/generator/api/client.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from .addr import ParsecOrganizationAddr
 from .common import (
+    U64,
     DateTime,
     DeviceID,
     DeviceLabel,
@@ -21,6 +22,8 @@ from .common import (
     UserID,
     UserProfile,
     Variant,
+    VariantItemTuple,
+    VariantItemUnit,
     VlobID,
     RealmRole,
 )
@@ -80,6 +83,16 @@ class ClientInfoError(ErrorVariant):
         pass
 
 
+class ActiveUsersLimit(Variant):
+    LimitedTo = VariantItemTuple(U64)
+    NoLimit = VariantItemUnit
+
+
+class ServerConfig(Structure):
+    user_profile_outsider_allowed: bool
+    active_users_limit: ActiveUsersLimit
+
+
 class ClientInfo(Structure):
     organization_addr: ParsecOrganizationAddr
     organization_id: OrganizationID
@@ -88,6 +101,7 @@ class ClientInfo(Structure):
     device_label: DeviceLabel
     human_handle: HumanHandle
     current_profile: UserProfile
+    server_config: ServerConfig
 
 
 async def client_info(

--- a/bindings/generator/api/common.py
+++ b/bindings/generator/api/common.py
@@ -38,8 +38,8 @@ class EnumItemUnit:
 #     class Foo(Variant):
 #         class A:
 #             a: int
-#         B: VariantItemTuple(int, int)
-#         C: VariantItemUnit
+#         B = VariantItemTuple(int, int)
+#         C = VariantItemUnit
 class Variant:
     pass
 
@@ -245,3 +245,10 @@ class RealmRole(Enum):
     Manager = EnumItemUnit
     Contributor = EnumItemUnit
     Reader = EnumItemUnit
+
+
+class InvitationStatus(Enum):
+    Idle = EnumItemUnit
+    Ready = EnumItemUnit
+    Finished = EnumItemUnit
+    Cancelled = EnumItemUnit

--- a/bindings/generator/api/events.py
+++ b/bindings/generator/api/events.py
@@ -2,12 +2,56 @@
 
 from typing import Callable
 
-from .common import Variant
+from .common import Variant, VlobID, DateTime, InvitationToken, InvitationStatus
 
 
 class ClientEvent(Variant):
     class Ping:
         ping: str
+
+    class Offline:
+        pass
+
+    class Online:
+        pass
+
+    class ServerConfigChanged:
+        pass
+
+    # class WorkspaceSelfRoleChanged:
+    #     workspace_id: VlobID
+
+    # class WorkspaceEntryChanged:
+    #     workspace_id: VlobID
+    #     vlob_id: VlobID
+
+    class InvitationChanged:
+        token: InvitationToken
+        status: InvitationStatus
+
+    class TooMuchDriftWithServerClock:
+        server_timestamp: DateTime
+        client_timestamp: DateTime
+        ballpark_client_early_offset: float
+        ballpark_client_late_offset: float
+
+    # class ExpiredOrganization:
+    #     pass
+
+    # class RevokedSelfUser:
+    #     pass
+
+    class IncompatibleServer:
+        detail: str
+
+    # class InvalidKeysBundle:
+    #     detail: str
+
+    # class InvalidCertificate:
+    #     detail: str
+
+    # class InvalidManifest:
+    #     detail: str
 
 
 class OnClientEventCallback(Callable[[ClientEvent], None]):  # type: ignore[misc]

--- a/bindings/generator/api/invite.py
+++ b/bindings/generator/api/invite.py
@@ -27,6 +27,7 @@ from .common import (
     UserID,
     UserProfile,
     Variant,
+    InvitationStatus,
 )
 from .config import ClientConfig
 from .events import OnClientEventCallback
@@ -301,13 +302,6 @@ async def claimer_device_finalize_save_local_device(
 #
 # Invitation greeter
 #
-
-
-class InvitationStatus(Enum):
-    Idle = EnumItemUnit
-    Ready = EnumItemUnit
-    Finished = EnumItemUnit
-    Cancelled = EnumItemUnit
 
 
 class InvitationEmailSentStatus(Enum):

--- a/client/src/parsec/login.ts
+++ b/client/src/parsec/login.ts
@@ -1,6 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { libparsec } from '@/plugins/libparsec';
+import { ActiveUsersLimitTag, libparsec } from '@/plugins/libparsec';
 
 import { needsMocks } from '@/parsec/environment';
 import { DEFAULT_HANDLE, getClientConfig } from '@/parsec/internals';
@@ -131,6 +131,12 @@ export async function getClientInfo(): Promise<Result<ClientInfo, ClientInfoErro
         humanHandle: {
           email: 'user@host.com',
           label: 'Gordon Freeman',
+        },
+        serverConfig: {
+          userProfileOutsiderAllowed: true,
+          activeUsersLimit: {
+            tag: ActiveUsersLimitTag.NoLimit,
+          },
         },
       },
     };

--- a/client/src/parsec/organization.ts
+++ b/client/src/parsec/organization.ts
@@ -9,7 +9,7 @@ import {
   AvailableDevice,
   BootstrapOrganizationError,
   ClientConfig,
-  ClientEventPing,
+  ClientEvent,
   DeviceFileType,
   OrganizationID,
   OrganizationInfo,
@@ -29,7 +29,7 @@ export async function createOrganization(
   password: string,
   deviceLabel: string,
 ): Promise<Result<AvailableDevice, BootstrapOrganizationError>> {
-  function parsecEventCallback(event: ClientEventPing): void {
+  function parsecEventCallback(event: ClientEvent): void {
     console.log('On event', event);
   }
 

--- a/client/src/plugins/libparsec/definitions.ts
+++ b/client/src/plugins/libparsec/definitions.ts
@@ -104,6 +104,7 @@ export interface ClientInfo {
     deviceLabel: DeviceLabel
     humanHandle: HumanHandle
     currentProfile: UserProfile
+    serverConfig: ServerConfig
 }
 
 export interface DeviceClaimFinalizeInfo {
@@ -173,6 +174,11 @@ export interface OpenOptions {
     truncate: boolean
     create: boolean
     createNew: boolean
+}
+
+export interface ServerConfig {
+    userProfileOutsiderAllowed: boolean
+    activeUsersLimit: ActiveUsersLimit
 }
 
 export interface StartedWorkspaceInfo {
@@ -251,6 +257,23 @@ export interface WorkspaceUserAccessInfo {
     currentProfile: UserProfile
     currentRole: RealmRole
 }
+
+// ActiveUsersLimit
+export enum ActiveUsersLimitTag {
+    LimitedTo = 'ActiveUsersLimitLimitedTo',
+    NoLimit = 'ActiveUsersLimitNoLimit',
+}
+
+export interface ActiveUsersLimitLimitedTo {
+    tag: ActiveUsersLimitTag.LimitedTo
+    x1: U64
+}
+export interface ActiveUsersLimitNoLimit {
+    tag: ActiveUsersLimitTag.NoLimit
+}
+export type ActiveUsersLimit =
+  | ActiveUsersLimitLimitedTo
+  | ActiveUsersLimitNoLimit
 
 // BootstrapOrganizationError
 export enum BootstrapOrganizationErrorTag {
@@ -504,15 +527,52 @@ export type ClientCreateWorkspaceError =
 
 // ClientEvent
 export enum ClientEventTag {
+    IncompatibleServer = 'ClientEventIncompatibleServer',
+    InvitationChanged = 'ClientEventInvitationChanged',
+    Offline = 'ClientEventOffline',
+    Online = 'ClientEventOnline',
     Ping = 'ClientEventPing',
+    ServerConfigChanged = 'ClientEventServerConfigChanged',
+    TooMuchDriftWithServerClock = 'ClientEventTooMuchDriftWithServerClock',
 }
 
+export interface ClientEventIncompatibleServer {
+    tag: ClientEventTag.IncompatibleServer
+    detail: string
+}
+export interface ClientEventInvitationChanged {
+    tag: ClientEventTag.InvitationChanged
+    token: InvitationToken
+    status: InvitationStatus
+}
+export interface ClientEventOffline {
+    tag: ClientEventTag.Offline
+}
+export interface ClientEventOnline {
+    tag: ClientEventTag.Online
+}
 export interface ClientEventPing {
     tag: ClientEventTag.Ping
     ping: string
 }
+export interface ClientEventServerConfigChanged {
+    tag: ClientEventTag.ServerConfigChanged
+}
+export interface ClientEventTooMuchDriftWithServerClock {
+    tag: ClientEventTag.TooMuchDriftWithServerClock
+    serverTimestamp: DateTime
+    clientTimestamp: DateTime
+    ballparkClientEarlyOffset: number
+    ballparkClientLateOffset: number
+}
 export type ClientEvent =
+  | ClientEventIncompatibleServer
+  | ClientEventInvitationChanged
+  | ClientEventOffline
+  | ClientEventOnline
   | ClientEventPing
+  | ClientEventServerConfigChanged
+  | ClientEventTooMuchDriftWithServerClock
 
 // ClientGetUserDeviceError
 export enum ClientGetUserDeviceErrorTag {

--- a/libparsec/crates/client/src/config.rs
+++ b/libparsec/crates/client/src/config.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 
 pub use libparsec_client_connection::ProxyConfig;
+use libparsec_types::prelude::*;
 
 pub const DEFAULT_WORKSPACE_STORAGE_CACHE_SIZE: u64 = 512 * 1024 * 1024;
 
@@ -36,4 +37,23 @@ pub struct ClientConfig {
     /// If `false`, nothing runs & react in the background, useful for tests
     /// or CLI where the client is started to only perform a single operation.
     pub with_monitors: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerConfig {
+    pub user_profile_outsider_allowed: bool,
+    pub active_users_limit: ActiveUsersLimit,
+}
+
+// It's easy to provide "good enough" default value so that the config is guaranteed
+// to be always available \o/
+// Note in practice this default config should be overwritten as soon as the client
+// connects to the server (server always starts by sending a SSE event about its config).
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            user_profile_outsider_allowed: false,
+            active_users_limit: ActiveUsersLimit::NoLimit,
+        }
+    }
 }

--- a/libparsec/crates/client/src/lib.rs
+++ b/libparsec/crates/client/src/lib.rs
@@ -11,6 +11,7 @@ mod user;
 pub mod workspace;
 
 // For clarity, user & certificate stuff are re-exposed through client
+pub use certif::*;
 pub use client::*;
 pub use config::*;
 pub use event_bus::*;

--- a/libparsec/crates/client/src/monitors/connection.rs
+++ b/libparsec/crates/client/src/monitors/connection.rs
@@ -35,7 +35,7 @@ fn dispatch_api_event(event: APIEvent, event_bus: &EventBus) {
             active_users_limit,
             user_profile_outsider_allowed,
         } => {
-            let event = EventServerConfigChanged {
+            let event = EventServerConfigNotified {
                 active_users_limit,
                 user_profile_outsider_allowed,
             };
@@ -45,9 +45,9 @@ fn dispatch_api_event(event: APIEvent, event_bus: &EventBus) {
             token,
             invitation_status,
         } => {
-            let event = EventInviteStatusChanged {
-                invitation_status,
+            let event = EventInvitationChanged {
                 token,
+                status: invitation_status,
             };
             event_bus.send(&event);
         }
@@ -148,7 +148,7 @@ fn handle_sse_error(
             ControlFlow::Break(())
         }
         ConnectionError::RevokedUser => {
-            event_bus.send(&EventRevokedUser);
+            event_bus.send(&EventRevokedSelfUser);
             ControlFlow::Break(())
         }
         ConnectionError::UnsupportedApiVersion {

--- a/libparsec/crates/client/src/monitors/mod.rs
+++ b/libparsec/crates/client/src/monitors/mod.rs
@@ -3,6 +3,7 @@
 mod base;
 mod certif_poll;
 mod connection;
+mod server_config;
 mod user_sync;
 mod workspace_inbound_sync;
 mod workspace_outbound_sync;
@@ -12,6 +13,7 @@ mod workspaces_refresh_list;
 pub(crate) use base::*;
 pub(crate) use certif_poll::*;
 pub(crate) use connection::*;
+pub(crate) use server_config::*;
 pub(crate) use user_sync::*;
 pub(crate) use workspace_inbound_sync::*;
 pub(crate) use workspace_outbound_sync::*;

--- a/libparsec/crates/client/src/monitors/server_config.rs
+++ b/libparsec/crates/client/src/monitors/server_config.rs
@@ -1,0 +1,62 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use std::{future::Future, sync::Arc};
+
+use libparsec_platform_async::{pretend_future_is_send_on_web, sleep};
+
+use super::Monitor;
+use crate::{
+    event_bus::{EventBus, EventServerConfigChanged, EventServerConfigNotified},
+    Client, ServerConfig,
+};
+
+const SERVER_CONFIG_MONITOR_NAME: &str = "server_config";
+
+pub(crate) async fn start_server_config_monitor(
+    client: Arc<Client>,
+    event_bus: EventBus,
+) -> Monitor {
+    let future = {
+        let task_future = task_future_factory(client, event_bus.clone());
+        pretend_future_is_send_on_web(task_future)
+    };
+    Monitor::start(event_bus, SERVER_CONFIG_MONITOR_NAME, None, future, None).await
+}
+
+fn task_future_factory(client: Arc<Client>, event_bus: EventBus) -> impl Future<Output = ()> {
+    let events_connection_lifetime = event_bus.connect({
+        let event_bus = event_bus.clone();
+        move |e: &EventServerConfigNotified| {
+            let EventServerConfigNotified {
+                active_users_limit,
+                user_profile_outsider_allowed,
+            } = e;
+            let new = ServerConfig {
+                active_users_limit: *active_users_limit,
+                user_profile_outsider_allowed: *user_profile_outsider_allowed,
+            };
+            let mut config_has_changed = false;
+
+            client.update_server_config(|config| {
+                if *config != new {
+                    *config = new;
+                    config_has_changed = true;
+                }
+            });
+
+            if config_has_changed {
+                event_bus.send(&EventServerConfigChanged);
+            }
+        }
+    });
+
+    async move {
+        // Our coroutine is only here to keep the event connection alive.
+        let _events_connection_lifetime = events_connection_lifetime;
+        // We want to sleep forever, but we can only do it for `Duration::MAX` (which is
+        // very, very long but not infinite). Hence the loop, which is mostly theorical.
+        loop {
+            sleep(std::time::Duration::MAX).await;
+        }
+    }
+}

--- a/libparsec/crates/client/src/monitors/server_config.rs
+++ b/libparsec/crates/client/src/monitors/server_config.rs
@@ -54,7 +54,7 @@ fn task_future_factory(client: Arc<Client>, event_bus: EventBus) -> impl Future<
         // Our coroutine is only here to keep the event connection alive.
         let _events_connection_lifetime = events_connection_lifetime;
         // We want to sleep forever, but we can only do it for `Duration::MAX` (which is
-        // very, very long but not infinite). Hence the loop, which is mostly theorical.
+        // very, very long but not infinite). Hence the loop, which is mostly theoretical.
         loop {
             sleep(std::time::Duration::MAX).await;
         }

--- a/libparsec/crates/types/src/invite.rs
+++ b/libparsec/crates/types/src/invite.rs
@@ -29,7 +29,7 @@ pub enum InvitationType {
  * InvitationStatus
  */
 
-#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum InvitationStatus {
     Idle,

--- a/libparsec/src/client.rs
+++ b/libparsec/src/client.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use libparsec_client::ServerConfig;
 pub use libparsec_client::{
     ClientCreateWorkspaceError, ClientGetCurrentSelfProfileError, ClientGetUserDeviceError,
     ClientListUserDevicesError, ClientListUsersError, ClientListWorkspaceUsersError,
@@ -217,6 +218,7 @@ pub struct ClientInfo {
     pub device_label: DeviceLabel,
     pub human_handle: HumanHandle,
     pub current_profile: UserProfile,
+    pub server_config: ServerConfig,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -246,6 +248,7 @@ pub async fn client_info(client: Handle) -> Result<ClientInfo, ClientInfoError> 
                     e.context("Cannot retrieve profile").into()
                 }
             })?,
+        server_config: client.server_config(),
     })
 }
 

--- a/libparsec/src/config.rs
+++ b/libparsec/src/config.rs
@@ -2,7 +2,7 @@
 
 use std::{path::PathBuf, sync::Arc};
 
-pub use libparsec_client::{ProxyConfig, WorkspaceStorageCacheSize};
+pub use libparsec_client::{ProxyConfig, ServerConfig, WorkspaceStorageCacheSize};
 pub use libparsec_types::prelude::*;
 
 pub const PARSEC_CONFIG_DIR: &str = "PARSEC_CONFIG_DIR";

--- a/libparsec/src/events.rs
+++ b/libparsec/src/events.rs
@@ -6,34 +6,77 @@
 use std::sync::Arc;
 
 use libparsec_client::EventBusConnectionLifetime;
+use libparsec_types::prelude::*;
 
 pub enum ClientEvent {
     // Dummy event for tests only
-    Ping { ping: String },
-    // // Events related to server connection
-    // Offline(libparsec_client::EventOffline),
-    // Online(libparsec_client::EventOnline),
-    // MissedServerEvents(libparsec_client::EventMissedServerEvents),
-    // TooMuchDriftWithServerClock(libparsec_client::EventTooMuchDriftWithServerClock),
-    // ExpiredOrganization(libparsec_client::EventExpiredOrganization),
-    // RevokedUser(libparsec_client::EventRevokedUser),
-    // IncompatibleServer(libparsec_client::EventIncompatibleServer),
-    // // Events related to ops
-    // InvalidMessage(libparsec_client::EventInvalidMessage),
-    // // Events related to monitors
-    // CertificatesMonitorCrashed(libparsec_client::EventCertificatesMonitorCrashed),
-    // InvalidCertificate(libparsec_client::EventInvalidCertificate),
-    // // TODO
-    // // // Logs events
-    // // LogInfo,
-    // // LogWarning,
-    // // LogError,
+    Ping {
+        ping: String,
+    },
+    // Server connection
+    Offline,
+    Online,
+    // Server-notified changes
+    ServerConfigChanged,
+    // TODO
+    // WorkspaceSelfRoleChanged {
+    //     workspace_id: VlobID,
+    // },
+    // TODO
+    // WorkspaceEntryChanged {
+    //     workspace_id: VlobID,
+    //     entry_id: VlobID,
+    // },
+    InvitationChanged {
+        token: InvitationToken,
+        status: InvitationStatus,
+    },
+    // Error from server & server-provided data
+    // TODO
+    // ExpiredOrganization,
+    // TODO
+    // RevokedSelfUser,
+    TooMuchDriftWithServerClock {
+        server_timestamp: DateTime,
+        client_timestamp: DateTime,
+        ballpark_client_early_offset: Float,
+        ballpark_client_late_offset: Float,
+    },
+    IncompatibleServer {
+        detail: String,
+    },
+    // TODO
+    // InvalidKeysBundle {
+    //     detail: String,
+    // },
+    // TODO
+    // InvalidCertificate {
+    //     detail: String,
+    // },
+    // TODO
+    // InvalidManifest {
+    //     detail: String,
+    // },
 }
 
 pub(crate) struct OnEventCallbackPlugged {
     pub event_bus: libparsec_client::EventBus,
 
     _ping: EventBusConnectionLifetime<libparsec_client::EventPing>,
+    _offline: EventBusConnectionLifetime<libparsec_client::EventOffline>,
+    _online: EventBusConnectionLifetime<libparsec_client::EventOnline>,
+    _server_config_changed: EventBusConnectionLifetime<libparsec_client::EventServerConfigChanged>,
+    // _workspace_self_role_changed: EventBusConnectionLifetime<libparsec_client::EventWorkspaceSelfRoleChanged>,
+    // _workspace_entry_changed: EventBusConnectionLifetime<libparsec_client::EventWorkspaceEntryChanged>,
+    _invitation_changed: EventBusConnectionLifetime<libparsec_client::EventInvitationChanged>,
+    // _expired_organization: EventBusConnectionLifetime<libparsec_client::EventExpiredOrganization>,
+    // _revoked_user: EventBusConnectionLifetime<libparsec_client::EventRevokedSelfUser>,
+    _too_much_drift_with_server_clock:
+        EventBusConnectionLifetime<libparsec_client::EventTooMuchDriftWithServerClock>,
+    _incompatible_server: EventBusConnectionLifetime<libparsec_client::EventIncompatibleServer>,
+    // _invalid_keys_bundle: EventBusConnectionLifetime<libparsec_client::EventInvalidKeysBundle>,
+    // _invalid_certificate: EventBusConnectionLifetime<libparsec_client::EventInvalidCertificate>,
+    // _invalid_manifest: EventBusConnectionLifetime<libparsec_client::EventInvalidManifest>,
 }
 
 impl OnEventCallbackPlugged {
@@ -62,6 +105,8 @@ impl OnEventCallbackPlugged {
 
         let event_bus = libparsec_client::EventBus::default();
 
+        // Connect events
+
         let ping = {
             let on_event_callback = on_event_callback.clone();
             event_bus.connect(move |e: &libparsec_client::EventPing| {
@@ -71,9 +116,116 @@ impl OnEventCallbackPlugged {
             })
         };
 
+        let offline = {
+            let on_event_callback = on_event_callback.clone();
+            event_bus.connect(move |_: &libparsec_client::EventOffline| {
+                (on_event_callback)(ClientEvent::Offline);
+            })
+        };
+        let online = {
+            let on_event_callback = on_event_callback.clone();
+            event_bus.connect(move |_: &libparsec_client::EventOnline| {
+                (on_event_callback)(ClientEvent::Online);
+            })
+        };
+
+        let server_config_changed = {
+            let on_event_callback = on_event_callback.clone();
+            event_bus.connect(move |_: &libparsec_client::EventServerConfigChanged| {
+                (on_event_callback)(ClientEvent::ServerConfigChanged);
+            })
+        };
+        // let workspace_self_role_changed = {
+        //     let on_event_callback = on_event_callback.clone();
+        //     event_bus.connect(move |e: &libparsec_client::EventWorkspaceSelfRoleChanged| {
+        //         (on_event_callback)(ClientEvent::WorkspaceSelfRoleChanged);
+        //     })
+        // };
+        // let workspace_entry_changed = {
+        //     let on_event_callback = on_event_callback.clone();
+        //     event_bus.connect(move |e: &libparsec_client::EventWorkspaceEntryChanged| {
+        //         (on_event_callback)(ClientEvent::WorkspaceEntryChanged);
+        //     })
+        // };
+        let invitation_changed = {
+            let on_event_callback = on_event_callback.clone();
+            event_bus.connect(move |e: &libparsec_client::EventInvitationChanged| {
+                (on_event_callback)(ClientEvent::InvitationChanged {
+                    token: e.token,
+                    status: e.status,
+                });
+            })
+        };
+        // let expired_organization = {
+        //     let on_event_callback = on_event_callback.clone();
+        //     event_bus.connect(move |_: &libparsec_client::EventExpiredOrganization| {
+        //         (on_event_callback)(ClientEvent::ExpiredOrganization);
+        //     })
+        // };
+        // let revoked_user = {
+        //     let on_event_callback = on_event_callback.clone();
+        //     event_bus.connect(move |_: &libparsec_client::EventRevokedSelfUser| {
+        //         (on_event_callback)(ClientEvent::RevokedSelfUser);
+        //     })
+        // };
+        let too_much_drift_with_server_clock = {
+            let on_event_callback = on_event_callback.clone();
+            event_bus.connect(
+                move |e: &libparsec_client::EventTooMuchDriftWithServerClock| {
+                    (on_event_callback)(ClientEvent::TooMuchDriftWithServerClock {
+                        ballpark_client_early_offset: e.ballpark_client_early_offset,
+                        ballpark_client_late_offset: e.ballpark_client_late_offset,
+                        client_timestamp: e.client_timestamp,
+                        server_timestamp: e.server_timestamp,
+                    });
+                },
+            )
+        };
+        let incompatible_server = {
+            let on_event_callback = on_event_callback.clone();
+            event_bus.connect(move |e: &libparsec_client::EventIncompatibleServer| {
+                (on_event_callback)(ClientEvent::IncompatibleServer {
+                    detail: e.0.to_string(),
+                });
+            })
+        };
+        // let invalid_keys_bundle = {
+        //     let on_event_callback = on_event_callback.clone();
+        //     event_bus.connect(move |e: &libparsec_client::EventInvalidKeysBundle| {
+        //         (on_event_callback)(ClientEvent::InvalidKeysBundle);
+        //     })
+        // };
+        // let invalid_certificate = {
+        //     let on_event_callback = on_event_callback.clone();
+        //     event_bus.connect(move |e: &libparsec_client::EventInvalidCertificate| {
+        //         (on_event_callback)(ClientEvent::InvalidCertificate {
+        //             detail: e.0.to_string(),
+        //         });
+        //     })
+        // };
+        // let invalid_manifest = {
+        //     let on_event_callback = on_event_callback.clone();
+        //     event_bus.connect(move |e: &libparsec_client::EventInvalidManifest| {
+        //         (on_event_callback)(ClientEvent::InvalidManifest);
+        //     })
+        // };
+
         Self {
             event_bus,
             _ping: ping,
+            _offline: offline,
+            _online: online,
+            _server_config_changed: server_config_changed,
+            // _workspace_self_role_changed: workspace_self_role_changed,
+            // _workspace_entry_changed: workspace_entry_changed,
+            _invitation_changed: invitation_changed,
+            _too_much_drift_with_server_clock: too_much_drift_with_server_clock,
+            // _expired_organization: expired_organization,
+            // _revoked_user: revoked_user,
+            _incompatible_server: incompatible_server,
+            // _invalid_keys_bundle: invalid_keys_bundle,
+            // _invalid_certificate: invalid_certificate,
+            // _invalid_manifest: invalid_manifest,
         }
     }
 }


### PR DESCRIPTION
Bound events:
- `Ping`: for test onyl, just ignore it
- `Offline` & `Online`
- `ServerConfigChanged` always triggered once on first SSE connection with the server (given before the connection, the client starts with a "good enough" default server config)
- `InvitationChanged`
- `TooMuchDriftWithServerClock`
- `IncompatibleServer` 

Main event missing are `ExpiredOrganization` & `RevokedSelfUser` for errors, and `WorkspaceSelfRoleChanged` (on sharing/unsharing) & `WorkspaceEntryChanged` (when data change)

Additional missing events are the ones to inform about the synchronization progress (both for inbound and outbound sync)