### PR TITLE
Add mountpoint for macos

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -49,135 +49,135 @@ permissions:
 jobs:
   # Cannot factorize the jobs with a matrix since we use a service container that is
   # only available on linux (see https://github.com/orgs/community/discussions/25578)
-  test-rust-linux:
-    name: "🐧 Linux: 🦀 Rust tests"
-    # Just a fail-safe timeout, see the fine grain per-task timeout instead
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
-    # Testbed server comes as a Docker image, so it will eventually goes out of sync
-    # with the tests (typically a new API is introduced in the Parsec server, or a new
-    # testbed template is introduced).
-    # In such case, the container url should be updated from the, see:
-    # https://github.com/Scille/parsec-cloud/pkgs/container/parsec-cloud%2Fparsec-testbed-server
-    env:
-      TESTBED_SERVER: http://localhost:6777
-    services:
-      parsec-testbed-server:
-        image: ghcr.io/scille/parsec-cloud/parsec-testbed-server:3.0.0-b.6.dev.19811.e388245
-        ports:
-          - 6777:6777
-    steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # pin v4.1.2
-        timeout-minutes: 5
+  # test-rust-linux:
+  #   name: "🐧 Linux: 🦀 Rust tests"
+  #   # Just a fail-safe timeout, see the fine grain per-task timeout instead
+  #   timeout-minutes: 30
+  #   runs-on: ubuntu-20.04
+  #   # Testbed server comes as a Docker image, so it will eventually goes out of sync
+  #   # with the tests (typically a new API is introduced in the Parsec server, or a new
+  #   # testbed template is introduced).
+  #   # In such case, the container url should be updated from the, see:
+  #   # https://github.com/Scille/parsec-cloud/pkgs/container/parsec-cloud%2Fparsec-testbed-server
+  #   env:
+  #     TESTBED_SERVER: http://localhost:6777
+  #   services:
+  #     parsec-testbed-server:
+  #       image: ghcr.io/scille/parsec-cloud/parsec-testbed-server:3.0.0-b.6.dev.19811.e388245
+  #       ports:
+  #         - 6777:6777
+  #   steps:
+  #     - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # pin v4.1.2
+  #       timeout-minutes: 5
 
-      - uses: actions-rust-lang/setup-rust-toolchain@b113a30d27a8e59c969077c0a0168cc13dab5ffc # pin v1.8.0
-        with:
-          # We setup the cache by hand, see below
-          cache: false
-        timeout-minutes: 10
+  #     - uses: actions-rust-lang/setup-rust-toolchain@b113a30d27a8e59c969077c0a0168cc13dab5ffc # pin v1.8.0
+  #       with:
+  #         # We setup the cache by hand, see below
+  #         cache: false
+  #       timeout-minutes: 10
 
-      - name: Retrieve Rust cache
-        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # pin v2.7.3
-        with:
-          # Cache is limited to 10Go (and cache is ~700mo per platform !). On top of that.
-          # cache is only shared between master and the PRs (and not across PRs).
-          # So we only save the cache on master build given it's the ones that are the
-          # most likely to be reused.
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-        timeout-minutes: 5
+  #     - name: Retrieve Rust cache
+  #       uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # pin v2.7.3
+  #       with:
+  #         # Cache is limited to 10Go (and cache is ~700mo per platform !). On top of that.
+  #         # cache is only shared between master and the PRs (and not across PRs).
+  #         # So we only save the cache on master build given it's the ones that are the
+  #         # most likely to be reused.
+  #         save-if: ${{ github.ref == 'refs/heads/master' }}
+  #       timeout-minutes: 5
 
-      # Install fuse
-      - name: Install fuse
-        shell: bash
-        run: |
-          until sudo apt-get -y install fuse3 libfuse3-dev; do
-            echo "Fail to install APT package retrying ...";
-          done
-        timeout-minutes: 5
+  #     # Install fuse
+  #     - name: Install fuse
+  #       shell: bash
+  #       run: |
+  #         until sudo apt-get -y install fuse3 libfuse3-dev; do
+  #           echo "Fail to install APT package retrying ...";
+  #         done
+  #       timeout-minutes: 5
 
