### PR TITLE
Factorize `build_next_conflicted_name`

### DIFF
--- a/libparsec/crates/client/src/workspace/transactions/inbound_sync.rs
+++ b/libparsec/crates/client/src/workspace/transactions/inbound_sync.rs
@@ -399,46 +399,13 @@ async fn update_store_with_remote_child(
                     Some((child_name, _)) => child_name.to_owned(),
                 };
 
-                let (child_base_name, child_extension) = child_name.base_and_extension();
                 let mut attempt = 2;
-                macro_rules! build_next_conflicted_name {
-                    () => {{
-                        let mut base_name = child_base_name;
-                        let mut extension = child_extension;
-                        loop {
-                            let name = match extension {
-                                None => format!("{} ({})", base_name, attempt),
-                                Some(extension) => {
-                                    format!("{} ({}).{}", base_name, attempt, extension)
-                                }
-                            };
-                            match name.parse::<EntryName>() {
-                                Ok(name) => break name,
-                                // Entry name too long
-                                Err(EntryNameError::NameTooLong) => {
-                                    // Simply strip 10 characters from the first name then try again
-                                    if base_name.len() > 10 {
-                                        base_name = &base_name[..base_name.len() - 10];
-                                    } else {
-                                        // Very rare case where the extensions are very long,
-                                        // we have no choice but to strip it...
-                                        let extension_str = extension.expect("must be present");
-                                        extension =
-                                            Some(&extension_str[..extension_str.len() - 10]);
-                                    }
-                                }
-                                // Not possible given name is only composed of valid characters
-                                Err(EntryNameError::InvalidName) => unreachable!(),
-                            }
-                        }
-                    }};
-                }
-                let mut conflicted_name = build_next_conflicted_name!();
+                let mut conflicted_name = child_name.build_next_conflicted_name(attempt);
                 loop {
                     match parent_manifest_mut.children.entry(conflicted_name) {
                         std::collections::hash_map::Entry::Occupied(_) => {
                             attempt += 1;
-                            conflicted_name = build_next_conflicted_name!();
+                            conflicted_name = child_name.build_next_conflicted_name(attempt);
                         }
                         std::collections::hash_map::Entry::Vacant(entry) => {
                             entry.insert(conflicted.base.id);
@@ -544,46 +511,13 @@ async fn update_store_with_remote_child(
                     Some((child_name, _)) => child_name.to_owned(),
                 };
 
-                let (child_base_name, child_extension) = child_name.base_and_extension();
                 let mut attempt = 2;
-                macro_rules! build_next_conflicted_name {
-                    () => {{
-                        let mut base_name = child_base_name;
-                        let mut extension = child_extension;
-                        loop {
-                            let name = match extension {
-                                None => format!("{} ({})", base_name, attempt),
-                                Some(extension) => {
-                                    format!("{} ({}).{}", base_name, attempt, extension)
-                                }
-                            };
-                            match name.parse::<EntryName>() {
-                                Ok(name) => break name,
-                                // Entry name too long
-                                Err(EntryNameError::NameTooLong) => {
-                                    // Simply strip 10 characters from the first name then try again
-                                    if base_name.len() > 10 {
-                                        base_name = &base_name[..base_name.len() - 10];
-                                    } else {
-                                        // Very rare case where the extensions are very long,
-                                        // we have no choice but to strip it...
-                                        let extension_str = extension.expect("must be present");
-                                        extension =
-                                            Some(&extension_str[..extension_str.len() - 10]);
-                                    }
-                                }
-                                // Not possible given name is only composed of valid characters
-                                Err(EntryNameError::InvalidName) => unreachable!(),
-                            }
-                        }
-                    }};
-                }
-                let mut conflicted_name = build_next_conflicted_name!();
+                let mut conflicted_name = child_name.build_next_conflicted_name(attempt);
                 loop {
                     match parent_manifest_mut.children.entry(conflicted_name) {
                         std::collections::hash_map::Entry::Occupied(_) => {
                             attempt += 1;
-                            conflicted_name = build_next_conflicted_name!();
+                            conflicted_name = child_name.build_next_conflicted_name(attempt);
                         }
                         std::collections::hash_map::Entry::Vacant(entry) => {
                             entry.insert(conflicted.base.id);

--- a/libparsec/crates/types/src/fs_path.rs
+++ b/libparsec/crates/types/src/fs_path.rs
@@ -65,7 +65,7 @@ impl EntryName {
         }
     }
 
-    pub fn build_next_conflicted_name(&self, attempt: usize) -> Self {
+    pub fn build_next_conflicted_name(&self, attempt: u32) -> Self {
         let (mut base_name, mut extension) = self.base_and_extension();
 
         loop {

--- a/libparsec/crates/types/src/fs_path.rs
+++ b/libparsec/crates/types/src/fs_path.rs
@@ -64,6 +64,36 @@ impl EntryName {
             None => (self.0.as_str(), None),
         }
     }
+
+    pub fn build_next_conflicted_name(&self, attempt: usize) -> Self {
+        let (mut base_name, mut extension) = self.base_and_extension();
+
+        loop {
+            let name = match extension {
+                None => format!("{} ({})", base_name, attempt),
+                Some(extension) => {
+                    format!("{} ({}).{}", base_name, attempt, extension)
+                }
+            };
+            match name.parse::<Self>() {
+                Ok(name) => return name,
+                // Entry name too long
+                Err(EntryNameError::NameTooLong) => {
+                    // Simply strip 10 characters from the first name then try again
+                    if base_name.len() > 10 {
+                        base_name = &base_name[..base_name.len() - 10];
+                    } else {
+                        // Very rare case where the extensions are very long,
+                        // we have no choice but to strip it...
+                        let extension_str = extension.expect("must be present");
+                        extension = Some(&extension_str[..extension_str.len() - 10]);
+                    }
+                }
+                // Not possible given name is only composed of valid characters
+                Err(EntryNameError::InvalidName) => unreachable!(),
+            }
+        }
+    }
 }
 
 impl std::convert::AsRef<str> for EntryName {

--- a/libparsec/crates/types/tests/unit/fs_path.rs
+++ b/libparsec/crates/types/tests/unit/fs_path.rs
@@ -23,6 +23,37 @@ fn entry_name_too_long() {
 }
 
 #[rstest]
+#[case(
+    "aaa.aaa".to_string().parse().unwrap(),
+    2,
+    "aaa (2).aaa".parse().unwrap()
+)]
+#[case::long_base_name((
+    "a".repeat(251) + ".aaa").parse().unwrap(),
+    2,
+    ("a".repeat(241) + " (2).aaa").parse().unwrap()
+)]
+#[case::long_extension(
+    ("aaa.".to_string() + &"a".repeat(251)).parse().unwrap(),
+    2,
+    ("aaa (2).".to_string() + &"a".repeat(241)).parse().unwrap()
+)]
+#[case::big_attempt(
+    ("a".repeat(251) + ".aaa").parse().unwrap(),
+    u32::MAX,
+    ("a".repeat(231) + &format!(" ({}).aaa", u32::MAX)).parse().unwrap()
+)]
+fn entry_name_next_conflicted_name(
+    #[case] name: EntryName,
+    #[case] attempt: u32,
+    #[case] expected: EntryName,
+) {
+    let conflicted_name = name.build_next_conflicted_name(attempt);
+
+    p_assert_eq!(conflicted_name, expected)
+}
+
+#[rstest]
 #[case("")]
 #[case(".")]
 #[case("..")]


### PR DESCRIPTION
It's way better to factorize this code without using macro, because macro can capture some variables in the current scope, so it is harder to read.

I would like to improve too (remove the loop)
The loop seems not be a performance problem but maybe harder to read ?