### PR TITLE
[fix #7296]: Update nightly tag only on releaser workflow success

### DIFF
--- a/.github/workflows/_releaser_nightly_build.yml
+++ b/.github/workflows/_releaser_nightly_build.yml
@@ -35,12 +35,12 @@ jobs:
         timeout-minutes: 1
 
       - name: Create nightly release
-        run: python misc/releaser.py build --nightly --yes --no-gpg-sign
+        run: python misc/releaser.py build --nightly --yes --no-gpg-sign --skip-tag
         timeout-minutes: 2
 
       - name: Get commit for nightly tag
         id: commit
-        run: echo "id=$(git rev-parse nightly)" | tee -a $GITHUB_OUTPUT
+        run: echo "id=$(git rev-parse HEAD)" | tee -a $GITHUB_OUTPUT
         timeout-minutes: 1
 
       - name: Parse version

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -158,6 +158,12 @@ jobs:
           GH_ARGS: --repo=${{ github.server_url}}/${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
 
+      - name: Update the nightly tag
+        if: env.NIGHTLY_RELEASE == 'true'
+        run: |
+          git tag --force nightly ${{ needs.version.outputs.commit_sha }}
+          git push --force origin refs/tags/nightly
+
       - name: Create release
         if: github.event_name == 'schedule' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
         # FIXME: rollback to `softprops/action-gh-release` once the issue <https://github.com/softprops/action-gh-release/issues/362> is fixed.


### PR DESCRIPTION
Update the release script to allow to skip the creation and push of the release tag. 
This allow to configure the releaser workflow to skip the nightly tag creation on schedule runs. 
Then the nightly tag updated upon the creation of the new nightly release.