### PR TITLE
Use single version of `genrandom`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if 1.0.0",
- "getrandom 0.2.14",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -1424,19 +1424,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if 1.0.0",
- "js-sys",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
@@ -1444,7 +1431,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -1994,8 +1981,7 @@ dependencies = [
  "digest",
  "ed25519-dalek",
  "generic-array",
- "getrandom 0.1.16",
- "getrandom 0.2.14",
+ "getrandom",
  "hex",
  "hex-literal",
  "lazy_static",
@@ -2442,7 +2428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -2452,7 +2438,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom",
 ]
 
 [[package]]
@@ -2479,7 +2465,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d75440242411c87dc39847b0e33e961ec1f10326a9d8ecf9c1ea64a3b3c13dc"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom",
  "libloading",
  "neon-macros",
  "once_cell",
@@ -3213,7 +3199,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom",
 ]
 
 [[package]]
@@ -3240,7 +3226,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom",
  "libredox",
  "thiserror",
 ]
@@ -4433,7 +4419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "atomic",
- "getrandom 0.2.14",
+ "getrandom",
  "rand",
  "serde",
  "wasm-bindgen",
@@ -4484,12 +4470,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,9 +122,7 @@ fnmatch-regex = { version = "0.2.0", default-features = false }
 fuser = { version = "0.14.0", default-features =  false }
 futures = { version = "0.3.30", default-features = false }
 generic-array = { version = "0.14.7", default-features = false }
-# Two versions of `getrandom` needed in `libparsec_crypto`
-getrandom_01 = { package = "getrandom", version = "0.1.16", default-features = false }
-getrandom_02 = { package = "getrandom", version = "0.2.14", default-features = false }
+getrandom = { package = "getrandom", version = "0.2.14", default-features = false }
 glob = { version = "0.3.1", default-features = false }
 gloo-timers = { version = "0.3.0", default-features = false }
 hex-literal = { version = "0.4.1", default-features = false }
@@ -156,8 +154,6 @@ proptest-state-machine = { version = "0.3.0", default-features = false }
 proc-macro2 = { version = "1.0.81", default-features = false }
 pyo3 = { version = "0.19.2", default-features = false }
 quote = { version = "1.0.36", default-features = false }
-# Two versions of `rand` needed in `libparsec_crypto`
-rand_08 = { package = "rand", version = "0.8.5", default-features = false }
 rand = { version = "0.8.5", default-features = false }
 regex = { version = "1.10.4", default-features = false }
 regex-syntax = { version = "0.8.3", default-features = false }

--- a/libparsec/crates/crypto/Cargo.toml
+++ b/libparsec/crates/crypto/Cargo.toml
@@ -119,14 +119,9 @@ sha2 = { workspace = true, features = ["std"] }  # Optional rustcrypto dep
 x25519-dalek = { workspace = true, features = ["alloc", "zeroize", "precomputed-tables"] }  # Optional rustcrypto dep
 crypto_secretbox = { workspace = true, features = ["alloc", "getrandom", "salsa20"] }  # Optional rustcrypto dep
 # Cryptographic randomness is required for generating SecretKey, SigningKey and PrivateKey
-# For SecretKey, we have `crypto_box` -> [...] -> `rand_core~=0.6` -> `getrandom~=0.2`
-# For SingingKey&PrivateKey we have `<dalek stuff>` -> `rand~=0.5` -> `getrandom~=0.1`
-# So we end up with two version of `getrandom` which have each they own way of
-# configuring wasm-unknown-unknown web support (see [features] part).
-getrandom_01 = { workspace = true }  # Optional rustcrypto dep
-getrandom_02 = { workspace = true }  # Optional rustcrypto dep
-# rand 0.8 relies on rand_core~=0.6/getrandom~=0.2
-rand_08 = { workspace = true, features = ["std", "std_rng"] }  # Optional rustcrypto dep
+# `getrandom` is a dependency of `rand`, we specify it here in order  to configure its `wasm-unknown-unknown` web support (see [target] part).
+getrandom = { workspace = true }  # Optional rustcrypto dep
+rand = { workspace = true, features = ["std", "std_rng"] }  # Optional rustcrypto dep
 
 [dev-dependencies]
 pretty_assertions = { workspace = true, features = ["std", "unstable"] }
@@ -141,8 +136,7 @@ rstest = { workspace = true, features = ["async-timeout"] }
 # RustCrypto stuff
 #
 
-getrandom_01 = { workspace = true, features = ["wasm-bindgen"] }  # Optional rustcrypto dep
-getrandom_02 = { workspace = true, features = ["js"] }  # Optional rustcrypto dep
+getrandom = { workspace = true, features = ["js"] }  # Optional rustcrypto dep
 
 [target.'cfg(target_os = "macos")'.dependencies]
 openssl = { workspace = true, optional = true, features = ["vendored"] }

