### PR TITLE
Use double click for files

### DIFF
--- a/client/src/components/files/FileCard.vue
+++ b/client/src/components/files/FileCard.vue
@@ -4,7 +4,7 @@
   <ion-item
     class="file-card-item ion-no-padding"
     :class="{ selected: entry.isSelected }"
-    @click="$emit('click', $event, entry)"
+    @dblclick="$emit('click', $event, entry)"
     @mouseenter="isHovered = true"
     @mouseleave="isHovered = false"
   >

--- a/client/src/components/files/FileListItem.vue
+++ b/client/src/components/files/FileListItem.vue
@@ -6,7 +6,7 @@
     lines="full"
     :detail="false"
     :class="{ selected: entry.isSelected }"
-    @click="$emit('click', $event, entry)"
+    @dblclick="$emit('click', $event, entry)"
     @mouseenter="isHovered = true"
     @mouseleave="isHovered = false"
   >

--- a/client/tests/component/specs/testFileCard.spec.ts
+++ b/client/tests/component/specs/testFileCard.spec.ts
@@ -46,7 +46,7 @@ describe('File Card Item', () => {
 
     expect(wrapper.get('.card-content__title').text()).to.equal('A File.txt');
     expect(wrapper.get('.card-content-last-update').text()).to.equal('Last updated:now');
-    wrapper.trigger('click');
+    wrapper.trigger('dblclick');
     expect(wrapper.emitted('click')?.length).to.equal(1);
     expect(wrapper.emitted('click')?.at(0)?.at(1)).to.deep.equal(FILE);
     wrapper.get('.card-option').trigger('click');
@@ -86,7 +86,7 @@ describe('File Card Item', () => {
     expect(wrapper.get('.card-content__title').text()).to.equal('A Folder');
     expect(wrapper.get('.card-content-last-update').text()).to.equal('Last updated:now');
     // expect(wrapper.get('.label-size')).not.to.be.visible;
-    wrapper.trigger('click');
+    wrapper.trigger('dblclick');
     expect(wrapper.emitted('click')?.length).to.equal(1);
     expect(wrapper.emitted('click')?.at(0)?.at(1)).to.deep.equal(FOLDER);
     wrapper.get('.card-option').trigger('click');

--- a/client/tests/component/specs/testFileListItem.spec.ts
+++ b/client/tests/component/specs/testFileListItem.spec.ts
@@ -47,7 +47,7 @@ describe('File List Item', () => {
     expect(wrapper.get('.file-name__label').text()).to.equal('A File.txt');
     expect(wrapper.get('.label-last-update').text()).to.equal('now');
     expect(wrapper.get('.label-size').text()).to.equal('40.3 GB');
-    wrapper.trigger('click');
+    wrapper.trigger('dblclick');
     expect(wrapper.emitted('click')?.length).to.equal(1);
     expect(wrapper.emitted('click')?.at(0)?.at(1)).to.deep.equal(FILE);
     wrapper.get('.options-button').trigger('click');
@@ -87,7 +87,7 @@ describe('File List Item', () => {
     expect(wrapper.get('.file-name__label').text()).to.equal('A Folder');
     expect(wrapper.get('.label-last-update').text()).to.equal('now');
     // expect(wrapper.get('.label-size')).not.to.be.visible;
-    wrapper.trigger('click');
+    wrapper.trigger('dblclick');
     expect(wrapper.emitted('click')?.length).to.equal(1);
     expect(wrapper.emitted('click')?.at(0)?.at(1)).to.deep.equal(FOLDER);
     wrapper.get('.options-button').trigger('click');

--- a/client/tests/e2e/specs/test_folders_page.ts
+++ b/client/tests/e2e/specs/test_folders_page.ts
@@ -248,7 +248,7 @@ describe('Check folders page', () => {
 
   // it('Test move one file', () => {
   //   // .first() will always be a folder, as there's always at least one folder
-  //   cy.get('.folder-container').find('.file-list-item').first().click();
+  //   cy.get('.folder-container').find('.file-list-item').first().dblclick();
   //   cy.get('.folder-container').find('.file-list-item').last().find('ion-checkbox').invoke('show').click();
   //   cy.get('#button-moveto').contains('Move to').click();
   //   cy.get('.folder-selection-modal').find('.ms-modal-header__title').contains('Move one item');
@@ -277,7 +277,7 @@ describe('Check folders page', () => {
   // });
 
   // it('Tests move files', () => {
-  //   cy.get('.folder-container').find('.file-list-item').first().click();
+  //   cy.get('.folder-container').find('.file-list-item').first().dblclick();
   //   cy.get('.folder-list-header').find('ion-checkbox').click();
   //   cy.get('#button-moveto').contains('Move to').click();
   //   cy.get('.folder-selection-modal')
@@ -301,7 +301,7 @@ describe('Check folders page', () => {
   // });
 
   // it('Tests copy one file', () => {
-  //   cy.get('.folder-container').find('.file-list-item').first().click();
+  //   cy.get('.folder-container').find('.file-list-item').first().dblclick();
   //   cy.get('.folder-container').find('.file-list-item').last().find('ion-checkbox').invoke('show').click();
   //   // cspell:disable-next-line
   //   cy.get('#button-makeacopy').contains('Make a copy').click();
@@ -323,7 +323,7 @@ describe('Check folders page', () => {
   // });
 
   // it('Tests copy files', () => {
-  //   cy.get('.folder-container').find('.file-list-item').first().click();
+  //   cy.get('.folder-container').find('.file-list-item').first().dblclick();
   //   cy.get('.folder-list-header').find('ion-checkbox').click();
   //   // cspell:disable-next-line
   //   cy.get('#button-makeacopy').contains('Make a copy').click();
@@ -347,7 +347,7 @@ describe('Check folders page', () => {
   // });
 
   // it('Test move file back/forward', () => {
-  //   cy.get('.folder-container').find('.file-list-item').first().click();
+  //   cy.get('.folder-container').find('.file-list-item').first().dblclick();
   //   cy.get('.folder-container').find('.file-list-item').last().find('ion-checkbox').invoke('show').click();
   //   cy.get('#button-moveto').contains('Move to').click();
   //   cy.get('.folder-selection-modal').find('.ms-modal-header__title').contains('Move one item');


### PR DESCRIPTION
Use dblclick instead of click for interacting with entries (navigating into a folder or opening a file).

`@dblclick` replaces `@click` directly on the `FileListItem` and `FileCard` and emit a `click` event. This is because it's not possible to have both `dblclick` and `click` emitted correctly at the same time (a dblclick will always trigger a click first).

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
