### PR TITLE
[MS] fixes links opening multiple times of second instances

### DIFF
--- a/client/electron/src/setup.ts
+++ b/client/electron/src/setup.ts
@@ -153,9 +153,6 @@ export class ElectronCapacitorApp {
   }
 
   async init(): Promise<void> {
-    if (!app.requestSingleInstanceLock()) {
-      return;
-    }
     const icon = nativeImage.createFromPath(join(app.getAppPath(), 'assets', process.platform === 'win32' ? 'icon.ico' : 'icon.png'));
     this.mainWindowState = windowStateKeeper({
       defaultWidth: 1000,


### PR DESCRIPTION
## Describe your changes

`second-instance` is fired for each `requestSingleInstanceLock` and `setupElectronDeepLinking` call.

## Checklist

- [ ] Keep changes in the pull request as small as possible
- [ ] Ensure the commit history is sanitized
- [ ] Give a meaningful title to your PR
- [ ] Describe your changes
- [ ] Link any related issue in the description
- [ ] Link any dependent pull request in the description
- [ ] I have added or updated relevant tests
