### PR TITLE
Add missing tests for API realm_*

### DIFF
--- a/server/tests/api_v4/authenticated/test_realm_create.py
+++ b/server/tests/api_v4/authenticated/test_realm_create.py
@@ -1,20 +1,45 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-from parsec._parsec import DateTime, RealmRole, RealmRoleCertificate, VlobID, authenticated_cmds
+import pytest
+
+from parsec._parsec import (
+    DateTime,
+    HashAlgorithm,
+    RealmKeyRotationCertificate,
+    RealmRole,
+    RealmRoleCertificate,
+    SecretKey,
+    SecretKeyAlgorithm,
+    VlobID,
+    authenticated_cmds,
+)
 from parsec.events import EventRealmCertificate
-from tests.common import Backend, CoolorgRpcClients
+from tests.common import (
+    AuthenticatedRpcClient,
+    Backend,
+    CoolorgRpcClients,
+    get_last_realm_certificate_timestamp,
+)
+
+
+def realm_role_certificate(
+    author: AuthenticatedRpcClient,
+    timestamp: DateTime = DateTime.now(),
+    realm_id: VlobID = VlobID.new(),
+    role: RealmRole = RealmRole.OWNER,
+) -> RealmRoleCertificate:
+    """Utility function to create a RealmRoleCertificate"""
+    return RealmRoleCertificate(
+        author=author.device_id,
+        timestamp=timestamp,
+        realm_id=realm_id,
+        role=role,
+        user_id=author.device_id.user_id,
+    )
 
 
 async def test_authenticated_realm_create_ok(coolorg: CoolorgRpcClients, backend: Backend) -> None:
