### PR TITLE
[MS] Fixed the new workspace button in the sidebar

### DIFF
--- a/client/src/views/sidebar-menu/SidebarMenuPage.vue
+++ b/client/src/views/sidebar-menu/SidebarMenuPage.vue
@@ -107,6 +107,7 @@
                   class="list-workspaces-header__button"
                   id="new-workspace"
                   :icon="addCircle"
+                  v-show="userInfo && userInfo.currentProfile !== UserProfile.Outsider"
                   @click="createWorkspace"
                 />
               </ion-header>

--- a/client/src/views/workspaces/WorkspacesPage.vue
+++ b/client/src/views/workspaces/WorkspacesPage.vue
@@ -155,7 +155,7 @@ import {
   getPathLink as parsecGetPathLink,
   listWorkspaces as parsecListWorkspaces,
 } from '@/parsec';
-import { getCurrentRouteQuery, navigateToWorkspace, watchRoute } from '@/router';
+import { Routes, getCurrentRouteQuery, navigateTo, navigateToWorkspace, watchRoute } from '@/router';
 import { Groups, HotkeyManager, HotkeyManagerKey, Hotkeys, Modifiers, Platforms } from '@/services/hotkeyManager';
 import { Information, InformationKey, InformationLevel, InformationManager, PresentationMode } from '@/services/informationManager';
 import { StorageManager, StorageManagerKey } from '@/services/storageManager';
@@ -200,6 +200,7 @@ const routeWatchCancel = watchRoute(async () => {
   const query = getCurrentRouteQuery();
   if (query.workspaceName) {
     await createWorkspace(query.workspaceName);
+    await navigateTo(Routes.Workspaces, { query: {} });
   }
 });
 


### PR DESCRIPTION
The new workspace button in the sidebar had two issues:
1. It was visible by outsiders
2. It redirected to the /workspace url and added a `query` string with the workspace name, to let the workspaces page handle the creation. Problem was, this url was not updated after creating the workspace, meaning that you could create a ton of workspace by refreshing the workspace page.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
 