### PR TITLE
Don't include `electron` in the `desktop-updates` group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -194,9 +194,11 @@ updates:
       timezone: Europe/Paris
     open-pull-requests-limit: 5
     groups:
-      electron-dependencies:
+      desktop-updates:
         patterns:
           - "*"
+        exclude-patterns:
+          - electron
     rebase-strategy: disabled
 
   - package-ecosystem: npm


### PR DESCRIPTION
Simplify updating `desktop` dependencies by excluding `electron` from the list.

Also rename `desktop-updates` from `electron-dependencies`