### PR TITLE
[MS] Configure electron-logs and exposes an API for the page to log to electron

### DIFF
--- a/client/electron/src/communicationChannels.ts
+++ b/client/electron/src/communicationChannels.ts
@@ -8,6 +8,7 @@ export enum PageToWindowChannel {
   UpdateAvailabilityRequest = 'parsec-update-availability-request',
   UpdateApp = 'parsec-update-app',
   PrepareUpdate = 'parsec-prepare-update',
+  Log = 'parsec-log',
 }
 
 export enum WindowToPageChannel {

--- a/client/electron/src/index.ts
+++ b/client/electron/src/index.ts
@@ -142,3 +142,7 @@ ipcMain.on(PageToWindowChannel.PrepareUpdate, async () => {
     myCapacitorApp.sendEvent(WindowToPageChannel.CleanUpBeforeUpdate);
   }
 });
+
+ipcMain.on(PageToWindowChannel.Log, async (_event, level: 'debug' | 'info' | 'warn' | 'error', message: string) => {
+  myCapacitorApp.log(level, message);
+});

--- a/client/electron/src/preload.ts
+++ b/client/electron/src/preload.ts
@@ -35,5 +35,8 @@ process.once('loaded', () => {
     prepareUpdate: () => {
       ipcRenderer.send(PageToWindowChannel.PrepareUpdate);
     },
+    log: (level: 'debug' | 'info' | 'warn' | 'error', message: string) => {
+      ipcRenderer.send(PageToWindowChannel.Log, level, message);
+    },
   });
 });

--- a/client/electron/src/updater.ts
+++ b/client/electron/src/updater.ts
@@ -2,7 +2,6 @@
 
 import type { CustomPublishOptions, ProgressInfo, UpdateInfo, XElement } from 'builder-util-runtime';
 import { newError, parseXml } from 'builder-util-runtime';
-import type { Logger } from 'electron-log';
 import type { BaseUpdater, AppUpdater as _AppUpdater } from 'electron-updater';
 import { CancellationToken } from 'electron-updater';
 import { GitHubProvider, computeReleaseNotes } from 'electron-updater/out/providers/GitHubProvider';
@@ -384,9 +383,6 @@ export default class AppUpdater {
     }
 
     this.updater.logger = require('electron-log/node');
-
-    (this.updater.logger as Logger).transports.file.level = 'debug';
-    (this.updater.logger as Logger).transports.console.level = 'debug';
 
     publishOption.nightlyBuild = (process.env.FORCE_NIGHTLY || '0') === '1' || publishOption.nightlyBuild;
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -276,6 +276,9 @@ async function setupApp(): Promise<void> {
       prepareUpdate: (): void => {
         console.log('Not available');
       },
+      log: (level: 'debug' | 'info' | 'warn' | 'error', message: string): void => {
+        console.log(`[MOCKED-ELECTRON-LOG] ${level}: ${message}`);
+      },
     };
   }
 }
@@ -380,6 +383,7 @@ declare global {
       getUpdateAvailability: () => void;
       updateApp: () => void;
       prepareUpdate: () => void;
+      log: (level: 'debug' | 'info' | 'warn' | 'error', message: string) => void;
     };
   }
 }

--- a/client/src/parsec/login.ts
+++ b/client/src/parsec/login.ts
@@ -120,6 +120,7 @@ export async function login(
         });
         break;
       case ClientEventTag.IncompatibleServer:
+        window.electronAPI.log('warn', `IncompatibleServerEvent: ${event.detail}`);
         distributor.dispatchEvent(Events.Offline);
         distributor.dispatchEvent(Events.IncompatibleServer);
         break;
@@ -136,7 +137,7 @@ export async function login(
         eventDistributor.dispatchEvent(Events.WorkspaceUpdated);
         break;
       default:
-        console.log(`Unhandled event ${event.tag}`);
+        window.electronAPI.log('debug', `Unhandled event ${event.tag}`);
         break;
     }
   }

--- a/client/src/plugins/libparsec/index.ts
+++ b/client/src/plugins/libparsec/index.ts
@@ -33,7 +33,7 @@ class ParsecProxy {
       // eslint-disable-next-line no-prototype-builtins
       if (result && result.hasOwnProperty('ok') && !(result as { ok: boolean }).ok) {
         const resultError = result as { ok: boolean; error: { tag: string; error: string } };
-        console.warn(`Error when calling ${name}: ${resultError.error.tag} (${resultError.error.error})`);
+        window.electronAPI.log('debug', `Error when calling ${name}: ${resultError.error.tag} (${resultError.error.error})`);
       }
       return result;
     };


### PR DESCRIPTION
Closes #7475 

`console.log` called by the page are not logged anywhere. This exposes an electron API that uses electron-logs to store the logs into a file. It's not done automatically, we have to call `window.electronAPI.log()` to log something. Used it by default on `IncompatibleServerEvents` and for failed calls to the bindings.

Also added a `--log-debug` option to set the log level to debug.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description