### PR TITLE
Fix wrong value for `release_tag` input provided by the releaser workflow

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -204,4 +204,4 @@ jobs:
       contents: read
       id-token: write
     with:
-      release_tag: ${{ github.event_name == 'schedule' && 'nightly' || github.ref }}
+      release_tag: ${{ github.event_name == 'schedule' && 'nightly' || github.ref_name }}


### PR DESCRIPTION
The publish workflow expect the input `release_tag` to be the tag name to use. But that value should not contains the `refs/tags/` prefix, which will cause a failure when used with `gh` commands.