### PR TITLE
[MS] Add the ability to start an update

### DIFF
--- a/client/electron/src/communicationChannels.ts
+++ b/client/electron/src/communicationChannels.ts
@@ -7,6 +7,7 @@ export enum PageToWindowChannel {
   MountpointUpdate = 'parsec-mountpoint-update',
   UpdateAvailabilityRequest = 'parsec-update-availability-request',
   UpdateApp = 'parsec-update-app',
+  PrepareUpdate = 'parsec-prepare-update',
 }
 
 export enum WindowToPageChannel {
@@ -14,4 +15,5 @@ export enum WindowToPageChannel {
   UpdateAvailability = 'parsec-update-availability',
   OpenLink = 'parsec-open-link',
   CloseRequest = 'parsec-close-request',
+  CleanUpBeforeUpdate = 'parsec-clean-up-before-update',
 }

--- a/client/electron/src/index.ts
+++ b/client/electron/src/index.ts
@@ -136,3 +136,9 @@ ipcMain.on(PageToWindowChannel.UpdateApp, async () => {
 ipcMain.on(PageToWindowChannel.UpdateAvailabilityRequest, async () => {
   myCapacitorApp.checkForUpdates();
 });
+
+ipcMain.on(PageToWindowChannel.PrepareUpdate, async () => {
+  if (myCapacitorApp.updater && myCapacitorApp.updater.isUpdateDownloaded()) {
+    myCapacitorApp.sendEvent(WindowToPageChannel.CleanUpBeforeUpdate);
+  }
+});

--- a/client/electron/src/preload.ts
+++ b/client/electron/src/preload.ts
@@ -32,5 +32,8 @@ process.once('loaded', () => {
     updateApp: () => {
       ipcRenderer.send(PageToWindowChannel.UpdateApp);
     },
+    prepareUpdate: () => {
+      ipcRenderer.send(PageToWindowChannel.PrepareUpdate);
+    },
   });
 });

--- a/client/electron/src/setup.ts
+++ b/client/electron/src/setup.ts
@@ -142,7 +142,11 @@ export class ElectronCapacitorApp {
   }
 
   updateApp(): void {
-    console.log('In electron update app. Sadly does nothing for now :(');
+    if (this.updater && this.updater.isUpdateDownloaded()) {
+      this.updater.quitAndInstall();
+    } else {
+      console.warn('Update app has been called but no update has been downloaded');
+    }
   }
 
   /**

--- a/client/electron/src/updater.ts
+++ b/client/electron/src/updater.ts
@@ -200,6 +200,18 @@ export default class AppUpdater {
     }
   }
 
+  quitAndInstall(): void {
+    if (!this.isUpdateDownloaded()) {
+      console.log('quitAndInstall() called when update has not been downloaded.');
+      return;
+    }
+    this.updater.quitAndInstall();
+  }
+
+  isUpdateDownloaded(): boolean {
+    return this.state === UpdaterState.UpdateDownloaded;
+  }
+
   emit<U extends UpdaterState>(event: U, ...args: Parameters<ListenerSignature[U]>): void {
     this.listeners[event].forEach((listener) => (listener as (...args: Parameters<ListenerSignature[U]>) => void)(...args));
   }

--- a/client/src/components/notifications/NewVersionAvailableNotification.vue
+++ b/client/src/components/notifications/NewVersionAvailableNotification.vue
@@ -33,12 +33,13 @@
 </template>
 
 <script setup lang="ts">
-import { formatTimeSince } from 'megashark-lib';
+import { Answer, askQuestion, formatTimeSince } from 'megashark-lib';
 import NotificationItem from '@/components/notifications/NotificationItem.vue';
 import { Notification } from '@/services/notificationManager';
 import { NewVersionAvailableData } from '@/services/informationManager';
-import { IonIcon, IonText } from '@ionic/vue';
+import { IonIcon, IonText, popoverController } from '@ionic/vue';
 import { arrowForward, sparkles } from 'ionicons/icons';
+import { navigateTo, Routes } from '@/router';
 
 const props = defineProps<{
   notification: Notification;
@@ -47,7 +48,15 @@ const props = defineProps<{
 const data: NewVersionAvailableData = props.notification.getData<NewVersionAvailableData>();
 
 async function update(): Promise<void> {
-  window.electronAPI.updateApp();
+  await popoverController.dismiss();
+  const answer = await askQuestion('HomePage.topbar.updateConfirmTitle', 'HomePage.topbar.updateConfirmQuestion', {
+    yesText: 'HomePage.topbar.updateYes',
+    noText: 'HomePage.topbar.updateNo',
+  });
+  if (answer === Answer.Yes) {
+    await navigateTo(Routes.Home, { replace: true, skipHandle: true });
+    window.electronAPI.prepareUpdate();
+  }
 }
 </script>
 

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -108,6 +108,10 @@
             "logoutYes": "Log out",
             "logoutNo": "Stay connected",
             "logoutFailed": "An error occured while logging out.",
+            "updateConfirmTitle": "Update Parsec",
+            "updateConfirmQuestion": "You will be logged out and the application will close. Make sure to save your work before. Do you want to continue?",
+            "updateYes": "Update Parsec",
+            "updateNo": "Later",
             "updateAvailable": "Update available",
             "newVersionAvailable": "New version available"
         },

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -108,6 +108,10 @@
             "logoutYes": "Se déconnecter",
             "logoutNo": "Rester connecté(e)",
             "logoutFailed": "Une erreur est survenue lors de la déconnexion.",
+            "updateConfirmTitle": "Mettre à jour Parsec",
+            "updateConfirmQuestion": "Vous serez déconnecté(e) et l'application sera fermée. Assurez vous de ne pas avoir d'opérations en cours. Souhaitez-vous continuer ?",
+            "updateYes": "Mettre à jour Parsec",
+            "updateNo": "Plus tard",
             "updateAvailable": "Mise à jour disponible",
             "newVersionAvailable": "Nouvelle version disponible"
         },

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -236,6 +236,10 @@ async function setupApp(): Promise<void> {
         );
       }
     });
+    window.electronAPI.receive('parsec-clean-up-before-update', async () => {
+      await cleanBeforeQuitting(injectionProvider);
+      window.electronAPI.updateApp();
+    });
   } else {
     window.electronAPI = {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -266,9 +270,11 @@ async function setupApp(): Promise<void> {
           );
         }
       },
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
       updateApp: (): void => {
         console.log('Not available.');
+      },
+      prepareUpdate: (): void => {
+        console.log('Not available');
       },
     };
   }
@@ -373,6 +379,7 @@ declare global {
       sendMountpointFolder: (path: string) => void;
       getUpdateAvailability: () => void;
       updateApp: () => void;
+      prepareUpdate: () => void;
     };
   }
 }

--- a/client/src/views/header/ProfileHeader.vue
+++ b/client/src/views/header/ProfileHeader.vue
@@ -110,7 +110,16 @@ async function openPopover(event: Event): Promise<void> {
   if (data === undefined) {
     return;
   }
-  if (data.option === ProfilePopoverOption.LogOut) {
+  if (data.option === ProfilePopoverOption.Update) {
+    const answer = await askQuestion('HomePage.topbar.updateConfirmTitle', 'HomePage.topbar.updateConfirmQuestion', {
+      yesText: 'HomePage.topbar.updateYes',
+      noText: 'HomePage.topbar.updateNo',
+    });
+    if (answer === Answer.Yes) {
+      await navigateTo(Routes.Home, { replace: true, skipHandle: true });
+      window.electronAPI.prepareUpdate();
+    }
+  } else if (data.option === ProfilePopoverOption.LogOut) {
     const answer = await askQuestion(
       'HomePage.topbar.logoutConfirmTitle',
       importManager.isImporting() ? 'HomePage.topbar.logoutImportsConfirmQuestion' : 'HomePage.topbar.logoutConfirmQuestion',

--- a/client/src/views/header/ProfileHeaderPopover.vue
+++ b/client/src/views/header/ProfileHeaderPopover.vue
@@ -12,7 +12,7 @@
       <div
         button
         class="main-list__item update-item"
-        @click="update"
+        @click="onOptionClick(ProfilePopoverOption.Update)"
         v-show="updateAvailability.updateAvailable"
       >
         <ion-text class="update-item-text subtitles-normal">
@@ -84,6 +84,7 @@ export enum ProfilePopoverOption {
   LogOut = 2,
   App = 3,
   MyProfile = 4,
+  Update = 5,
 }
 </script>
 
@@ -106,10 +107,6 @@ async function onOptionClick(option: ProfilePopoverOption): Promise<void> {
   await popoverController.dismiss({
     option: option,
   });
-}
-
-async function update(): Promise<void> {
-  window.electronAPI.updateApp();
 }
 </script>
 


### PR DESCRIPTION
Linked to #5613 

A click on an update button in Parsec will send a `prepareUpdate` event to Electron. Electron will then inform the app to cleanup (logout, cancel the imports, ...) and the app will then tell electron to quit and update. At least, that's the theory.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
