### PR TITLE
[MS] Fixed date translations

### DIFF
--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -509,6 +509,7 @@
     },
     "common": {
         "date": {
+            "asIs": "{date}",
             "fewSeconds": "now",
             "lessThanAMinute": "< 1 minute",
             "lastLoginMinutes": "one minute ago | {minutes} minutes ago",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -509,6 +509,7 @@
     },
     "common": {
         "date": {
+            "asIs": "{date}",
             "fewSeconds": "à l'instant",
             "lessThanAMinute": "< 1 minute",
             "lastLoginMinutes": "il y a une minute | il y a {minutes} minutes",

--- a/client/src/services/translation.ts
+++ b/client/src/services/translation.ts
@@ -94,10 +94,15 @@ export function translate(content: Translatable | undefined): string {
   return typeof content === 'string' ? t(content) : t(content.key, content.data, content.count);
 }
 
-export function formatDate(date: DateTime, format: DateFormat = 'long'): string {
+export function formatDate(date: DateTime, format: DateFormat = 'long'): Translatable {
   const { d } = i18n.global;
 
-  return d(date.toJSDate(), format);
+  // Bit of a trickery.
+  // `d` from i18n returns an already formatted date as string
+  // But in our case, we want it to be a Translatable instead so it can be processed
+  // as every other translation.
+  // We use a translation key that just returns the string given as parameter.
+  return { key: 'common.date.asIs', data: { date: d(date.toJSDate(), format) } };
 }
 
 export function getProfileTranslationKey(profile: UserProfile): Translatable {

--- a/client/src/views/home/CreateOrganizationModal.vue
+++ b/client/src/views/home/CreateOrganizationModal.vue
@@ -192,7 +192,7 @@ import {
   createOrganization as parsecCreateOrganization,
 } from '@/parsec';
 import { Information, InformationLevel, InformationManager, PresentationMode } from '@/services/informationManager';
-import { Translatable, formatDate } from '@/services/translation';
+import { Translatable, formatDate, translate } from '@/services/translation';
 import SummaryStep, { OrgInfo } from '@/views/home/SummaryStep.vue';
 import { IonButton, IonButtons, IonFooter, IonHeader, IonIcon, IonPage, IonText, IonTitle, modalController } from '@ionic/vue';
 import { checkmarkDone, chevronBack, chevronForward, close } from 'ionicons/icons';
@@ -417,8 +417,8 @@ async function nextStep(): Promise<void> {
           message = {
             key: 'CreateOrganization.errors.timestampOutOfBallpark',
             data: {
-              clientTime: formatDate(result.error.clientTimestamp, 'long'),
-              serverTime: formatDate(result.error.serverTimestamp, 'long'),
+              clientTime: translate(formatDate(result.error.clientTimestamp, 'long')),
+              serverTime: translate(formatDate(result.error.serverTimestamp, 'long')),
             },
           };
           pageStep.value = CreateOrganizationStep.SummaryStep;


### PR DESCRIPTION
Translation problems on date where `formatDate()` would return a translatable with key/data in most cases, except when the date was used directly (ie not `03/04/2024`, not `4 days ago`). This caused the already formatted date to go through the translation (`$msTranslate('03/04/2024')`) which caused a warning, because the key does not exist.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
