### PR TITLE
[MS] Updated how workspaces are being initialized and refreshed

### DIFF
--- a/client/src/views/sidebar-menu/SidebarMenuPage.vue
+++ b/client/src/views/sidebar-menu/SidebarMenuPage.vue
@@ -254,6 +254,9 @@ const divider = ref();
 const { defaultWidth, initialWidth, computedWidth, wasReset } = useSidebarMenu();
 const userInfo: Ref<ClientInfo | null> = ref(null);
 
+// Replace by events when available
+let intervalId: any = null;
+
 // watching wasReset value
 const resetWatchCancel: WatchStopHandle = watch(wasReset, (value) => {
   if (value) {
@@ -322,6 +325,7 @@ onMounted(async () => {
     });
     gesture.enable();
   }
+  intervalId = setInterval(loadAll, 10000);
 });
 
 onUnmounted(() => {
@@ -330,6 +334,9 @@ onUnmounted(() => {
   }
   resetWatchCancel();
   organizationWatchCancel();
+  if (intervalId) {
+    clearInterval(intervalId);
+  }
 });
 
 function onMove(detail: GestureDetail): void {


### PR DESCRIPTION
Closes #6800 

Updated how workspace are initialized by splitting the listing from the mounting, and refresh workspaces and files every 10s (temporary solution while we wait for events).

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
   