### PR TITLE
Use ubuntu 22.04 instead of 20.04 for the client package workflow

### DIFF
--- a/.github/workflows/package-client.yml
+++ b/.github/workflows/package-client.yml
@@ -117,7 +117,7 @@ jobs:
         include:
           - name: 🐧 Linux
             platform: linux
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - name: 🏁 Windows
             platform: windows
             os: windows-2022
@@ -174,6 +174,11 @@ jobs:
         if: matrix.platform == 'linux'
         uses: canonical/setup-lxd@4e959f8e0d9c5feb27d44c5e4d9a330a782edee0 # pin v0.1.1
         timeout-minutes: 2
+
+      - name: Linux > Debug installed packages
+        if: matrix.platform == 'linux'
+        run: apt-cache policy snapd fuse3 libfuse3-dev libssl libssl-dev
+        continue-on-error: true
 
       - name: Windows > Install WinFSP
         if: matrix.platform == 'windows'

--- a/client/electron/package.js
+++ b/client/electron/package.js
@@ -105,7 +105,7 @@ const options = {
     base: 'core22',
     grade: 'devel',
     allowNativeWayland: true,
-    stagePackages: ['default', 'fuse3'],
+    stagePackages: ['default', 'fuse3', 'libssl3'],
     confinement: 'classic',
   },
 


### PR DESCRIPTION
The more recent version use libssl 3.0 by default instead of 1.1.