### PR TITLE
Trigger the wasm tests more frequently

### DIFF
--- a/.github/filters/ci.yml
+++ b/.github/filters/ci.yml
@@ -19,6 +19,11 @@ rust-platform-crates: &rust-platform-crates libparsec/crates/platform_*/**
 
 rust-cli: &rust-cli cli/**
 
+rust-test-wasm: &rust-test-wasm
+  - *rust-platform-crates
+  - *rust-toolchain
+  - *rust-dependencies-workspace
+
 rust-changes: &rust-changes
   - *rust-dependencies-workspace
   - *rust-libparsec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       rust: ${{ steps.need-check.outputs.rust }}
       python: ${{ steps.need-check.outputs.python }}
       python-style-only: ${{ steps.need-check.outputs.python_style_only }}
-      rust-platform-crates: ${{ steps.need-check.outputs.rust_platform_crates }}
+      rust-test-wasm: ${{ steps.need-check.outputs.rust_test_wasm }}
       rust-dependencies: ${{ steps.need-check.outputs.rust_dependencies }}
       web: ${{ steps.need-check.outputs.web }}
       docs: ${{ steps.need-check.outputs.docs }}
@@ -61,7 +61,7 @@ jobs:
           # Basically we want to only check the python code style when we modify a file that ins't related to the parsec server (e.g.: bindings/generator/generate.py)
           # Thus don't require to run the python test.
           NEED_CHECK_python_style_only: ${{ steps.changes.outputs.python-jobs == 'false' && steps.changes.outputs.any-python-files == 'true' }}
-          NEED_CHECK_rust_platform_crates: ${{ steps.changes.outputs.rust-platform-crates == 'true' }}
+          NEED_CHECK_rust_test_wasm: ${{ steps.changes.outputs.rust-test-wasm == 'true' }}
           NEED_CHECK_rust_dependencies: ${{ steps.changes.outputs.rust-dependencies-workspace == 'true' }}
           NEED_CHECK_docs: ${{ steps.changes.outputs.docs-jobs == 'true' }}
 
@@ -87,7 +87,7 @@ jobs:
           import os
           import json
 
-          NOT_A_JOB = ('python-style-only', 'rust-platform-crates')
+          NOT_A_JOB = ('python-style-only', 'rust-test-wasm')
 
           needs = json.loads(os.environ["NEEDS"])
 
@@ -202,7 +202,7 @@ jobs:
     if: needs.dispatch.outputs.rust == 'true'
     uses: ./.github/workflows/ci-rust.yml
     with:
-      run-wasm-tests: ${{ needs.dispatch.outputs.rust-platform-crates == 'true' }}
+      run-wasm-tests: ${{ needs.dispatch.outputs.rust-test-wasm == 'true' }}
       check-cargo-deny: ${{ needs.dispatch.outputs.rust-dependencies == 'true' }}
 
   web:


### PR DESCRIPTION
The wasm tests will be run when the toolchain is changed or the dependencies is updated