### PR TITLE
Use `npm update` to up `megashark-lib`

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -31,7 +31,7 @@
         "electron:debug": "npm run electron:copy && cd electron && npm run electron:start",
         "prettier:check": "prettier . --check",
         "prettier:fix": "prettier . --write",
-        "megashark:update": "npm cache clean --force && rm -rf node_modules && rm package-lock.json && npm install",
+        "megashark:update": "npm update megashark-lib",
         "megashark:local:start": "npm link megashark-lib",
         "megashark:local:stop": "npm unlink megashark-lib --no-save && npm install"
     },


### PR DESCRIPTION
That prevent removing `package-lock.json` that maybe update intermediate dependencies without care.