### PR TITLE
[MS] Added new version available notification

### DIFF
--- a/client/electron/src/setup.ts
+++ b/client/electron/src/setup.ts
@@ -97,6 +97,12 @@ export class ElectronCapacitorApp {
       directory: join(app.getAppPath(), 'app'),
       scheme: this.customScheme,
     });
+
+    // Check periodically if an update is available
+    setInterval(async () => {
+      const updateInfo = await this.getUpdateInfo();
+      this.sendEvent(WindowToPageChannel.UpdateAvailability, updateInfo.updateAvailable, updateInfo.version);
+    }, 600000); // 10min
   }
 
   // Helper function to load in the app.

--- a/client/src/components/notifications/NewVersionAvailableNotification.vue
+++ b/client/src/components/notifications/NewVersionAvailableNotification.vue
@@ -1,0 +1,71 @@
+<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+
+<template>
+  <notification-item
+    :notification="notification"
+    @click="update"
+  >
+    <div class="notification-icon-container">
+      <ion-icon
+        class="notification-icon"
+        :icon="sparkles"
+      />
+    </div>
+    <div class="notification-details">
+      <ion-text class="notification-details__message body">
+        {{ $msTranslate('notificationCenter.newVersionAvailable') }}
+        <span class="notification-details__message-version">
+          {{ $msTranslate({ key: 'formatter.version', data: { version: data.newVersion } }) }}
+        </span>
+      </ion-text>
+      <ion-text class="notification-details__time body-sm">
+        <span class="hover-state">
+          {{ $msTranslate('notificationCenter.update') }}
+        </span>
+        <span class="default-state">{{ $msTranslate(formatTimeSince(notification.time, '', 'short')) }}</span>
+        <ion-icon
+          class="arrow-icon hover-state"
+          :icon="arrowForward"
+        />
+      </ion-text>
+    </div>
+  </notification-item>
+</template>
+
+<script setup lang="ts">
+import { formatTimeSince } from 'megashark-lib';
+import NotificationItem from '@/components/notifications/NotificationItem.vue';
+import { Notification } from '@/services/notificationManager';
+import { NewVersionAvailableData } from '@/services/informationManager';
+import { IonIcon, IonText } from '@ionic/vue';
+import { arrowForward, sparkles } from 'ionicons/icons';
+
+const props = defineProps<{
+  notification: Notification;
+}>();
+
+const data: NewVersionAvailableData = props.notification.getData<NewVersionAvailableData>();
+
+async function update(): Promise<void> {
+  window.electronAPI.updateApp();
+}
+</script>
+
+<style scoped lang="scss">
+.notification-icon-container {
+  background: var(--background-icon-info);
+  color: var(--color-icon-info);
+}
+
+.arrow-icon {
+  margin-left: auto;
+}
+
+.hover-state {
+  display: none;
+}
+
+.notification-details__message-version {
+  color: var(--parsec-color-light-secondary-grey);
+}
+</style>

--- a/client/src/components/notifications/index.ts
+++ b/client/src/components/notifications/index.ts
@@ -4,6 +4,7 @@ import AllImportedElementsNotification from '@/components/notifications/AllImpor
 import DefaultNotification from '@/components/notifications/DefaultNotification.vue';
 import MultipleUsersJoinWorkspaceNotification from '@/components/notifications/MultipleUsersJoinWorkspaceNotification.vue';
 import NewDeviceNotification from '@/components/notifications/NewDeviceNotification.vue';
+import NewVersionAvailableNotification from '@/components/notifications/NewVersionAvailableNotification.vue';
 import UserJoinWorkspaceNotification from '@/components/notifications/UserJoinWorkspaceNotification.vue';
 import UserSharedDocumentNotification from '@/components/notifications/UserSharedDocumentNotification.vue';
 import WorkspaceAccessNotification from '@/components/notifications/WorkspaceAccessNotification.vue';
