### PR TITLE
Add tests for realm_unshare

### DIFF
--- a/server/tests/api_v4/authenticated/test_realm_unshare.py
+++ b/server/tests/api_v4/authenticated/test_realm_unshare.py
@@ -1,33 +1,54 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
+
 import pytest
 
-from parsec._parsec import DateTime, RealmRole, RealmRoleCertificate, authenticated_cmds
+from parsec._parsec import (
+    DateTime,
+    HashAlgorithm,
+    RealmKeyRotationCertificate,
+    RealmRole,
+    RealmRoleCertificate,
+    RevokedUserCertificate,
+    SecretKey,
+    SecretKeyAlgorithm,
+    UserID,
+    VlobID,
+    authenticated_cmds,
+)
 from parsec.events import EventRealmCertificate
-from tests.common import Backend, CoolorgRpcClients
+from tests.common import Backend, CoolorgRpcClients, patch_realm_role_certificate
 
 
-async def test_authenticated_realm_share_ok(coolorg: CoolorgRpcClients, backend: Backend) -> None:
-    timestamp = DateTime.now()
-    certif = RealmRoleCertificate(
+@pytest.fixture
+def alice_unshare_bob_certificate(coolorg: CoolorgRpcClients) -> RealmRoleCertificate:
+    return RealmRoleCertificate(
         author=coolorg.alice.device_id,
-        timestamp=timestamp,
+        timestamp=DateTime.now(),
         realm_id=coolorg.wksp1_id,
+        user_id=coolorg.bob.user_id,
         role=None,
-        user_id=coolorg.bob.device_id.user_id,
-    ).dump_and_sign(coolorg.alice.signing_key)
+    )
 
+
+async def test_authenticated_realm_unshare_ok(
+    coolorg: CoolorgRpcClients,
+    backend: Backend,
+    alice_unshare_bob_certificate: RealmRoleCertificate,
+) -> None:
     with backend.event_bus.spy() as spy:
         rep = await coolorg.alice.realm_unshare(
-            realm_role_certificate=certif,
+            realm_role_certificate=alice_unshare_bob_certificate.dump_and_sign(
+                coolorg.alice.signing_key
+            ),
         )
         assert rep == authenticated_cmds.v4.realm_unshare.RepOk()
         await spy.wait_event_occurred(
             EventRealmCertificate(
                 organization_id=coolorg.organization_id,
-                timestamp=timestamp,
-                realm_id=coolorg.wksp1_id,
-                user_id=coolorg.bob.device_id.user_id,
+                timestamp=alice_unshare_bob_certificate.timestamp,
+                realm_id=alice_unshare_bob_certificate.realm_id,
+                user_id=alice_unshare_bob_certificate.user_id,
                 role_removed=True,
             )
         )
