### PR TITLE
Fix path of the BUSL license in script `releaser.py`

### DIFF
--- a/misc/releaser.py
+++ b/misc/releaser.py
@@ -47,7 +47,7 @@ PYTHON_EXECUTABLE_PATH = sys.executable
 LICENSE_CONVERSION_DELAY = 4 * 365 * 24 * 3600  # 4 years
 PROJECT_DIR = Path(__file__).resolve().parent.parent
 HISTORY_FILE = PROJECT_DIR / "HISTORY.rst"
-BUSL_LICENSE_FILE = PROJECT_DIR / "licenses/BUSL-Scille.txt"
+BUSL_LICENSE_FILE = PROJECT_DIR / "LICENSE"
 
 FRAGMENTS_DIR = PROJECT_DIR / "newsfragments"
 FRAGMENT_TYPES = {

--- a/misc/version_updater.py
+++ b/misc/version_updater.py
@@ -309,7 +309,7 @@ FILES_WITH_VERSION_INFO: dict[Path, dict[Tool, RawRegexes]] = {
         Tool.Python: [ReplaceRegex(r'^python = "\^[0-9.]+"$', 'python = "^{version}"')]
     },
     ROOT_DIR / "libparsec/version": {Tool.Parsec: [ReplaceRegex(r"^.*$", "{version}")]},
-    ROOT_DIR / "licenses/BUSL-Scille.txt": {
+    ROOT_DIR / "LICENSE": {
         Tool.Parsec: [
             ReplaceRegex(r"^Licensed Work:  Parsec v.*$", "Licensed Work:  Parsec v{version}")
         ]


### PR DESCRIPTION
The BUSL license file was moved to `LICENSE` in #7059 but the path was not updated in the script.