### PR TITLE
Remove test feature `libparsec_crypto/test-unsecure-but-fast-secretkey-from-password`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,7 +2170,6 @@ name = "libparsec_tests_fixtures"
 version = "3.0.0-a.0+dev"
 dependencies = [
  "libparsec_client_connection",
- "libparsec_crypto",
  "libparsec_platform_device_loader",
  "libparsec_platform_storage",
  "libparsec_testbed",

--- a/libparsec/Cargo.toml
+++ b/libparsec/Cargo.toml
@@ -20,7 +20,6 @@ test-utils = [
     "libparsec_platform_device_loader/test-with-testbed",
     "libparsec_platform_storage/test-with-testbed",
     "libparsec_types/test-mock-time",
-    "libparsec_crypto/test-unsecure-but-fast-secretkey-from-password"
 ]
 cli-tests = ["dep:libparsec_tests_fixtures"]
 

--- a/libparsec/crates/crypto/Cargo.toml
+++ b/libparsec/crates/crypto/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 workspace = true
 
 [features]
-test-unsecure-but-fast-secretkey-from-password = []
 vendored-openssl = ["openssl/vendored"]
 use-sodiumoxide = [
     "dep:sodiumoxide",

--- a/libparsec/crates/crypto/tests/secret.rs
+++ b/libparsec/crates/crypto/tests/secret.rs
@@ -118,7 +118,6 @@ fn invalid_passphrase(#[case] bad_passphrase: &str, #[case] key_length: usize) {
     );
 }
 
-#[cfg_attr(feature = "test-unsecure-but-fast-secretkey-from-password", ignore)]
 #[test]
 fn from_password() {
     let password = "P@ssw0rd.".to_owned().into();

--- a/libparsec/crates/tests_fixtures/Cargo.toml
+++ b/libparsec/crates/tests_fixtures/Cargo.toml
@@ -16,7 +16,6 @@ default = [
     "test-with-client-connection-testbed",
     "test-with-platform-device-loader-testbed",
     "test-with-platform-storage-testbed",
-    "test-with-unsecure-but-fast-secretkey-from-password",
 ]
 test-with-client-connection-testbed = [
     "libparsec_client_connection",
@@ -30,10 +29,6 @@ test-with-platform-storage-testbed = [
     "libparsec_platform_storage",
     "libparsec_platform_storage/test-with-testbed",
 ]
-test-with-unsecure-but-fast-secretkey-from-password = [
-    "libparsec_crypto",
-    "libparsec_crypto/test-unsecure-but-fast-secretkey-from-password",
-]
 
 [dependencies]
 libparsec_types = { workspace = true, features = [ "test-fixtures", "test-mock-time" ] }
@@ -43,7 +38,6 @@ libparsec_testbed = { workspace = true }
 libparsec_client_connection = { workspace = true, optional = true }
 libparsec_platform_device_loader = { workspace = true, optional = true }
 libparsec_platform_storage = { workspace = true, optional = true }
-libparsec_crypto = { workspace = true, optional = true }
 
 uuid = { workspace = true, features = ["v4", "fast-rng"] }
 # `assert_matches!()` requires `unstable` feature

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -22,7 +22,6 @@ vendored-openssl = ["libparsec_crypto/vendored-openssl"]
 test-utils = [
     "dep:libparsec_testbed",
     "libparsec_types/test-mock-time",
-    "libparsec_crypto/test-unsecure-but-fast-secretkey-from-password"
 ]
 
 [dependencies]


### PR DESCRIPTION
Test shouldn't be impacted performance-wise given device loader's testbed implementation already [entirely skip the password-to-key generation step \o/](https://github.com/Scille/parsec-cloud/blob/93c4fbb3b39e53f0bb832c91aefac0aca7f7f36d/libparsec/crates/platform_device_loader/src/testbed.rs#L212-L213).