### PR TITLE
[MS] Keyring information missing style

### DIFF
--- a/client/src/components/core/ms-text/MsReportText.vue
+++ b/client/src/components/core/ms-text/MsReportText.vue
@@ -43,22 +43,22 @@ function getIcon(): string {
 <style scoped lang="scss">
 .ms-info {
   --ms-alert-text-background-color: var(--parsec-color-light-primary-100);
-  --ms-alert-text-icon-color: var(--parsec-color-light-primary-500);
+  --ms-alert-text-icon-color: var(--parsec-color-light-primary-700);
 }
 
 .ms-success {
   --ms-alert-text-background-color: var(--parsec-color-light-success-100);
-  --ms-alert-text-icon-color: var(--parsec-color-light-success-500);
+  --ms-alert-text-icon-color: var(--parsec-color-light-success-700);
 }
 
 .ms-warning {
   --ms-alert-text-background-color: var(--parsec-color-light-warning-100);
-  --ms-alert-text-icon-color: var(--parsec-color-light-warning-500);
+  --ms-alert-text-icon-color: var(--parsec-color-light-warning-700);
 }
 
 .ms-error {
   --ms-alert-text-background-color: var(--parsec-color-light-danger-100);
-  --ms-alert-text-icon-color: var(--parsec-color-light-danger-500);
+  --ms-alert-text-icon-color: var(--parsec-color-light-danger-700);
 }
 
 .container-textinfo {

--- a/client/src/components/devices/KeyringInformation.vue
+++ b/client/src/components/devices/KeyringInformation.vue
@@ -1,13 +1,21 @@
 <!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
 
 <template>
-  <div>
-    {{ translate('Authentication.keyringInfo') }}
+  <div class="keyring-info">
+    <ms-report-text :theme="MsReportTheme.Info">
+      {{ translate('Authentication.keyringInfo') }}
+    </ms-report-text>
   </div>
 </template>
 
 <script setup lang="ts">
+import { MsReportText } from '@/components/core/ms-text';
+import { MsReportTheme } from '@/components/core/ms-types';
 import { translate } from '@/services/translation';
 </script>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+.keyring-info {
+  margin-top: 1rem;
+}
+</style>


### PR DESCRIPTION
Style was forgotten on the message provide when the user chose Keyring authentification.

## Checklist

- [ ] Keep changes in the pull request as small as possible
   <!-- Move unrelated changes to a new pull request -->
- [ ] Ensure the commit history is sanitized