--- a/libparsec/crates/crypto/src/rustcrypto/private.rs
+++ b/libparsec/crates/crypto/src/rustcrypto/private.rs
@@ -48,7 +48,7 @@ mod sealed_box {
     pub fn seal(data: &[u8], pk: &PublicKey) -> Vec<u8> {
         let mut out = Vec::with_capacity(SEALED_OVERHEAD + data.len());
 
-        let ep_sk = SecretKey::generate(&mut rand_08::thread_rng());
+        let ep_sk = SecretKey::generate(&mut rand::thread_rng());
         let ep_pk = ep_sk.public_key();
         out.extend_from_slice(ep_pk.as_bytes());
 
@@ -126,7 +126,7 @@ impl PrivateKey {
     }
 
     pub fn generate() -> Self {
-        Self(crypto_box::SecretKey::generate(&mut rand_08::thread_rng()))
+        Self(crypto_box::SecretKey::generate(&mut rand::thread_rng()))
     }
 
     pub fn decrypt_from_self(&self, ciphered: &[u8]) -> Result<Vec<u8>, CryptoError> {

--- a/libparsec/crates/crypto/src/rustcrypto/secret.rs
+++ b/libparsec/crates/crypto/src/rustcrypto/secret.rs
@@ -3,9 +3,11 @@
 use argon2::{Algorithm, Argon2, Params, Version};
 use blake2::Blake2bMac;
 use crypto_box::aead::Aead;
-use crypto_secretbox::{AeadCore, Key, XSalsa20Poly1305};
+use crypto_secretbox::{
+    aead::{rand_core::RngCore, OsRng},
+    AeadCore, Key, XSalsa20Poly1305,
+};
 use digest::{consts::U5, KeyInit, Mac};
-use rand_08::{rngs::OsRng, RngCore};
 use serde::Deserialize;
 use serde_bytes::Bytes;
 
@@ -25,7 +27,7 @@ impl SecretKey {
     pub const SIZE: usize = XSalsa20Poly1305::KEY_SIZE;
 
     pub fn generate() -> Self {
-        Self(XSalsa20Poly1305::generate_key(rand_08::thread_rng()))
+        Self(XSalsa20Poly1305::generate_key(rand::thread_rng()))
     }
 
     pub fn encrypt(&self, data: &[u8]) -> Vec<u8> {
@@ -33,7 +35,7 @@ impl SecretKey {
         // TODO: zero copy with preallocated buffer
         // let mut ciphered = Vec::with_capacity(NONCE_SIZE + TAG_SIZE + data.len());
         let cipher = XSalsa20Poly1305::new(&self.0);
-        let nonce = XSalsa20Poly1305::generate_nonce(&mut rand_08::thread_rng());
+        let nonce = XSalsa20Poly1305::generate_nonce(&mut rand::thread_rng());
         // TODO: handle this error ?
         let mut ciphered = cipher.encrypt(&nonce, data).expect("encryption failure !");
         let mut res = vec![];

--- a/libparsec/crates/crypto/src/rustcrypto/sequester.rs
+++ b/libparsec/crates/crypto/src/rustcrypto/sequester.rs
@@ -42,7 +42,7 @@ impl SequesterPrivateKeyDer {
     const ALGORITHM: &'static str = "RSAES-OAEP-SHA256-XSALSA20-POLY1305";
 
     pub fn generate_pair(size_in_bits: SequesterKeySize) -> (Self, SequesterPublicKeyDer) {
-        let priv_key = RsaPrivateKey::new(&mut rand_08::thread_rng(), size_in_bits as usize)
+        let priv_key = RsaPrivateKey::new(&mut rand::thread_rng(), size_in_bits as usize)
             .expect("Cannot generate the RSA key");
         let pub_key = RsaPublicKey::from(&priv_key);
 
@@ -148,7 +148,7 @@ impl SequesterPublicKeyDer {
     // Encryption format:
     //   <algorithm name>:<encrypted secret key with RSA key><encrypted data with secret key>
     pub fn encrypt(&self, data: &[u8]) -> Vec<u8> {
-        let mut rng = rand_08::thread_rng();
+        let mut rng = rand::thread_rng();
         let padding = Oaep::new::<Sha256>();
         let secret_key = SecretKey::generate();
         let secret_key_encrypted = self
@@ -230,7 +230,7 @@ impl SequesterSigningKeyDer {
     // Signature format:
     //   <algorithm name>:<signature><data>
     pub fn sign(&self, data: &[u8]) -> Vec<u8> {
-        let mut rng = rand_08::thread_rng();
+        let mut rng = rand::thread_rng();
         let signature = self.0.sign_with_rng(&mut rng, data);
 
         serialize_with_armor(

--- a/libparsec/crates/crypto/src/rustcrypto/sign.rs
+++ b/libparsec/crates/crypto/src/rustcrypto/sign.rs
@@ -36,9 +36,7 @@ impl SigningKey {
     }
 
     pub fn generate() -> Self {
-        Self(ed25519_dalek::SigningKey::generate(
-            &mut rand_08::thread_rng(),
-        ))
+        Self(ed25519_dalek::SigningKey::generate(&mut rand::thread_rng()))
     }
 
     /// Sign the message and prefix it with the signature.

--- a/libparsec/crates/crypto/src/rustcrypto/utils.rs
+++ b/libparsec/crates/crypto/src/rustcrypto/utils.rs
@@ -1,6 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use rand_08::{rngs::OsRng, RngCore};
+use rand::{rngs::OsRng, RngCore};
 
 pub fn generate_nonce() -> Vec<u8> {
     let mut nonce = vec![0; 64];


### PR DESCRIPTION
`crypto` was the only crate that depends on `getrandom_01` even tho it didn't use it in the code.
This will allow `dependabot` to update `getrandom`.

Changes
-------

- Remove the dependency `getrandom_01`.
- Rename dependency `getrandom_02` to `getrandom`.
- Rename dependency `rand_08` to `rand`.
- Use `rand_core` provided by `crypto_secretbox`.