### PR TITLE
Rollback electron-is-dev to 2.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -187,6 +187,10 @@ updates:
     labels:
       - I-Dependency
       - I-Javascript
+    ignore:
+      # `electron-is-dev@3` require to build the electron app in ESM mode, but capacitor doesn't support it yet.
+      - dependency-name: electron-is-dev
+        versions: [^3.0.0]
     schedule:
       interval: weekly
       day: monday

--- a/client/electron/package-lock.json
+++ b/client/electron/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@capacitor-community/electron": "^5.0.1",
                 "chokidar": "~3.6.0",
-                "electron-is-dev": "~3.0.1",
+                "electron-is-dev": "^2.0.0",
                 "electron-log": "^5.1.2",
                 "electron-serve": "~1.3.0",
                 "electron-unhandled": "~4.0.1",
@@ -42,14 +42,6 @@
                 "keyv": "^4.5.2",
                 "mime-types": "~2.1.35",
                 "ora": "^5.4.1"
-            }
-        },
-        "node_modules/@capacitor-community/electron/node_modules/electron-is-dev": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-2.0.0.tgz",
-            "integrity": "sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA==",
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@capacitor-community/electron/node_modules/fs-extra": {
@@ -2070,12 +2062,9 @@
             }
         },
         "node_modules/electron-is-dev": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-3.0.1.tgz",
-            "integrity": "sha512-8TjjAh8Ec51hUi3o4TaU0mD3GMTOESi866oRNavj9A3IQJ7pmv+MJVmdZBFGw4GFT36X7bkqnuDNYvkQgvyI8Q==",
-            "engines": {
-                "node": ">=18"
-            },
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-2.0.0.tgz",
+            "integrity": "sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA==",
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
@@ -2164,14 +2153,6 @@
                 "lodash.debounce": "^4.0.8",
                 "serialize-error": "^8.1.0"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/electron-unhandled/node_modules/electron-is-dev": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-2.0.0.tgz",
-            "integrity": "sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA==",
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }

--- a/client/electron/package.json
+++ b/client/electron/package.json
@@ -22,7 +22,7 @@
     "dependencies": {
         "@capacitor-community/electron": "^5.0.1",
         "chokidar": "~3.6.0",
-        "electron-is-dev": "~3.0.1",
+        "electron-is-dev": "^2.0.0",
         "electron-log": "^5.1.2",
         "electron-serve": "~1.3.0",
         "electron-unhandled": "~4.0.1",


### PR DESCRIPTION
The latest version of electron-is-dev (3.0.1) requires to build ESM module but capacitor don't support that currently.