-      # Install cargo nextest command
-      - uses: taiki-e/install-action@e4ef34df890c5af6027f55257634401a93b14dc7 # pin v2.32.9
-        with:
-          tool: nextest@0.9.54, wasm-pack@0.11.0, cargo-deny@0.14.3
+      # # Install cargo nextest command
+      # - uses: taiki-e/install-action@e4ef34df890c5af6027f55257634401a93b14dc7 # pin v2.32.9
+      #   with:
+      #     tool: nextest@0.9.54, wasm-pack@0.11.0, cargo-deny@0.14.3
 
-      - name: Build CLI binary
-        run: cargo build ${{ env.CARGO_CI_FLAGS }} --package parsec_cli --features testenv
-        timeout-minutes: 5
+  #     - name: Build CLI binary
+  #       run: cargo build ${{ env.CARGO_CI_FLAGS }} --package parsec_cli --features testenv
+  #       timeout-minutes: 5
 
-      - name: Test CLI
-        run: cargo nextest run ${{ env.CARGO_NEXTEST_CI_FLAGS }} --package parsec_cli --features testenv
-        timeout-minutes: 10
+  #     - name: Test CLI
+  #       run: cargo nextest run ${{ env.CARGO_NEXTEST_CI_FLAGS }} --package parsec_cli --features testenv
+  #       timeout-minutes: 10
 
-      - name: Categorize workspace crates
-        id: crates
-        run: |
-          (
-            for type in agnostic platform bindings; do
-              echo -n "$type=" && python misc/libparsec_crates_flags.py $type
-            done
-          ) | tee -a $GITHUB_OUTPUT
-        timeout-minutes: 2
+  #     - name: Categorize workspace crates
+  #       id: crates
+  #       run: |
+  #         (
+  #           for type in agnostic platform bindings; do
+  #             echo -n "$type=" && python misc/libparsec_crates_flags.py $type
+  #           done
+  #         ) | tee -a $GITHUB_OUTPUT
+  #       timeout-minutes: 2
 
-      - name: Test agnostic rust codebase
-        run: cargo nextest run ${{ env.CARGO_NEXTEST_CI_FLAGS }} ${{ steps.crates.outputs.agnostic }}
-        env:
-          RUST_LOG: debug
-        timeout-minutes: 10
+  #     - name: Test agnostic rust codebase
+  #       run: cargo nextest run ${{ env.CARGO_NEXTEST_CI_FLAGS }} ${{ steps.crates.outputs.agnostic }}
+  #       env:
+  #         RUST_LOG: debug
+  #       timeout-minutes: 10
 
-      # By default `libparsec_crypto` uses RustCrypto, so here we test the sodiumoxide
-      # implementation and it compatibility with the rest of the project
-      - name: Test sodiumoxide rust crypto
-        run: cargo nextest run ${{ env.CARGO_NEXTEST_CI_FLAGS }} --package libparsec_crypto --features use-sodiumoxide
-        env:
-          RUST_LOG: debug
-        timeout-minutes: 10
+  #     # By default `libparsec_crypto` uses RustCrypto, so here we test the sodiumoxide
+  #     # implementation and it compatibility with the rest of the project
+  #     - name: Test sodiumoxide rust crypto
+  #       run: cargo nextest run ${{ env.CARGO_NEXTEST_CI_FLAGS }} --package libparsec_crypto --features use-sodiumoxide
+  #       env:
+  #         RUST_LOG: debug
+  #       timeout-minutes: 10
 
-      - name: Check agnostic & platform crates using sodium crypto features
-        run: cargo check ${{ env.CARGO_CI_FLAGS }} ${{ steps.crates.outputs.agnostic }} ${{ steps.crates.outputs.platform }} --features use-sodiumoxide
-        timeout-minutes: 10
-        env:
-          RUST_LOG: debug
+  #     - name: Check agnostic & platform crates using sodium crypto features
+  #       run: cargo check ${{ env.CARGO_CI_FLAGS }} ${{ steps.crates.outputs.agnostic }} ${{ steps.crates.outputs.platform }} --features use-sodiumoxide
+  #       timeout-minutes: 10
+  #       env:
+  #         RUST_LOG: debug
 
