### PR TITLE
Fix failure on empty `version.patch`

### DIFF
--- a/.github/workflows/package-client.yml
+++ b/.github/workflows/package-client.yml
@@ -78,7 +78,7 @@ jobs:
           run-id: ${{ inputs.version_patch_run_id || github.run_id }}
 
       - name: Apply version.patch
-        run: git apply ${{ runner.temp }}/version.patch/version.patch
+        run: git apply --allow-empty ${{ runner.temp }}/version.patch/version.patch
 
       - name: Install dependencies
         run: npm clean-install
@@ -158,7 +158,7 @@ jobs:
           run-id: ${{ inputs.version_patch_run_id || github.run_id }}
 
       - name: Apply version.patch
-        run: git apply ${{ runner.temp }}/version.patch/version.patch
+        run: git apply --allow-empty ${{ runner.temp }}/version.patch/version.patch
 
       - name: Linux > Install fuse devel
         if: matrix.platform == 'linux'

--- a/.github/workflows/package-server.yml
+++ b/.github/workflows/package-server.yml
@@ -95,7 +95,7 @@ jobs:
           run-id: ${{ inputs.version_patch_run_id || github.run_id }}
 
       - name: Apply version.patch
-        run: git apply ${{ runner.temp }}/version.patch/version.patch
+        run: git apply --allow-empty ${{ runner.temp }}/version.patch/version.patch
 
       - name: Build wheel
         uses: pypa/cibuildwheel@ce3fb7832089eb3e723a0a99cab7f3eaccf074fd  # pin v2.16.5


### PR DESCRIPTION
The `version.patch` file could be empty if the version change is already applied on the target branch. This append when the workflow `releaser` is scheduled, since at that moment we have a job who update the `releases/nightly` branch with the latest version.