### PR TITLE
[MS] Handle no default option in dropdown popover

### DIFF
--- a/client/src/components/core/ms-dropdown/MsDropdown.vue
+++ b/client/src/components/core/ms-dropdown/MsDropdown.vue
@@ -36,7 +36,7 @@ import { caretDown, chevronDown } from 'ionicons/icons';
 import { Ref, ref } from 'vue';
 
 const props = defineProps<{
-  defaultOption?: any;
+  defaultOptionKey?: any;
   label?: string;
   title?: string;
   description?: string;
@@ -49,7 +49,7 @@ const emits = defineEmits<{
   (e: 'change', value: MsDropdownChangeEvent): void;
 }>();
 
-const selectedOption: Ref<MsOption | undefined> = ref(props.defaultOption ? props.options.get(props.defaultOption) : undefined);
+const selectedOption: Ref<MsOption | undefined> = ref(props.defaultOptionKey ? props.options.get(props.defaultOptionKey) : undefined);
 const labelRef = ref(selectedOption.value?.label || props.label);
 const isPopoverOpen = ref(false);
 const appearanceRef = ref(props.appearance ?? MsAppearance.Outline);
@@ -60,7 +60,7 @@ async function openPopover(event: Event): Promise<void> {
     cssClass: 'dropdown-popover',
     componentProps: {
       options: props.options,
-      defaultOption: selectedOption.value?.key,
+      defaultOptionKey: selectedOption.value?.key,
     },
     event: event,
     alignment: 'end',

--- a/client/src/components/core/ms-dropdown/MsDropdownPopover.vue
+++ b/client/src/components/core/ms-dropdown/MsDropdownPopover.vue
@@ -4,7 +4,7 @@
   <ion-list class="container">
     <ion-item
       class="option body"
-      :class="{ selected: selectedOption?.key === option.key, 'item-disabled': option.disabled }"
+      :class="{ selected: defaultOptionKey === option.key, 'item-disabled': option.disabled }"
       button
       lines="none"
       v-for="option in options.set"
@@ -26,8 +26,8 @@
         slot="end"
         :icon="checkmark"
         class="icon checked"
-        :class="{ selected: selectedOption?.key === option.key }"
-        v-if="selectedOption?.key === option.key"
+        :class="{ selected: defaultOptionKey === option.key }"
+        v-if="defaultOptionKey === option.key"
       />
       <ms-information-tooltip
         v-if="option.disabled && option.disabledReason"
@@ -44,21 +44,15 @@ import { MsInformationTooltip } from '@/components/core/ms-tooltip';
 import { MsOption, MsOptions } from '@/components/core/ms-types';
 import { IonIcon, IonItem, IonLabel, IonList, popoverController } from '@ionic/vue';
 import { checkmark } from 'ionicons/icons';
-import { ref } from 'vue';
 
-const props = defineProps<{
-  defaultOption?: any;
+defineProps<{
+  defaultOptionKey?: any;
   options: MsOptions;
 }>();
 
-const selectedOption = ref(props.defaultOption ? props.options.get(props.defaultOption) : props.options.at(0));
-
-async function onOptionClick(option?: MsOption): Promise<void> {
-  if (option) {
-    selectedOption.value = option;
-  }
+async function onOptionClick(option: MsOption): Promise<void> {
   await popoverController.dismiss({
-    option: selectedOption.value,
+    option: option,
   });
 }
 </script>

--- a/client/src/components/workspaces/WorkspaceUserRole.vue
+++ b/client/src/components/workspaces/WorkspaceUserRole.vue
@@ -12,7 +12,7 @@
       class="dropdown"
       :options="options"
       :disabled="disabled"
-      :default-option="role || NOT_SHARED_KEY"
+      :default-option-key="role || NOT_SHARED_KEY"
       :appearance="MsAppearance.Clear"
       @change="$emit('roleUpdate', user, getRoleFromString($event.option.key))"
     />

--- a/client/src/views/settings/SettingsView.vue
+++ b/client/src/views/settings/SettingsView.vue
@@ -53,7 +53,7 @@
                 <ms-dropdown
                   class="dropdown"
                   :options="languageOptions"
-                  :default-option="$i18n.locale"
+                  :default-option-key="$i18n.locale"
                   @change="changeLang($event.option.key)"
                 />
               </settings-option>
@@ -66,7 +66,7 @@
                 <ms-dropdown
                   class="dropdown"
                   :options="themeOptions"
-                  :default-option="'light' ? 'light' : config.theme"
+                  :default-option-key="'light' ? 'light' : config.theme"
                   @change="changeTheme($event.option.key)"
                   :disabled="true"
                 />


### PR DESCRIPTION
Avoid selecting an option by default in dropdown popover (see screenshot). Also renamed `defaultOption` in `defaultKey` since we're not passing a full option with the label but only the key.

![Screenshot 2024-03-25 141333](https://github.com/Scille/parsec-cloud/assets/18075498/15f81b17-599c-4f45-bbc9-dc7b9d4076f5)

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
   