### PR TITLE
[MS] App update API

### DIFF
--- a/client/electron/src/communicationChannels.ts
+++ b/client/electron/src/communicationChannels.ts
@@ -1,0 +1,17 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+export enum PageToWindowChannel {
+  ConfigUpdate = 'parsec-config-update',
+  CloseApp = 'parsec-close-app',
+  OpenFile = 'parsec-open-file',
+  MountpointUpdate = 'parsec-mountpoint-update',
+  UpdateAvailabilityRequest = 'parsec-update-availability-request',
+  UpdateApp = 'parsec-update-app',
+}
+
+export enum WindowToPageChannel {
+  OpenPathFailed = 'parsec-open-path-failed',
+  UpdateAvailability = 'parsec-update-availability',
+  OpenLink = 'parsec-open-link',
+  CloseRequest = 'parsec-close-request',
+}

--- a/client/electron/src/preload.ts
+++ b/client/electron/src/preload.ts
@@ -5,25 +5,32 @@ require('./rt/electron-rt');
 // User Defined Preload scripts below
 
 import { contextBridge, ipcRenderer } from 'electron';
+import { PageToWindowChannel } from './communicationChannels';
 import libparsec from './libparsec';
 
 process.once('loaded', () => {
   contextBridge.exposeInMainWorld('libparsec_plugin', libparsec);
   contextBridge.exposeInMainWorld('electronAPI', {
     sendConfig: (config: any) => {
-      ipcRenderer.send('config-update', config);
+      ipcRenderer.send(PageToWindowChannel.ConfigUpdate, config);
     },
     receive: (channel: string, f: (data: any) => Promise<void>) => {
       ipcRenderer.on(channel, async (event, data) => await f(data));
     },
     closeApp: () => {
-      ipcRenderer.send('close-app');
+      ipcRenderer.send(PageToWindowChannel.CloseApp);
     },
     openFile: (path: string) => {
-      ipcRenderer.send('open-file', path);
+      ipcRenderer.send(PageToWindowChannel.OpenFile, path);
     },
     sendMountpointFolder: (path: string) => {
-      ipcRenderer.send('mountpoint-update', path);
+      ipcRenderer.send(PageToWindowChannel.MountpointUpdate, path);
+    },
+    getUpdateAvailability: () => {
+      ipcRenderer.send(PageToWindowChannel.UpdateAvailabilityRequest);
+    },
+    updateApp: () => {
+      ipcRenderer.send(PageToWindowChannel.UpdateApp);
     },
   });
 });

--- a/client/electron/src/setup.ts
+++ b/client/electron/src/setup.ts
@@ -10,6 +10,8 @@ import log from 'electron-log/main';
 import electronServe from 'electron-serve';
 import windowStateKeeper from 'electron-window-state';
 import { join } from 'path';
