### PR TITLE
[MS] Correctly translate formatTimeSince calls

### DIFF
--- a/client/src/components/notifications/AllImportedElementsNotification.vue
+++ b/client/src/components/notifications/AllImportedElementsNotification.vue
@@ -20,7 +20,7 @@
         >
           {{ $msTranslate('notificationCenter.openImportedMenu') }}
         </span>
-        <span class="default-state">{{ formatTimeSince(notification.time, '', 'short') }}</span>
+        <span class="default-state">{{ $msTranslate(formatTimeSince(notification.time, '', 'short')) }}</span>
         <ion-icon
           class="arrow-icon hover-state"
           :icon="arrowForward"

--- a/client/src/components/notifications/DefaultNotification.vue
+++ b/client/src/components/notifications/DefaultNotification.vue
@@ -21,7 +21,7 @@
         <span>{{ $msTranslate(notification.information.message) }}</span>
       </ion-label>
       <ion-text class="notification-details__time body-sm">
-        <span>{{ formatTimeSince(notification.time, '', 'short') }}</span>
+        <span>{{ $msTranslate(formatTimeSince(notification.time, '', 'short')) }}</span>
       </ion-text>
     </div>
   </notification-item>

--- a/client/src/components/notifications/MultipleUsersJoinWorkspaceNotification.vue
+++ b/client/src/components/notifications/MultipleUsersJoinWorkspaceNotification.vue
@@ -29,7 +29,7 @@
         >
           {{ $msTranslate('notificationCenter.viewJoinedUsers') }}
         </span>
-        <span class="default-state">{{ formatTimeSince(notification.time, '', 'short') }}</span>
+        <span class="default-state">{{ $msTranslate(formatTimeSince(notification.time, '', 'short')) }}</span>
       </ion-text>
     </div>
   </notification-item>

--- a/client/src/components/notifications/NewDeviceNotification.vue
+++ b/client/src/components/notifications/NewDeviceNotification.vue
@@ -19,7 +19,7 @@
         <span class="hover-state">
           {{ $msTranslate('notificationCenter.goToDevices') }}
         </span>
-        <span class="default-state">{{ formatTimeSince(notification.time, '', 'short') }}</span>
+        <span class="default-state">{{ $msTranslate(formatTimeSince(notification.time, '', 'short')) }}</span>
         <ion-icon
           class="arrow-icon hover-state"
           :icon="arrowForward"

--- a/client/src/components/notifications/UserJoinWorkspaceNotification.vue
+++ b/client/src/components/notifications/UserJoinWorkspaceNotification.vue
@@ -21,7 +21,7 @@
         </i18n-t>
       </ion-text>
       <ion-text class="notification-details__time body-sm">
-        <span>{{ formatTimeSince(notification.time, '', 'short') }}</span>
+        <span>{{ $msTranslate(formatTimeSince(notification.time, '', 'short')) }}</span>
       </ion-text>
     </div>
   </notification-item>

--- a/client/src/components/notifications/UserSharedDocumentNotification.vue
+++ b/client/src/components/notifications/UserSharedDocumentNotification.vue
@@ -22,7 +22,7 @@
           </i18n-t>
         </ion-text>
         <ion-text class="notification-details__time body-sm">
-          <span>{{ formatTimeSince(notification.time, '', 'short') }}</span>
+          <span>{{ $msTranslate(formatTimeSince(notification.time, '', 'short')) }}</span>
         </ion-text>
       </div>
     </div>

--- a/client/src/components/notifications/WorkspaceAccessNotification.vue
+++ b/client/src/components/notifications/WorkspaceAccessNotification.vue
@@ -26,7 +26,7 @@
         >
           {{ $msTranslate('notificationCenter.goToWorkspace') }}
         </span>
-        <span class="default-state">{{ formatTimeSince(notification.time, '', 'short') }}</span>
+        <span class="default-state">{{ $msTranslate(formatTimeSince(notification.time, '', 'short')) }}</span>
         <ion-icon
           class="arrow-icon hover-state"
           :icon="arrowForward"

--- a/client/src/components/notifications/WorkspaceRoleChangedNotification.vue
+++ b/client/src/components/notifications/WorkspaceRoleChangedNotification.vue
@@ -24,7 +24,7 @@
         </i18n-t>
       </ion-text>
       <ion-text class="notification-details__time body-sm">
-        <span>{{ formatTimeSince(notification.time, '', 'short') }}</span>
+        <span>{{ $msTranslate(formatTimeSince(notification.time, '', 'short')) }}</span>
       </ion-text>
     </div>
   </notification-item>

--- a/client/src/components/users/InvitationPopoverItem.vue
+++ b/client/src/components/users/InvitationPopoverItem.vue
@@ -17,7 +17,7 @@
       <!-- invitation action -->
       <div class="invitation-actions">
         <div class="invitation-actions-date">
-          <span class="default-state body-sm">{{ formatTimeSince(invitation.createdOn, '', 'short') }}</span>
+          <span class="default-state body-sm">{{ $msTranslate(formatTimeSince(invitation.createdOn, '', 'short')) }}</span>
           <ion-button
             fill="clear"
             class="hover-state copy-link"

--- a/client/src/views/home/OrganizationListPage.vue
+++ b/client/src/views/home/OrganizationListPage.vue
@@ -122,7 +122,9 @@
                         />
                         <ion-text class="body-sm">
                           {{
-                            device.slug in storedDeviceDataDict ? formatTimeSince(storedDeviceDataDict[device.slug].lastLogin, '--') : '--'
+                            device.slug in storedDeviceDataDict
+                              ? $msTranslate(formatTimeSince(storedDeviceDataDict[device.slug].lastLogin, '--'))
+                              : '--'
                           }}
                         </ion-text>
                       </ion-col>


### PR DESCRIPTION
Some calls to `formatTimeSince` weren't translated.