### PR TITLE
Connection monitor correctly handles HTTP 504&502 (i.e. bad response due to gateway)

### DIFF
--- a/libparsec/crates/client_connection/src/invited_cmds.rs
+++ b/libparsec/crates/client_connection/src/invited_cmds.rs
@@ -113,6 +113,9 @@ impl InvitedCmds {
                 let response_body = resp.bytes().await?;
                 Ok(response_body)
             }
+
+            // HTTP codes used by Parsec
+
             401 => Err(ConnectionError::MissingAuthenticationInfo),
             403 => Err(ConnectionError::BadAuthenticationInfo),
             404 => Err(ConnectionError::InvitationNotFound),
@@ -125,9 +128,21 @@ impl InvitedCmds {
             460 => Err(ConnectionError::ExpiredOrganization),
             // No 461&462: no user here
             // No 498: invitation token cannot expire like an authentication token
+
+            // Other HTTP codes
+
             // We typically use HTTP 503 in the tests to simulate server offline,
             // so it should behave just like if we were not able to connect
-            503 => Err(ConnectionError::NoResponse(None)),
+            // On top of that we should also handle 502 and 504 as they are related
+            // to a gateway.
+            #[allow(clippy::manual_range_patterns)]
+            502 // Bad Gateway
+            | 503 // Service Unavailable
+            | 504 // Gateway Timeout
+            => Err(ConnectionError::NoResponse(None)),
+
+            // Finally all other HTTP codes are not supposed to occur (well except if
+            // an HTTP proxy starts modifying the response, but that's another story...)
             _ => Err(ConnectionError::InvalidResponseStatus(resp.status())),
         }
     }

--- a/libparsec/crates/client_connection/tests/unit/invited.rs
+++ b/libparsec/crates/client_connection/tests/unit/invited.rs
@@ -5,12 +5,10 @@
 #![allow(clippy::unwrap_used)]
 
 use crate::{
-    test_register_low_level_send_hook, AuthenticatedCmds, Bytes, ConnectionError, HeaderMap,
-    HeaderValue, InvitedCmds, ProxyConfig, ResponseMock, StatusCode,
+    test_register_low_level_send_hook, Bytes, ConnectionError, HeaderMap, HeaderValue, InvitedCmds,
+    ProxyConfig, ResponseMock, StatusCode,
 };
-use libparsec_protocol::{
-    authenticated_cmds::latest as authenticated_cmds, invited_cmds::latest as invited_cmds,
-};
+use libparsec_protocol::invited_cmds::latest as invited_cmds;
 use libparsec_tests_fixtures::prelude::*;
 use libparsec_types::prelude::*;
 
@@ -28,24 +26,9 @@ async fn ok_with_server(env: &TestbedEnv) {
 }
 
 async fn ok(env: &TestbedEnv, mocked: bool) {
-    let alice = env.local_device("alice@dev1");
-
-    // Create an invitation on the server
-    let invitation_token = if mocked {
-        InvitationToken::default()
-    } else {
-        let cmds =
-            AuthenticatedCmds::new(&env.discriminant_dir, alice.clone(), ProxyConfig::default())
-                .unwrap();
-
-        let rep = cmds
-            .send(authenticated_cmds::invite_new_device::Req { send_email: false })
-            .await;
-        match rep.unwrap() {
-            authenticated_cmds::invite_new_device::Rep::Ok { token, .. } => token,
-            rep => panic!("unexpected reply: {:?}", rep),
-        }
-    };
+    let invitation_token = env
+        .customize(|builder| builder.new_device_invitation("alice@dev1").map(|e| e.token))
+        .await;
 
     // Good request
 


### PR DESCRIPTION
Fix #7474