-      - name: unlock keyring
-        uses: t1m0thyj/unlock-keyring@728cc718a07b5e7b62c269fc89295e248b24cba7 # pin v1.1.0
+  #     - name: unlock keyring
+  #       uses: t1m0thyj/unlock-keyring@728cc718a07b5e7b62c269fc89295e248b24cba7 # pin v1.1.0
 
-      # Use sodiumoxide here given 1) it is composed of C code, so not totally
-      # platform independant and 2) it is what is going to be used in release
-      - name: Test platform crates using sodium crypto features (🐧 Linux specific)
-        shell: bash
-        run: cargo nextest run ${{ env.CARGO_NEXTEST_CI_FLAGS }} ${{ steps.crates.outputs.platform }} --features libparsec_crypto/use-sodiumoxide
-        timeout-minutes: 30
-        env:
-          RUST_LOG: debug
+  #     # Use sodiumoxide here given 1) it is composed of C code, so not totally
+  #     # platform independant and 2) it is what is going to be used in release
+  #     - name: Test platform crates using sodium crypto features (🐧 Linux specific)
+  #       shell: bash
+  #       run: cargo nextest run ${{ env.CARGO_NEXTEST_CI_FLAGS }} ${{ steps.crates.outputs.platform }} --features libparsec_crypto/use-sodiumoxide
+  #       timeout-minutes: 30
+  #       env:
+  #         RUST_LOG: debug
 
-      - name: Test platform-async on wasm
-        if: inputs.run-wasm-tests
-        run: wasm-pack test --headless --firefox libparsec/crates/platform_async
-        timeout-minutes: 10
+  #     - name: Test platform-async on wasm
+  #       if: inputs.run-wasm-tests
+  #       run: wasm-pack test --headless --firefox libparsec/crates/platform_async
+  #       timeout-minutes: 10
 
-      - name: Test platform-storage on wasm
-        if: inputs.run-wasm-tests
-        run: wasm-pack test --headless --firefox libparsec/crates/platform_storage
-        timeout-minutes: 10
+  #     - name: Test platform-storage on wasm
+  #       if: inputs.run-wasm-tests
+  #       run: wasm-pack test --headless --firefox libparsec/crates/platform_storage
+  #       timeout-minutes: 10
 
-      # Clippy basically compile the project, hence it's faster to run it in
-      # the job where compilation cache is reused !
-      - name: Check cargo-clippy
-        run: cargo clippy ${{ env.CARGO_CI_FLAGS }} --verbose
-        timeout-minutes: 10
+  #     # Clippy basically compile the project, hence it's faster to run it in
+  #     # the job where compilation cache is reused !
+  #     - name: Check cargo-clippy
+  #       run: cargo clippy ${{ env.CARGO_CI_FLAGS }} --verbose
+  #       timeout-minutes: 10
 
-      - name: Check rust code format
-        run: cargo fmt --check
-        timeout-minutes: 2
+  #     - name: Check rust code format
+  #       run: cargo fmt --check
+  #       timeout-minutes: 2
 
-      - name: Check restricted usage with cargo-deny
-        if: inputs.check-cargo-deny
-        run: |
-          echo "::add-matcher::.github/custom-problem-matchers/cargo-deny.json"
-          # cargo-deny outputs the report on stderr and it needs to be redirected to stdout for the problem matcher to work.
-          cargo deny --color=never check --hide-inclusion-graph --show-stats 2>&1
-          echo "::remove-matcher owner=cargo-deny::"
-        timeout-minutes: 2
+  #     - name: Check restricted usage with cargo-deny
+  #       if: inputs.check-cargo-deny
+  #       run: |
+  #         echo "::add-matcher::.github/custom-problem-matchers/cargo-deny.json"
+  #         # cargo-deny outputs the report on stderr and it needs to be redirected to stdout for the problem matcher to work.
+  #         cargo deny --color=never check --hide-inclusion-graph --show-stats 2>&1
+  #         echo "::remove-matcher owner=cargo-deny::"
+  #       timeout-minutes: 2
 
   test-rust-non-linux:
     strategy:
