### PR TITLE
Provide own custom snapcraft for electron app 

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -199,6 +199,7 @@ gifv
 gloo
 gradlew
 grapheq
+gsettings
 gtod
 guce
 guci
@@ -208,6 +209,7 @@ hatin'
 headerlink
 helloerror
 Hellow
+hicolor
 HKCR
 HKCU
 HKLM
@@ -253,6 +255,7 @@ latexpdf
 latexpdfja
 letterpaper
 levelno
+libappindicator
 libasound
 libassimp
 libbz
@@ -264,6 +267,7 @@ libegl
 libexpat
 libfontconfig
 libfuse
+libgbm
 libgl
 libgltfgeometryloader
 libgltfsceneexport
@@ -273,8 +277,11 @@ libgstcamerabin
 libgstmediacapture
 libgstmediaplayer
 libgstreamer
+libgtk
 libmpdec
 libncursesw
+libnspr
+libnss
 libopenglrenderer
 libpulse
 libpython
@@ -301,6 +308,7 @@ libqvnc
 libqwebgl
 librsvg
 libscene
+libsecret
 LibSodium
 libsqlite
 libtinfo
@@ -311,6 +319,7 @@ libxcb
 libxcomposite
 libxext
 libxkbcommon
+libxss
 linkcheck
 linuxsys
 Ljava
@@ -398,6 +407,7 @@ onboarded
 oneof
 oneofschema
 Onone
+opengl
 opses
 OpsLimit
 ORGANIZATIONID
@@ -458,6 +468,7 @@ psutil
 pubkey
 PUBLICKEYBYTES
 pubout
+pulseaudio
 pwhash
 pwsh
 PyClass

--- a/.github/workflows/package-client.yml
+++ b/.github/workflows/package-client.yml
@@ -107,7 +107,76 @@ jobs:
           path: client/dist/
           if-no-files-found: error
 
-  electron:
+  electron-snap:
+    needs: version
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # pin v4.1.2
+        with:
+          ref: ${{ inputs.commit_sha }}
+        timeout-minutes: 5
+
+      - name: Download version.patch artifact
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # pin v4.1.4
+        with:
+          name: version.patch
+          path: ${{ runner.temp }}/version.patch
+          run-id: ${{ inputs.version_patch_run_id || github.run_id }}
+
+      - name: Load version config
+        id: version
+        shell: bash
+        run: |
+          cat version.patch/version.ini > "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
+        working-directory: ${{ runner.temp }}
+
+      - name: Apply version.patch
+        run: git apply --allow-empty ${{ runner.temp }}/version.patch/version.patch
+
+      - name: Install snapcraft
+        uses: samuelmeuli/action-snapcraft@d33c176a9b784876d966f80fb1b461808edc0641 # pin v2.1.1
+        timeout-minutes: 1
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@4e959f8e0d9c5feb27d44c5e4d9a330a782edee0 # pin v0.1.1
+        timeout-minutes: 2
+
+      - name: Patch cannot install cypress on lxd
+        run: npm remove cypress{,-file-upload,-real-events,-vite}
+        working-directory: client
+        timeout-minutes: 2
+
+      - name: Build snap
+        run: |
+          ln -sv client/electron/snap
+          snapcraft pack --use-lxd -v
+        timeout-minutes: 30
+
+      - name: Rename artifacts
+        shell: bash
+        run: |
+          ARCH=$(uname -m)
+          mv -v parsec-v3_*_*.snap Parsec-v3_${{ steps.version.outputs.full }}_linux_$ARCH.snap
+
+      # Install syft
+      - uses: taiki-e/install-action@3068b7dc83db15fc2676a3ce4ae1ebb878685f59 # pin v2.29.7
+        with:
+          tool: syft@0.84.0
+
+      - name: Generate SBOM
+        run: syft packages --config=.syft.yaml --output=spdx-json=Parsec-SBOM-Electron-linux.spdx.json .
+
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin v4.3.1
+        with:
+          name: ${{ runner.os }}-${{ runner.arch }}-electron-app
+          path: |
+            Parsec-v3_${{ steps.version.outputs.full }}_linux_*.snap
+            Parsec-SBOM-Electron-linux.spdx.json
+          if-no-files-found: error
+        timeout-minutes: 10
+
+  electron-non-linux:
     needs: version
     # Always run the job if `version` job is skipped otherwise only if `version` job was successful.
     if: ${{ inputs.version_patch_run_id != '' && always() || success() }}
