### PR TITLE
[MS] Smart refresh of file list

### DIFF
--- a/client/src/views/files/FoldersPage.vue
+++ b/client/src/views/files/FoldersPage.vue
@@ -423,8 +423,8 @@ async function listFolder(): Promise<void> {
         }
       }
     }
-    folders.value.replace(newFolders);
-    files.value.replace(newFiles);
+    folders.value.smartUpdate(newFolders);
+    files.value.smartUpdate(newFiles);
   } else {
     informationManager.present(
       new Information({


### PR DESCRIPTION
Smart update of the files: instead of just clearing the list and replacing it by the new one, we calculate the difference between the old file list and the new one and update only was has to be updated.

Closes #6869 

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes

