### PR TITLE
[MS] Updated import manager to file operation manager

### DIFF
--- a/client/src/components/files/FileCardImporting.vue
+++ b/client/src/components/files/FileCardImporting.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script setup lang="ts">
-import { ImportData } from '@/services/importManager';
+import { ImportData } from '@/services/fileOperationManager';
 import { IonAvatar, IonIcon, IonItem, IonText, IonTitle } from '@ionic/vue';
 import { document } from 'ionicons/icons';
 import { MsSpinner } from 'megashark-lib';

--- a/client/src/components/files/FileCopyItem.vue
+++ b/client/src/components/files/FileCopyItem.vue
@@ -18,17 +18,15 @@
       <div class="element-type">
         <div class="element-type__icon">
           <ms-image
-            :image="getFileIcon(fileCache.name)"
+            :image="getFileIcon('')"
             class="file-icon"
           />
         </div>
       </div>
       <div class="element-details">
-        <ion-text class="element-details__name body">
-          {{ shortenFileName(fileCache.name) }}
-        </ion-text>
+        <ion-text class="element-details__name body">{{ shortenFileName('') }} </ion-text>
         <ion-label class="element-details__size body-sm">
-          <span class="default-state">{{ $msTranslate(formatFileSize(fileCache.size)) }}</span>
+          <span class="default-state">{{ formatFileSize(1337) }}</span>
           <span
             class="default-state"
             v-if="workspaceInfo"
@@ -128,20 +126,16 @@
 import { formatFileSize, getFileIcon, shortenFileName } from '@/common/file';
 import { MsImage, MsInformationTooltip } from 'megashark-lib';
 import { StartedWorkspaceInfo, getWorkspaceInfo } from '@/parsec';
-import { ImportData, FileOperationState } from '@/services/fileOperationManager';
+import { CopyData, FileOperationState } from '@/services/fileOperationManager';
 import { IonButton, IonIcon, IonItem, IonLabel, IonProgressBar, IonText } from '@ionic/vue';
 import { arrowForward, checkmark, close } from 'ionicons/icons';
 import { Ref, onMounted, ref } from 'vue';
 
 const props = defineProps<{
-  operationData: ImportData;
+  operationData: CopyData;
   progress: number;
   state: FileOperationState;
 }>();
-
-// Props get refreshed for every event but the file name or size
-// will never change, so we cache them.
-const fileCache = structuredClone(props.operationData.file);
 
 const workspaceInfo: Ref<StartedWorkspaceInfo | null> = ref(null);
 
