### PR TITLE
Fix filename conflict when copying sbom file

### DIFF
--- a/.github/workflows/package-client.yml
+++ b/.github/workflows/package-client.yml
@@ -168,7 +168,7 @@ jobs:
           tool: syft@0.84.0
 
       - name: Generate SBOM
-        run: syft packages --config=.syft.yaml --output=spdx-json=Parsec-SBOM-Electron-linux.spdx.json .
+        run: syft packages --config=.syft.yaml --output=spdx-json=Parsec-SBOM-Electron-linux-snap.spdx.json .
 
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # pin v4.3.3
         with:
@@ -280,7 +280,7 @@ jobs:
           tool: syft@0.84.0
 
       - name: Generate SBOM
-        run: syft packages --config=.syft.yaml --output=spdx-json=client/electron/dist/Parsec-SBOM-Electron-${{ matrix.platform }}.spdx.json .
+        run: syft packages --config=.syft.yaml --output=spdx-json=client/electron/dist/Parsec-SBOM-Electron-${{ matrix.platform }}-${{ matrix.extension }}.spdx.json .
 
       - name: Debug dist folder
         if: runner.debug || false


### PR DESCRIPTION
During the last step of the releaser workflow (releaser.yml), we copy the generated SBOM files with a glob pattern like so:

```shell
cp -v artifacts/**/Parsec-SBOM-*.spdx.json release-files
```

This command fail because we have two file who have the same name: `Parsec-SBOM-Electron-linux-snap.spdx.json`

To fix that, we simply add the extension of the generated application file (`snap`, `AppImage`, `dmg`, `exe`)