@@ -115,9 +184,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: 🐧 Linux
-            platform: linux
-            os: ubuntu-22.04
           - name: 🏁 Windows
             platform: windows
             os: windows-2022
@@ -155,30 +221,6 @@ jobs:
 
       - name: Apply version.patch
         run: git apply --allow-empty ${{ runner.temp }}/version.patch/version.patch
-
-      - name: Linux > Install fuse devel
-        if: matrix.platform == 'linux'
-        run: |
-          until sudo apt-get install fuse3 libfuse3-dev; do
-            sleep 1;
-            echo "Retrying";
-          done
-        timeout-minutes: 1
-
-      - name: Linux > Install snapcraft
-        if: matrix.platform == 'linux'
-        uses: samuelmeuli/action-snapcraft@d33c176a9b784876d966f80fb1b461808edc0641 # pin v2.1.1
-        timeout-minutes: 1
-
-      - name: Linux > Setup LXD
-        if: matrix.platform == 'linux'
-        uses: canonical/setup-lxd@4e959f8e0d9c5feb27d44c5e4d9a330a782edee0 # pin v0.1.1
-        timeout-minutes: 2
-
-      - name: Linux > Debug installed packages
-        if: matrix.platform == 'linux'
-        run: apt-cache policy snapd fuse3 libfuse3-dev libssl libssl-dev
-        continue-on-error: true
 
       - name: Windows > Install WinFSP
         if: matrix.platform == 'windows'
@@ -218,14 +260,6 @@ jobs:
 
       - name: Generate SBOM
         run: syft packages --config=.syft.yaml --output=spdx-json=client/electron/dist/Parsec-SBOM-Electron-${{ matrix.platform }}.spdx.json .
-
-      - name: Linux > rename artifacts
-        if: matrix.platform == 'linux'
-        shell: bash
-        run: |
-          ARCH=$(uname -m)
-          mv -v parsec-v3_*_*.snap Parsec-v3_${{ steps.version.outputs.full }}_linux_$ARCH.snap
-        working-directory: client/electron/dist
 
       - name: Windows > rename artifacts
         if: matrix.platform == 'windows'

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,8 @@ node_modules
 
 # Each dev can set up their own env
 client/.env
+
+# snapcraft
+/prime
+/snap
+/*.snap

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -34,6 +34,7 @@ npm-debug.log*
 /electron/app/
 /electron/build/
 /electron/dist/
+/electron/out/
 # `trampoline.ts` is set during build depending on the target
 /src/plugins/libparsec/trampoline.ts
 # Cypress captures on test error

--- a/client/.prettierrc.json5
+++ b/client/.prettierrc.json5
@@ -13,7 +13,7 @@
             },
         },
         {
-            files: ['*.yml'],
+            files: ['*.yml', '*.yaml'],
             options: {
                 singleQuote: false,
             },

--- a/client/electron/package.js
+++ b/client/electron/package.js
@@ -8,6 +8,7 @@ const PARSEC_SCHEME = 'parsec3';
  * @returns {{
  *   mode: 'test' | 'prod',
  *   platform: 'linux' | 'win32' | 'darwin',
+ *   targets: string[],
  * }}
  */
 function cli() {
@@ -23,25 +24,30 @@ function cli() {
       .default(builder.DEFAULT_TARGET)
       .makeOptionMandatory(true),
   );
+  program.argument('[target...]', 'Targets to build');
 
   program.parse();
-  return program.opts();
+  return {
+    ...program.opts(),
+    targets: program.args,
+  };
 }
 
 /**
  * @param {string} platform
+ * @param {string[]} targets
  * @return {Map<builder.Platform, Map<builder.Arch, string[]>>}
  */
