### PR TITLE
[MS] Re-enable send email for device onboarding

### DIFF
--- a/client/src/common/date.ts
+++ b/client/src/common/date.ts
@@ -32,3 +32,18 @@ export function formatTimeSince(
     return translate('common.date.fewSeconds');
   }
 }
+
+export async function startCounter(ms: number, step: number, callback: (elapsed: number) => Promise<void>): Promise<void> {
+  await callback(0);
+  let count = 0;
+  const interval = setInterval(async () => {
+    count += 1;
+    if (count * step > ms) {
+      clearInterval(interval);
+      await callback(ms);
+    } else {
+      await callback(count * step);
+    }
+  }, step);
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -595,6 +595,7 @@
                 "start": "Start",
                 "sendEmail": "Send link by email",
                 "reSendEmail": "Resend email",
+                "waitBeforeResending": "Wait {seconds}s",
                 "cancelGreet": {
                     "yes": "Cancel process",
                     "no": "Resume"

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -595,6 +595,7 @@
                 "start": "Démarrer",
                 "sendEmail": "Envoyer le lien par email",
                 "reSendEmail": "Renvoyer l'email",
+                "waitBeforeResending": "Attendez {seconds}s",
                 "cancelGreet": {
                     "yes": "Annuler le processus",
                     "no": "Reprendre"

--- a/client/src/parsec/greet_device.ts
+++ b/client/src/parsec/greet_device.ts
@@ -12,14 +12,13 @@ import {
   DeviceGreetInProgress3Info,
   DeviceGreetInProgress4Info,
   DeviceGreetInitialInfo,
-  DeviceInvitation,
   DeviceLabel,
   GreetInProgressError,
   InvitationEmailSentStatus,
   NewInvitationInfo,
   Result,
 } from '@/parsec/types';
-import { InvitationStatus, InvitationToken, InviteListItemTag, ParsecInvitationAddr, SASCode, libparsec } from '@/plugins/libparsec';
+import { InvitationToken, ParsecInvitationAddr, SASCode, libparsec } from '@/plugins/libparsec';
 
 export class DeviceGreet {
   handle: ConnectionHandle | null;
@@ -75,31 +74,9 @@ export class DeviceGreet {
   }
 
   async createInvitation(sendEmail = true): Promise<Result<NewInvitationInfo, ClientNewDeviceInvitationError>> {
-    async function getExistingInvitation(clientHandle: ConnectionHandle): Promise<DeviceInvitation | null> {
-      const invitationsResult = await libparsec.clientListInvitations(clientHandle);
-      if (invitationsResult.ok) {
-        const deviceInvitations = invitationsResult.value.filter(
-          (inv) => inv.tag === InviteListItemTag.Device && (inv.status === InvitationStatus.Idle || inv.status === InvitationStatus.Ready),
-        );
-        if (deviceInvitations.length > 0) {
-          return deviceInvitations[0] as DeviceInvitation;
-        }
-      }
-      return null;
-    }
-
     const clientHandle = getParsecHandle();
 
     if (clientHandle !== null && !needsMocks()) {
-      const existingInvitation = await getExistingInvitation(clientHandle);
-      if (existingInvitation) {
-        this.invitationLink = existingInvitation.addr;
-        this.token = existingInvitation.token;
-        return {
-          ok: true,
-          value: { addr: existingInvitation.addr, token: existingInvitation.token, emailSentStatus: InvitationEmailSentStatus.Success },
-        };
-      }
       const result = await libparsec.clientNewDeviceInvitation(clientHandle, sendEmail);
       if (result.ok) {
         this.invitationLink = result.value.addr;
@@ -123,15 +100,14 @@ export class DeviceGreet {
   }
 
   async sendEmail(): Promise<boolean> {
-    return true;
-    // Do nothing for now, we don't have the right API
-    // const clientHandle = getParsecHandle();
-    // if (clientHandle !== null && !needsMocks()) {
-    //   const result = await libparsec.clientNewDeviceInvitation(clientHandle, true);
-    //   return result.ok;
-    // } else {
-    //   return true;
-    // }
+    const clientHandle = getParsecHandle();
+
+    if (clientHandle !== null && !needsMocks()) {
+      const result = await libparsec.clientNewDeviceInvitation(clientHandle, true);
+      return result.ok;
+    } else {
+      return true;
+    }
   }
 
   async startGreet(): Promise<Result<DeviceGreetInitialInfo, ClientStartInvitationGreetError>> {


### PR DESCRIPTION
Re-enables the ability to send an email when greeting a new device. I added a little bit of magic to discourage spamming.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes

   