### PR TITLE
Detect when a glog pattern produce no match

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -33,13 +33,13 @@ To start hacking, follow the basic steps detailed below:
        cd parsec-cloud
        ```
 
-    2. [`Rust v1.71.1`](https://www.rust-lang.org/fr/learn/get-started)
+    2. [`Rust v1.75.0`](https://www.rust-lang.org/fr/learn/get-started)
 
        > We use a `rust-toolchain.toml` file, so you can just install `rustup` and `cargo`
        > The required toolchain will be install automatically.
 
        ```shell
-       curl --proto '=https' --tlsv1.2 -sSL https://sh.rustup.rs | sh -s -- --default-toolchain none # You can replace `none` with `1.71.1`
+       curl --proto '=https' --tlsv1.2 -sSL https://sh.rustup.rs | sh -s -- --default-toolchain none # You can replace `none` with `1.75.0`
        ```
 
        > You then need to add the installation path to your `PATH` variable (or equivalent).


### PR DESCRIPTION
The file `docs/development/README.md` was not monitored by the script since it was renamed from `quickstart.md`. The script will now check that the glob pattern produce at least one match and will log an error if it does not.