@@ -18,4 +19,5 @@ export const Notifications = {
   UserSharedDocumentNotification,
   WorkspaceAccessNotification,
   WorkspaceRoleChangedNotification,
+  NewVersionAvailableNotification,
 };

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -22,7 +22,7 @@
         "expiredOrganization": "This organization has expired. Please contact an administrator."
     },
     "formatter": {
-        "version": "v{version} "
+        "version": "(v{version})"
     },
     "workspaceRoles": {
         "updateRejectedReasons": {
@@ -68,7 +68,9 @@
         "viewJoinedUsers": "View users",
         "goToDevices": "Go to my devices",
         "openEnclosingFolder": "Open enclosing folder",
-        "noNotification": "You are up to date!"
+        "noNotification": "You are up to date!",
+        "update": "Update",
+        "newVersionAvailable": "A new version is available"
     },
     "invitationList": {
         "title": "Invitations",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -22,7 +22,7 @@
         "expiredOrganization": "Cette organisation a expiré. Veuillez contacter un administrateur."
     },
     "formatter": {
-        "version": "v{version} "
+        "version": "(v{version}) "
     },
     "workspaceRoles": {
         "updateRejectedReasons": {
@@ -68,7 +68,9 @@
         "viewJoinedUsers": "Voir les utilisateurs",
         "goToDevices": "Accéder à mes appareils",
         "openEnclosingFolder": "Ouvrir le dossier",
-        "noNotification": "Vous êtes à jour !"
+        "noNotification": "Vous êtes à jour !",
+        "update": "Mettre à jour",
+        "newVersionAvailable": "Mise à jour disponible"
     },
     "invitationList": {
         "title": "Invitations",

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -26,7 +26,7 @@ import { getLoggedInDevices, getOrganizationHandle, isElectron, listAvailableDev
 import { Platform, libparsec } from '@/plugins/libparsec';
 import { Events } from '@/services/eventDistributor';
 import { HotkeyManager, HotkeyManagerKey } from '@/services/hotkeyManager';
-import { Information, InformationLevel, InformationManager, PresentationMode } from '@/services/informationManager';
+import { Information, InformationDataType, InformationLevel, InformationManager, PresentationMode } from '@/services/informationManager';
 import { InjectionProvider, InjectionProviderKey } from '@/services/injectionProvider';
 import { Answer, Base64, I18n, MegaSharkPlugin, Validity, askQuestion } from 'megashark-lib';
 
@@ -210,6 +210,17 @@ async function setupApp(): Promise<void> {
     });
     window.electronAPI.receive('parsec-update-availability', async (updateAvailable: boolean, version?: string) => {
       injectionProvider.distributeEventToAll(Events.UpdateAvailability, { updateAvailable: updateAvailable, version: version });
+      if (updateAvailable && version) {
+        injectionProvider.notifyAll(
+          new Information({
+            message: '',
+            level: InformationLevel.Info,
+            unique: true,
+            data: { type: InformationDataType.NewVersionAvailable, newVersion: version },
+          }),
+          PresentationMode.Notification,
+        );
+      }
     });
   } else {
     window.electronAPI = {
@@ -234,6 +245,15 @@ async function setupApp(): Promise<void> {
       getUpdateAvailability: (): void => {
         if (needsMocks()) {
           injectionProvider.distributeEventToAll(Events.UpdateAvailability, { updateAvailable: true, version: '3.1.0' });
+          injectionProvider.notifyAll(
+            new Information({
+              message: '',
+              level: InformationLevel.Info,
+              unique: true,
+              data: { type: InformationDataType.NewVersionAvailable, newVersion: '3.1.0' },
+            }),
+            PresentationMode.Notification,
+          );
         }
       },
       // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/client/src/services/informationManager.ts
+++ b/client/src/services/informationManager.ts
@@ -17,6 +17,7 @@ export enum InformationDataType {
   UserSharedDocument,
   AllImportedElements,
   NewDevice,
+  NewVersionAvailable,
 }
 
 export interface AbstractInformationData {
@@ -75,6 +76,12 @@ export interface NewDeviceData extends AbstractInformationData {
   type: InformationDataType.NewDevice;
 }
 
+// A new version of the app is available
+export interface NewVersionAvailableData extends AbstractInformationData {
+  type: InformationDataType.NewVersionAvailable;
+  newVersion: string;
+}
+
 export type InformationData =
   | NewWorkspaceAccessData
   | WorkspaceRoleChangedData
@@ -82,7 +89,8 @@ export type InformationData =
   | MultipleUsersJoinWorkspaceData
   | UserSharedDocumentData
   | AllImportedElementsData
-  | NewDeviceData;
+  | NewDeviceData
+  | NewVersionAvailableData;
 
 export enum InformationLevel {
   Info = 'INFO',
@@ -95,6 +103,7 @@ export interface InformationOptions {
   message: Translatable;
   level: InformationLevel;
   data?: InformationData;
+  unique?: boolean;
 }
 
 export class Information {
@@ -102,12 +111,14 @@ export class Information {
   message: Translatable;
   level: InformationLevel;
   data?: InformationData;
+  unique?: boolean;
 
-  constructor({ message, level, data }: InformationOptions) {
+  constructor({ message, level, data, unique }: InformationOptions) {
     this.id = uuid4();
     this.message = message;
     this.level = level;
     this.data = data;
+    this.unique = unique;
   }
 
   get theme(): MsReportTheme {

--- a/client/src/services/injectionProvider.ts
+++ b/client/src/services/injectionProvider.ts
@@ -3,7 +3,7 @@
 import { ConnectionHandle, needsMocks } from '@/parsec';
 import { EventData, EventDistributor, Events } from '@/services/eventDistributor';
 import { ImportManager } from '@/services/importManager';
-import { InformationManager } from '@/services/informationManager';
+import { Information, InformationManager } from '@/services/informationManager';
 
 interface Injections {
   importManager: ImportManager;
@@ -64,6 +64,12 @@ export class InjectionProvider {
   async distributeEventToAll(event: Events, data: EventData): Promise<void> {
     for (const injections of this.injections.values()) {
       await injections.eventDistributor.dispatchEvent(event, data);
+    }
+  }
+
+  async notifyAll(info: Information, mode: number): Promise<void> {
+    for (const injections of this.injections.values()) {
+      await injections.informationManager.present(info, mode);
     }
   }
 

--- a/client/src/services/notificationManager.ts
+++ b/client/src/services/notificationManager.ts
@@ -10,6 +10,7 @@ export class Notification {
   information: Information;
   time: DateTime;
   read: boolean;
+
   constructor(information: Information) {
     this.information = information;
     this.time = DateTime.now();
@@ -35,6 +36,18 @@ export class NotificationManager {
   }
 
   add(information: Information): void {
+    // Some notification should only be shown once
+    if (information.unique) {
+      const existing = this.notifications.value.find((notif) => {
+        if (notif.information.data && information.data && notif.information.data.type === information.data.type) {
+          return true;
+        }
+        return false;
+      });
+      if (existing) {
+        return;
+      }
+    }
     const notification = new Notification(information);
     this.notifications.value.unshift(notification);
   }

--- a/client/src/views/header/NotificationCenterPopover.vue
+++ b/client/src/views/header/NotificationCenterPopover.vue
@@ -79,6 +79,8 @@ function getComponentType(notification: Notification): Component {
       return Notifications.AllImportedElementsNotification;
     case InformationDataType.NewDevice:
       return Notifications.NewDeviceNotification;
+    case InformationDataType.NewVersionAvailable:
+      return Notifications.NewVersionAvailableNotification;
     default:
       return Notifications.DefaultNotification;
   }

--- a/client/src/views/header/ProfileHeader.vue
+++ b/client/src/views/header/ProfileHeader.vue
@@ -58,7 +58,6 @@ const eventDistributor: EventDistributor = inject(EventDistributorKey)!;
 const injectionProvider: InjectionProvider = inject(InjectionProviderKey)!;
 const updateAvailability: Ref<UpdateAvailabilityData> = ref({ updateAvailable: false });
 let eventCbId: null | string = null;
-let intervalId: any = null;
 
 const props = defineProps<{
   name: string;
@@ -80,19 +79,12 @@ onMounted(async () => {
     },
   );
 
-  intervalId = setInterval(async () => {
-    window.electronAPI.getUpdateAvailability();
-  }, 600000); // Checking every 10min
-  // Also calling it right now
   window.electronAPI.getUpdateAvailability();
 });
 
 onUnmounted(async () => {
   if (eventCbId) {
     eventDistributor.removeCallback(eventCbId);
-  }
-  if (intervalId) {
-    clearInterval(intervalId);
   }
 });
 


### PR DESCRIPTION
Add a notification for when an update is available.

1. The interval to check if a new version is available is now done in Electron. This avoid having 4 queries if 4 orgs are connected, now it's only done once and dispatched to every one. And maybe we won't even need the setInterval in the end.
2. Add a `unique` option on `Information`. This one is a bit tricky because all we want is a notification to inform that a new version is available. We don't care about the message nor the criticity. And it shouldn't be repeated every 10min either. So it's a bit of an outlier and doesn't fit the information system we have now.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes

closes #7099
  