+import { WindowToPageChannel } from './communicationChannels';
+import { WinRegistry } from './winRegistry';
 
 // Define components for a watcher to detect when the webapp is changed so we can reload in Dev mode.
 const reloadWatcher = {
@@ -58,12 +60,14 @@ export class ElectronCapacitorApp {
   private config: object;
   public forceClose: boolean;
   private APP_GUID = '2f56a772-db54-4a32-b264-28c42970f684';
-  private regedit: any = null;
+  private winRegistry: WinRegistry | null = null;
 
   constructor(capacitorFileConfig: CapacitorElectronConfig, appMenuBarMenuTemplate?: (MenuItemConstructorOptions | MenuItem)[]) {
     this.CapacitorFileConfig = capacitorFileConfig;
 
     this.customScheme = this.CapacitorFileConfig.electron?.customUrlScheme ?? 'capacitor-electron';
+
+    this.winRegistry = new WinRegistry(this.APP_GUID, app.getAppPath());
 
     this.TrayMenuTemplate = [
       new MenuItem({
@@ -78,15 +82,6 @@ export class ElectronCapacitorApp {
     log.initialize();
     if (!electronIsDev) {
       Object.assign(console, log.functions);
-    }
-
-    if (process.platform === 'win32') {
-      const reg = require('regedit');
-      if (!electronIsDev) {
-        const vbsDirectory = join(app.getAppPath(), '../vbs');
-        reg.setExternalVBSLocation(vbsDirectory);
-      }
-      this.regedit = reg.promisified;
     }
 
     if (appMenuBarMenuTemplate) {
@@ -109,7 +104,7 @@ export class ElectronCapacitorApp {
   }
 
   async quitApp(): Promise<void> {
-    await this.removeMountpointFromQuickAccess();
+    await this.winRegistry.removeMountpointFromQuickAccess();
     app.quit();
   }
 
@@ -118,8 +113,22 @@ export class ElectronCapacitorApp {
     return this.MainWindow;
   }
 
+  sendEvent(event: WindowToPageChannel, ...args: any[]): void {
+    this.MainWindow.webContents.send(event, args);
+  }
+
   getCustomURLScheme(): string {
     return this.customScheme;
+  }
+
+  updateApp(): void {}
+
+  // Will evolve with auto-update
+  async getUpdateInfo(): Promise<{ updateAvailable: boolean; version?: string }> {
+    const rand = Math.floor(Math.random() * 2);
+    // const result = await appUpdater.checkForUpdates();
+    // return result.updateInfo....
+    return rand === 1 ? { updateAvailable: true, version: '3.1.0' } : { updateAvailable: false };
   }
 
   updateConfig(newConfig: object): void {
@@ -136,165 +145,15 @@ export class ElectronCapacitorApp {
         label: this.config.hasOwnProperty('locale') && (this.config as any).locale === 'fr-FR' ? 'Quitter' : 'Quit',
         click: () => {
           this.showMainWindow();
-          this.MainWindow.webContents.send('close-request');
+          this.sendEvent(WindowToPageChannel.CloseRequest);
         },
       }),
     ];
     this.TrayIcon.setContextMenu(Menu.buildFromTemplate(this.TrayMenuTemplate));
   }
 
-  private async addMountpointToQuickAccess(mountpointPath: string): Promise<void> {
-    if (process.platform !== 'win32' || !this.regedit) {
-      return;
-    }
-    await this.removeMountpointFromQuickAccess();
-
-    const baseKey1 = `HKCU\\Software\\Classes\\CLSID\\{${this.APP_GUID}}`;
-    const baseKey2 = `HKCU\\Software\\Classes\\Wow6432Node\\CLSID\\{${this.APP_GUID}}`;
-    const systemRoot = process.env.SYSTEMROOT || 'C:\\Windows';
-    const iconPath = this.getIconPaths().tray;
-
-    for (const key of [baseKey1, baseKey2]) {
-      await this.regedit.createKey([key]);
-      await this.regedit.putValue({
-        [key]: {
-          AppName: {
-            value: 'Parsec',
-            type: 'REG_DEFAULT',
-          },
-          SortOrderIndex: {
-            value: 0x42,
-            type: 'REG_DWORD',
-          },
-          'System.IsPinnedToNamespaceTree': {
-            value: 0x01,
-            type: 'REG_DWORD',
-          },
-        },
-      });
-      await this.regedit.createKey([`${key}\\DefaultIcon`]);
-      await this.regedit.putValue({
-        [`${key}\\DefaultIcon`]: {
-          IconPath: {
-            value: iconPath,
-            type: 'REG_DEFAULT',
-          },
-        },
-      });
-      await this.regedit.createKey([`${key}\\InProcServer32`]);
-      await this.regedit.putValue({
-        [`${key}\\InProcServer32`]: {
-          IconPath: {
-            value: `${systemRoot}\\system32\\shell32.dll`,
-            type: 'REG_DEFAULT',
-          },
-        },
-      });
-      await this.regedit.createKey([`${key}\\Instance`]);
-      await this.regedit.putValue({
-        [`${key}\\Instance`]: {
-          CLSID: {
-            value: '{0E5AAE11-A475-4c5b-AB00-C66DE400274E}',
-            type: 'REG_SZ',
-          },
-        },
-      });
-      await this.regedit.createKey([`${key}\\Instance\\InitPropertyBag`]);
-      await this.regedit.putValue({
-        [`${key}\\Instance\\InitPropertyBag`]: {
-          Attributes: {
-            value: 0x11,
-            type: 'REG_DWORD',
-          },
-          TargetFolderPath: {
-            value: mountpointPath,
-            type: 'REG_SZ',
-          },
-        },
-      });
-
-      await this.regedit.createKey([`${key}\\ShellFolder`]);
-      await this.regedit.putValue({
-        [`${key}\\ShellFolder`]: {
-          Attributes: {
-            value: 0xf080004d,
-            type: 'REG_DWORD',
-          },
-          FolderValueFlags: {
-            value: 0x28,
-            type: 'REG_DWORD',
-          },
-        },
-      });
-    }
-
-    await this.regedit.createKey(`HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Desktop\\NameSpace\\{${this.APP_GUID}}`);
-    await this.regedit.putValue({
-      [`HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Desktop\\NameSpace\\{${this.APP_GUID}}`]: {
-        AppName: {
-          value: 'Parsec',
-          type: 'REG_DEFAULT',
-        },
-      },
-    });
-
-    await this.regedit.putValue({
-      'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\HideDesktopIcons\\NewStartPanel': {
-        [`{${this.APP_GUID}}`]: {
-          value: 0x1,
-          type: 'REG_DWORD',
-        },
-      },
-    });
-  }
-
-  private async removeMountpointFromQuickAccess(): Promise<void> {
-    async function _silentDeleteValues(regedit: any, values: string[]): Promise<void> {
-      try {
-        await regedit.deleteValue(values);
-      } catch (_err) {}
-    }
-
-    async function _silentDeleteKeys(regedit: any, keys: string[]): Promise<void> {
-      try {
-        await regedit.deleteKey(keys);
-      } catch (_err) {}
-    }
-
-    if (process.platform !== 'win32' || !this.regedit) {
-      return;
-    }
-    const baseKey1 = `HKCU\\Software\\Classes\\CLSID\\{${this.APP_GUID}}`;
-    const baseKey2 = `HKCU\\Software\\Classes\\Wow6432Node\\CLSID\\{${this.APP_GUID}}`;
-
-    for (const key of [baseKey1, baseKey2]) {
-      await _silentDeleteValues(this.regedit, [
-        `${key}\\SortOrderIndex`,
-        `${key}\\System.IsPinnedToNamespaceTree`,
-        `${key}\\Instance\\CLSID`,
-        `${key}\\Instance\\InitPropertyBag\\Attributes`,
-        `${key}\\Instance\\InitPropertyBag\\TargetFolderPath`,
-        `${key}\\ShellFolder\\Attributes`,
-        `${key}\\ShellFolder\\FolderValueFlags`,
-        `${key}\\Instance\\InitPropertyBag`,
-        `${key}\\Instance`,
-      ]);
-      await _silentDeleteKeys(this.regedit, [`${key}\\DefaultIcon`, `${key}\\InProcServer32`, `${key}\\ShellFolder`, key]);
-    }
-
-    await _silentDeleteValues(this.regedit, [
-      `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Desktop\\NameSpace\\{${this.APP_GUID}}`,
-    ]);
-    await _silentDeleteKeys(this.regedit, [
-      `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Desktop\\NameSpace\\{${this.APP_GUID}}`,
-    ]);
-    await _silentDeleteValues(this.regedit, [
-      `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\HideDesktopIcons\\NewStartPanel\\{${this.APP_GUID}}`,
-    ]);
-  }
-
   updateMountpoint(path: string): void {
-    this.addMountpointToQuickAccess(path);
+    this.winRegistry.addMountpointToQuickAccess(path, this.getIconPaths().tray);
   }
 
   isTrayEnabled(): boolean {

--- a/client/electron/src/winRegistry.ts
+++ b/client/electron/src/winRegistry.ts
@@ -1,0 +1,170 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import electronIsDev from 'electron-is-dev';
+import { join } from 'path';
+
+export class WinRegistry {
+  private regedit: any = null;
+  private APP_GUID: string = '';
+
+  constructor(appGuid: string, appPath: string) {
+    this.APP_GUID = appGuid;
+    if (process.platform === 'win32') {
+      const reg = require('regedit');
+      if (!electronIsDev) {
+        const vbsDirectory = join(appPath, '../vbs');
+        reg.setExternalVBSLocation(vbsDirectory);
+      }
+      this.regedit = reg.promisified;
+    }
+  }
+
+  async addMountpointToQuickAccess(mountpointPath: string, iconPath: string): Promise<void> {
+    if (process.platform !== 'win32' || !this.regedit) {
+      return;
+    }
+    await this.removeMountpointFromQuickAccess();
+
+    const baseKey1 = `HKCU\\Software\\Classes\\CLSID\\{${this.APP_GUID}}`;
+    const baseKey2 = `HKCU\\Software\\Classes\\Wow6432Node\\CLSID\\{${this.APP_GUID}}`;
+    const systemRoot = process.env.SYSTEMROOT || 'C:\\Windows';
+
+    for (const key of [baseKey1, baseKey2]) {
+      await this.regedit.createKey([key]);
+      await this.regedit.putValue({
+        [key]: {
+          AppName: {
+            value: 'Parsec',
+            type: 'REG_DEFAULT',
+          },
+          SortOrderIndex: {
+            value: 0x42,
+            type: 'REG_DWORD',
+          },
+          'System.IsPinnedToNamespaceTree': {
+            value: 0x01,
+            type: 'REG_DWORD',
+          },
+        },
+      });
+      await this.regedit.createKey([`${key}\\DefaultIcon`]);
+      await this.regedit.putValue({
+        [`${key}\\DefaultIcon`]: {
+          IconPath: {
+            value: iconPath,
+            type: 'REG_DEFAULT',
+          },
+        },
+      });
+      await this.regedit.createKey([`${key}\\InProcServer32`]);
+      await this.regedit.putValue({
+        [`${key}\\InProcServer32`]: {
+          IconPath: {
+            value: `${systemRoot}\\system32\\shell32.dll`,
+            type: 'REG_DEFAULT',
+          },
+        },
+      });
+      await this.regedit.createKey([`${key}\\Instance`]);
+      await this.regedit.putValue({
+        [`${key}\\Instance`]: {
+          CLSID: {
+            value: '{0E5AAE11-A475-4c5b-AB00-C66DE400274E}',
+            type: 'REG_SZ',
+          },
+        },
+      });
+      await this.regedit.createKey([`${key}\\Instance\\InitPropertyBag`]);
+      await this.regedit.putValue({
+        [`${key}\\Instance\\InitPropertyBag`]: {
+          Attributes: {
+            value: 0x11,
+            type: 'REG_DWORD',
+          },
+          TargetFolderPath: {
+            value: mountpointPath,
+            type: 'REG_SZ',
+          },
+        },
+      });
+
+      await this.regedit.createKey([`${key}\\ShellFolder`]);
+      await this.regedit.putValue({
+        [`${key}\\ShellFolder`]: {
+          Attributes: {
+            value: 0xf080004d,
+            type: 'REG_DWORD',
+          },
+          FolderValueFlags: {
+            value: 0x28,
+            type: 'REG_DWORD',
+          },
+        },
+      });
+    }
+
+    await this.regedit.createKey(`HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Desktop\\NameSpace\\{${this.APP_GUID}}`);
+    await this.regedit.putValue({
+      [`HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Desktop\\NameSpace\\{${this.APP_GUID}}`]: {
+        AppName: {
+          value: 'Parsec',
+          type: 'REG_DEFAULT',
+        },
+      },
+    });
+
+    await this.regedit.putValue({
+      'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\HideDesktopIcons\\NewStartPanel': {
+        [`{${this.APP_GUID}}`]: {
+          value: 0x1,
+          type: 'REG_DWORD',
+        },
+      },
+    });
+  }
+
+  async removeMountpointFromQuickAccess(): Promise<void> {
+    async function _silentDeleteValues(regedit: any, values: string[]): Promise<void> {
+      try {
+        await regedit.deleteValue(values);
+      } catch (_err) {}
+    }
+
+    async function _silentDeleteKeys(regedit: any, keys: string[]): Promise<void> {
+      try {
+        await regedit.deleteKey(keys);
+      } catch (_err) {}
+    }
+
+    if (process.platform !== 'win32' || !this.regedit) {
+      return;
+    }
+    const baseKey1 = `HKCU\\Software\\Classes\\CLSID\\{${this.APP_GUID}}`;
+    const baseKey2 = `HKCU\\Software\\Classes\\Wow6432Node\\CLSID\\{${this.APP_GUID}}`;
+
+    for (const key of [baseKey1, baseKey2]) {
+      await _silentDeleteValues(this.regedit, [
+        `${key}\\SortOrderIndex`,
+        `${key}\\System.IsPinnedToNamespaceTree`,
+        `${key}\\Instance\\CLSID`,
+        `${key}\\Instance\\InitPropertyBag\\Attributes`,
+        `${key}\\Instance\\InitPropertyBag\\TargetFolderPath`,
+        `${key}\\ShellFolder\\Attributes`,
+        `${key}\\ShellFolder\\FolderValueFlags`,
+        `${key}\\Instance\\InitPropertyBag`,
+        `${key}\\Instance`,
+      ]);
+      await _silentDeleteKeys(this.regedit, [`${key}\\DefaultIcon`, `${key}\\InProcServer32`, `${key}\\ShellFolder`, key]);
+    }
+
+    await _silentDeleteValues(this.regedit, [
+      `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Desktop\\NameSpace\\{${this.APP_GUID}}`,
+    ]);
+    await _silentDeleteKeys(this.regedit, [
+      `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Desktop\\NameSpace\\{${this.APP_GUID}}`,
+    ]);
+    await _silentDeleteValues(this.regedit, [
+      `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\HideDesktopIcons\\NewStartPanel\\{${this.APP_GUID}}`,
+    ]);
+  }
+}

--- a/client/src/services/eventDistributor.ts
+++ b/client/src/services/eventDistributor.ts
@@ -14,6 +14,7 @@ enum Events {
   IncompatibleServer = 1 << 5,
   ClientRevoked = 1 << 6,
   ExpiredOrganization = 1 << 7,
+  UpdateAvailability = 1 << 8,
 }
 
 interface WorkspaceCreatedData {
@@ -31,7 +32,12 @@ interface InvitationUpdatedData {
 
 interface WorkspaceFavoriteData {}
 
-type EventData = WorkspaceCreatedData | OnlineData | OfflineData | InvitationUpdatedData | WorkspaceFavoriteData;
+interface UpdateAvailabilityData {
+  updateAvailable: boolean;
+  version?: string;
+}
+
+type EventData = WorkspaceCreatedData | OnlineData | OfflineData | InvitationUpdatedData | WorkspaceFavoriteData | UpdateAvailabilityData;
 
 interface Callback {
   id: string;
@@ -65,4 +71,14 @@ class EventDistributor {
   }
 }
 
-export { EventData, EventDistributor, Events, InvitationUpdatedData, OfflineData, OnlineData, WorkspaceCreatedData, WorkspaceFavoriteData };
+export {
+  EventData,
+  EventDistributor,
+  Events,
+  InvitationUpdatedData,
+  OfflineData,
+  OnlineData,
+  UpdateAvailabilityData,
+  WorkspaceCreatedData,
+  WorkspaceFavoriteData,
+};

--- a/client/src/services/injectionProvider.ts
+++ b/client/src/services/injectionProvider.ts
@@ -1,7 +1,7 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 import { ConnectionHandle, needsMocks } from '@/parsec';
-import { EventDistributor } from '@/services/eventDistributor';
+import { EventData, EventDistributor, Events } from '@/services/eventDistributor';
 import { ImportManager } from '@/services/importManager';
 import { InformationManager } from '@/services/informationManager';
 
@@ -59,6 +59,12 @@ export class InjectionProvider {
 
   getDefault(): Injections {
     return this.default;
+  }
+
+  async distributeEventToAll(event: Events, data: EventData): Promise<void> {
+    for (const injections of this.injections.values()) {
+      await injections.eventDistributor.dispatchEvent(event, data);
+    }
   }
 
   async clean(handle: ConnectionHandle): Promise<void> {

--- a/client/src/views/header/ProfileHeader.vue
+++ b/client/src/views/header/ProfileHeader.vue
@@ -82,6 +82,7 @@ async function openPopover(event: Event): Promise<void> {
     componentProps: {
       email: props.email,
       profile: props.profile,
+      eventDistributor: eventDistributor,
     },
     event: event,
     showBackdrop: false,

--- a/client/src/views/header/ProfileHeaderPopover.vue
+++ b/client/src/views/header/ProfileHeaderPopover.vue
@@ -78,15 +78,39 @@ export enum ProfilePopoverOption {
 <script setup lang="ts">
 import { APP_VERSION } from '@/common/mocks';
 import TagProfile from '@/components/users/TagProfile.vue';
-import { UserProfile } from '@/parsec';
+import { isElectron, UserProfile } from '@/parsec';
+import { EventData, EventDistributor, Events, UpdateAvailabilityData } from '@/services/eventDistributor';
 import { popoverController } from '@ionic/core';
 import { IonIcon, IonItem, IonLabel, IonList, IonText } from '@ionic/vue';
 import { cog, logOut, personCircle } from 'ionicons/icons';
+import { onMounted, onUnmounted } from 'vue';
 
-defineProps<{
+let cbId: string | null = null;
+
+const props = defineProps<{
   email: string;
   profile: UserProfile;
+  eventDistributor: EventDistributor;
 }>();
+
+async function onUpdateAvailability(event: Events, data: EventData): Promise<void> {
+  // The whole process of handling new updates should be moved to
+  // its own component
+  const _updateData = data as UpdateAvailabilityData;
+}
+
+onMounted(async () => {
+  cbId = await props.eventDistributor.registerCallback(Events.UpdateAvailability, onUpdateAvailability);
+  if (isElectron()) {
+    window.electronAPI.getUpdateAvailability();
+  }
+});
+
+onUnmounted(async () => {
+  if (cbId) {
+    await props.eventDistributor.removeCallback(cbId);
+  }
+});
 
 async function onOptionClick(option: ProfilePopoverOption): Promise<void> {
   await popoverController.dismiss({


### PR DESCRIPTION
Closes #7097 

Exposes
`window.electronAPI.getUpdateAvailability()` that returns an event through the eventDistributor with the update info
`window.electronAPI.updateApp()` to start the update

It also includes a bit of refactoring:
1. uses enums instead of raw strings for the communication channel
2. moved win registry related functions to their own file

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
   