### PR TITLE
[fix #6535]: Add WinFSP installer to the Electron build

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -31,6 +31,11 @@ asyncpg
 athrow
 authurl
 archivings
+oname
+PLUGINSDIR
+macroend
+msiexec
+insertmacro
 archs
 autobuild
 autojump

--- a/client/electron/assets/installer.nsh
+++ b/client/electron/assets/installer.nsh
@@ -1,0 +1,30 @@
+!define WINFSP_VERSION "2.0.23075"
+!define WINFSP_FILE "winfsp-${WINFSP_VERSION}.msi"
+
+!macro installWinFSP
+    File /oname=$PLUGINSDIR\${WINFSP_FILE} ${PROJECT_DIR}\build\${WINFSP_FILE}
+    ; Use /qn to for silent installation
+    ExecWait '"msiexec" /i "$PLUGINSDIR\${WINFSP_FILE}" /qn'
+!macroend
+
+!macro mayInstallWinFSP
+    ClearErrors
+    ReadRegStr $0 HKCR "Installer\Dependencies\WinFsp" "Version"
+    ${If} ${Errors}
+        !insertmacro installWinFSP
+    ${Else}
+        ; Required to use `VersionCompare` macro
+        !include "WordFunc.nsh"
+
+        ${VersionCompare} "$0" "2.0.0" $R0
+        ${VersionCompare} "$0" "2.1.0" $R1
+        ${If} $R1 < 2 ; Currently installed version is >= 2.1.0
+            ${OrIf} $R0 == 2 ; Currently installed version is < 2.0.0
+            !insertmacro installWinFSP
+        ${EndIf}
+    ${EndIf}
+!macroend
+
+!macro customInstall
+    !insertmacro mayInstallWinFSP
+!macroend

--- a/client/electron/electron-builder.config.yml
+++ b/client/electron/electron-builder.config.yml
@@ -5,7 +5,9 @@ directories:
 
 files:
   - assets/**/*
+  - "!assets/installer.nsh"
   - build/**/*
+  - "!build/**/*.msi"
   - app/**/*
 
 publish:
@@ -41,5 +43,7 @@ snap:
   stagePackages:
     - default
     - fuse3
+
+beforePack: ./scripts/before-pack.js
 
 extends: null

--- a/client/electron/package-lock.json
+++ b/client/electron/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "parsec-v3-alpha",
+    "name": "parsec-v3",
     "version": "3.0.0-a.0+dev",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "parsec-v3-alpha",
+            "name": "parsec-v3",
             "version": "3.0.0-a.0+dev",
             "license": "BUSL-1.1",
             "dependencies": {
@@ -18,6 +18,7 @@
                 "electron-window-state": "~5.0.3"
             },
             "devDependencies": {
+                "axios": "^1.6.7",
                 "electron": "^28.1.3",
                 "electron-builder": "~24.9.1",
                 "typescript": "~5.3.3"
@@ -880,6 +881,17 @@
             "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
             "engines": {
                 "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/axios": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+            "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+            "dev": true,
+            "dependencies": {
+                "follow-redirects": "^1.15.4",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/balanced-match": {
@@ -2004,6 +2016,26 @@
                 "node": ">=8"
             }
         },
+        "node_modules/follow-redirects": {
+            "version": "1.15.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+            "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/form-data": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -3061,6 +3093,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "dev": true
         },
         "node_modules/pump": {
             "version": "3.0.0",
@@ -4468,6 +4506,17 @@
             "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
             "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
         },
+        "axios": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+            "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+            "dev": true,
+            "requires": {
+                "follow-redirects": "^1.15.4",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
+            }
+        },
         "balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -5314,6 +5363,12 @@
                 "to-regex-range": "^5.0.1"
             }
         },
+        "follow-redirects": {
+            "version": "1.15.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+            "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+            "dev": true
+        },
         "form-data": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -6082,6 +6137,12 @@
                     "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
                 }
             }
+        },
+        "proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "dev": true
         },
         "pump": {
             "version": "3.0.0",

--- a/client/electron/package.json
+++ b/client/electron/package.json
@@ -29,6 +29,7 @@
         "electron-window-state": "~5.0.3"
     },
     "devDependencies": {
+        "axios": "^1.6.7",
         "electron": "^28.1.3",
         "electron-builder": "~24.9.1",
         "typescript": "~5.3.3"

--- a/client/electron/scripts/before-pack.js
+++ b/client/electron/scripts/before-pack.js
@@ -1,0 +1,65 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+const builder = require('electron-builder');
+
+const WINFSP_VERSION = '2.0.23075';
+const WINFSP_RELEASE_BRANCH = 'v2.0';
+const WINFSP_URL = `https://github.com/winfsp/winfsp/releases/download/${WINFSP_RELEASE_BRANCH}/winfsp-${WINFSP_VERSION}.msi`;
+// `wget -O /dev/stdout ${WINFSP_URL} | openssl dgst -sha256 -binary | openssl base64 -A`
+const WINFSP_SHA256SUM = 'YyTcgRlKagj5e2rsowPPXCMlxT7eFTuun8Q3jwg4wQE=';
+const WINFSP_DEST_FILE = `build/winfsp-${WINFSP_VERSION}.msi`;
+
+/**
+ *
+ * @param {string} url
+ * @param {string} sha256sum The expected sha256sum in base64
+ * @param {path} dest
+ */
+async function downloadFile(url, sha256sum, dest) {
+  const axios = require('axios');
+  const { createHash } = require('node:crypto');
+  const fs = require('node:fs');
+  const stream = require('node:stream/promises');
+
+  const hash = createHash('sha256');
+  const destStream = fs.createWriteStream(dest, {
+    encoding: 'binary',
+  });
+
+  /**
+   * @type {import('axios').AxiosResponse<import('node:stream').Readable>}
+   */
+  const response = await axios({
+    method: 'get',
+    url,
+    responseType: 'stream',
+  });
+
+  if (response.status !== 200) {
+    throw new Error(`Failed to download ${url}: invalid response: ${response.status}`);
+  }
+
+  await Promise.all([stream.pipeline(response.data, hash), stream.pipeline(response.data, destStream)]);
+
+  const fileDigest = hash.digest('base64');
+  if (fileDigest !== sha256sum) {
+    throw new Error(`Failed to download ${url}: sha256sum mismatch: got ${fileDigest} expected ${sha256sum}`);
+  }
+}
+
+/**
+ * @param {import('app-builder-lib/out/configuration').BeforePackContext} context
+ */
+exports.default = async function beforePack(context) {
+  switch (context.electronPlatformName) {
+    case builder.Platform.WINDOWS.nodeName:
+      console.log('Downloading WinFSP');
+      await downloadFile(WINFSP_URL, WINFSP_SHA256SUM, WINFSP_DEST_FILE).then(() =>
+        console.log(`WinFSP downloaded to ${WINFSP_DEST_FILE}`),
+      );
+      break;
+    default:
+      console.log(`No hook for platform ${context.electronPlatformName}`);
+      break;
+  }
+};


### PR DESCRIPTION
- Use the electron-builder hook `boforePack` to download the WinFSP.
- Add a custom NSIS script to install WinFSP if it's not already installed.