### PR TITLE
[MS] Correctly displays workspace sharing

### DIFF
--- a/client/src/views/workspaces/WorkspacesPage.vue
+++ b/client/src/views/workspaces/WorkspacesPage.vue
@@ -264,7 +264,6 @@ async function refreshWorkspacesList(): Promise<void> {
   }
   const result = await parsecListWorkspaces();
   if (result.ok) {
-    workspaceList.value = result.value;
     for (const wk of result.value) {
       const sharingResult = await parsecGetWorkspaceSharing(wk.id, false);
       if (sharingResult.ok) {
@@ -281,6 +280,7 @@ async function refreshWorkspacesList(): Promise<void> {
         }
       }
     }
+    workspaceList.value = result.value;
   } else {
     informationManager.present(
       new Information({

--- a/client/tests/e2e/specs/test_workspaces_page.ts
+++ b/client/tests/e2e/specs/test_workspaces_page.ts
@@ -116,6 +116,12 @@ describe('Check workspaces page', () => {
     cy.get('.popover-viewport').get('.list-group-title').should('have.length', 3);
   });
 
+  it('Check workspace sharing', () => {
+    cy.get('.card').first().find('.shared-group').find('ion-avatar').as('avatars').should('have.length', 2);
+    cy.get('@avatars').eq(0).contains('Ko');
+    cy.get('@avatars').eq(1).contains('Ce');
+  });
+
   // FIXME: disabled for now
   // it('Get link to the workspace', () => {
   //   cy.get('.card').eq(0).find('.card-option').click();


### PR DESCRIPTION
Workspace sharing info were not being refreshed because Vue only watches the array, not the content of the array.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes