### PR TITLE
Fix snapcraft upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,9 @@ on:
     types:
       - published
       - edited
+  pull_request:
+    paths:
+      - .github/workflows/publish.yml
 
 # We set `concurrency` to prevent having this workflow being run on code that is not up-to-date on a PR (a user make multiple push in a quick manner).
 # But on the main branch, we don't want that behavior.
@@ -27,7 +30,7 @@ concurrency:
 
 
 env:
-  RELEASE_TAG: ${{ github.event_name == 'release' && github.ref_name || inputs.release_tag }}
+  RELEASE_TAG: ${{ (github.event_name == 'release' && github.ref_name) || (github.event_name == 'pull_request' && 'nightly') || inputs.release_tag }}
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,6 +86,12 @@ jobs:
         uses: samuelmeuli/action-snapcraft@d33c176a9b784876d966f80fb1b461808edc0641 # pin v2.1.1
         timeout-minutes: 2
 
+      - name: Whoami snap
+        run: snapcraft whoami
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_CREDENTIALS }}
+        timeout-minutes: 2
+
       - name: Upload Snap
         run: snapcraft upload --release=nightly/stable snap/Parsec_${{ steps.version.outputs.full }}_linux_*.snap
         env:

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -217,13 +217,10 @@ jobs:
 
   publish:
     needs: releaser
-    # FIXME: We currently cannot publish the release, we need additional snap track that are in discussion to be added
-    # (https://forum.snapcraft.io/t/track-request-for-parsec-snap/40471)
-    if: false
-    # if: >-
-    #   (github.event_name == 'schedule' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')))
-    #   && needs.releaser.result == 'success'
-    #   && always()
+    if: >-
+      (github.event_name == 'schedule' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')))
+      && needs.releaser.result == 'success'
+      && always()
     uses: ./.github/workflows/publish.yml
     permissions:
       contents: read

--- a/client/electron/snap/snapcraft.yaml
+++ b/client/electron/snap/snapcraft.yaml
@@ -9,19 +9,21 @@ type: app
 
 apps:
   parsec:
-    plugs:
-      - desktop
-      - desktop-legacy
-      - home
-      - wayland
-      - x11
-      - opengl
-      - browser-support
-      - network
-      - gsettings
-      - audio-playback
-      - pulseaudio
-      - password-manager-service
+    # Since we use `classic` confinement,
+    # We don't need to specify a list of plugs.
+    # plugs:
+    #   - desktop
+    #   - desktop-legacy
+    #   - home
+    #   - wayland
+    #   - x11
+    #   - opengl
+    #   - browser-support
+    #   - network
+    #   - gsettings
+    #   - audio-playback
+    #   - pulseaudio
+    #   - password-manager-service
     desktop: usr/share/applications/parsec.desktop
     command: bin/desktop-launch
 


### PR DESCRIPTION
- Run publish workflow on PR to test it (it will upload the latest nightly release).
- Fix snapcraft publish error where a snap in classic mode cannot use plugs/slots.
- Re-enable publish job in the release workflow