### PR TITLE
Set confinement to classic for electron-builder

### DIFF
--- a/client/electron/package.js
+++ b/client/electron/package.js
@@ -106,6 +106,7 @@ const options = {
     grade: 'devel',
     allowNativeWayland: true,
     stagePackages: ['default', 'fuse3'],
+    confinement: 'classic',
   },
 
   beforePack: './scripts/before-pack.js',


### PR DESCRIPTION
The fuse interface on snap only allow to create a fuse filesystem under `SNAP_USER_{DATA,COMMON}` (`/home/<username>/snap/<snap name/{common,<revision>}`) or `SNAP_{DATA,COMMON}` (`/var/snap/<snap name>/{common,<revision>}`).