### PR TITLE
Don't create an updater if the configuration isn't available

### DIFF
--- a/client/electron/src/updater.ts
+++ b/client/electron/src/updater.ts
@@ -47,10 +47,28 @@ class CustomGithubProvider extends GitHubProvider {
   }
 }
 
-const publishOption: CustomPublishOptions | CustomGitHubOptions = {
-  ...require('../assets/publishConfig.json'),
-  updateProvider: CustomGithubProvider,
-};
+function loadPublishOption(): (CustomPublishOptions & CustomGitHubOptions) | undefined {
+  let data = undefined;
+  try {
+    data = require('../assets/publishConfig.json');
+  } catch {
+    console.log('Failed to load publish config file');
+    return undefined;
+  }
+
+  return {
+    ...data,
+    updateProvider: CustomGithubProvider,
+  };
+}
+
+export function createAppUpdater(): AppUpdater | undefined {
+  const publishOption = loadPublishOption();
+  if (publishOption === undefined) {
+    return undefined;
+  }
+  return new AppUpdater(publishOption);
+}
 
 export interface UpdateAvailable {
   version: string;
@@ -89,7 +107,7 @@ export default class AppUpdater {
     [UpdaterState.UpdateDownloaded]: [],
   };
 
-  constructor() {
+  constructor(publishOption: CustomPublishOptions & CustomGitHubOptions) {
     switch (process.platform) {
       case 'darwin':
         const { MacUpdater } = require('electron-updater');


### PR DESCRIPTION
If we're in dev mode, we likely don't have the publish configuration file. 
In that case, we should not create the updater and consider no update will be available.