-    timestamp = DateTime.now()
-    wksp_id = VlobID.new()
-    certif = RealmRoleCertificate(
-        author=coolorg.alice.device_id,
-        timestamp=timestamp,
-        realm_id=wksp_id,
-        role=RealmRole.OWNER,
-        user_id=coolorg.alice.device_id.user_id,
-    )
+    certif = realm_role_certificate(coolorg.alice)
 
     with backend.event_bus.spy() as spy:
         rep = await coolorg.alice.realm_create(
@@ -24,23 +49,109 @@ async def test_authenticated_realm_create_ok(coolorg: CoolorgRpcClients, backend
         await spy.wait_event_occurred(
             EventRealmCertificate(
                 organization_id=coolorg.organization_id,
-                timestamp=timestamp,
-                realm_id=wksp_id,
+                timestamp=certif.timestamp,
+                realm_id=certif.realm_id,
                 user_id=coolorg.alice.device_id.user_id,
                 role_removed=False,
             )
         )
 
 
-# async def test_authenticated_realm_create_already_exists(
-#     coolorg: CoolorgRpcClients, backend: Backend
-# ) -> None:
-#     block_id = BlockID.new()
-#     block = b"<block content>"
+async def test_authenticated_realm_create_already_exists(
+    coolorg: CoolorgRpcClients, backend: Backend
+) -> None:
+    certif = realm_role_certificate(coolorg.alice, realm_id=coolorg.wksp1_id)
+    rep = await coolorg.alice.realm_create(
+        realm_role_certificate=certif.dump_and_sign(coolorg.alice.signing_key)
+    )
+    assert rep == authenticated_cmds.v4.realm_create.RepRealmAlreadyExists(
+        last_realm_certificate_timestamp=get_last_realm_certificate_timestamp(
+            testbed_template=coolorg.testbed_template,
+            realm_id=coolorg.wksp1_id,
+        )
+    )
 
-#     await backend.block.create(
-#         coolorg.organization_id, coolorg.alice.device_id, block_id, coolorg.wksp1_id, block
-#     )
 
-#     rep = await coolorg.alice.block_create(block_id, coolorg.wksp1_id, block)
-#     assert rep == authenticated_cmds.v4.block_create.RepAlreadyExists()
+@pytest.mark.parametrize(
+    "kind",
+    (
+        "dummy_data",
+        "bad_author",
+    ),
+)
+async def test_authenticated_realm_create_invalid_certificate(
+    coolorg: CoolorgRpcClients, kind: str
+) -> None:
+    match kind:
+        case "dummy_data":
+            authenticated_client = coolorg.alice
+            certif = b"<dummy data>"
+        case "bad_author":
+            authenticated_client = coolorg.alice
+            certif = realm_role_certificate(coolorg.bob).dump_and_sign(coolorg.bob.signing_key)
+        case unknown:
+            assert False, unknown
+
+    rep = await authenticated_client.realm_create(realm_role_certificate=certif)
+    assert rep == authenticated_cmds.v4.realm_create.RepInvalidCertificate()
+
+
+async def test_authenticated_realm_create_timestamp_out_of_ballpark(
+    coolorg: CoolorgRpcClients,
+    timestamp_out_of_ballpark: DateTime,
+) -> None:
+    certif = realm_role_certificate(coolorg.alice, timestamp=timestamp_out_of_ballpark)
+    rep = await coolorg.alice.realm_create(
+        realm_role_certificate=certif.dump_and_sign(coolorg.alice.signing_key)
+    )
+    assert isinstance(rep, authenticated_cmds.v4.realm_create.RepTimestampOutOfBallpark)
+    assert rep.ballpark_client_early_offset == 300.0
+    assert rep.ballpark_client_late_offset == 320.0
+    assert rep.client_timestamp == timestamp_out_of_ballpark
+
+
+@pytest.mark.parametrize(
+    "timestamp_offset",
+    (pytest.param(0, id="same_timestamp"), pytest.param(1, id="previous_timestamp")),
+)
+async def test_authenticated_realm_create_require_greater_timestamp(
+    coolorg: CoolorgRpcClients,
+    backend: Backend,
+    timestamp_offset: int,
+) -> None:
+    last_certificate_timestamp = DateTime.now()
+    same_or_previous_timestamp = last_certificate_timestamp.subtract(seconds=timestamp_offset)
+
+    # 1) Performa a key rotation to add a new certificate at last_certificate_timestamp
+
+    outcome = await backend.realm.rotate_key(
+        now=last_certificate_timestamp,
+        organization_id=coolorg.organization_id,
+        author=coolorg.alice.device_id,
+        author_verify_key=coolorg.alice.signing_key.verify_key,
+        keys_bundle=b"",
+        per_participant_keys_bundle_access={
+            coolorg.alice.user_id: b"<alice keys bundle access>",
+            coolorg.bob.user_id: b"<bob keys bundle access>",
+        },
+        realm_key_rotation_certificate=RealmKeyRotationCertificate(
+            author=coolorg.alice.device_id,
+            timestamp=last_certificate_timestamp,
+            hash_algorithm=HashAlgorithm.SHA256,
+            encryption_algorithm=SecretKeyAlgorithm.XSALSA20_POLY1305,
+            key_index=2,
+            realm_id=coolorg.wksp1_id,
+            key_canary=SecretKey.generate().encrypt(b""),
+        ).dump_and_sign(coolorg.alice.signing_key),
+    )
+    assert isinstance(outcome, RealmKeyRotationCertificate)
+
+    # 2) Try to create a realm with same or previous timestamp
+
+    certif = realm_role_certificate(coolorg.alice, timestamp=same_or_previous_timestamp)
+    rep = await coolorg.alice.realm_create(
+        realm_role_certificate=certif.dump_and_sign(coolorg.alice.signing_key)
+    )
+    assert rep == authenticated_cmds.v4.realm_create.RepRequireGreaterTimestamp(
+        strictly_greater_than=last_certificate_timestamp
+    )

--- a/server/tests/api_v4/authenticated/test_realm_rename.py
+++ b/server/tests/api_v4/authenticated/test_realm_rename.py
@@ -15,20 +15,68 @@ from parsec._parsec import (
     authenticated_cmds,
 )
 from parsec.events import EventRealmCertificate
-from tests.common import Backend, CoolorgRpcClients, get_last_realm_certificate_timestamp
+from tests.common import (
+    AuthenticatedRpcClient,
+    Backend,
+    CoolorgRpcClients,
+    get_last_realm_certificate_timestamp,
+)
+
+
+def realm_name_certificate(
+    author: AuthenticatedRpcClient,
+    timestamp: DateTime = DateTime.now(),
+    realm_id: VlobID = VlobID.new(),
+    key_index: int = 1,
+) -> RealmNameCertificate:
+    """Utility function to create a RealmNameCertificate"""
+    return RealmNameCertificate(
+        author=author.device_id,
+        timestamp=timestamp,
+        realm_id=realm_id,
+        key_index=key_index,
+        encrypted_name=b"<encrypted name>",
+    )
+
+
+def realm_role_certificate(
+    author: AuthenticatedRpcClient,
+    realm_id: VlobID,
+    timestamp: DateTime = DateTime.now(),
+    role: RealmRole = RealmRole.OWNER,
+) -> RealmRoleCertificate:
+    """Utility function to create a RealmRoleCertificate"""
+    return RealmRoleCertificate(
+        author=author.device_id,
+        timestamp=timestamp,
+        realm_id=realm_id,
+        role=role,
+        user_id=author.user_id,
+    )
+
+
+def realm_key_rotation_certificate(
+    author: AuthenticatedRpcClient,
+    realm_id: VlobID,
+    key_index: int,
+    timestamp: DateTime = DateTime.now(),
+):
+    """Utility function to perform a RealmKeyRotationCertificate"""
+    return RealmKeyRotationCertificate(
+        author=author.device_id,
+        timestamp=timestamp,
+        realm_id=realm_id,
+        key_index=key_index,
+        encryption_algorithm=SecretKeyAlgorithm.XSALSA20_POLY1305,
+        hash_algorithm=HashAlgorithm.SHA256,
+        key_canary=SecretKey.generate().encrypt(b""),
+    )
 
 
 async def test_authenticated_realm_rename_rotate_key_ok_subsequent_rename(
     coolorg: CoolorgRpcClients, backend: Backend
 ) -> None:
-    t1 = DateTime.now()
-    certif = RealmNameCertificate(
-        author=coolorg.alice.device_id,
-        timestamp=t1,
-        realm_id=coolorg.wksp1_id,
-        key_index=1,
-        encrypted_name=b"<encrypted name>",
-    )
+    certif = realm_name_certificate(coolorg.alice, realm_id=coolorg.wksp1_id)
 
     with backend.event_bus.spy() as spy:
         rep = await coolorg.alice.realm_rename(
@@ -39,7 +87,7 @@ async def test_authenticated_realm_rename_rotate_key_ok_subsequent_rename(
         await spy.wait_event_occurred(
             EventRealmCertificate(
                 organization_id=coolorg.organization_id,
-                timestamp=t1,
+                timestamp=certif.timestamp,
                 realm_id=coolorg.wksp1_id,
                 user_id=coolorg.alice.device_id.user_id,
                 role_removed=False,
@@ -50,43 +98,26 @@ async def test_authenticated_realm_rename_rotate_key_ok_subsequent_rename(
 async def test_authenticated_realm_rename_rotate_key_ok_initial_rename(
     coolorg: CoolorgRpcClients, backend: Backend
 ) -> None:
-    # Create a new realm (so it has not been renamed yet)
+    # 1) Create a new realm (so it has not been renamed yet)
 
-    t0 = DateTime.now()
-    wksp2_id = VlobID.new()
-    certif = RealmRoleCertificate(
-        author=coolorg.alice.device_id,
-        timestamp=t0,
-        realm_id=wksp2_id,
-        role=RealmRole.OWNER,
-        user_id=coolorg.alice.device_id.user_id,
-    )
+    new_realm_id = VlobID.new()
+    role_certificate = realm_role_certificate(coolorg.alice, new_realm_id)
     outcome = await backend.realm.create(
-        now=t0,
+        now=role_certificate.timestamp,
         organization_id=coolorg.organization_id,
         author=coolorg.alice.device_id,
         author_verify_key=coolorg.alice.signing_key.verify_key,
-        realm_role_certificate=certif.dump_and_sign(coolorg.alice.signing_key),
+        realm_role_certificate=role_certificate.dump_and_sign(coolorg.alice.signing_key),
     )
     assert isinstance(outcome, RealmRoleCertificate)
 
-    # New realm must have it initial key rotation to allow for initial rename
+    # 2) New realm must have its initial key rotation to allow for initial rename
 
-    t1 = DateTime.now()
-    key = SecretKey.generate()
-    key_canary = key.encrypt(b"")
-    certif = RealmKeyRotationCertificate(
-        author=coolorg.alice.device_id,
-        timestamp=t1,
-        realm_id=wksp2_id,
-        key_index=1,
-        encryption_algorithm=SecretKeyAlgorithm.XSALSA20_POLY1305,
-        hash_algorithm=HashAlgorithm.SHA256,
-        key_canary=key_canary,
+    key_rotation_certif = realm_key_rotation_certificate(
+        coolorg.alice, realm_id=new_realm_id, key_index=1
     )
-    realm_key_rotation_certificate = certif.dump_and_sign(coolorg.alice.signing_key)
     outcome = await backend.realm.rotate_key(
-        now=t1,
+        now=key_rotation_certif.timestamp,
         organization_id=coolorg.organization_id,
         author=coolorg.alice.device_id,
         author_verify_key=coolorg.alice.signing_key.verify_key,
@@ -94,20 +125,13 @@ async def test_authenticated_realm_rename_rotate_key_ok_initial_rename(
         per_participant_keys_bundle_access={
             coolorg.alice.device_id.user_id: b"<alice keys bundle access>",
         },
-        realm_key_rotation_certificate=realm_key_rotation_certificate,
+        realm_key_rotation_certificate=key_rotation_certif.dump_and_sign(coolorg.alice.signing_key),
     )
     assert isinstance(outcome, RealmKeyRotationCertificate)
 
-    # Now do the actual initial rename
+    # 3) Now do the actual (initial) rename
 
-    t1 = DateTime.now()
-    certif = RealmNameCertificate(
-        author=coolorg.alice.device_id,
-        timestamp=t1,
-        realm_id=wksp2_id,
-        key_index=1,
-        encrypted_name=b"<encrypted name>",
-    )
+    certif = realm_name_certificate(coolorg.alice, realm_id=new_realm_id)
     with backend.event_bus.spy() as spy:
         rep = await coolorg.alice.realm_rename(
             realm_name_certificate=certif.dump_and_sign(coolorg.alice.signing_key),
@@ -117,8 +141,8 @@ async def test_authenticated_realm_rename_rotate_key_ok_initial_rename(
         await spy.wait_event_occurred(
             EventRealmCertificate(
                 organization_id=coolorg.organization_id,
-                timestamp=t1,
-                realm_id=wksp2_id,
+                timestamp=certif.timestamp,
+                realm_id=certif.realm_id,
                 user_id=coolorg.alice.device_id.user_id,
                 role_removed=False,
             )
@@ -126,17 +150,9 @@ async def test_authenticated_realm_rename_rotate_key_ok_initial_rename(
 
 
 async def test_authenticated_realm_rename_initial_name_already_exists(
-    coolorg: CoolorgRpcClients, backend: Backend
+    coolorg: CoolorgRpcClients,
 ) -> None:
-    t1 = DateTime.now()
-    certif = RealmNameCertificate(
-        author=coolorg.alice.device_id,
-        timestamp=t1,
-        realm_id=coolorg.wksp1_id,
-        key_index=1,
-        encrypted_name=b"<encrypted name>",
-    )
-
+    certif = realm_name_certificate(coolorg.alice, realm_id=coolorg.wksp1_id)
     rep = await coolorg.alice.realm_rename(
         realm_name_certificate=certif.dump_and_sign(coolorg.alice.signing_key),
         initial_name_or_fail=True,
@@ -150,7 +166,7 @@ async def test_authenticated_realm_rename_initial_name_already_exists(
 
 @pytest.mark.parametrize("kind", ("author_not_realm_owner", "author_no_realm_access"))
 async def test_authenticated_realm_rename_author_not_allowed(
-    coolorg: CoolorgRpcClients, backend: Backend, kind: str
+    coolorg: CoolorgRpcClients, kind: str
 ) -> None:
     match kind:
         case "author_not_realm_owner":
@@ -162,15 +178,7 @@ async def test_authenticated_realm_rename_author_not_allowed(
         case _:
             assert False
 
-    t1 = DateTime.now()
-    certif = RealmNameCertificate(
-        author=author.device_id,
-        timestamp=t1,
-        realm_id=coolorg.wksp1_id,
-        key_index=1,
-        encrypted_name=b"<encrypted name>",
-    )
-
+    certif = realm_name_certificate(author, realm_id=coolorg.wksp1_id)
     rep = await author.realm_rename(
         realm_name_certificate=certif.dump_and_sign(author.signing_key),
         initial_name_or_fail=False,
@@ -178,18 +186,9 @@ async def test_authenticated_realm_rename_author_not_allowed(
     assert rep == authenticated_cmds.v4.realm_rename.RepAuthorNotAllowed()
 
 
-async def test_authenticated_realm_rename_realm_not_found(
-    coolorg: CoolorgRpcClients, backend: Backend
-) -> None:
-    t1 = DateTime.now()
-    certif = RealmNameCertificate(
-        author=coolorg.alice.device_id,
-        timestamp=t1,
-        realm_id=VlobID.new(),  # Dummy realm ID
-        key_index=1,
-        encrypted_name=b"<encrypted name>",
-    )
-
+async def test_authenticated_realm_rename_realm_not_found(coolorg: CoolorgRpcClients) -> None:
+    bad_realm_id = VlobID.new()
+    certif = realm_name_certificate(coolorg.alice, realm_id=bad_realm_id)
     rep = await coolorg.alice.realm_rename(
         realm_name_certificate=certif.dump_and_sign(coolorg.alice.signing_key),
         initial_name_or_fail=False,
@@ -212,21 +211,12 @@ async def test_authenticated_realm_rename_bad_key_index(
     match kind:
         case "key_index_too_old":
             # Do another key rotation so that current key index is 2
-            t0 = DateTime.now()
-            key = SecretKey.generate()
-            key_canary = key.encrypt(b"")
-            certif = RealmKeyRotationCertificate(
-                author=coolorg.alice.device_id,
-                timestamp=t0,
-                realm_id=coolorg.wksp1_id,
-                key_index=2,
-                encryption_algorithm=SecretKeyAlgorithm.XSALSA20_POLY1305,
-                hash_algorithm=HashAlgorithm.SHA256,
-                key_canary=key_canary,
+            wksp_id = coolorg.wksp1_id
+            key_rotation_certif = realm_key_rotation_certificate(
+                coolorg.alice, realm_id=wksp_id, key_index=2
             )
-            realm_key_rotation_certificate = certif.dump_and_sign(coolorg.alice.signing_key)
             outcome = await backend.realm.rotate_key(
-                now=t0,
+                now=key_rotation_certif.timestamp,
                 organization_id=coolorg.organization_id,
                 author=coolorg.alice.device_id,
                 author_verify_key=coolorg.alice.signing_key.verify_key,
@@ -235,12 +225,13 @@ async def test_authenticated_realm_rename_bad_key_index(
                     coolorg.alice.device_id.user_id: b"<alice keys bundle access>",
                     coolorg.bob.device_id.user_id: b"<bob keys bundle access>",
                 },
-                realm_key_rotation_certificate=realm_key_rotation_certificate,
+                realm_key_rotation_certificate=key_rotation_certif.dump_and_sign(
+                    coolorg.alice.signing_key
+                ),
             )
             assert isinstance(outcome, RealmKeyRotationCertificate)
             bad_key_index = 1
-            wksp_id = coolorg.wksp1_id
-            wksp_last_certificate_timestamp = t0
+            wksp_last_certificate_timestamp = key_rotation_certif.timestamp
         case "key_index_too_far_forward":
             bad_key_index = 2
             wksp_id = coolorg.wksp1_id
@@ -254,37 +245,24 @@ async def test_authenticated_realm_rename_bad_key_index(
                 coolorg.testbed_template, wksp_id
             )
         case "realm_had_no_key_rotation_yet":
-            t0 = DateTime.now()
-            wksp_id = VlobID.new()
-            certif = RealmRoleCertificate(
-                author=coolorg.alice.device_id,
-                timestamp=t0,
-                realm_id=wksp_id,
-                role=RealmRole.OWNER,
-                user_id=coolorg.alice.device_id.user_id,
-            )
+            # Create a new realm, which does not have a key rotation yet
+            new_realm_id = VlobID.new()
+            role_certificate = realm_role_certificate(coolorg.alice, new_realm_id)
             outcome = await backend.realm.create(
-                now=t0,
+                now=role_certificate.timestamp,
                 organization_id=coolorg.organization_id,
                 author=coolorg.alice.device_id,
                 author_verify_key=coolorg.alice.signing_key.verify_key,
-                realm_role_certificate=certif.dump_and_sign(coolorg.alice.signing_key),
+                realm_role_certificate=role_certificate.dump_and_sign(coolorg.alice.signing_key),
             )
             assert isinstance(outcome, RealmRoleCertificate)
             bad_key_index = 1
-            wksp_last_certificate_timestamp = t0
+            wksp_id = new_realm_id
+            wksp_last_certificate_timestamp = role_certificate.timestamp
         case _:
             assert False
 
-    t1 = DateTime.now()
-    certif = RealmNameCertificate(
-        author=coolorg.alice.device_id,
-        timestamp=t1,
-        realm_id=wksp_id,
-        key_index=bad_key_index,
-        encrypted_name=b"<encrypted name>",
-    )
-
+    certif = realm_name_certificate(coolorg.alice, realm_id=wksp_id, key_index=bad_key_index)
     rep = await coolorg.alice.realm_rename(
         realm_name_certificate=certif.dump_and_sign(coolorg.alice.signing_key),
         initial_name_or_fail=False,
@@ -294,28 +272,95 @@ async def test_authenticated_realm_rename_bad_key_index(
     )
 
 
-@pytest.mark.parametrize("kind", ("dummy_data", "bad_author"))
+@pytest.mark.parametrize(
+    "kind",
+    ("dummy_data", "bad_author"),
+)
 async def test_authenticated_realm_rename_invalid_certificate(
-    coolorg: CoolorgRpcClients, backend: Backend, kind: str
+    coolorg: CoolorgRpcClients, kind: str
 ) -> None:
-    t1 = DateTime.now()
     match kind:
         case "dummy_data":
-            realm_key_rotation_certificate = b"<dummy data>"
+            certif = b"<dummy data>"
         case "bad_author":
-            certif = RealmNameCertificate(
-                author=coolorg.bob.device_id,
-                timestamp=t1,
-                realm_id=coolorg.wksp1_id,
-                key_index=1,
-                encrypted_name=b"<encrypted name>",
+            certif = realm_name_certificate(coolorg.bob, realm_id=coolorg.wksp1_id).dump_and_sign(
+                coolorg.bob.signing_key
             )
-            realm_key_rotation_certificate = certif.dump_and_sign(coolorg.bob.signing_key)
-        case _:
-            assert False
+        case unknown:
+            assert False, unknown
 
     rep = await coolorg.alice.realm_rename(
-        realm_name_certificate=realm_key_rotation_certificate,
+        realm_name_certificate=certif,
         initial_name_or_fail=False,
     )
     assert rep == authenticated_cmds.v4.realm_rename.RepInvalidCertificate()
+
+
+@pytest.mark.xfail(
+    reason="TODO: realm_rename never returns RepRequireGreaterTimestamp. Not implemented?"
+)
+@pytest.mark.parametrize(
+    "timestamp_offset",
+    (pytest.param(0, id="same_timestamp"), pytest.param(1, id="previous_timestamp")),
+)
+async def test_authenticated_realm_rename_require_greater_timestamp(
+    coolorg: CoolorgRpcClients,
+    backend: Backend,
+    timestamp_offset: int,
+) -> None:
+    last_certificate_timestamp = DateTime.now()
+    same_or_previous_timestamp = last_certificate_timestamp.subtract(seconds=timestamp_offset)
+
+    # 1) Performa a key rotation to add a new certificate at last_certificate_timestamp
+
+    outcome = await backend.realm.rotate_key(
+        now=last_certificate_timestamp,
+        organization_id=coolorg.organization_id,
+        author=coolorg.alice.device_id,
+        author_verify_key=coolorg.alice.signing_key.verify_key,
+        keys_bundle=b"",
+        per_participant_keys_bundle_access={
+            coolorg.alice.user_id: b"<alice keys bundle access>",
+            coolorg.bob.user_id: b"<bob keys bundle access>",
+        },
+        realm_key_rotation_certificate=RealmKeyRotationCertificate(
+            author=coolorg.alice.device_id,
+            timestamp=last_certificate_timestamp,
+            hash_algorithm=HashAlgorithm.SHA256,
+            encryption_algorithm=SecretKeyAlgorithm.XSALSA20_POLY1305,
+            key_index=2,
+            realm_id=coolorg.wksp1_id,
+            key_canary=SecretKey.generate().encrypt(b""),
+        ).dump_and_sign(coolorg.alice.signing_key),
+    )
+    assert isinstance(outcome, RealmKeyRotationCertificate)
+
+    # 2) Try to create a realm with same or previous timestamp
+
+    certif = realm_name_certificate(
+        coolorg.alice, timestamp=same_or_previous_timestamp, realm_id=coolorg.wksp1_id, key_index=2
+    )
+    rep = await coolorg.alice.realm_rename(
+        realm_name_certificate=certif.dump_and_sign(coolorg.alice.signing_key),
+        initial_name_or_fail=False,
+    )
+    assert rep == authenticated_cmds.v4.realm_rename.RepRequireGreaterTimestamp(
+        strictly_greater_than=last_certificate_timestamp
+    )
+
+
+async def test_authenticated_realm_rename_timestamp_out_of_ballpark(
+    coolorg: CoolorgRpcClients,
+    timestamp_out_of_ballpark: DateTime,
+) -> None:
+    certif = realm_name_certificate(
+        coolorg.alice, timestamp=timestamp_out_of_ballpark, realm_id=coolorg.wksp1_id
+    )
+    rep = await coolorg.alice.realm_rename(
+        realm_name_certificate=certif.dump_and_sign(coolorg.alice.signing_key),
+        initial_name_or_fail=True,
+    )
+    assert isinstance(rep, authenticated_cmds.v4.realm_rename.RepTimestampOutOfBallpark)
+    assert rep.ballpark_client_early_offset == 300.0
+    assert rep.ballpark_client_late_offset == 320.0
+    assert rep.client_timestamp == timestamp_out_of_ballpark

--- a/server/tests/api_v4/authenticated/test_realm_rename.py
+++ b/server/tests/api_v4/authenticated/test_realm_rename.py
@@ -271,7 +271,6 @@ async def test_authenticated_realm_rename_bad_key_index(
     certif = patch_realm_name_certificate(
         alice_name_certificate, realm_id=wksp_id, key_index=bad_key_index
     )
-    print(certif)
     rep = await coolorg.alice.realm_rename(
         realm_name_certificate=certif.dump_and_sign(coolorg.alice.signing_key),
         initial_name_or_fail=False,

--- a/server/tests/api_v4/authenticated/test_realm_unshare.py
+++ b/server/tests/api_v4/authenticated/test_realm_unshare.py
@@ -1,33 +1,54 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
+
 import pytest
 
-from parsec._parsec import DateTime, RealmRole, RealmRoleCertificate, authenticated_cmds
+from parsec._parsec import (
+    DateTime,
+    HashAlgorithm,
+    RealmKeyRotationCertificate,
+    RealmRole,
+    RealmRoleCertificate,
+    RevokedUserCertificate,
+    SecretKey,
+    SecretKeyAlgorithm,
+    UserID,
+    VlobID,
+    authenticated_cmds,
+)
 from parsec.events import EventRealmCertificate
-from tests.common import Backend, CoolorgRpcClients
+from tests.common import Backend, CoolorgRpcClients, patch_realm_role_certificate
 
 
-async def test_authenticated_realm_share_ok(coolorg: CoolorgRpcClients, backend: Backend) -> None:
-    timestamp = DateTime.now()
-    certif = RealmRoleCertificate(
+@pytest.fixture
+def alice_unshare_bob_certificate(coolorg: CoolorgRpcClients) -> RealmRoleCertificate:
+    return RealmRoleCertificate(
         author=coolorg.alice.device_id,
-        timestamp=timestamp,
+        timestamp=DateTime.now(),
         realm_id=coolorg.wksp1_id,
+        user_id=coolorg.bob.user_id,
         role=None,
-        user_id=coolorg.bob.device_id.user_id,
-    ).dump_and_sign(coolorg.alice.signing_key)
+    )
 
+
+async def test_authenticated_realm_unshare_ok(
+    coolorg: CoolorgRpcClients,
+    backend: Backend,
+    alice_unshare_bob_certificate: RealmRoleCertificate,
+) -> None:
     with backend.event_bus.spy() as spy:
         rep = await coolorg.alice.realm_unshare(
-            realm_role_certificate=certif,
+            realm_role_certificate=alice_unshare_bob_certificate.dump_and_sign(
+                coolorg.alice.signing_key
+            ),
         )
         assert rep == authenticated_cmds.v4.realm_unshare.RepOk()
         await spy.wait_event_occurred(
             EventRealmCertificate(
                 organization_id=coolorg.organization_id,
-                timestamp=timestamp,
-                realm_id=coolorg.wksp1_id,
-                user_id=coolorg.bob.device_id.user_id,
+                timestamp=alice_unshare_bob_certificate.timestamp,
+                realm_id=alice_unshare_bob_certificate.realm_id,
+                user_id=alice_unshare_bob_certificate.user_id,
                 role_removed=True,
             )
         )
@@ -39,30 +60,128 @@ async def test_authenticated_realm_share_ok(coolorg: CoolorgRpcClients, backend:
     assert coolorg.wksp1_id not in bob_realms
 
 
+@pytest.mark.parametrize("kind", ("author_is_reader", "author_is_not_shared"))
+async def test_authenticated_realm_unshare_author_not_allowed(
+    coolorg: CoolorgRpcClients,
+    alice_unshare_bob_certificate: RealmRoleCertificate,
+    kind: str,
+) -> None:
+    match kind:
+        case "author_is_reader":
+            author = coolorg.bob
+        case "author_is_not_shared":
+            author = coolorg.mallory
+        case unknown:
+            assert False, unknown
+
+    certif = patch_realm_role_certificate(
+        alice_unshare_bob_certificate, author=author.device_id, user_id=coolorg.alice.user_id
+    )
+    rep = await author.realm_unshare(
+        realm_role_certificate=certif.dump_and_sign(author.signing_key),
+    )
+    assert rep == authenticated_cmds.v4.realm_unshare.RepAuthorNotAllowed()
+
+
+async def test_authenticated_realm_unshare_realm_not_found(
+    coolorg: CoolorgRpcClients,
+    alice_unshare_bob_certificate: RealmRoleCertificate,
+) -> None:
+    bad_realm_id = VlobID.new()
+    certif = patch_realm_role_certificate(alice_unshare_bob_certificate, realm_id=bad_realm_id)
+    rep = await coolorg.alice.realm_unshare(
+        realm_role_certificate=certif.dump_and_sign(coolorg.alice.signing_key),
+    )
+    assert rep == authenticated_cmds.v4.realm_unshare.RepRealmNotFound()
+
+
+@pytest.mark.parametrize(
+    "kind",
+    (
+        "user_unknown",
+        pytest.param(
+            "user_revoked",
+            marks=pytest.mark.xfail(
+                reason="TODO: Should fail if user to be unshared is revoked. Not implemented?"
+            ),
+        ),
+    ),
+)
+async def test_authenticated_realm_unshare_recipient_not_found(
+    coolorg: CoolorgRpcClients,
+    backend: Backend,
+    alice_unshare_bob_certificate: RealmRoleCertificate,
+    kind: str,
+) -> None:
+    match kind:
+        case "user_unknown":
+            bad_recipient = UserID("unknown")
+        case "user_revoked":
+            bad_recipient = coolorg.bob.user_id
+            # Revoke user Bob
+            revoke_timestamp = DateTime.now()
+            outcome = await backend.user.revoke_user(
+                now=revoke_timestamp,
+                organization_id=coolorg.organization_id,
+                author=coolorg.alice.device_id,
+                author_verify_key=coolorg.alice.signing_key.verify_key,
+                revoked_user_certificate=RevokedUserCertificate(
+                    author=coolorg.alice.device_id,
+                    timestamp=revoke_timestamp,
+                    user_id=coolorg.bob.device_id.user_id,
+                ).dump_and_sign(coolorg.alice.signing_key),
+            )
+            assert isinstance(outcome, RevokedUserCertificate)
+        case unknown:
+            assert False, unknown
+    certif = patch_realm_role_certificate(
+        alice_unshare_bob_certificate, user_id=bad_recipient, timestamp=DateTime.now()
+    )
+    rep = await coolorg.alice.realm_unshare(
+        realm_role_certificate=certif.dump_and_sign(coolorg.alice.signing_key),
+    )
+    assert rep == authenticated_cmds.v4.realm_unshare.RepRecipientNotFound()
+
+
+async def test_authenticated_realm_unshare_recipient_already_unshared(
+    coolorg: CoolorgRpcClients,
+    backend: Backend,
+    alice_unshare_bob_certificate: RealmRoleCertificate,
+) -> None:
+    # 1) Use certificate to unshare Bob via the backend
+    outcome = await backend.realm.unshare(
+        alice_unshare_bob_certificate.timestamp,
+        coolorg.organization_id,
+        coolorg.alice.device_id,
+        alice_unshare_bob_certificate.dump_and_sign(coolorg.alice.signing_key),
+    )
+    assert isinstance(outcome, RealmRoleCertificate)
+
+    # 2) Try to unshare Bob again, now via the API
+    rep = await coolorg.alice.realm_unshare(
+        realm_role_certificate=alice_unshare_bob_certificate.dump_and_sign(
+            coolorg.alice.signing_key
+        ),
+    )
+    assert rep == authenticated_cmds.v4.realm_unshare.RepRecipientAlreadyUnshared(
+        last_realm_certificate_timestamp=alice_unshare_bob_certificate.timestamp
+    )
+
+
 @pytest.mark.parametrize("kind", ("dummy_certif", "invalid_role", "self_unshare"))
 async def test_authenticated_realm_unshare_invalid_certificate(
-    coolorg: CoolorgRpcClients, kind: str
+    coolorg: CoolorgRpcClients, alice_unshare_bob_certificate: RealmRoleCertificate, kind: str
 ) -> None:
-    timestamp = DateTime.now()
-
     match kind:
         case "dummy_certif":
             certif = b"<dummy>"
         case "invalid_role":
-            certif = RealmRoleCertificate(
-                author=coolorg.alice.device_id,
-                timestamp=timestamp,
-                realm_id=coolorg.wksp1_id,
-                role=RealmRole.READER,
-                user_id=coolorg.bob.device_id.user_id,
+            certif = patch_realm_role_certificate(
+                alice_unshare_bob_certificate, role=RealmRole.READER
             ).dump_and_sign(coolorg.alice.signing_key)
         case "self_unshare":
-            certif = RealmRoleCertificate(
-                author=coolorg.alice.device_id,
-                timestamp=timestamp,
-                realm_id=coolorg.wksp1_id,
-                role=None,
-                user_id=coolorg.alice.device_id.user_id,
+            certif = patch_realm_role_certificate(
+                alice_unshare_bob_certificate, user_id=coolorg.alice.user_id
             ).dump_and_sign(coolorg.alice.signing_key)
         case unknown:
             assert False, unknown
@@ -73,5 +192,68 @@ async def test_authenticated_realm_unshare_invalid_certificate(
     assert rep == authenticated_cmds.v4.realm_unshare.RepInvalidCertificate()
 
 
-# TODO: test unshare on revoked user
-# TODO: test unshare with certificate containing a non-null role
+async def test_authenticated_realm_unshare_timestamp_out_of_ballpark(
+    coolorg: CoolorgRpcClients,
+    alice_unshare_bob_certificate: RealmRoleCertificate,
+    timestamp_out_of_ballpark: DateTime,
+) -> None:
+    certif = patch_realm_role_certificate(
+        alice_unshare_bob_certificate, timestamp=timestamp_out_of_ballpark
+    )
+    rep = await coolorg.alice.realm_unshare(
+        realm_role_certificate=certif.dump_and_sign(coolorg.alice.signing_key),
+    )
+    assert isinstance(rep, authenticated_cmds.v4.realm_unshare.RepTimestampOutOfBallpark)
+    assert rep.ballpark_client_early_offset == 300.0
+    assert rep.ballpark_client_late_offset == 320.0
+    assert rep.client_timestamp == timestamp_out_of_ballpark
+
+
+@pytest.mark.parametrize(
+    "timestamp_offset",
+    (pytest.param(0, id="same_timestamp"), pytest.param(1, id="previous_timestamp")),
+)
+async def test_authenticated_realm_unshare_require_greater_timestamp(
+    coolorg: CoolorgRpcClients,
+    backend: Backend,
+    alice_unshare_bob_certificate: RealmRoleCertificate,
+    timestamp_offset: int,
+) -> None:
+    last_certificate_timestamp = DateTime.now()
+    same_or_previous_timestamp = last_certificate_timestamp.subtract(seconds=timestamp_offset)
+
+    # 1) Performa a key rotation to add a new certificate at last_certificate_timestamp
+
+    outcome = await backend.realm.rotate_key(
+        now=last_certificate_timestamp,
+        organization_id=coolorg.organization_id,
+        author=coolorg.alice.device_id,
+        author_verify_key=coolorg.alice.signing_key.verify_key,
+        keys_bundle=b"",
+        per_participant_keys_bundle_access={
+            coolorg.alice.user_id: b"<alice keys bundle access>",
+            coolorg.bob.user_id: b"<bob keys bundle access>",
+        },
+        realm_key_rotation_certificate=RealmKeyRotationCertificate(
+            author=coolorg.alice.device_id,
+            timestamp=last_certificate_timestamp,
+            hash_algorithm=HashAlgorithm.SHA256,
+            encryption_algorithm=SecretKeyAlgorithm.XSALSA20_POLY1305,
+            key_index=2,
+            realm_id=coolorg.wksp1_id,
+            key_canary=SecretKey.generate().encrypt(b""),
+        ).dump_and_sign(coolorg.alice.signing_key),
+    )
+    assert isinstance(outcome, RealmKeyRotationCertificate)
+
+    # 2) Try to unshare a realm with same or previous timestamp
+
+    certif = patch_realm_role_certificate(
+        alice_unshare_bob_certificate, timestamp=same_or_previous_timestamp
+    )
+    rep = await coolorg.alice.realm_unshare(
+        realm_role_certificate=certif.dump_and_sign(coolorg.alice.signing_key),
+    )
+    assert rep == authenticated_cmds.v4.realm_unshare.RepRequireGreaterTimestamp(
+        strictly_greater_than=last_certificate_timestamp
+    )

--- a/server/tests/common/__init__.py
+++ b/server/tests/common/__init__.py
@@ -6,6 +6,7 @@ from _pytest.logging import LogCaptureFixture as VanillaLogCaptureFixture
 from .backend import *  # noqa
 from .client import *  # noqa
 from .postgresql import *  # noqa
+from .realm import *  # noqa
 
 
 # customized in `tests/conftest.py`

--- a/server/tests/common/backend.py
+++ b/server/tests/common/backend.py
@@ -5,7 +5,7 @@ from typing import AsyncGenerator, Iterator
 
 import pytest
 
-from parsec._parsec import ParsecAddr
+from parsec._parsec import DateTime, ParsecAddr
 from parsec.asgi import AsgiApp
 from parsec.asgi import app as asgi_app
 from parsec.backend import Backend, backend_factory
@@ -77,3 +77,8 @@ def testbed(backend: Backend) -> TestbedBackend:
 @pytest.fixture
 def ballpark_always_ok(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("parsec.ballpark.BALLPARK_ALWAYS_OK", True)
+
+
+@pytest.fixture
+def timestamp_out_of_ballpark() -> DateTime:
+    return DateTime.now().subtract(seconds=3600)

--- a/server/tests/common/realm.py
+++ b/server/tests/common/realm.py
@@ -1,16 +1,34 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-
 from typing import Optional
 
 from parsec._parsec import (
     DateTime,
     DeviceID,
+    RealmNameCertificate,
     RealmRole,
     RealmRoleCertificate,
     UserID,
     VlobID,
 )
+
+
+def patch_realm_name_certificate(
+    certif: RealmNameCertificate,
+    author: Optional[DeviceID] = None,
+    timestamp: Optional[DateTime] = None,
+    realm_id: Optional[VlobID] = None,
+    key_index: Optional[int] = None,
+    encrypted_name: Optional[bytes] = None,
+) -> RealmNameCertificate:
+    """Utility function to patch one or more RealmNameCertificate fields"""
+    return RealmNameCertificate(
+        author=author or certif.author,
+        timestamp=timestamp or certif.timestamp,
+        realm_id=realm_id or certif.realm_id,
+        key_index=key_index if key_index is not None else certif.key_index,
+        encrypted_name=encrypted_name or certif.encrypted_name,
+    )
 
 
 def patch_realm_role_certificate(

--- a/server/tests/common/realm.py
+++ b/server/tests/common/realm.py
@@ -1,0 +1,32 @@
+# Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+
+from typing import Optional
+
+from parsec._parsec import (
+    DateTime,
+    DeviceID,
+    RealmRole,
+    RealmRoleCertificate,
+    UserID,
+    VlobID,
+)
+
+
+def patch_realm_role_certificate(
+    certif: RealmRoleCertificate,
+    author: Optional[DeviceID] = None,
+    timestamp: Optional[DateTime] = None,
+    realm_id: Optional[VlobID] = None,
+    user_id: Optional[UserID] = None,
+    role: Optional[RealmRole] = None,
+    force_no_role: bool = False,
+) -> RealmRoleCertificate:
+    """Utility function to patch one or more RealmRoleCertificate fields"""
+    return RealmRoleCertificate(
+        author=author or certif.author,
+        timestamp=timestamp or certif.timestamp,
+        realm_id=realm_id or certif.realm_id,
+        user_id=user_id or certif.user_id,
+        role=None if force_no_role else (role or certif.role),
+    )


### PR DESCRIPTION
This PR adds missing tests for commands:
  - `realm_create`
  - `realm_rename`
  - `realm_rotate_key`
  - `realm_unshare`

Also:
- Add some `pytest.fixture` to improve test readability
- Add `common/realm.py` file with functions to patch certificates. IMO this also improves test readability because each test only patches what is needed, instead of creating certificates every time which has a lot of redundancy
- Fix test function names in `realm_share`

Closes #6684 
Closes #6685 
Closes #6686
Closes #6687  