### PR TITLE
Use `directories` entry to group all actions in a single entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,10 @@ updates:
   #################
 
   - package-ecosystem: github-actions
-    directory: /
+    directories:
+      - /
+      - /.github/actions/setup-python-poetry
+      - /.github/actions/use-pre-commit
     pull-request-branch-name:
       separator: "-"
     labels:
@@ -17,39 +20,9 @@ updates:
       time: "04:20"
       timezone: Europe/Paris
     groups:
-      github-workflows:
+      github-actions:
         patterns:
           - "*"
-    open-pull-requests-limit: 5
-    rebase-strategy: disabled
-
-  - package-ecosystem: github-actions
-    directory: /.github/actions/setup-python-poetry
-    pull-request-branch-name:
-      separator: "-"
-    labels:
-      - I-Dependency
-      - I-Github-Actions
-    schedule:
-      interval: weekly
-      day: monday
-      time: "04:20"
-      timezone: Europe/Paris
-    open-pull-requests-limit: 5
-    rebase-strategy: disabled
-
-  - package-ecosystem: github-actions
-    directory: /.github/actions/use-pre-commit
-    pull-request-branch-name:
-      separator: "-"
-    labels:
-      - I-Dependency
-      - I-Github-Actions
-    schedule:
-      interval: weekly
-      day: monday
-      time: "04:20"
-      timezone: Europe/Paris
     open-pull-requests-limit: 5
     rebase-strategy: disabled
 


### PR DESCRIPTION
Only for the `github-actions` package ecosystem right, to test how Dependabot will behave with grouping.