### PR TITLE
[MS] Sort files and folders after imports

### DIFF
--- a/client/src/views/files/FoldersPage.vue
+++ b/client/src/views/files/FoldersPage.vue
@@ -292,6 +292,9 @@ const eventDistributor: EventDistributor = inject(EventDistributorKey)!;
 
 const FOLDERS_PAGE_DATA_KEY = 'FoldersPage';
 
+const sortProperty = ref(SortProperty.Name);
+const sortAsc = ref(true);
+
 const fileOperations: Ref<Array<FileOperationProgress>> = ref([]);
 const currentPath = ref('/');
 const folders = ref(new EntryCollection<FolderModel>());
@@ -507,6 +510,8 @@ async function onDisplayStateChange(): Promise<void> {
 function onSortChange(event: MsSorterChangeEvent): void {
   folders.value.sort(event.option.key, event.sortByAsc);
   files.value.sort(event.option.key, event.sortByAsc);
+  sortProperty.value = event.option.key;
+  sortAsc.value = event.sortByAsc;
 }
 
 async function onFileOperationState(state: FileOperationState, operationData?: FileOperationData, stateData?: StateData): Promise<void> {
@@ -556,6 +561,7 @@ async function onFileOperationState(state: FileOperationState, operationData?: F
           existing.updated = statResult.value.updated;
           existing.isSelected = false;
         }
+        files.value.sort(sortProperty.value, sortAsc.value);
       }
     }
   } else if (state === FileOperationState.EntryMoved && operationData) {
@@ -592,6 +598,7 @@ async function onFileOperationState(state: FileOperationState, operationData?: F
           if (!folders.value.getEntries().find((entry) => entry.id === statResult.value.id)) {
             (statResult.value as FolderModel).isSelected = false;
             folders.value.append(statResult.value as FolderModel);
+            folders.value.sort(sortProperty.value, sortAsc.value);
           }
         }
       }
@@ -708,6 +715,8 @@ async function listFolder(): Promise<void> {
     }
     folders.value.smartUpdate(newFolders);
     files.value.smartUpdate(newFiles);
+    folders.value.sort(sortProperty.value, sortAsc.value);
+    files.value.sort(sortProperty.value, sortAsc.value);
   } else {
     informationManager.present(
       new Information({


### PR DESCRIPTION
Closes #7483 

Re-sort files and folders when a new file is added and when re-listing. Going at it the naive way, would probably be better to insert in the right order directly, but it's more complicated, we'll see how this holds on.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
  