-function getBuildTargets(platform) {
+function getBuildTargets(platform, targets) {
   switch (platform) {
     case 'linux':
-      return builder.Platform.LINUX.createTarget();
+      return builder.Platform.LINUX.createTarget(targets);
     case 'darwin':
-      return builder.Platform.MAC.createTarget();
+      return builder.Platform.MAC.createTarget(targets);
     case 'win32':
-      return builder.Platform.WINDOWS.createTarget();
+      return builder.Platform.WINDOWS.createTarget(targets);
     case builder.DEFAULT_TARGET:
-      return builder.Platform.current().createTarget();
+      return builder.Platform.current().createTarget(targets);
     default:
       throw new Error(`Unknown platform: ${platform}`);
   }
@@ -49,7 +55,7 @@ function getBuildTargets(platform) {
 const OPTS = cli();
 console.debug(OPTS);
 
-const BUILD_TARGETS = getBuildTargets(OPTS.platform);
+const BUILD_TARGETS = getBuildTargets(OPTS.platform, OPTS.targets);
 console.log('BUILD_TARGETS', BUILD_TARGETS);
 
 /**

--- a/client/electron/snap/snapcraft.yaml
+++ b/client/electron/snap/snapcraft.yaml
@@ -1,0 +1,182 @@
+name: parsec-v3
+base: core22
+version: 3.0.0-a.0+dev
+summary: Secure cloud framework
+description: Parsec is an open-source cloud-based application that allow simple yet cryptographically secure file hosting.
+grade: devel
+confinement: classic
+type: app
+
+apps:
+  parsec-v3:
+    plugs:
+      - desktop
+      - desktop-legacy
+      - home
+      - wayland
+      - x11
+      - opengl
+      - browser-support
+      - network
+      - gsettings
+      - audio-playback
+      - pulseaudio
+      - password-manager-service
+    desktop: usr/share/applications/parsec-v3.desktop
+    command: command.sh
+
+parts:
+  libparsec:
+    plugin: nil
+    source: .
+    build-packages:
+      - python3
+      - libssl-dev
+      - libfuse3-dev
+      - pkg-config
+      - patchelf
+    stage-packages:
+      # libssl3 is provided by core22
+      - fuse3
+    build-snaps:
+      - node/18/stable
+    stage:
+      - libparsec.d.ts
+      - libparsec.node
+      - bin # include fusermount bin
+      - sbin # include mount.fuse, needed ?
+      - lib # include libfuse3
+    prime:
+      - -libparsec.d.ts
+      - -libparsec.node
+    build-attributes:
+      - enable-patchelf
+    override-build: |
+      set -x
+
+      # Set system alias for python
+      update-alternatives --install /usr/local/bin/python python $(which python3) 100
+
+      # Install rust
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh /dev/stdin -y --default-toolchain none
+      source "$HOME/.cargo/env"
+
+      # Debug software versions
+      node --version
+      npm --version
+      python --version
+      cargo --version
+
+      cd bindings/electron
+      npm clean-install
+      npm run build:release
+
+      cp -va dist/libparsec/index.node "$CRAFT_PART_INSTALL/libparsec.node"
+      cp -va dist/libparsec/index.d.ts "$CRAFT_PART_INSTALL/libparsec.d.ts"
+
+  parsec:
+    after:
+      - libparsec
+      - wrapper
+    plugin: nil
+    source: .
+    build-snaps:
+      - node/18/stable
+    build-attributes:
+      - enable-patchelf
+    override-build: |
+      set -x
+
+      # Debug software versions
+      node --version
+      npm --version
+
+      cd client
+      npm clean-install
+      npm run electron:copy
+
+      cd electron
+      npm clean-install
+
+      # Copy bindings
+      rm -rf build # Cleanup build folder
+      mkdir -pv build/{src,generated-ts/src}
+      cp -v "${CRAFT_STAGE}/libparsec.node" build/src/libparsec.node
+      cp -v "${CRAFT_STAGE}/libparsec.d.ts" build/generated-ts/src/libparsec.d.ts
+
+      # Compile typescript
+      npx tsc
+
+      # Package
+      node package.js --mode prod --platform linux dir
+
+      cp -vr dist/linux-unpacked "$CRAFT_PART_INSTALL"/app
+
+  parsec-v3-desktop:
+    plugin: nil
+    source: client/electron/assets
+    build-environment:
+      - ICON_PATH: usr/share/icons/hicolor/512x512/apps/parsec-v3.png
+      - DESKTOP_PATH: usr/share/applications/parsec-v3.desktop
+      - PARSEC_SCHEME: parsec-v3
+    stage:
+      - "*"
+    override-build: |
+      mkdir -p $(dirname "$CRAFT_PART_INSTALL"/$ICON_PATH)
+      cp -v icon.png "$CRAFT_PART_INSTALL"/$ICON_PATH
+
+      mkdir -p $(dirname "$CRAFT_PART_INSTALL"/$DESKTOP_PATH)
+      cat << EOF > "$CRAFT_PART_INSTALL"/$DESKTOP_PATH
+      [Desktop Entry]
+      Name=Parsec-v3
+      Comment=Secure cloud framework
+      Exec=\${SNAP}/command.sh %u
+      Icon=\${SNAP}/$ICON_PATH
+      Terminal=false
+      Type=Application
+      Categories=Office Network FileTransfer FileSystem Security
+      MimeType=x-scheme-handler/$PARSEC_SCHEME;
+      EOF
+
+  electron-lib:
+    plugin: nil
+    stage-packages:
+      - libgtk-3-0
+      - libgbm1
+      - libasound2
+    build-attributes:
+      - enable-patchelf
+
+  wrapper:
+    after:
+      - electron-lib
+    plugin: nil
+    build-packages:
+      - p7zip-full
+    build-environment:
+      # https://github.com/electron-userland/electron-builder-binaries/releases/snap-template-4.0-2
+      - SNAP_TEMPLATE_URL: https://github.com/electron-userland/electron-builder-binaries/releases/download/snap-template-4.0-2/snap-template-electron-4.0-2-amd64.tar.7z
+      # The checksum is provided in base64 format in the release page.
+      - SNAP_TEMPLATE_SHA512: 3d8862410e4a1387b3ada2c4ed3393d9a14f1a404d8c72d137b0bca803da0ba55c9075371fed26f8903f5a6c7af377ca513d99070a3d329f3612e866428e5639
+    build-attributes:
+      - enable-patchelf
+    stage:
+      - "*"
+    override-build: |
+      set -x
+
+      ARCHIVE_FILE=$(basename "$SNAP_TEMPLATE_URL")
+
+      curl -L -O "$SNAP_TEMPLATE_URL"
+      echo "${SNAP_TEMPLATE_SHA512}  $ARCHIVE_FILE" | sha512sum -c
+
+      mkdir -v template
+      7z x -so "$ARCHIVE_FILE" | tar --extract --file - --directory template
+
+      cat > template/command.sh << EOF
+      #!/bin/bash -e
+      exec "\$SNAP/desktop-init.sh" "\$SNAP/desktop-common.sh" "\$SNAP/desktop-gnome-specific.sh" "\$SNAP/app/parsec-v3" "\$@" --no-sandbox
+      EOF
+      chmod a+x template/command.sh
+
+      cp -rv template/. "$CRAFT_PART_INSTALL"

--- a/misc/version_updater.py
+++ b/misc/version_updater.py
@@ -197,6 +197,9 @@ FILES_WITH_VERSION_INFO: dict[Path, dict[Tool, RawRegexes]] = {
             ),
         ]
     },
+    ROOT_DIR / "client/electron/snap/snapcraft.yaml": {
+        Tool.Parsec: [ReplaceRegex(r"version: .*", "version: {version}")],
+    },
     ROOT_DIR / "client/electron/package.json": {
         Tool.License: [JSON_LICENSE_FIELD],
         Tool.Parsec: [JSON_VERSION_FIELD],


### PR DESCRIPTION
The custom `snapcraft` as the following benefits:

- `libparsec` is build inside of it, so it will use their the same
  environment between build and run.
- We have the `patchelf` hook that is run patching binaries & libraries
  to use snap provided libs.

Other changes
-------------

- Add specific job to package the electron app on Linux using `snapcraft`.
- Update `package.js` to take a target argument (e.g.: `dir`, `appimage`,
  `nsis`, ...).