### PR TITLE
[MS] Injections by connection handle for multi org

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -7,118 +7,18 @@
 </template>
 
 <script setup lang="ts">
-import { EventData, EventDistributor, EventDistributorKey, Events } from '@/services/eventDistributor';
-import { Information, InformationLevel, InformationManager, InformationManagerKey, PresentationMode } from '@/services/informationManager';
 import { StorageManager, StorageManagerKey } from '@/services/storageManager';
-import { translate } from '@/services/translation';
 import { toggleDarkMode } from '@/states/darkMode';
 import { SplashScreen } from '@capacitor/splash-screen';
 import { IonApp, IonRouterOutlet } from '@ionic/vue';
-import { inject, onMounted, onUnmounted } from 'vue';
+import { inject, onMounted } from 'vue';
 
 const storageManager: StorageManager = inject(StorageManagerKey)!;
-const informationManager: InformationManager = inject(InformationManagerKey)!;
-const eventDistributor: EventDistributor = inject(EventDistributorKey)!;
-let eventCbId: null | string = null;
-let ignoreOnlineEvent = true;
-
-async function handleEvent(event: Events, _data: EventData): Promise<void> {
-  switch (event) {
-    case Events.Offline: {
-      informationManager.present(
-        new Information({
-          message: translate('notification.serverOffline'),
-          level: InformationLevel.Warning,
-        }),
-        PresentationMode.Notification,
-      );
-      break;
-    }
-    case Events.Online: {
-      if (ignoreOnlineEvent) {
-        ignoreOnlineEvent = false;
-        return;
-      }
-      informationManager.present(
-        new Information({
-          message: translate('notification.serverOnline'),
-          level: InformationLevel.Info,
-        }),
-        PresentationMode.Notification,
-      );
-      break;
-    }
-    case Events.IncompatibleServer: {
-      informationManager.present(
-        new Information({
-          message: translate('notification.incompatibleServer'),
-          level: InformationLevel.Error,
-        }),
-        PresentationMode.Notification,
-      );
-      await informationManager.present(
-        new Information({
-          message: translate('globalErrors.incompatibleServer'),
-          level: InformationLevel.Error,
-        }),
-        PresentationMode.Modal,
-      );
-      break;
-    }
-    case Events.ExpiredOrganization: {
-      informationManager.present(
-        new Information({
-          message: translate('notification.expiredOrganization'),
-          level: InformationLevel.Error,
-        }),
-        PresentationMode.Notification,
-      );
-      await informationManager.present(
-        new Information({
-          message: translate('globalErrors.expiredOrganization'),
-          level: InformationLevel.Error,
-        }),
-        PresentationMode.Modal,
-      );
-      break;
-    }
-    case Events.ClientRevoked: {
-      informationManager.present(
-        new Information({
-          message: translate('notification.clientRevoked'),
-          level: InformationLevel.Error,
-        }),
-        PresentationMode.Notification,
-      );
-      await informationManager.present(
-        new Information({
-          message: translate('globalErrors.clientRevoked'),
-          level: InformationLevel.Error,
-        }),
-        PresentationMode.Modal,
-      );
-      break;
-    }
-  }
-}
 
 onMounted(async (): Promise<void> => {
   SplashScreen.hide();
 
   const config = await storageManager.retrieveConfig();
   toggleDarkMode(config.theme);
-
-  eventCbId = await eventDistributor.registerCallback(
-    Events.Offline | Events.Online | Events.IncompatibleServer | Events.ExpiredOrganization | Events.ClientRevoked,
-    async (event: Events, data: EventData) => {
-      await handleEvent(event, data);
-    },
-  );
-});
-
-onUnmounted(async () => {
-  if (eventCbId) {
-    eventDistributor.removeCallback(eventCbId);
-  }
 });
 </script>

--- a/client/src/common/base64.ts
+++ b/client/src/common/base64.ts
@@ -1,0 +1,14 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+function fromObject(obj: object): string {
+  return btoa(JSON.stringify(obj));
+}
+
+function toObject(data: string): object {
+  return JSON.parse(atob(data));
+}
+
+export const Base64 = {
+  fromObject,
+  toObject,
+};

--- a/client/src/components/core/ms-spinner/MsSpinner.vue
+++ b/client/src/components/core/ms-spinner/MsSpinner.vue
@@ -2,12 +2,6 @@
 
 <template>
   <div class="container">
-    <div class="container-logo">
-      <ms-image
-        :image="LogoIconGradient"
-        class="image"
-      />
-    </div>
     <ion-text class="subtitles-normal container-text">
       {{ title }}
     </ion-text>
@@ -19,7 +13,6 @@
 </template>
 
 <script setup lang="ts">