@@ -39,30 +60,128 @@ async def test_authenticated_realm_share_ok(coolorg: CoolorgRpcClients, backend:
     assert coolorg.wksp1_id not in bob_realms
 
 
+@pytest.mark.parametrize("kind", ("author_is_reader", "author_is_not_shared"))
+async def test_authenticated_realm_unshare_author_not_allowed(
+    coolorg: CoolorgRpcClients,
+    alice_unshare_bob_certificate: RealmRoleCertificate,
+    kind: str,
+) -> None:
+    match kind:
+        case "author_is_reader":
+            author = coolorg.bob
+        case "author_is_not_shared":
+            author = coolorg.mallory
+        case unknown:
+            assert False, unknown
+
+    certif = patch_realm_role_certificate(
+        alice_unshare_bob_certificate, author=author.device_id, user_id=coolorg.alice.user_id
+    )
+    rep = await author.realm_unshare(
+        realm_role_certificate=certif.dump_and_sign(author.signing_key),
+    )
+    assert rep == authenticated_cmds.v4.realm_unshare.RepAuthorNotAllowed()
+
+
+async def test_authenticated_realm_unshare_realm_not_found(
+    coolorg: CoolorgRpcClients,
+    alice_unshare_bob_certificate: RealmRoleCertificate,
+) -> None:
+    bad_realm_id = VlobID.new()
+    certif = patch_realm_role_certificate(alice_unshare_bob_certificate, realm_id=bad_realm_id)
+    rep = await coolorg.alice.realm_unshare(
+        realm_role_certificate=certif.dump_and_sign(coolorg.alice.signing_key),
+    )
+    assert rep == authenticated_cmds.v4.realm_unshare.RepRealmNotFound()
+
+
+@pytest.mark.parametrize(
+    "kind",
+    (
+        "user_unknown",
+        pytest.param(
+            "user_revoked",
+            marks=pytest.mark.xfail(
+                reason="TODO: Should fail if user to be unshared is revoked. Not implemented?"
+            ),
+        ),
+    ),
+)
+async def test_authenticated_realm_unshare_recipient_not_found(
+    coolorg: CoolorgRpcClients,
+    backend: Backend,
+    alice_unshare_bob_certificate: RealmRoleCertificate,
+    kind: str,
+) -> None:
+    match kind:
+        case "user_unknown":
+            bad_recipient = UserID("unknown")
+        case "user_revoked":
+            bad_recipient = coolorg.bob.user_id
+            # Revoke user Bob
+            revoke_timestamp = DateTime.now()
+            outcome = await backend.user.revoke_user(
+                now=revoke_timestamp,
+                organization_id=coolorg.organization_id,
+                author=coolorg.alice.device_id,
+                author_verify_key=coolorg.alice.signing_key.verify_key,
+                revoked_user_certificate=RevokedUserCertificate(
+                    author=coolorg.alice.device_id,
+                    timestamp=revoke_timestamp,
+                    user_id=coolorg.bob.device_id.user_id,
+                ).dump_and_sign(coolorg.alice.signing_key),
+            )
+            assert isinstance(outcome, RevokedUserCertificate)
+        case unknown:
+            assert False, unknown
+    certif = patch_realm_role_certificate(
+        alice_unshare_bob_certificate, user_id=bad_recipient, timestamp=DateTime.now()
+    )
+    rep = await coolorg.alice.realm_unshare(
+        realm_role_certificate=certif.dump_and_sign(coolorg.alice.signing_key),
+    )
+    assert rep == authenticated_cmds.v4.realm_unshare.RepRecipientNotFound()
+
+
+async def test_authenticated_realm_unshare_recipient_already_unshared(
+    coolorg: CoolorgRpcClients,
+    backend: Backend,
+    alice_unshare_bob_certificate: RealmRoleCertificate,
+) -> None:
+    # 1) Use certificate to unshare Bob via the backend
+    outcome = await backend.realm.unshare(
+        alice_unshare_bob_certificate.timestamp,
+        coolorg.organization_id,
+        coolorg.alice.device_id,
+        alice_unshare_bob_certificate.dump_and_sign(coolorg.alice.signing_key),
+    )
+    assert isinstance(outcome, RealmRoleCertificate)
+
+    # 2) Try to unshare Bob again, now via the API
+    rep = await coolorg.alice.realm_unshare(
+        realm_role_certificate=alice_unshare_bob_certificate.dump_and_sign(
+            coolorg.alice.signing_key
+        ),
+    )
+    assert rep == authenticated_cmds.v4.realm_unshare.RepRecipientAlreadyUnshared(
+        last_realm_certificate_timestamp=alice_unshare_bob_certificate.timestamp
+    )
+
+
 @pytest.mark.parametrize("kind", ("dummy_certif", "invalid_role", "self_unshare"))
 async def test_authenticated_realm_unshare_invalid_certificate(
-    coolorg: CoolorgRpcClients, kind: str
+    coolorg: CoolorgRpcClients, alice_unshare_bob_certificate: RealmRoleCertificate, kind: str
 ) -> None:
-    timestamp = DateTime.now()
-
     match kind:
         case "dummy_certif":
             certif = b"<dummy>"
         case "invalid_role":
-            certif = RealmRoleCertificate(
-                author=coolorg.alice.device_id,
-                timestamp=timestamp,
-                realm_id=coolorg.wksp1_id,
-                role=RealmRole.READER,
-                user_id=coolorg.bob.device_id.user_id,
+            certif = patch_realm_role_certificate(
+                alice_unshare_bob_certificate, role=RealmRole.READER
             ).dump_and_sign(coolorg.alice.signing_key)
         case "self_unshare":
-            certif = RealmRoleCertificate(
-                author=coolorg.alice.device_id,
-                timestamp=timestamp,
-                realm_id=coolorg.wksp1_id,
-                role=None,
-                user_id=coolorg.alice.device_id.user_id,
+            certif = patch_realm_role_certificate(
+                alice_unshare_bob_certificate, user_id=coolorg.alice.user_id
             ).dump_and_sign(coolorg.alice.signing_key)
         case unknown:
             assert False, unknown
@@ -73,5 +192,68 @@ async def test_authenticated_realm_unshare_invalid_certificate(
     assert rep == authenticated_cmds.v4.realm_unshare.RepInvalidCertificate()
 
 
-# TODO: test unshare on revoked user
-# TODO: test unshare with certificate containing a non-null role
+async def test_authenticated_realm_unshare_timestamp_out_of_ballpark(
+    coolorg: CoolorgRpcClients,
+    alice_unshare_bob_certificate: RealmRoleCertificate,
+    timestamp_out_of_ballpark: DateTime,
+) -> None:
+    certif = patch_realm_role_certificate(
+        alice_unshare_bob_certificate, timestamp=timestamp_out_of_ballpark
+    )
+    rep = await coolorg.alice.realm_unshare(
+        realm_role_certificate=certif.dump_and_sign(coolorg.alice.signing_key),
+    )
+    assert isinstance(rep, authenticated_cmds.v4.realm_unshare.RepTimestampOutOfBallpark)
+    assert rep.ballpark_client_early_offset == 300.0
+    assert rep.ballpark_client_late_offset == 320.0
+    assert rep.client_timestamp == timestamp_out_of_ballpark
+
+
+@pytest.mark.parametrize(
+    "timestamp_offset",
+    (pytest.param(0, id="same_timestamp"), pytest.param(1, id="previous_timestamp")),
+)
+async def test_authenticated_realm_unshare_require_greater_timestamp(
+    coolorg: CoolorgRpcClients,
+    backend: Backend,
+    alice_unshare_bob_certificate: RealmRoleCertificate,
+    timestamp_offset: int,
+) -> None:
+    last_certificate_timestamp = DateTime.now()
+    same_or_previous_timestamp = last_certificate_timestamp.subtract(seconds=timestamp_offset)
+
+    # 1) Performa a key rotation to add a new certificate at last_certificate_timestamp
+
+    outcome = await backend.realm.rotate_key(
+        now=last_certificate_timestamp,
+        organization_id=coolorg.organization_id,
+        author=coolorg.alice.device_id,
+        author_verify_key=coolorg.alice.signing_key.verify_key,
+        keys_bundle=b"",
+        per_participant_keys_bundle_access={
+            coolorg.alice.user_id: b"<alice keys bundle access>",
+            coolorg.bob.user_id: b"<bob keys bundle access>",
+        },
+        realm_key_rotation_certificate=RealmKeyRotationCertificate(
+            author=coolorg.alice.device_id,
+            timestamp=last_certificate_timestamp,
+            hash_algorithm=HashAlgorithm.SHA256,
+            encryption_algorithm=SecretKeyAlgorithm.XSALSA20_POLY1305,
+            key_index=2,
+            realm_id=coolorg.wksp1_id,
+            key_canary=SecretKey.generate().encrypt(b""),
+        ).dump_and_sign(coolorg.alice.signing_key),
+    )
+    assert isinstance(outcome, RealmKeyRotationCertificate)
+
+    # 2) Try to unshare a realm with same or previous timestamp
+
+    certif = patch_realm_role_certificate(
+        alice_unshare_bob_certificate, timestamp=same_or_previous_timestamp
+    )
+    rep = await coolorg.alice.realm_unshare(
+        realm_role_certificate=certif.dump_and_sign(coolorg.alice.signing_key),
+    )
+    assert rep == authenticated_cmds.v4.realm_unshare.RepRequireGreaterTimestamp(
+        strictly_greater_than=last_certificate_timestamp
+    )

--- a/server/tests/common/__init__.py
+++ b/server/tests/common/__init__.py
@@ -6,6 +6,7 @@ from _pytest.logging import LogCaptureFixture as VanillaLogCaptureFixture
 from .backend import *  # noqa
 from .client import *  # noqa
 from .postgresql import *  # noqa
+from .realm import *  # noqa
 
 
 # customized in `tests/conftest.py`

--- a/server/tests/common/backend.py
+++ b/server/tests/common/backend.py
@@ -5,7 +5,7 @@ from typing import AsyncGenerator, Iterator
 
 import pytest
 
-from parsec._parsec import ParsecAddr
+from parsec._parsec import DateTime, ParsecAddr
 from parsec.asgi import AsgiApp
 from parsec.asgi import app as asgi_app
 from parsec.backend import Backend, backend_factory
@@ -77,3 +77,8 @@ def testbed(backend: Backend) -> TestbedBackend:
 @pytest.fixture
 def ballpark_always_ok(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("parsec.ballpark.BALLPARK_ALWAYS_OK", True)
+
+
+@pytest.fixture
+def timestamp_out_of_ballpark() -> DateTime:
+    return DateTime.now().subtract(seconds=3600)

--- a/server/tests/common/realm.py
+++ b/server/tests/common/realm.py
@@ -1,0 +1,32 @@
+# Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+
+from typing import Optional
+
+from parsec._parsec import (
+    DateTime,
+    DeviceID,
+    RealmRole,
+    RealmRoleCertificate,
+    UserID,
+    VlobID,
+)
+
+
+def patch_realm_role_certificate(
+    certif: RealmRoleCertificate,
+    author: Optional[DeviceID] = None,
+    timestamp: Optional[DateTime] = None,
+    realm_id: Optional[VlobID] = None,
+    user_id: Optional[UserID] = None,
+    role: Optional[RealmRole] = None,
+    force_no_role: bool = False,
+) -> RealmRoleCertificate:
+    """Utility function to patch one or more RealmRoleCertificate fields"""
+    return RealmRoleCertificate(
+        author=author or certif.author,
+        timestamp=timestamp or certif.timestamp,
+        realm_id=realm_id or certif.realm_id,
+        user_id=user_id or certif.user_id,
+        role=None if force_no_role else (role or certif.role),
+    )


### PR DESCRIPTION
Also:
- Add some `pytest.fixture` for better readability in `realm_share` and `realm_unshare` tests
- Add `common/realm.py` file with `patch_realm_role_certificate`: IMO this improves readability because the test only patches what is needed, instead of creating certificates every time which has a lot of redundancy
- Fix test function names in `realm_share`

Closes #6686 