@@ -158,7 +152,7 @@ onMounted(async () => {
 
 defineEmits<{
   (event: 'cancel', id: string): void;
-  (event: 'click', operationData: ImportData, state: FileOperationState): void;
+  (event: 'click', operationData: CopyData, state: FileOperationState): void;
 }>();
 </script>
 

--- a/client/src/components/files/FileListItemImporting.vue
+++ b/client/src/components/files/FileListItemImporting.vue
@@ -61,7 +61,7 @@ import { formatFileSize, getFileIcon } from '@/common/file';
 import { MsImage } from 'megashark-lib';
 import UserAvatarName from '@/components/users/UserAvatarName.vue';
 import { ClientInfo, getClientInfo } from '@/parsec';
-import { ImportData } from '@/services/importManager';
+import { ImportData } from '@/services/fileOperationManager';
 import { IonIcon, IonItem, IonLabel } from '@ionic/vue';
 import { cloudOffline } from 'ionicons/icons';
 import { Ref, onMounted, ref } from 'vue';

--- a/client/src/components/files/FileMoveItem.vue
+++ b/client/src/components/files/FileMoveItem.vue
@@ -18,17 +18,15 @@
       <div class="element-type">
         <div class="element-type__icon">
           <ms-image
-            :image="getFileIcon(fileCache.name)"
+            :image="getFileIcon('')"
             class="file-icon"
           />
         </div>
       </div>
       <div class="element-details">
-        <ion-text class="element-details__name body">
-          {{ shortenFileName(fileCache.name) }}
-        </ion-text>
+        <ion-text class="element-details__name body">{{ shortenFileName('') }} </ion-text>
         <ion-label class="element-details__size body-sm">
-          <span class="default-state">{{ $msTranslate(formatFileSize(fileCache.size)) }}</span>
+          <span class="default-state">{{ formatFileSize(1337) }}</span>
           <span
             class="default-state"
             v-if="workspaceInfo"
@@ -128,20 +126,16 @@
 import { formatFileSize, getFileIcon, shortenFileName } from '@/common/file';
 import { MsImage, MsInformationTooltip } from 'megashark-lib';
 import { StartedWorkspaceInfo, getWorkspaceInfo } from '@/parsec';
-import { ImportData, FileOperationState } from '@/services/fileOperationManager';
+import { MoveData, FileOperationState } from '@/services/fileOperationManager';
 import { IonButton, IonIcon, IonItem, IonLabel, IonProgressBar, IonText } from '@ionic/vue';
 import { arrowForward, checkmark, close } from 'ionicons/icons';
 import { Ref, onMounted, ref } from 'vue';
 
 const props = defineProps<{
-  operationData: ImportData;
+  operationData: MoveData;
   progress: number;
   state: FileOperationState;
 }>();
-
-// Props get refreshed for every event but the file name or size
-// will never change, so we cache them.
-const fileCache = structuredClone(props.operationData.file);
 
 const workspaceInfo: Ref<StartedWorkspaceInfo | null> = ref(null);
 
@@ -158,7 +152,7 @@ onMounted(async () => {
 
 defineEmits<{
   (event: 'cancel', id: string): void;
-  (event: 'click', operationData: ImportData, state: FileOperationState): void;
+  (event: 'click', operationData: MoveData, state: FileOperationState): void;
 }>();
 </script>
 

--- a/client/src/components/files/index.ts
+++ b/client/src/components/files/index.ts
@@ -2,6 +2,7 @@
 
 import FileCard from '@/components/files/FileCard.vue';
 import FileCardImporting from '@/components/files/FileCardImporting.vue';
+import FileCopyItem from '@/components/files/FileCopyItem.vue';
 import FileDropZone from '@/components/files/FileDropZone.vue';
 import FileGridDisplay from '@/components/files/FileGridDisplay.vue';
 import FileImportPopover from '@/components/files/FileImportPopover.vue';
@@ -9,6 +10,7 @@ import FileInputs from '@/components/files/FileInputs.vue';
 import FileListDisplay from '@/components/files/FileListDisplay.vue';
 import FileListItem from '@/components/files/FileListItem.vue';
 import FileListItemImporting from '@/components/files/FileListItemImporting.vue';
+import FileMoveItem from '@/components/files/FileMoveItem.vue';
 import FileUploadItem from '@/components/files/FileUploadItem.vue';
 
 export { EntryCollection, ImportType, SortProperty } from '@/components/files/types';
@@ -18,6 +20,7 @@ export type { FileImportTuple, FolderSelectionOptions } from '@/components/files
 export {
   FileCard,
   FileCardImporting,
+  FileCopyItem,
   FileDropZone,
   FileGridDisplay,
   FileImportPopover,
@@ -25,5 +28,6 @@ export {
   FileListDisplay,
   FileListItem,
   FileListItemImporting,
+  FileMoveItem,
   FileUploadItem,
 };

--- a/client/src/components/files/types.ts
+++ b/client/src/components/files/types.ts
@@ -1,7 +1,7 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 import { EntryID, EntryStatFile, EntryStatFolder } from '@/parsec';
-import { ImportData } from '@/services/importManager';
+import { ImportData } from '@/services/fileOperationManager';
 
 export enum SortProperty {
   Name,

--- a/client/src/parsec/file.ts
+++ b/client/src/parsec/file.ts
@@ -1,6 +1,7 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 import { needsMocks } from '@/parsec/environment';
+import { wait } from '@/parsec/internals';
 import { Path } from '@/parsec/path';
 import { getParsecHandle, getWorkspaceHandle } from '@/parsec/routing';
 import {
@@ -378,6 +379,7 @@ export async function writeFile(
   if (clientHandle && !needsMocks()) {
     return await libparsec.fdWrite(workspaceHandle, fd, offset, data);
   } else {
-    return { ok: true, value: 1337 };
+    await wait(100);
+    return { ok: true, value: data.length };
   }
 }

--- a/client/src/router/types.ts
+++ b/client/src/router/types.ts
@@ -36,7 +36,7 @@ const routes: Array<RouteRecordRaw> = [
   },
   {
     // ConnectedLayout ensure that every children components are provided
-    // with an importManager, informationManager and eventDistributor
+    // with a fileOperationManager, informationManager and eventDistributor
     // that correspond with the current ConnectionHandle.
     path: '/connected',
     component: () => import('@/views/layouts/ConnectedLayout.vue'),
@@ -50,8 +50,8 @@ const routes: Array<RouteRecordRaw> = [
             component: () => import('@/views/header/HeaderPage.vue'),
             children: [
               {
-                path: '/imports',
-                component: () => import('@/views/layouts/ImportLayout.vue'),
+                path: '/fileOp',
+                component: () => import('@/views/layouts/FileOperationLayout.vue'),
                 children: [
                   {
                     path: `/:handle(\\d+)/${Routes.Workspaces}`,

--- a/client/src/services/injectionProvider.ts
+++ b/client/src/services/injectionProvider.ts
@@ -2,11 +2,11 @@
 
 import { ConnectionHandle, needsMocks } from '@/parsec';
 import { EventData, EventDistributor, Events } from '@/services/eventDistributor';
-import { ImportManager } from '@/services/importManager';
+import { FileOperationManager } from '@/services/fileOperationManager';
 import { Information, InformationManager } from '@/services/informationManager';
 
 interface Injections {
-  importManager: ImportManager;
+  fileOperationManager: FileOperationManager;
   eventDistributor: EventDistributor;
   informationManager: InformationManager;
 }
@@ -20,7 +20,7 @@ export class InjectionProvider {
   constructor() {
     this.injections = new Map();
     this.default = {
-      importManager: new ImportManager(),
+      fileOperationManager: new FileOperationManager(),
       eventDistributor: new EventDistributor(),
       informationManager: new InformationManager(),
     };
@@ -34,7 +34,7 @@ export class InjectionProvider {
       return;
     }
     this.injections.set(handle, {
-      importManager: new ImportManager(),
+      fileOperationManager: new FileOperationManager(),
       eventDistributor: eventDistributor,
       informationManager: new InformationManager(handle),
     });
@@ -78,7 +78,7 @@ export class InjectionProvider {
     if (!inj) {
       return;
     }
-    await inj.importManager.stop();
+    await inj.fileOperationManager.stop();
     this.injections.delete(handle);
   }
 

--- a/client/src/views/header/ProfileHeader.vue
+++ b/client/src/views/header/ProfileHeader.vue
@@ -39,7 +39,7 @@ import { UserProfile, logout as parsecLogout } from '@/parsec';
 import { Routes, getConnectionHandle, navigateTo } from '@/router';
 import { EventData, EventDistributor, EventDistributorKey, Events, UpdateAvailabilityData } from '@/services/eventDistributor';
 import useUploadMenu from '@/services/fileUploadMenu';
-import { ImportManager, ImportManagerKey } from '@/services/importManager';
+import { FileOperationManager, FileOperationManagerKey } from '@/services/fileOperationManager';
 import { Information, InformationLevel, InformationManager, InformationManagerKey, PresentationMode } from '@/services/informationManager';
 import { InjectionProvider, InjectionProviderKey } from '@/services/injectionProvider';
 import { Answer, askQuestion, I18n } from 'megashark-lib';
@@ -53,7 +53,7 @@ const isOnline = ref(true);
 const isPopoverOpen = ref(false);
 
 const informationManager: InformationManager = inject(InformationManagerKey)!;
-const importManager: ImportManager = inject(ImportManagerKey)!;
+const fileOperationManager: FileOperationManager = inject(FileOperationManagerKey)!;
 const eventDistributor: EventDistributor = inject(EventDistributorKey)!;
 const injectionProvider: InjectionProvider = inject(InjectionProviderKey)!;
 const updateAvailability: Ref<UpdateAvailabilityData> = ref({ updateAvailable: false });
@@ -113,7 +113,7 @@ async function openPopover(event: Event): Promise<void> {
   if (data.option === ProfilePopoverOption.LogOut) {
     const answer = await askQuestion(
       'HomePage.topbar.logoutConfirmTitle',
-      importManager.isImporting() ? 'HomePage.topbar.logoutImportsConfirmQuestion' : 'HomePage.topbar.logoutConfirmQuestion',
+      fileOperationManager.isImporting() ? 'HomePage.topbar.logoutImportsConfirmQuestion' : 'HomePage.topbar.logoutConfirmQuestion',
       {
         yesText: 'HomePage.topbar.logoutYes',
         noText: 'HomePage.topbar.logoutNo',

--- a/client/src/views/layouts/ConnectedLayout.vue
+++ b/client/src/views/layouts/ConnectedLayout.vue
@@ -13,7 +13,7 @@
 import { needsMocks } from '@/parsec';
 import { getConnectionHandle } from '@/router';
 import { EventDistributor, EventDistributorKey } from '@/services/eventDistributor';
-import { ImportManagerKey } from '@/services/importManager';
+import { FileOperationManagerKey } from '@/services/fileOperationManager';
 import { InformationManagerKey } from '@/services/informationManager';
 import { InjectionProvider, InjectionProviderKey } from '@/services/injectionProvider';
 import { IonContent, IonPage, IonRouterOutlet } from '@ionic/vue';
@@ -33,7 +33,7 @@ onMounted(async () => {
   }
   const inj = injectionProvider.getInjections(handle);
   // Provide the injections to children
-  provide(ImportManagerKey, inj.importManager);
+  provide(FileOperationManagerKey, inj.fileOperationManager);
   provide(InformationManagerKey, inj.informationManager);
   provide(EventDistributorKey, inj.eventDistributor);
   initialized.value = true;

--- a/client/src/views/layouts/FileOperationLayout.vue
+++ b/client/src/views/layouts/FileOperationLayout.vue
@@ -4,12 +4,12 @@
   <ion-page>
     <ion-content>
       <ion-router-outlet />
-      <file-upload-menu />
+      <file-operation-menu />
     </ion-content>
   </ion-page>
 </template>
 
 <script lang="ts" setup>
-import FileUploadMenu from '@/views/files/FileUploadMenu.vue';
+import FileOperationMenu from '@/views/files/FileOperationMenu.vue';
 import { IonContent, IonPage, IonRouterOutlet } from '@ionic/vue';
 </script>


### PR DESCRIPTION
The idea is to re-use the import manager and menu for other file operations like copy and move. This is the first step, it doesn't include copy or move yet, it shouldn't change anything in terms of UX/UI.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes