### PR TITLE
Fix electron-snap skipped because `version` is ignored on release

### DIFF
--- a/.github/workflows/package-client.yml
+++ b/.github/workflows/package-client.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - .github/workflows/package-client.yml
       - ./client/electron/package.js
+      - ./client/electron/snap
   workflow_call:
     inputs:
       version:

--- a/.github/workflows/package-client.yml
+++ b/.github/workflows/package-client.yml
@@ -110,6 +110,8 @@ jobs:
   electron-snap:
     needs: version
     runs-on: ubuntu-22.04
+    # Always run the job if `version` job is skipped otherwise only if `version` job was successful.
+    if: ${{ inputs.version_patch_run_id != '' && always() || success() }}
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # pin v4.1.2
         with:


### PR DESCRIPTION
Forgot to use the same condition has the other jobs