-import { LogoIconGradient, MsImage } from '@/components/core/ms-image';
 import { IonSpinner, IonText } from '@ionic/vue';
 
 defineProps<{
@@ -30,21 +23,11 @@ defineProps<{
 <style scoped lang="scss">
 .container {
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
   width: 100%;
   overflow: hidden;
-  gap: 1.5rem;
-
-  &-logo {
-    max-width: 3.625rem;
-
-    .image {
-      width: 100%;
-      height: auto;
-    }
-  }
+  gap: 0.5rem;
 
   &-text {
     color: var(--parsec-color-light-secondary-grey);

--- a/client/src/components/header/InvitationsButton.vue
+++ b/client/src/components/header/InvitationsButton.vue
@@ -18,7 +18,7 @@
 <script setup lang="ts">
 import { Answer, MsModalResult, askQuestion } from '@/components/core';
 import { ClientCancelInvitationErrorTag, UserInvitation, cancelInvitation, listUserInvitations } from '@/parsec';
-import { Routes, navigateTo, watchOrganizationSwitch } from '@/router';
+import { Routes, navigateTo } from '@/router';
 import { EventData, EventDistributor, EventDistributorKey, Events } from '@/services/eventDistributor';
 import { Information, InformationLevel, InformationManager, InformationManagerKey, PresentationMode } from '@/services/informationManager';
 import { translate } from '@/services/translation';
@@ -33,8 +33,6 @@ const eventDistributor: EventDistributor = inject(EventDistributorKey)!;
 let eventCbId: string | null = null;
 const invitations: Ref<UserInvitation[]> = ref([]);
 
-const organizationWatchCancel = watchOrganizationSwitch(updateInvitations);
-
 onMounted(async () => {
   eventCbId = await eventDistributor.registerCallback(Events.InvitationUpdated, async (event: Events, _data: EventData) => {
     if (event === Events.InvitationUpdated) {
@@ -45,7 +43,6 @@ onMounted(async () => {
 });
 
 onUnmounted(async () => {
-  organizationWatchCancel();
   if (eventCbId) {
     await eventDistributor.removeCallback(eventCbId);
   }
@@ -66,6 +63,9 @@ async function openInvitationsPopover(event: Event): Promise<void> {
     event: event,
     cssClass: 'invitations-list-popover',
     showBackdrop: false,
+    componentProps: {
+      informationManager: informationManager,
+    },
   });
   await popover.present();
   const { role, data } = await popover.onDidDismiss();
@@ -136,6 +136,7 @@ async function greetUser(invitation: UserInvitation): Promise<void> {
     cssClass: 'greet-organization-modal',
     componentProps: {
       invitation: invitation,
+      informationManager: informationManager,
     },
   });
   await modal.present();

--- a/client/src/components/users/InvitationPopoverItem.vue
+++ b/client/src/components/users/InvitationPopoverItem.vue
@@ -52,13 +52,13 @@
 import { writeTextToClipboard } from '@/common/clipboard';
 import { formatTimeSince } from '@/common/date';
 import { UserInvitation } from '@/parsec';
-import { Information, InformationLevel, InformationManager, InformationManagerKey, PresentationMode } from '@/services/informationManager';
+import { Information, InformationLevel, InformationManager, PresentationMode } from '@/services/informationManager';
 import { translate } from '@/services/translation';
 import { IonButton, IonButtons, IonItem, IonLabel } from '@ionic/vue';
-import { inject } from 'vue';
 
-defineProps<{
+const props = defineProps<{
   invitation: UserInvitation;
+  informationManager: InformationManager;
 }>();
 
 defineEmits<{
@@ -66,12 +66,10 @@ defineEmits<{
   (e: 'greetUser', invitation: UserInvitation): void;
 }>();
 
-const informationManager: InformationManager = inject(InformationManagerKey)!;
-
 async function copyLink(invitation: UserInvitation): Promise<void> {
   const result = await writeTextToClipboard(invitation.addr);
   if (result) {
-    informationManager.present(
+    props.informationManager.present(
       new Information({
         message: translate('UsersPage.invitation.linkCopiedToClipboard'),
         level: InformationLevel.Info,
@@ -79,7 +77,7 @@ async function copyLink(invitation: UserInvitation): Promise<void> {
       PresentationMode.Toast,
     );
   } else {
-    informationManager.present(
+    props.informationManager.present(
       new Information({
         message: translate('UsersPage.invitation.linkNotCopiedToClipboard'),
         level: InformationLevel.Error,

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -124,7 +124,8 @@
             "emailLabel": "Email",
             "passwordLabel": "Password",
             "passwordError": "Incorrect password.",
-            "login": "Log in"
+            "login": "Log in",
+            "loading": "Loading..."
         },
         "organizationActionSheet": "Organization",
         "keyringFailed": "Could not log in",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -124,7 +124,8 @@
             "emailLabel": "Email",
             "passwordLabel": "Mot de passe",
             "passwordError": "Le mot de passe est invalide.",
-            "login": "Se connecter"
+            "login": "Se connecter",
+            "loading": "Chargement..."
         },
         "organizationActionSheet": "Organisation",
         "keyringFailed": "Impossible de se connecter",

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -12,4 +12,4 @@ export {
   getWorkspaceHandle,
 } from '@/router/params';
 export * from '@/router/types';
-export { watchOrganizationSwitch, watchRoute } from '@/router/watchers';
+export { watchRoute } from '@/router/watchers';

--- a/client/src/router/navigation.ts
+++ b/client/src/router/navigation.ts
@@ -1,9 +1,9 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
+import { Base64 } from '@/common/base64';
 import { ConnectionHandle, EntryName, WorkspaceHandle } from '@/parsec';
 import { getConnectionHandle } from '@/router/params';
-import { Query, Routes, getCurrentRoute, getRouter } from '@/router/types';
-import { organizationKey } from '@/router/watchers';
+import { Query, RouteBackup, Routes, getCurrentRoute, getRouter } from '@/router/types';
 import { LocationQueryRaw, RouteParamsRaw } from 'vue-router';
 
 export interface NavigationOptions {
@@ -50,15 +50,6 @@ export async function routerGoBack(): Promise<void> {
   router.go(-1);
 }
 
-interface RouteBackup {
-  handle: ConnectionHandle;
-  data: {
-    route: Routes;
-    params: object;
-    query: Query;
-  };
-}
-
 const routesBackup: Array<RouteBackup> = [];
 
 export async function switchOrganization(handle: ConnectionHandle | null, backup = true): Promise<void> {
@@ -91,7 +82,6 @@ export async function switchOrganization(handle: ConnectionHandle | null, backup
   // No handle, navigate to organization list
   if (!handle) {
     await navigateTo(Routes.Home, { skipHandle: true, replace: true });
-    organizationKey.value += 1;
   } else {
     const backup = routesBackup.find((bk) => bk.handle === handle);
     if (!backup) {
@@ -99,7 +89,6 @@ export async function switchOrganization(handle: ConnectionHandle | null, backup
       return;
     }
     console.log('Restoring', backup.data.route, backup.data.params, backup.data.query);
-    await navigateTo(backup.data.route, { params: backup.data.params, query: backup.data.query, skipHandle: true, replace: true });
-    organizationKey.value += 1;
+    await navigateTo(Routes.Loading, { skipHandle: true, replace: true, query: { loginInfo: Base64.fromObject(backup) } });
   }
 }

--- a/client/src/router/watchers.ts
+++ b/client/src/router/watchers.ts
@@ -1,15 +1,9 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 import { getCurrentRoute } from '@/router/types';
-import { Ref, WatchStopHandle, ref, watch } from 'vue';
-
-export const organizationKey: Ref<number> = ref(0);
+import { WatchStopHandle, watch } from 'vue';
 
 export function watchRoute(callback: () => Promise<void>): WatchStopHandle {
   const currentRoute = getCurrentRoute();
   return watch(currentRoute, callback);
-}
-
-export function watchOrganizationSwitch(callback: () => Promise<void>): WatchStopHandle {
-  return watch(organizationKey, callback);
 }

--- a/client/src/services/injectionProvider.ts
+++ b/client/src/services/injectionProvider.ts
@@ -1,0 +1,74 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { ConnectionHandle, needsMocks } from '@/parsec';
+import { EventDistributor } from '@/services/eventDistributor';
+import { ImportManager } from '@/services/importManager';
+import { InformationManager } from '@/services/informationManager';
+
+interface Injections {
+  importManager: ImportManager;
+  eventDistributor: EventDistributor;
+  informationManager: InformationManager;
+}
+
+export const InjectionProviderKey = 'InjectionProvider';
+
+export class InjectionProvider {
+  injections: Map<ConnectionHandle, Injections>;
+  default: Injections;
+
+  constructor() {
+    this.injections = new Map();
+    this.default = {
+      importManager: new ImportManager(),
+      eventDistributor: new EventDistributor(),
+      informationManager: new InformationManager(),
+    };
+  }
+
+  createNewInjections(handle: ConnectionHandle, eventDistributor: EventDistributor): void {
+    const inj = this.injections.get(handle);
+
+    if (inj) {
+      console.error('Already has injections for this handle', handle);
+      return;
+    }
+    this.injections.set(handle, {
+      importManager: new ImportManager(),
+      eventDistributor: eventDistributor,
+      informationManager: new InformationManager(),
+    });
+  }
+
+  getInjections(handle: ConnectionHandle): Injections {
+    const inj = this.injections.get(handle);
+
+    if (!inj) {
+      if (needsMocks()) {
+        return this.getDefault();
+      }
+      console.warn('Could not get injections for handle', handle);
+      return this.default;
+    }
+    return inj;
+  }
+
+  getDefault(): Injections {
+    return this.default;
+  }
+
+  async clean(handle: ConnectionHandle): Promise<void> {
+    const inj = this.injections.get(handle);
+    if (!inj) {
+      return;
+    }
+    await inj.importManager.stop();
+    this.injections.delete(handle);
+  }
+
+  async cleanAll(): Promise<void> {
+    for (const key of this.injections.keys()) {
+      await this.clean(key);
+    }
+  }
+}

--- a/client/src/views/devices/DevicesPage.vue
+++ b/client/src/views/devices/DevicesPage.vue
@@ -173,6 +173,9 @@ async function onAddDeviceClick(): Promise<void> {
     component: GreetDeviceModal,
     canDismiss: true,
     cssClass: 'greet-organization-modal',
+    componentProps: {
+      informationManager: informationManager,
+    },
   });
   await modal.present();
   const modalResult = await modal.onWillDismiss();

--- a/client/src/views/devices/GreetDeviceModal.vue
+++ b/client/src/views/devices/GreetDeviceModal.vue
@@ -234,7 +234,7 @@ import DeviceCard from '@/components/devices/DeviceCard.vue';
 import SasCodeChoice from '@/components/sas-code/SasCodeChoice.vue';
 import SasCodeProvide from '@/components/sas-code/SasCodeProvide.vue';
 import { DeviceGreet } from '@/parsec';
-import { Information, InformationLevel, InformationManager, InformationManagerKey, PresentationMode } from '@/services/informationManager';
+import { Information, InformationLevel, InformationManager, PresentationMode } from '@/services/informationManager';
 import { translate } from '@/services/translation';
 import {
   IonButton,
@@ -253,7 +253,7 @@ import {
 } from '@ionic/vue';
 import { checkmarkCircle, close, copy } from 'ionicons/icons';
 import QRCodeVue3 from 'qrcode-vue3';
-import { computed, inject, onMounted, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 
 enum GreetDeviceStep {
   WaitForGuest = 1,
@@ -263,13 +263,16 @@ enum GreetDeviceStep {
   Summary = 5,
 }
 
+const props = defineProps<{
+  informationManager: InformationManager;
+}>();
+
 const pageStep = ref(GreetDeviceStep.WaitForGuest);
 const canGoForward = ref(false);
 const waitingForGuest = ref(true);
 const isEmailSent = ref(false);
 const elapsedCount = ref(0);
 const greeter = ref(new DeviceGreet());
-const informationManager: InformationManager = inject(InformationManagerKey)!;
 const linkCopiedToClipboard = ref(false);
 const cancelled = ref(false);
 
@@ -345,7 +348,7 @@ async function startProcess(): Promise<void> {
   waitingForGuest.value = true;
   const result = await greeter.value.startGreet();
   if (!result.ok) {
-    informationManager.present(
+    props.informationManager.present(
       new Information({
         message: translate('DevicesPage.greet.errors.startFailed'),
         level: InformationLevel.Error,
@@ -357,7 +360,7 @@ async function startProcess(): Promise<void> {
   }
   const waitResult = await greeter.value.initialWaitGuest();
   if (!waitResult.ok && !cancelled.value) {
-    informationManager.present(
+    props.informationManager.present(
       new Information({
         message: translate('DevicesPage.greet.errors.startFailed'),
         level: InformationLevel.Error,
@@ -422,7 +425,7 @@ async function cancelModal(): Promise<boolean> {
 }
 
 async function showErrorAndRestart(message: string): Promise<void> {
-  informationManager.present(
+  props.informationManager.present(
     new Information({
       message: message,
       level: InformationLevel.Error,
@@ -438,7 +441,7 @@ async function nextStep(): Promise<void> {
     return;
   }
   if (pageStep.value === GreetDeviceStep.Summary) {
-    informationManager.present(
+    props.informationManager.present(
       new Information({
         message: translate('DevicesPage.greet.success'),
         level: InformationLevel.Success,
@@ -485,7 +488,7 @@ async function copyLink(): Promise<void> {
   setTimeout(() => {
     linkCopiedToClipboard.value = false;
   }, 5000);
-  informationManager.present(
+  props.informationManager.present(
     new Information({
       message: translate('DevicesPage.greet.linkCopiedToClipboard'),
       level: InformationLevel.Info,
@@ -507,7 +510,7 @@ async function sendEmail(): Promise<void> {
     isEmailSent.value = true;
     startCounter(5000, 1000, updateCounter);
   } else {
-    informationManager.present(
+    props.informationManager.present(
       new Information({
         message: translate('DevicesPage.greet.errors.emailFailed'),
         level: InformationLevel.Error,

--- a/client/src/views/files/FileUploadModal.vue
+++ b/client/src/views/files/FileUploadModal.vue
@@ -17,16 +17,14 @@
 import { Answer, askQuestion, MsModal } from '@/components/core';
 import { FileDropZone, FileImport } from '@/components/files';
 import { entryStat, Path, WorkspaceHandle, WorkspaceID } from '@/parsec';
-import { ImportManager, ImportManagerKey } from '@/services/importManager';
+import { ImportManager } from '@/services/importManager';
 import { translate } from '@/services/translation';
-import { inject } from 'vue';
-
-const importManager = inject(ImportManagerKey) as ImportManager;
 
 const props = defineProps<{
   currentPath: string;
   workspaceHandle: WorkspaceHandle;
   workspaceId: WorkspaceID;
+  importManager: ImportManager;
 }>();
 
 interface FileImportTuple {
@@ -65,7 +63,7 @@ async function importFiles(imports: FileImportTuple[]): Promise<void> {
     }
   }
   for (const imp of imports) {
-    await importManager.importFile(props.workspaceHandle, props.workspaceId, imp.file, imp.path);
+    await props.importManager.importFile(props.workspaceHandle, props.workspaceId, imp.file, imp.path);
   }
 }
 

--- a/client/src/views/files/FoldersPage.vue
+++ b/client/src/views/files/FoldersPage.vue
@@ -528,6 +528,7 @@ async function importFiles(): Promise<void> {
       currentPath: currentPath.value.toString(),
       workspaceHandle: workspaceInfo.value?.handle,
       workspaceId: workspaceInfo.value?.id,
+      importManager: importManager,
     },
   });
   await fileUploadModal.present();

--- a/client/src/views/header/HeaderPage.vue
+++ b/client/src/views/header/HeaderPage.vue
@@ -297,6 +297,9 @@ async function openNotificationCenter(event: Event): Promise<void> {
     event: event,
     cssClass: 'notification-center-popover',
     showBackdrop: false,
+    componentProps: {
+      notificationManager: informationManager.notificationManager,
+    },
   });
   await popover.present();
   await popover.onWillDismiss();

--- a/client/src/views/header/NotificationCenterPopover.vue
+++ b/client/src/views/header/NotificationCenterPopover.vue
@@ -41,16 +41,19 @@
 
 <script setup lang="ts">
 import { MsImage, NoNotification } from '@/components/core/ms-image';
-import { Notifications } from '@/components/notifications/index';
-import { InformationDataType, InformationManager, InformationManagerKey } from '@/services/informationManager';
-import { Notification } from '@/services/notificationManager';
+import { Notifications } from '@/components/notifications';
+import { InformationDataType } from '@/services/informationManager';
+import { Notification, NotificationManager } from '@/services/notificationManager';
 import { IonList, IonText, IonToggle } from '@ionic/vue';
-import { Ref, computed, inject, ref, type Component } from 'vue';
+import { Ref, computed, ref, type Component } from 'vue';
 
-const informationManager: InformationManager = inject(InformationManagerKey)!;
-const unreadCount = informationManager.notificationManager.getUnreadCount();
+const props = defineProps<{
+  notificationManager: NotificationManager;
+}>();
+
+const unreadCount = props.notificationManager.getUnreadCount();
 const notifications = computed(() => {
-  return informationManager.notificationManager
+  return props.notificationManager
     .getNotifications()
     .filter((n) => (onlyReadToggle.value ? !n.read : true))
     .sort((n1, n2) => n2.time.toMillis() - n1.time.toMillis());
@@ -83,7 +86,7 @@ function getComponentType(notification: Notification): Component {
 
 function onNotificationMouseOver(notification: Notification): void {
   if (!notification.read) {
-    informationManager.notificationManager.markAsRead(notification.information.id);
+    props.notificationManager.markAsRead(notification.information.id);
   }
 }
 </script>

--- a/client/src/views/header/ProfileHeaderPopover.vue
+++ b/client/src/views/header/ProfileHeaderPopover.vue
@@ -88,8 +88,8 @@ defineProps<{
   profile: UserProfile;
 }>();
 
-function onOptionClick(option: ProfilePopoverOption): void {
-  popoverController.dismiss({
+async function onOptionClick(option: ProfilePopoverOption): Promise<void> {
+  await popoverController.dismiss({
     option: option,
   });
 }

--- a/client/src/views/home/CreateOrganizationModal.vue
+++ b/client/src/views/home/CreateOrganizationModal.vue
@@ -191,12 +191,12 @@ import {
   DeviceSaveStrategyTag,
   createOrganization as parsecCreateOrganization,
 } from '@/parsec';
-import { Information, InformationLevel, InformationManager, InformationManagerKey, PresentationMode } from '@/services/informationManager';
+import { Information, InformationLevel, InformationManager, PresentationMode } from '@/services/informationManager';
 import { formatDate, translate } from '@/services/translation';
 import SummaryStep, { OrgInfo } from '@/views/home/SummaryStep.vue';
 import { IonButton, IonButtons, IonFooter, IonHeader, IonIcon, IonPage, IonText, IonTitle, modalController } from '@ionic/vue';
 import { checkmarkDone, chevronBack, chevronForward, close } from 'ionicons/icons';
-import { Ref, inject, onMounted, ref } from 'vue';
+import { Ref, onMounted, ref } from 'vue';
 
 enum CreateOrganizationStep {
   OrgNameStep = 1,
@@ -210,7 +210,6 @@ enum CreateOrganizationStep {
 
 const DEFAULT_SAAS_ADDR = 'parsec3://saas-demo-v3-fireraptor.parsec.cloud/ ';
 
-const informationManager: InformationManager = inject(InformationManagerKey)!;
 const pageStep = ref(CreateOrganizationStep.OrgNameStep);
 const orgName = ref('');
 const userInfo = ref();
@@ -221,6 +220,10 @@ const organizationNameInputRef = ref();
 
 const device: Ref<AvailableDevice | null> = ref(null);
 const orgInfo: Ref<null | OrgInfoValues> = ref(null);
+
+const props = defineProps<{
+  informationManager: InformationManager;
+}>();
 
 const fieldsUpdated = ref(false);
 
@@ -426,7 +429,7 @@ async function nextStep(): Promise<void> {
           break;
       }
       if (message) {
-        informationManager.present(
+        props.informationManager.present(
           new Information({
             message: message,
             level: InformationLevel.Error,

--- a/client/src/views/home/DeviceJoinOrganizationModal.vue
+++ b/client/src/views/home/DeviceJoinOrganizationModal.vue
@@ -163,13 +163,11 @@ import {
   ParsedParsecAddrTag,
   parseBackendAddr,
 } from '@/parsec';
-import { Information, InformationLevel, InformationManager, InformationManagerKey, PresentationMode } from '@/services/informationManager';
+import { Information, InformationLevel, InformationManager, PresentationMode } from '@/services/informationManager';
 import { translate } from '@/services/translation';
 import InformationJoinDevice from '@/views/home/InformationJoinDeviceStep.vue';
 import { checkmarkCircle, close } from 'ionicons/icons';
-import { computed, inject, onMounted, ref } from 'vue';
-
-const informationManager = inject(InformationManagerKey) as InformationManager;
+import { computed, onMounted, ref } from 'vue';
 
 enum DeviceJoinOrganizationStep {
   Information = 0,
@@ -187,6 +185,7 @@ const cancelled = ref(false);
 
 const props = defineProps<{
   invitationLink: string;
+  informationManager: InformationManager;
 }>();
 
 const waitingForHost = ref(true);
@@ -249,7 +248,7 @@ async function selectHostSas(selectedCode: string | null): Promise<void> {
 }
 
 async function showErrorAndRestart(message: string): Promise<void> {
-  informationManager.present(
+  props.informationManager.present(
     new Information({
       message: message,
       level: InformationLevel.Error,
@@ -315,7 +314,7 @@ async function nextStep(): Promise<void> {
       const strategy = authChoice.value.getSaveStrategy();
       const result = await claimer.value.finalize(strategy);
       if (!result.ok) {
-        informationManager.present(
+        props.informationManager.present(
           new Information({
             message: translate('ClaimDeviceModal.errors.saveDeviceFailed'),
             level: InformationLevel.Error,
@@ -336,7 +335,7 @@ async function nextStep(): Promise<void> {
       message: translate('ClaimDeviceModal.successMessage'),
       level: InformationLevel.Success,
     });
-    informationManager.present(notification, PresentationMode.Toast | PresentationMode.Console);
+    props.informationManager.present(notification, PresentationMode.Toast | PresentationMode.Console);
     const saveStrategy: DeviceSaveStrategy = authChoice.value.getSaveStrategy();
     const accessStrategy =
       saveStrategy.tag === DeviceSaveStrategyTag.Keyring
@@ -381,7 +380,7 @@ async function startProcess(): Promise<void> {
         message = translate('JoinOrganization.errors.offline');
         break;
     }
-    await informationManager.present(
+    await props.informationManager.present(
       new Information({
         message: message,
         level: InformationLevel.Error,
@@ -395,7 +394,7 @@ async function startProcess(): Promise<void> {
   if (!waitResult.ok && !cancelled.value) {
     await claimer.value.abort();
     await modalController.dismiss(null, MsModalResult.Cancel);
-    await informationManager.present(
+    await props.informationManager.present(
       new Information({
         message: translate('ClaimDeviceModal.errors.unexpected', { reason: waitResult.error.tag }),
         level: InformationLevel.Error,

--- a/client/src/views/home/UserJoinOrganizationModal.vue
+++ b/client/src/views/home/UserJoinOrganizationModal.vue
@@ -195,10 +195,10 @@ import {
   DeviceSaveStrategyTag,
   UserClaim,
 } from '@/parsec';
-import { Information, InformationLevel, InformationManager, InformationManagerKey, PresentationMode } from '@/services/informationManager';
+import { Information, InformationLevel, InformationManager, PresentationMode } from '@/services/informationManager';
 import { translate } from '@/services/translation';
 import { close } from 'ionicons/icons';
-import { computed, inject, onMounted, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 
 enum UserJoinOrganizationStep {
   WaitForHost = 1,
@@ -209,7 +209,6 @@ enum UserJoinOrganizationStep {
   Finish = 6,
 }
 
-const informationManager: InformationManager = inject(InformationManagerKey)!;
 const pageStep = ref(UserJoinOrganizationStep.WaitForHost);
 const userInfoPage = ref();
 const authChoice = ref();
@@ -220,6 +219,7 @@ const claimer = ref(new UserClaim());
 
 const props = defineProps<{
   invitationLink: string;
+  informationManager: InformationManager;
 }>();
 
 const waitingForHost = ref(true);
@@ -275,7 +275,7 @@ const titles = new Map<UserJoinOrganizationStep, Title>([
 ]);
 
 async function showErrorAndRestart(message: string): Promise<void> {
-  informationManager.present(
+  props.informationManager.present(
     new Information({
       message: message,
       level: InformationLevel.Error,
@@ -364,7 +364,7 @@ async function nextStep(): Promise<void> {
       // Error here is quite bad because the user has been created in the organization
       // but we fail to save the device. Don't really know what to do here.
       // So we just keep the dialog as is, they can click the button again, hoping it will work.
-      informationManager.present(
+      props.informationManager.present(
         new Information({
           message: translate('JoinOrganization.errors.saveDeviceFailed'),
           level: InformationLevel.Error,
@@ -390,7 +390,7 @@ async function nextStep(): Promise<void> {
       message: translate('JoinOrganization.successMessage'),
       level: InformationLevel.Success,
     });
-    informationManager.present(notification, PresentationMode.Toast | PresentationMode.Console);
+    props.informationManager.present(notification, PresentationMode.Toast | PresentationMode.Console);
     const saveStrategy: DeviceSaveStrategy = authChoice.value.getSaveStrategy();
     const accessStrategy =
       saveStrategy.tag === DeviceSaveStrategyTag.Keyring
@@ -436,7 +436,7 @@ async function startProcess(): Promise<void> {
         break;
     }
 
-    await informationManager.present(
+    await props.informationManager.present(
       new Information({
         message: message,
         level: InformationLevel.Error,
@@ -461,7 +461,7 @@ async function startProcess(): Promise<void> {
         break;
     }
 
-    await informationManager.present(
+    await props.informationManager.present(
       new Information({
         message: message,
         level: InformationLevel.Error,

--- a/client/src/views/layouts/ConnectedLayout.vue
+++ b/client/src/views/layouts/ConnectedLayout.vue
@@ -1,0 +1,137 @@
+<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+
+<template>
+  <!-- Don't load children components before we inject everything -->
+  <ion-page v-if="initialized">
+    <ion-content>
+      <ion-router-outlet />
+    </ion-content>
+  </ion-page>
+</template>
+
+<script lang="ts" setup>
+import { getConnectionHandle } from '@/router';
+import { EventData, EventDistributor, EventDistributorKey, Events } from '@/services/eventDistributor';
+import { ImportManagerKey } from '@/services/importManager';
+import { Information, InformationLevel, InformationManager, InformationManagerKey, PresentationMode } from '@/services/informationManager';
+import { InjectionProvider, InjectionProviderKey } from '@/services/injectionProvider';
+import { translate } from '@/services/translation';
+import { IonContent, IonPage, IonRouterOutlet } from '@ionic/vue';
+import { inject, onMounted, onUnmounted, provide, ref } from 'vue';
+
+const injectionProvider: InjectionProvider = inject(InjectionProviderKey)!;
+let informationManager: InformationManager;
+let eventDistributor: EventDistributor;
+let eventCbId: null | string = null;
+const initialized = ref(false);
+
+async function processEvents(): Promise<void> {
+  let ignoreOnlineEvent = true;
+
+  eventCbId = await eventDistributor.registerCallback(
+    Events.Offline | Events.Online | Events.IncompatibleServer | Events.ExpiredOrganization | Events.ClientRevoked,
+    async (event: Events, _data: EventData) => {
+      switch (event) {
+        case Events.Offline: {
+          informationManager.present(
+            new Information({
+              message: translate('notification.serverOffline'),
+              level: InformationLevel.Warning,
+            }),
+            PresentationMode.Notification,
+          );
+          break;
+        }
+        case Events.Online: {
+          if (ignoreOnlineEvent) {
+            ignoreOnlineEvent = false;
+            return;
+          }
+          informationManager.present(
+            new Information({
+              message: translate('notification.serverOnline'),
+              level: InformationLevel.Info,
+            }),
+            PresentationMode.Notification,
+          );
+          break;
+        }
+        case Events.IncompatibleServer: {
+          informationManager.present(
+            new Information({
+              message: translate('notification.incompatibleServer'),
+              level: InformationLevel.Error,
+            }),
+            PresentationMode.Notification,
+          );
+          await informationManager.present(
+            new Information({
+              message: translate('globalErrors.incompatibleServer'),
+              level: InformationLevel.Error,
+            }),
+            PresentationMode.Modal,
+          );
+          break;
+        }
+        case Events.ExpiredOrganization: {
+          informationManager.present(
+            new Information({
+              message: translate('notification.expiredOrganization'),
+              level: InformationLevel.Error,
+            }),
+            PresentationMode.Notification,
+          );
+          await informationManager.present(
+            new Information({
+              message: translate('globalErrors.expiredOrganization'),
+              level: InformationLevel.Error,
+            }),
+            PresentationMode.Modal,
+          );
+          break;
+        }
+        case Events.ClientRevoked: {
+          informationManager.present(
+            new Information({
+              message: translate('notification.clientRevoked'),
+              level: InformationLevel.Error,
+            }),
+            PresentationMode.Notification,
+          );
+          await informationManager.present(
+            new Information({
+              message: translate('globalErrors.clientRevoked'),
+              level: InformationLevel.Error,
+            }),
+            PresentationMode.Modal,
+          );
+          break;
+        }
+      }
+    },
+  );
+}
+
+onMounted(async () => {
+  const handle = getConnectionHandle();
+  if (!handle) {
+    console.error('Could not retrieve connection handle');
+    return;
+  }
+  const inj = injectionProvider.getInjections(handle);
+  // Provide the injections to children
+  provide(ImportManagerKey, inj.importManager);
+  provide(InformationManagerKey, inj.informationManager);
+  provide(EventDistributorKey, inj.eventDistributor);
+  initialized.value = true;
+  informationManager = inj.informationManager;
+  eventDistributor = inj.eventDistributor;
+  await processEvents();
+});
+
+onUnmounted(async () => {
+  if (eventCbId) {
+    eventDistributor.removeCallback(eventCbId);
+  }
+});
+</script>

--- a/client/src/views/layouts/LoadingLayout.vue
+++ b/client/src/views/layouts/LoadingLayout.vue
@@ -1,0 +1,78 @@
+<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+
+<template>
+  <ion-page>
+    <ion-content :fullscreen="true">
+      <div class="loading-container">
+        <div class="loading-content">
+          <ms-image
+            :image="LogoIconGradient"
+            class="logo-img"
+          />
+          <ms-spinner :title="$t('HomePage.organizationLogin.loading')" />
+        </div>
+      </div>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { Base64 } from '@/common/base64';
+import { MsImage, LogoIconGradient } from '@/components/core/ms-image';
+import { MsSpinner } from '@/components/core';
+import { getCurrentRouteQuery, navigateTo, RouteBackup, Routes } from '@/router';
+import { IonContent, IonPage } from '@ionic/vue';
+import { onMounted } from 'vue';
+
+onMounted(async () => {
+  setTimeout(async () => {
+    const query = getCurrentRouteQuery();
+    if (query.loginInfo) {
+      const loginInfo = Base64.toObject(query.loginInfo) as RouteBackup;
+      await navigateTo(loginInfo.data.route, {
+        params: loginInfo.data.params,
+        query: loginInfo.data.query,
+        skipHandle: true,
+        replace: true,
+      });
+    } else {
+      await navigateTo(Routes.Home, { skipHandle: true, replace: true });
+    }
+  }, 1000);
+});
+</script>
+
+<style scoped lang="scss">
+.loading-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  width: 100vw;
+  height: 100vh;
+}
+
+@keyframes LogoFadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.loading-content {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  width: fit-content;
+  gap: 0.5rem;
+
+  .logo-img {
+    animation: LogoFadeIn 0.8s ease-in-out;
+    width: 3.25rem;
+    height: 3.25rem;
+  }
+}
+</style>

--- a/client/src/views/sidebar-menu/SidebarMenuPage.vue
+++ b/client/src/views/sidebar-menu/SidebarMenuPage.vue
@@ -216,7 +216,6 @@ import {
   navigateTo,
   navigateToWorkspace,
   switchOrganization,
-  watchOrganizationSwitch,
 } from '@/router';
 import { EventData, EventDistributor, EventDistributorKey, Events } from '@/services/eventDistributor';
 import useSidebarMenu from '@/services/sidebarMenu';
@@ -290,8 +289,6 @@ async function createWorkspace(): Promise<void> {
   }
 }
 
-const organizationWatchCancel = watchOrganizationSwitch(loadAll);
-
 async function loadAll(): Promise<void> {
   const infoResult = await parsecGetClientInfo();
 
@@ -333,7 +330,6 @@ onUnmounted(() => {
     eventDistributor.removeCallback(eventDistributorCbId);
   }
   resetWatchCancel();
-  organizationWatchCancel();
   if (intervalId) {
     clearInterval(intervalId);
   }

--- a/client/src/views/users/GreetUserModal.vue
+++ b/client/src/views/users/GreetUserModal.vue
@@ -176,10 +176,10 @@ import TagProfile from '@/components/users/TagProfile.vue';
 import UserAvatarName from '@/components/users/UserAvatarName.vue';
 import UserInformation from '@/components/users/UserInformation.vue';
 import { UserGreet, UserInvitation, UserProfile } from '@/parsec';
-import { Information, InformationLevel, InformationManager, InformationManagerKey, PresentationMode } from '@/services/informationManager';
+import { Information, InformationLevel, InformationManager, PresentationMode } from '@/services/informationManager';
 import { translate } from '@/services/translation';
 import { close } from 'ionicons/icons';
-import { Ref, computed, inject, onMounted, onUnmounted, ref, watch } from 'vue';
+import { Ref, computed, onMounted, onUnmounted, ref, watch } from 'vue';
 
 enum GreetUserStep {
   WaitForGuest = 1,
@@ -193,6 +193,7 @@ enum GreetUserStep {
 const pageStep = ref(GreetUserStep.WaitForGuest);
 const props = defineProps<{
   invitation: UserInvitation;
+  informationManager: InformationManager;
 }>();
 
 const profile: Ref<UserProfile | null> = ref(null);
@@ -200,7 +201,6 @@ const guestInfoPage = ref();
 const canGoForward = ref(false);
 const waitingForGuest = ref(true);
 const greeter = ref(new UserGreet());
-const informationManager: InformationManager = inject(InformationManagerKey)!;
 
 const profileOptions: MsOptions = new MsOptions([
   {
@@ -293,7 +293,7 @@ async function startProcess(): Promise<void> {
   waitingForGuest.value = true;
   const result = await greeter.value.startGreet(props.invitation.token);
   if (!result.ok) {
-    informationManager.present(
+    props.informationManager.present(
       new Information({
         message: translate('UsersPage.greet.errors.startFailed'),
         level: InformationLevel.Error,
@@ -305,7 +305,7 @@ async function startProcess(): Promise<void> {
   }
   const waitResult = await greeter.value.initialWaitGuest();
   if (!waitResult.ok) {
-    informationManager.present(
+    props.informationManager.present(
       new Information({
         message: translate('UsersPage.greet.errors.startFailed'),
         level: InformationLevel.Error,
@@ -361,7 +361,7 @@ async function cancelModal(): Promise<boolean> {
 }
 
 async function showErrorAndRestart(message: string): Promise<void> {
-  informationManager.present(
+  props.informationManager.present(
     new Information({
       message: message,
       level: InformationLevel.Error,
@@ -377,7 +377,7 @@ async function nextStep(): Promise<void> {
     return;
   }
   if (pageStep.value === GreetUserStep.Summary) {
-    informationManager.present(
+    props.informationManager.present(
       new Information({
         message: translate('UsersPage.greet.success', {
           user: guestInfoPage.value.fullName,

--- a/client/src/views/users/InvitationsListPopover.vue
+++ b/client/src/views/users/InvitationsListPopover.vue
@@ -39,6 +39,7 @@
           :key="invitation.claimerEmail"
           @cancel="cancelInvitation"
           @greet-user="greetUser"
+          :information-manager="informationManager"
         />
       </ion-list>
     </div>
@@ -50,9 +51,14 @@ import { MsModalResult } from '@/components/core';
 import InvitationPopoverItem from '@/components/users/InvitationPopoverItem.vue';
 import { UserInvitation, listUserInvitations } from '@/parsec';
 import { currentRouteIsUserRoute } from '@/router';
+import { InformationManager } from '@/services/informationManager';
 import { IonButton, IonIcon, IonList, IonText, popoverController } from '@ionic/vue';
 import { personAdd } from 'ionicons/icons';
 import { Ref, onMounted, ref } from 'vue';
+
+defineProps<{
+  informationManager: InformationManager;
+}>();
 
 const invitations: Ref<UserInvitation[]> = ref([]);
 

--- a/client/src/views/users/MyProfilePage.vue
+++ b/client/src/views/users/MyProfilePage.vue
@@ -118,6 +118,9 @@ async function openChangePassword(): Promise<void> {
   const modal = await modalController.create({
     component: UpdatePasswordModal,
     cssClass: 'change-password-modal',
+    componentProps: {
+      informationManager: informationManager,
+    },
   });
   await modal.present();
   await modal.onWillDismiss();

--- a/client/src/views/users/UpdatePasswordModal.vue
+++ b/client/src/views/users/UpdatePasswordModal.vue
@@ -95,19 +95,22 @@ import {
   getCurrentAvailableDevice,
   changePassword as parsecChangePassword,
 } from '@/parsec';
-import { Information, InformationLevel, InformationManager, InformationManagerKey, PresentationMode } from '@/services/informationManager';
+import { Information, InformationLevel, InformationManager, PresentationMode } from '@/services/informationManager';
 import { translate } from '@/services/translation';
 import { IonButton, IonButtons, IonFooter, IonHeader, IonIcon, IonPage, IonTitle, modalController } from '@ionic/vue';
 import { close } from 'ionicons/icons';
-import { Ref, inject, onMounted, ref } from 'vue';
+import { Ref, onMounted, ref } from 'vue';
 
 enum ChangePasswordStep {
   OldPassword,
   NewPassword,
 }
 
+const props = defineProps<{
+  informationManager: InformationManager;
+}>();
+
 const currentDevice: Ref<AvailableDevice | null> = ref(null);
-const informationManager = inject(InformationManagerKey) as InformationManager;
 const pageStep = ref(ChangePasswordStep.OldPassword);
 const choosePasswordInput = ref();
 const oldPassword = ref('');
@@ -121,7 +124,7 @@ onMounted(async () => {
   currentDevice.value = deviceResult.ok ? deviceResult.value : null;
 
   if (!currentDevice.value) {
-    informationManager.present(
+    props.informationManager.present(
       new Information({
         message: translate('MyProfilePage.errors.cannotChangePassword'),
         level: InformationLevel.Error,
@@ -163,7 +166,7 @@ async function changePassword(): Promise<void> {
   );
 
   if (result.ok) {
-    informationManager.present(
+    props.informationManager.present(
       new Information({
         message: translate('MyProfilePage.passwordUpdated'),
         level: InformationLevel.Success,
@@ -180,7 +183,7 @@ async function changePassword(): Promise<void> {
         break;
       }
       default:
-        informationManager.present(
+        props.informationManager.present(
           new Information({
             message: translate('MyProfilePage.errors.cannotChangePassword'),
             level: InformationLevel.Error,

--- a/client/src/views/workspaces/WorkspaceSharingModal.vue
+++ b/client/src/views/workspaces/WorkspaceSharingModal.vue
@@ -48,18 +48,18 @@
 import { MsModal, MsSearchInput } from '@/components/core';
 import WorkspaceUserRole from '@/components/workspaces/WorkspaceUserRole.vue';
 import { UserProfile, UserTuple, WorkspaceID, WorkspaceRole, getClientProfile, getWorkspaceSharing, shareWorkspace } from '@/parsec';
-import { Information, InformationLevel, InformationManager, InformationManagerKey, PresentationMode } from '@/services/informationManager';
+import { Information, InformationLevel, InformationManager, PresentationMode } from '@/services/informationManager';
 import { translate, translateWorkspaceRole } from '@/services/translation';
 import { IonList, IonPage } from '@ionic/vue';
-import { Ref, inject, onMounted, onUnmounted, ref, watch } from 'vue';
+import { Ref, onMounted, onUnmounted, ref, watch } from 'vue';
 
-const informationManager: InformationManager = inject(InformationManagerKey)!;
 const search = ref('');
 let ownProfile = UserProfile.Outsider;
 
 const props = defineProps<{
   workspaceId: WorkspaceID;
   ownRole: WorkspaceRole | null;
+  informationManager: InformationManager;
 }>();
 
 const userRoles: Ref<Array<[UserTuple, WorkspaceRole | null]>> = ref([]);
@@ -109,7 +109,7 @@ async function refreshSharingInfo(searchString = ''): Promise<void> {
       userRoles.value = result.value;
     }
   } else {
-    informationManager.present(
+    props.informationManager.present(
       new Information({
         message: translate('WorkspaceSharing.listFailure.message'),
         level: InformationLevel.Error,
@@ -134,7 +134,7 @@ async function updateUserRole(user: UserTuple, role: WorkspaceRole | null): Prom
   // Trying to set the same role again
   if (current && current[1] === role) {
     if (role === null) {
-      informationManager.present(
+      props.informationManager.present(
         new Information({
           message: translate('WorkspaceSharing.listFailure.alreadyNotShared', { user: user.humanHandle.label }),
           level: InformationLevel.Info,
@@ -142,7 +142,7 @@ async function updateUserRole(user: UserTuple, role: WorkspaceRole | null): Prom
         PresentationMode.Toast,
       );
     } else {
-      informationManager.present(
+      props.informationManager.present(
         new Information({
           message: translate('WorkspaceSharing.listFailure.alreadyHasRole', {
             user: user.humanHandle.label,
@@ -158,7 +158,7 @@ async function updateUserRole(user: UserTuple, role: WorkspaceRole | null): Prom
   const result = await shareWorkspace(props.workspaceId, user.id, role);
   if (result.ok) {
     if (!role) {
-      informationManager.present(
+      props.informationManager.present(
         new Information({
           message: translate('WorkspaceSharing.unshareSuccess', {
             user: user.humanHandle.label,
@@ -168,7 +168,7 @@ async function updateUserRole(user: UserTuple, role: WorkspaceRole | null): Prom
         PresentationMode.Toast,
       );
     } else {
-      informationManager.present(
+      props.informationManager.present(
         new Information({
           message: translate('WorkspaceSharing.updateRoleSuccess', {
             user: user.humanHandle.label,
@@ -180,7 +180,7 @@ async function updateUserRole(user: UserTuple, role: WorkspaceRole | null): Prom
       );
     }
   } else {
-    informationManager.present(
+    props.informationManager.present(
       new Information({
         message: translate('WorkspaceSharing.updateRoleFailure', {
           user: user.humanHandle.label,

--- a/client/src/views/workspaces/WorkspacesPage.vue
+++ b/client/src/views/workspaces/WorkspacesPage.vue
@@ -374,6 +374,7 @@ async function onWorkspaceShareClick(_: Event, workspace: WorkspaceInfo): Promis
     componentProps: {
       workspaceId: workspace.id,
       ownRole: workspace.currentSelfRole,
+      informationManager: informationManager,
     },
     cssClass: 'workspace-sharing-modal',
   });

--- a/client/tests/e2e/specs/test_about_page.ts
+++ b/client/tests/e2e/specs/test_about_page.ts
@@ -14,8 +14,8 @@ describe('Check about page', () => {
 
   it('Opens the about page', () => {
     cy.get('.topbar-left__title').find('.title-h2').contains('About');
-    cy.get('.about-container').find('.app-info-key').as('keys').should('have.length', 4);
-    cy.get('.about-container').find('.app-info-value').as('values').should('have.length', 4);
+    cy.get('.about-container').find('.info-list').find('.app-info-key').as('keys').should('have.length', 4);
+    cy.get('.about-container').find('.info-list').find('.app-info-value').as('values').should('have.length', 4);
     cy.get('@keys').eq(0).contains('Version');
     cy.get('@keys').eq(1).contains('Developer');
     cy.get('@keys').eq(2).contains('License');

--- a/client/tests/e2e/specs/test_folders_page.ts
+++ b/client/tests/e2e/specs/test_folders_page.ts
@@ -430,7 +430,7 @@ describe('Check folders page', () => {
     cy.get('#folders-ms-action-bar').find('#button-copy-link').should('not.have.css', 'display', 'none');
     cy.get('#folders-ms-action-bar').find('#button-details').should('not.have.css', 'display', 'none');
 
-    cy.get('.file-list-item').first().find('.options-button').invoke('show').click();
+    cy.get('.file-list-item').first().find('.options-button').invoke('show').click({ force: true });
     cy.get('#file-context-menu').should('be.visible');
     cy.get('#file-context-menu').find('ion-item').as('menuItems').should('have.length', 7);
     cy.get('@menuItems').eq(0).contains('Manage file');


### PR DESCRIPTION
So. Multi-org has a lot of issues, because the same instances are reused for all orgs: importManager, notificationManager, eventDistributor, ... It means that when switching for one org to the other, the same imports notifications and events are used, which makes no sense.

This PR aims at fixing this!

We use default inject when not connected, and then when we log in, our `ConnectedLayout` creates one instance of each manager for this connection handle. We force all components to unmount, and they remount with the correct instance. The ConnectedLayout is parent to the whole connected part of the app, meaning it can use `provide()`.

The only caveat is that components created by ionic (popovers, modals, ...) are children of the App component, not children of `ConnectedLayout`, so they can't use `inject()` anymore to retrieve the provided instances. I don't think it's too big of a problem, it just means that the caller has to add it as props.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
