### PR TITLE
Flatten condition for the releaser job

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -63,7 +63,7 @@ jobs:
       - package-parsec-server
       - package-parsec-client
     name: 🚛 Releaser
-    if: join(needs.*.result, '-') == 'success-success-success' && always()
+    if: needs.version.result == 'success' && needs.package-parsec-client.result == 'success' && needs.package-parsec-server.result && always()
     runs-on: ubuntu-22.04
     steps:
       - name: Download every artifact generated (and uploaded)


### PR DESCRIPTION
The previous condition caused the job to not run event tho all requirement jobs completed successfully (and I don't have a way to debug that). I suspect that the job `schedule-nightly-release` is present in the `needs` object and that's what cause the problem.