### PR TITLE
[MS] Fine tuned workspace context menu

### DIFF
--- a/client/src/components/workspaces/utils.ts
+++ b/client/src/components/workspaces/utils.ts
@@ -83,16 +83,17 @@ export async function openWorkspaceContextMenu(
   event: Event,
   workspace: WorkspaceInfo,
   informationManager: InformationManager,
+  fromSidebar = false,
 ): Promise<void> {
   const clientProfile = await getClientProfile();
   const popover = await popoverController.create({
     component: WorkspaceContextMenu,
-    cssClass: 'workspace-context-menu',
+    cssClass: fromSidebar ? 'workspace-context-menu workspace-context-menu-sidebar' : 'workspace-context-menu',
     event: event,
     translucent: true,
     showBackdrop: false,
     dismissOnSelect: true,
-    alignment: 'end',
+    side: fromSidebar ? 'right' : 'bottom',
     componentProps: {
       workspaceName: workspace.currentName,
       clientProfile: clientProfile,

--- a/client/src/theme/components/popovers.scss
+++ b/client/src/theme/components/popovers.scss
@@ -88,6 +88,11 @@ ion-popover {
   --width: var(--popover-option-width);
 }
 
+.workspace-context-menu-sidebar {
+  --offset-x: 1.25rem;
+  --offset-y: -0.5rem;
+}
+
 #workspace-context-menu,
 #file-context-menu,
 #user-context-menu,

--- a/client/src/views/sidebar-menu/SidebarMenuPage.vue
+++ b/client/src/views/sidebar-menu/SidebarMenuPage.vue
@@ -124,7 +124,7 @@
                 <ion-label>{{ workspace.currentName }}</ion-label>
                 <div
                   class="workspace-option"
-                  @click.stop="openWorkspaceContextMenu($event, workspace, informationManager)"
+                  @click.stop="openWorkspaceContextMenu($event, workspace, informationManager, true)"
                 >
                   <ion-icon :icon="ellipsisHorizontal" />
                 </div>

--- a/client/src/views/workspaces/WorkspaceContextMenu.vue
+++ b/client/src/views/workspaces/WorkspaceContextMenu.vue
@@ -3,7 +3,7 @@
 <template>
   <ion-content id="workspace-context-menu">
     <div class="list-title">
-      <ion-label class="list-title__text">
+      <ion-label class="list-title__text button-large">
         {{ workspaceName }}
       </ion-label>
     </div>
@@ -152,14 +152,13 @@ defineProps<{
 <style lang="scss" scoped>
 .list-title {
   border-bottom: solid 1px var(--parsec-color-light-secondary-disabled);
-  padding: 0.5rem 0.75rem;
+  padding: 0.75rem 0.75rem;
   background-color: var(--parsec-color-light-secondary-premiere);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 
   &__text {
-    font-style: italic;
     color: var(--parsec-color-light-secondary-soft-text);
   }
 }


### PR DESCRIPTION
Closes #7050

From sidebar:
![Screenshot 2024-04-17 080927](https://github.com/Scille/parsec-cloud/assets/18075498/a50dc2cd-6c28-468d-b60c-26958d91e275)

From workspace card
![Screenshot 2024-04-17 082157](https://github.com/Scille/parsec-cloud/assets/18075498/58253792-2820-4d1c-982f-9029a1fdd1f4)

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
  