@@ -186,8 +186,8 @@ jobs:
         include:
           - name: 🍎 macOS
             os: macos-12
-          - name: 🏁 Windows
-            os: windows-2022
+          # - name: 🏁 Windows
+          #   os: windows-2022
     name: "${{ matrix.name }}: 🦀 Rust tests"
     # Just a fail-safe timeout, see the fine grain per-task timeout instead
     timeout-minutes: 60
@@ -231,6 +231,11 @@ jobs:
           unzip D:/a/_temp/winfsp-tests.zip -d D:/a/_temp/
           mv 'D:/a/_temp/winfsp-tests-x64.exe' 'C:/Program Files (x86)/WinFsp/bin/'
 
+      - name: Install macfuse
+        if: startsWith(matrix.os, 'macos')
+        shell: bash
+        run: brew install --cask macfuse
+
       # Install cargo nextest command
       - uses: taiki-e/install-action@e4ef34df890c5af6027f55257634401a93b14dc7 # pin v2.32.9
         with:
@@ -240,21 +245,20 @@ jobs:
         shell: bash
         run: |
           set -ex
-          PLATFORM_CRATES=`python3 misc/libparsec_crates_flags.py platform`
-          # TODO: mountpoint not supported yet on MacOS (macFUSE not installed on the CI)
-          if [[ '{{ matrix.os }}' = macos* ]]; then
-            PLATFORM_CRATES=`echo $PLATFORM_CRATES | sed -e 's/-p libparsec_platform_mountpoint//'`
-          fi
-          cargo nextest run ${{ env.CARGO_NEXTEST_CI_FLAGS }} $PLATFORM_CRATES --features libparsec_crypto/use-sodiumoxide
-          # By default `libparsec_crypto` uses RustCrypto, so here we test the sodiumoxide
-          # implementation and it compatibility with the rest of the project
-          cargo nextest run ${{ env.CARGO_NEXTEST_CI_FLAGS }} --package libparsec_crypto --features use-sodiumoxide
-          NON_BINDINGS_CRATES=`python3 misc/libparsec_crates_flags.py agnostic platform`
-          # TODO: mountpoint not supported yet on MacOS (macFUSE not installed on the CI)
-          if [[ '{{ matrix.os }}' = macos* ]]; then
-            NON_BINDINGS_CRATES=`echo $NON_BINDINGS_CRATES | sed -e 's/-p libparsec_platform_mountpoint//'`
-          fi
-          cargo check ${{ env.CARGO_CI_FLAGS }} $NON_BINDINGS_CRATES --features use-sodiumoxide
+          cargo nextest run -p libparsec_platform_mountpoint mount_unmount --nocapture
+          # PLATFORM_CRATES=`python3 misc/libparsec_crates_flags.py platform`
+          # if [[ '{{ matrix.os }}' = macos* ]]; then
+          #   PLATFORM_CRATES=`echo $PLATFORM_CRATES | sed -e 's/-p libparsec_platform_mountpoint//'`
+          # fi
+          # cargo nextest run ${{ env.CARGO_NEXTEST_CI_FLAGS }} $PLATFORM_CRATES --features libparsec_crypto/use-sodiumoxide
+          # # By default `libparsec_crypto` uses RustCrypto, so here we test the sodiumoxide
+          # # implementation and its compatibility with the rest of the project
+          # cargo nextest run ${{ env.CARGO_NEXTEST_CI_FLAGS }} --package libparsec_crypto --features use-sodiumoxide
+          # NON_BINDINGS_CRATES=`python3 misc/libparsec_crates_flags.py agnostic platform`
+          # if [[ '{{ matrix.os }}' = macos* ]]; then
+          #   NON_BINDINGS_CRATES=`echo $NON_BINDINGS_CRATES | sed -e 's/-p libparsec_platform_mountpoint//'`
+          # fi
+          # cargo check ${{ env.CARGO_CI_FLAGS }} $NON_BINDINGS_CRATES --features use-sodiumoxide
         timeout-minutes: 50 # It can be very slow if cache has missed
         env:
           RUST_LOG: debug

