### PR TITLE
Fix not a git repo to update nightly tag

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -160,6 +160,13 @@ jobs:
           GH_ARGS: --repo=${{ github.server_url}}/${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
 
+      - name: Checkout the repository to update the nightly tag
+        if: env.NIGHTLY_RELEASE == 'true'
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # pin v4.1.5
+        with:
+          ref: ${{ needs.version.outputs.commit_sha }}
+        timeout-minutes: 5
+
       - name: Update the nightly tag
         if: env.NIGHTLY_RELEASE == 'true'
         run: |


### PR DESCRIPTION
Checkout the repository on the last job if we need to update the nightly tag.