### PR TITLE
Declare local storage's SQLite tables as STRICT (to avoid error in table typing)

### DIFF
--- a/libparsec/crates/platform_storage/src/native/sql/create-certificates-table.sql
+++ b/libparsec/crates/platform_storage/src/native/sql/create-certificates-table.sql
@@ -29,7 +29,7 @@ CREATE TABLE IF NOT EXISTS certificates (
     certificate_type TEXT NOT NULL,
     filter1 BLOB,
     filter2 BLOB
-);
+) STRICT;
 
 CREATE INDEX IF NOT EXISTS certificates_type_filter1 ON certificates (certificate_type, filter1);
 CREATE INDEX IF NOT EXISTS certificates_type_filter2 ON certificates (certificate_type, filter2);

--- a/libparsec/crates/platform_storage/src/native/sql/create-chunks-table.sql
+++ b/libparsec/crates/platform_storage/src/native/sql/create-chunks-table.sql
@@ -3,7 +3,7 @@
 CREATE TABLE IF NOT EXISTS chunks (
     chunk_id BLOB PRIMARY KEY NOT NULL, -- UUID
     size INTEGER NOT NULL,
-    offline BOOLEAN NOT NULL,
+    offline INTEGER NOT NULL, -- Boolean
     accessed_on INTEGER, -- UNIX timestamp with microsecond precision
     data BLOB NOT NULL
-)
+) STRICT;

--- a/libparsec/crates/platform_storage/src/native/sql/create-prevent-sync-pattern-table.sql
+++ b/libparsec/crates/platform_storage/src/native/sql/create-prevent-sync-pattern-table.sql
@@ -3,5 +3,5 @@
 CREATE TABLE IF NOT EXISTS prevent_sync_pattern (
     _id INTEGER PRIMARY KEY NOT NULL,
     pattern TEXT NOT NULL,
-    fully_applied BOOLEAN NOT NULL
-);
+    fully_applied INTEGER NOT NULL -- Boolean
+) STRICT;

--- a/libparsec/crates/platform_storage/src/native/sql/create-realm-checkpoint-table.sql
+++ b/libparsec/crates/platform_storage/src/native/sql/create-realm-checkpoint-table.sql
@@ -3,4 +3,4 @@
 CREATE TABLE IF NOT EXISTS realm_checkpoint (
     _id INTEGER PRIMARY KEY NOT NULL,
     checkpoint INTEGER NOT NULL
-);
+) STRICT;

--- a/libparsec/crates/platform_storage/src/native/sql/create-remanence-table.sql
+++ b/libparsec/crates/platform_storage/src/native/sql/create-remanence-table.sql
@@ -2,5 +2,5 @@
 
 CREATE TABLE IF NOT EXISTS remanence (
     _id INTEGER PRIMARY KEY NOT NULL,
-    block_remanent BOOL NOT NULL
-)
+    block_remanent INTEGER NOT NULL -- Boolean
+) STRICT;

--- a/libparsec/crates/platform_storage/src/native/sql/create-temp-unreferenced-chunks-table.sql
+++ b/libparsec/crates/platform_storage/src/native/sql/create-temp-unreferenced-chunks-table.sql
@@ -2,4 +2,4 @@
 
 CREATE TEMP TABLE unreferenced_chunks(
     chunk_id BLOB PRIMARY KEY -- UUID
-);
+) STRICT;

--- a/libparsec/crates/platform_storage/src/native/sql/create-vlobs-table.sql
+++ b/libparsec/crates/platform_storage/src/native/sql/create-vlobs-table.sql
@@ -4,6 +4,6 @@ CREATE TABLE IF NOT EXISTS vlobs (
     vlob_id BLOB PRIMARY KEY NOT NULL, -- UUID
     base_version INTEGER NOT NULL,
     remote_version INTEGER NOT NULL,
-    need_sync BOOLEAN NOT NULL,
+    need_sync INTEGER NOT NULL, -- Boolean
     blob BLOB NOT NULL
-);
+) STRICT;


### PR DESCRIPTION
closes #6529

This should be mostly compatible with old way of declaring flexible tables, however it's always better to avoid exotic corner cases so merging it fast (or discarding early !) is advised ;-)