--- a/libparsec/crates/platform_mountpoint/Cargo.toml
+++ b/libparsec/crates/platform_mountpoint/Cargo.toml
@@ -16,7 +16,7 @@ winfsp_wrs = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(target_family = "unix")'.dependencies]
 fuser = { workspace = true, features = ["libfuse"] }
 libc = { workspace = true }
 

--- a/libparsec/crates/platform_mountpoint/src/lib.rs
+++ b/libparsec/crates/platform_mountpoint/src/lib.rs
@@ -1,54 +1,22 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-#[cfg(target_os = "linux")]
+#[cfg(target_family = "unix")]
 mod unix;
 #[cfg(target_os = "windows")]
 mod windows;
 
-#[cfg(target_os = "linux")]
+#[cfg(target_family = "unix")]
 pub(crate) use unix as platform;
 #[cfg(target_os = "windows")]
 pub(crate) use windows as platform;
 
-// TODO: UNIX implementation is linux-only for the moment
-#[cfg(target_os = "macos")]
-pub(crate) mod platform {
-    use std::sync::Arc;
-
-    use libparsec_client::WorkspaceOps;
-    use libparsec_types::prelude::*;
-
-    #[derive(Debug)]
-    pub struct Mountpoint {}
-
-    impl Mountpoint {
-        pub fn path(&self) -> &std::path::Path {
-            todo!()
-        }
-
-        pub fn to_os_path(&self, _parsec_path: &FsPath) -> std::path::PathBuf {
-            todo!()
-        }
-
-        pub async fn mount(_ops: Arc<WorkspaceOps>) -> anyhow::Result<Self> {
-            todo!()
-        }
-
-        pub async fn unmount(self) -> anyhow::Result<()> {
-            todo!()
-        }
-    }
-}
-
-// TODO: implement for Windows & macOS !
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+// TODO: implement for Windows !
+#[cfg(not(target_os = "windows"))]
 #[cfg(test)]
 pub(crate) use platform::LOOKUP_HOOK;
 
 pub use platform::Mountpoint;
 
-// TODO: implement for macOS !
-#[cfg(not(target_os = "macos"))]
 #[cfg(test)]
 #[path = "../tests/unit/operations/mod.rs"]
 #[allow(clippy::unwrap_used)]

--- a/libparsec/crates/platform_mountpoint/src/unix/mount.rs
+++ b/libparsec/crates/platform_mountpoint/src/unix/mount.rs
@@ -1,6 +1,12 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use std::{os::linux::fs::MetadataExt, sync::Arc, thread::JoinHandle};
+#[cfg(target_os = "macos")]
+use std::os::macos::fs::MetadataExt;
+
+#[cfg(target_os = "linux")]
+use std::os::linux::fs::MetadataExt;
+
+use std::{sync::Arc, thread::JoinHandle};
 
 use libparsec_client::{MountpointMountStrategy, WorkspaceOps};
 use libparsec_types::prelude::*;
@@ -56,8 +62,10 @@ impl Mountpoint {
                 fuser::MountOption::NoDev,
             ];
 
+            println!("create session {}", mountpoint_path.exists());
             let mut session = fuser::Session::new(filesystem, &mountpoint_path, &options)
                 .map_err(|err| anyhow::anyhow!("cannot mount: {}", err))?;
+            println!("session created");
 
             let unmounter = session.unmount_callable();
 

--- a/libparsec/crates/platform_mountpoint/tests/unit/operations/create_folder.rs
+++ b/libparsec/crates/platform_mountpoint/tests/unit/operations/create_folder.rs
@@ -149,7 +149,7 @@ async fn invalid_name(tmp_path: TmpPath, env: &TestbedEnv) {
     let raw_bad_name = b"new\xC0dir";
 
     // 0xC0 is not a valid UF8 character, however Linux rules are "no / and no \0"
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     let raw_bad_name = b"new\xC0dir";
 
     mount_and_test!(

--- a/libparsec/crates/platform_mountpoint/tests/unit/operations/linux_fusermount.rs
+++ b/libparsec/crates/platform_mountpoint/tests/unit/operations/linux_fusermount.rs
@@ -1,6 +1,12 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use std::{os::linux::fs::MetadataExt, path::PathBuf, sync::Arc};
+#[cfg(target_os = "macos")]
+use std::os::macos::fs::MetadataExt;
+
+#[cfg(target_os = "linux")]
+use std::os::linux::fs::MetadataExt;
+
+use std::{path::PathBuf, sync::Arc};
 
 use libparsec_client::{Client, WorkspaceOps};
 use libparsec_tests_fixtures::prelude::*;

--- a/libparsec/crates/platform_mountpoint/tests/unit/operations/mount_unmount.rs
+++ b/libparsec/crates/platform_mountpoint/tests/unit/operations/mount_unmount.rs
@@ -17,8 +17,9 @@ async fn mount_and_unmount(tmp_path: TmpPath, env: &TestbedEnv) {
     // 1) Mount with mountpoint base dir not existing
 
     let mountpoint_dir = {
+        println!("mount");
         let mountpoint = Mountpoint::mount(wksp1_ops.clone()).await.unwrap();
-
+        println!("mounted");
         let mountpoint_dir = mountpoint.path().to_owned();
 
         mountpoint.unmount().await.unwrap();


### PR DESCRIPTION
closes #6144

This is a start on the implementation of `mountpoint` for `MacOS`, it should be possible to use `fuser` for `macOS`, it uses `macfuse`(`osxfuse` is the old name).
`fuser` clearly shows that it supports `macOS` but it is untested (because you can find `#[cfg(target_os = "macos")]` in its code and see: https://github.com/cberner/fuser?tab=readme-ov-file#macos-untested where it describes how to install `macfuse`)

What I have done in this PR:
- Shorcut the `CI` to test `macOS platform` only
- Printed where the problem comes from (It's when we call `Session::new`)
- When I installed `macfuse`, `pkg-config --list-all` returns `fuse` in its list, so the reason is not that `fuser` can't find the library: you can see in `build.rs`: https://github.com/cberner/fuser/blob/master/build.rs#L11 it searches for `fuse` (it could be `fuse4x` according to https://github.com/fusepy/fusepy/blob/master/fuse.py#L90-L91 which is missing in the `build.rs`)
- According to an issue on `fuser`, the problem comes from an infinite loop when you `mount`: https://github.com/cberner/fuser/issues/211 this is also how it appears on the `CI`: the test `timeout`
- I have tried to tweak `fuser`'s version, because `fuse-rs` which was the old repository of `fuser` seemed to maintain `MacOS` (see: https://github.com/zargony/fuse-rs?tab=readme-ov-file#macos) I have also found a crate which use an old version (which is not compatible with our version of `fuser` for `linux`): https://github.com/mgree/ffs/blob/main/Cargo.toml#L30
- I tried to debug on the CI, but it seems too hard to find how the bug comes from, so I asked to debug on MacOS device.

Remote machine: (with `sw_vers`)                   
ProductName:            macOS
ProductVersion:         14.4.1
BuildVersion:           23E224

- Note that the CI uses macos-12

- I installed `macfuse` with `brew install --cask macfuse`
- When I run the example `hello.rs` of `fuser`, it throws the following error message: `mount_macfuse: the file system is not available (1)` with: `fuse_mount_compat25`

- I tried `/usr/bin/sudo /usr/bin/kmutil load -p /Library/Filesystems/macfuse.fs/Contents/Extensions/14/macfuse.kext` on the remote machine which throw `Error Domain=KMErrorDomain Code=27 "Extension with identifiers io.macfuse.filesystems.macfuse not approved to load. Please approve using System Preferences." UserInfo={NSLocalizedDescription=Extension with identifiers io.macfuse.filesystems.macfuse not approved to load. Please approve using System Preferences.}`
- I found https://github.com/osxfuse/osxfuse/issues/1000 which is a similar issue, but I don't know how to access gui interface from terminal :(

Utils: https://github.com/macfuse/macfuse/wiki/Getting-Started