### PR TITLE
Rename CertifOps to CertificateOps.

### DIFF
--- a/libparsec/crates/client/src/certif/add.rs
+++ b/libparsec/crates/client/src/certif/add.rs
@@ -6,7 +6,7 @@ use libparsec_types::prelude::*;
 
 use super::{
     store::{CertificatesStoreWriteGuard, GetCertificateError},
-    CertifOps, UpTo,
+    CertificateOps, UpTo,
 };
 use crate::{event_bus::EventInvalidCertificate, EventNewCertificates};
 
@@ -132,7 +132,7 @@ pub enum MaybeRedactedSwitch {
 }
 
 pub(super) async fn add_certificates_batch(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreWriteGuard<'_>,
     common_certificates: &[Bytes],
     sequester_certificates: &[Bytes],
@@ -379,7 +379,7 @@ macro_rules! verify_certificate_signature {
 /// Validate the given certificate by both checking it content (format, signature, etc.)
 /// and it global consistency with the others certificates.
 async fn validate_common_certificate(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreWriteGuard<'_>,
     signed: Bytes,
 ) -> Result<CommonTopicArcCertificate, CertifAddCertificatesBatchError> {
@@ -442,7 +442,7 @@ async fn validate_common_certificate(
 /// Validate the given certificate by both checking it content (format, signature, etc.)
 /// and it global consistency with the others certificates.
 async fn validate_realm_certificate(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreWriteGuard<'_>,
     realm_id: VlobID,
     signed: Bytes,
@@ -552,7 +552,7 @@ async fn validate_realm_certificate(
 /// Validate the given certificate by both checking it content (format, signature, etc.)
 /// and it global consistency with the others certificates.
 async fn validate_shamir_recovery_certificate(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreWriteGuard<'_>,
     signed: Bytes,
 ) -> Result<ShamirRecoveryTopicArcCertificate, CertifAddCertificatesBatchError> {
@@ -613,7 +613,7 @@ async fn validate_shamir_recovery_certificate(
 /// Validate the given certificate by both checking it content (format, signature, etc.)
 /// and it global consistency with the others certificates.
 async fn validate_sequester_certificate(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreWriteGuard<'_>,
     signed: Bytes,
 ) -> Result<SequesterTopicArcCertificate, CertifAddCertificatesBatchError> {
@@ -634,7 +634,7 @@ async fn validate_sequester_certificate(
 }
 
 async fn validate_sequester_authority_certificate(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreWriteGuard<'_>,
     signed: Bytes,
 ) -> Result<Arc<SequesterAuthorityCertificate>, CertifAddCertificatesBatchError> {
@@ -799,7 +799,7 @@ async fn check_user_not_revoked(
 /// Admin existence has already been checked while fetching it device's verify key,
 /// so what's left is checking it is not revoked and (optionally) it profile
 async fn check_author_not_revoked_and_profile(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreWriteGuard<'_>,
     up_to: DateTime,
     author: UserID,
@@ -886,7 +886,7 @@ async fn get_user_profile(
 }
 
 async fn check_user_certificate_consistency(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreWriteGuard<'_>,
     cooked: &UserCertificate,
     author_user_id: Option<UserID>,
@@ -1008,7 +1008,7 @@ async fn check_user_certificate_consistency(
 }
 
 async fn check_device_certificate_consistency(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreWriteGuard<'_>,
     cooked: &DeviceCertificate,
     author_user_id: Option<UserID>,
@@ -1162,7 +1162,7 @@ async fn check_device_certificate_consistency(
 }
 
 async fn check_user_update_certificate_consistency(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreWriteGuard<'_>,
     cooked: &UserUpdateCertificate,
     author_user_id: UserID,
@@ -1273,7 +1273,7 @@ async fn check_user_update_certificate_consistency(
 }
 
 async fn check_revoked_user_certificate_consistency(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreWriteGuard<'_>,
     cooked: &RevokedUserCertificate,
     author_user_id: UserID,
@@ -1503,7 +1503,7 @@ async fn check_realm_role_certificate_consistency(
 }
 
 async fn check_realm_name_certificate_consistency(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreWriteGuard<'_>,
     cooked: &RealmNameCertificate,
     author_user_id: UserID,
@@ -1590,7 +1590,7 @@ async fn check_realm_name_certificate_consistency(
 }
 
 async fn check_realm_key_rotation_certificate_consistency(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreWriteGuard<'_>,
     cooked: &RealmKeyRotationCertificate,
     author_user_id: UserID,
@@ -1677,7 +1677,7 @@ async fn check_realm_key_rotation_certificate_consistency(
 }
 
 async fn check_realm_archiving_certificate_consistency(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreWriteGuard<'_>,
     cooked: &RealmArchivingCertificate,
     author_user_id: UserID,
@@ -1764,7 +1764,7 @@ async fn check_realm_archiving_certificate_consistency(
 }
 
 async fn check_shamir_recovery_brief_certificate_consistency(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreWriteGuard<'_>,
     cooked: &ShamirRecoveryBriefCertificate,
     author_user_id: UserID,
@@ -1843,7 +1843,7 @@ async fn check_shamir_recovery_brief_certificate_consistency(
 }
 
 async fn check_shamir_recovery_share_certificate_consistency(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreWriteGuard<'_>,
     cooked: &ShamirRecoveryShareCertificate,
     author_user_id: UserID,

--- a/libparsec/crates/client/src/certif/block_validate.rs
+++ b/libparsec/crates/client/src/certif/block_validate.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use super::{
-    store::CertifForReadWithRequirementsError, CertifOps, InvalidCertificateError,
+    store::CertifForReadWithRequirementsError, CertificateOps, InvalidCertificateError,
     InvalidKeysBundleError,
 };
 #[derive(Debug, thiserror::Error)]
@@ -65,7 +65,7 @@ pub enum CertifValidateBlockError {
 }
 
 pub(super) async fn validate_block(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     needed_realm_certificate_timestamp: DateTime,
     realm_id: VlobID,
     key_index: IndexInt,

--- a/libparsec/crates/client/src/certif/list.rs
+++ b/libparsec/crates/client/src/certif/list.rs
@@ -6,7 +6,7 @@ use libparsec_types::prelude::*;
 
 use super::{
     store::{CertifStoreError, GetCertificateError},
-    CertifOps, UpTo,
+    CertificateOps, UpTo,
 };
 
 pub use super::store::CertifStoreError as CertifGetCurrentSelfProfileError;
@@ -17,7 +17,7 @@ pub use super::store::CertifStoreError as CertifListUserDevicesError;
 pub use super::store::CertifStoreError as CertifListWorkspaceUsersError;
 
 pub(super) async fn get_current_self_profile(
-    ops: &CertifOps,
+    ops: &CertificateOps,
 ) -> Result<UserProfile, CertifGetCurrentSelfProfileError> {
     ops.store
         .for_read(|store| store.get_current_self_profile())
@@ -26,7 +26,7 @@ pub(super) async fn get_current_self_profile(
 }
 
 pub(super) async fn get_current_self_realms_role(
-    ops: &CertifOps,
+    ops: &CertificateOps,
 ) -> Result<Vec<(VlobID, Option<RealmRole>, DateTime)>, CertifGetCurrentSelfRealmsRoleError> {
     // TODO: cache !
     let certifs = ops
@@ -55,7 +55,7 @@ pub(super) async fn get_current_self_realms_role(
 }
 
 pub(super) async fn get_current_self_realm_role(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     realm_id: VlobID,
 ) -> Result<Option<Option<RealmRole>>, CertifGetCurrentSelfRealmRoleError> {
     // TODO: cache !
@@ -87,7 +87,7 @@ pub struct UserInfo {
 }
 
 pub(super) async fn list_users(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     skip_revoked: bool,
     offset: Option<u32>,
     limit: Option<u32>,
@@ -163,7 +163,7 @@ pub struct DeviceInfo {
 }
 
 pub(super) async fn list_user_devices(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     user_id: UserID,
 ) -> Result<Vec<DeviceInfo>, CertifListUserDevicesError> {
     let certifs = ops
@@ -211,7 +211,7 @@ impl From<CertifStoreError> for CertifGetUserDeviceError {
 }
 
 pub(super) async fn get_user_device(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     device_id: DeviceID,
 ) -> Result<(UserInfo, DeviceInfo), CertifGetUserDeviceError> {
     ops.store
@@ -316,7 +316,7 @@ pub struct WorkspaceUserAccessInfo {
 /// List users currently part of the given workspace (i.e. user not revoked
 /// and with a valid role)
 pub(super) async fn list_workspace_users(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     realm_id: VlobID,
 ) -> Result<Vec<WorkspaceUserAccessInfo>, CertifListWorkspaceUsersError> {
     ops.store

--- a/libparsec/crates/client/src/certif/manifest_validate.rs
+++ b/libparsec/crates/client/src/certif/manifest_validate.rs
@@ -7,7 +7,7 @@ use crate::{certif::realm_keys_bundle, CertifDecryptForRealmError, EncrytionUsag
 
 use super::{
     store::{CertifForReadWithRequirementsError, CertificatesStoreReadGuard, GetCertificateError},
-    CertifOps, InvalidCertificateError, InvalidKeysBundleError, UpTo,
+    CertificateOps, InvalidCertificateError, InvalidKeysBundleError, UpTo,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -102,7 +102,7 @@ pub enum CertifValidateManifestError {
 }
 
 pub(super) async fn validate_user_manifest(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     needed_realm_certificate_timestamp: DateTime,
     needed_common_certificate_timestamp: DateTime,
     author: DeviceID,
@@ -166,7 +166,7 @@ pub(super) async fn validate_user_manifest(
 
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn validate_workspace_manifest(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     needed_realm_certificate_timestamp: DateTime,
     needed_common_certificate_timestamp: DateTime,
     realm_id: VlobID,
@@ -288,7 +288,7 @@ pub(super) async fn validate_workspace_manifest(
 
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn validate_child_manifest(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     needed_realm_certificate_timestamp: DateTime,
     needed_common_certificate_timestamp: DateTime,
     realm_id: VlobID,

--- a/libparsec/crates/client/src/certif/mod.rs
+++ b/libparsec/crates/client/src/certif/mod.rs
@@ -66,7 +66,7 @@ pub enum CertificateBasedActionOutcome {
 }
 
 #[derive(Debug)]
-pub(crate) struct CertifOps {
+pub(crate) struct CertificateOps {
     #[allow(unused)]
     config: Arc<ClientConfig>,
     device: Arc<LocalDevice>,
@@ -77,7 +77,7 @@ pub(crate) struct CertifOps {
 
 // For readability, we define the public interface here and let the actual
 // implementation in separated submodules
-impl CertifOps {
+impl CertificateOps {
     pub async fn start(
         config: Arc<ClientConfig>,
         device: Arc<LocalDevice>,

--- a/libparsec/crates/client/src/certif/poll.rs
+++ b/libparsec/crates/client/src/certif/poll.rs
@@ -7,7 +7,7 @@ use libparsec_types::prelude::*;
 
 use super::{
     store::{CertifStoreError, CertificatesStoreWriteGuard},
-    CertifAddCertificatesBatchError, CertifOps, InvalidCertificateError, MaybeRedactedSwitch,
+    CertifAddCertificatesBatchError, CertificateOps, InvalidCertificateError, MaybeRedactedSwitch,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -60,7 +60,7 @@ impl From<CertifStoreError> for CertifPollServerError {
 /// to avoid concurrency access changing certificates and breaking the deterministic
 /// order certificates must be added on.
 pub(super) async fn poll_server_for_new_certificates(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreWriteGuard<'_>,
     requirements: Option<&PerTopicLastTimestamps>,
 ) -> Result<(), CertifPollServerError> {
@@ -94,7 +94,7 @@ pub(super) async fn poll_server_for_new_certificates(
 }
 
 async fn poll_server_and_add_certificates(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreWriteGuard<'_>,
     last_stored_timestamps: PerTopicLastTimestamps,
 ) -> Result<MaybeRedactedSwitch, CertifPollServerError> {

--- a/libparsec/crates/client/src/certif/realm_create.rs
+++ b/libparsec/crates/client/src/certif/realm_create.rs
@@ -4,7 +4,7 @@ use libparsec_client_connection::ConnectionError;
 use libparsec_protocol::authenticated_cmds;
 use libparsec_types::prelude::*;
 
-use super::{store::CertifStoreError, CertifOps, CertificateBasedActionOutcome, UpTo};
+use super::{store::CertifStoreError, CertificateBasedActionOutcome, CertificateOps, UpTo};
 use crate::EventTooMuchDriftWithServerClock;
 
 #[derive(Debug, thiserror::Error)]
@@ -46,7 +46,7 @@ impl From<CertifStoreError> for CertifEnsureRealmCreatedError {
 }
 
 pub(super) async fn ensure_realm_created(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     realm_id: VlobID,
 ) -> Result<CertificateBasedActionOutcome, CertifEnsureRealmCreatedError> {
     let is_created = ops
@@ -74,7 +74,7 @@ pub(super) async fn ensure_realm_created(
 }
 
 async fn create_realm_idempotent(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     realm_id: VlobID,
 ) -> Result<CertificateBasedActionOutcome, CertifEnsureRealmCreatedError> {
     let mut timestamp = ops.device.now();

--- a/libparsec/crates/client/src/certif/realm_decrypt_name.rs
+++ b/libparsec/crates/client/src/certif/realm_decrypt_name.rs
@@ -4,7 +4,9 @@ use libparsec_types::prelude::*;
 
 use crate::{CertifDecryptForRealmError, EncrytionUsage};
 
-use super::{realm_keys_bundle, store::CertifStoreError, CertifOps, InvalidKeysBundleError, UpTo};
+use super::{
+    realm_keys_bundle, store::CertifStoreError, CertificateOps, InvalidKeysBundleError, UpTo,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum InvalidEncryptedRealmNameError {
@@ -58,7 +60,7 @@ pub enum CertifDecryptCurrentRealmNameError {
 }
 
 pub(super) async fn decrypt_current_realm_name(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     realm_id: VlobID,
 ) -> Result<(EntryName, DateTime), CertifDecryptCurrentRealmNameError> {
     ops.store

--- a/libparsec/crates/client/src/certif/realm_key_rotation.rs
+++ b/libparsec/crates/client/src/certif/realm_key_rotation.rs
@@ -8,7 +8,7 @@ use libparsec_protocol::authenticated_cmds;
 use libparsec_types::prelude::*;
 
 use super::{
-    store::CertifStoreError, CertifOps, CertificateBasedActionOutcome, InvalidCertificateError,
+    store::CertifStoreError, CertificateBasedActionOutcome, CertificateOps, InvalidCertificateError,
 };
 use crate::{certif::CertifPollServerError, EventTooMuchDriftWithServerClock};
 
@@ -55,7 +55,7 @@ impl From<CertifStoreError> for CertifRotateRealmKeyError {
 }
 
 pub(super) async fn ensure_realm_initial_key_rotation(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     realm_id: VlobID,
 ) -> Result<CertificateBasedActionOutcome, CertifRotateRealmKeyError> {
     // First look into our local certificates...
@@ -107,7 +107,7 @@ pub(super) async fn ensure_realm_initial_key_rotation(
 /// Note the fact this function is idempotent means the provided key may
 /// not be part of the realm's keys in the end !
 async fn realm_initial_key_rotation_idempotent(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     realm_id: VlobID,
 ) -> Result<CertificateBasedActionOutcome, CertifRotateRealmKeyError> {
     let key = KeyDerivation::generate();
@@ -282,14 +282,14 @@ async fn realm_initial_key_rotation_idempotent(
 // // - keys_bundle_heal
 
 // pub(super) async fn rotate_realm_key(
-//     ops: &CertifOps,
+//     ops: &CertificateOps,
 //     realm_id: VlobID,
 // ) -> Result<(), CertifRotateRealmKeyError> {
 //     todo!()
 // }
 
 // pub(super) async fn force_rotate_realm_key_for_healing(
-//     ops: &CertifOps,
+//     ops: &CertificateOps,
 //     realm_id: VlobID,
 // ) -> Result<(), CertifRotateRealmKeyError> {
 //     todo!()

--- a/libparsec/crates/client/src/certif/realm_keys_bundle.rs
+++ b/libparsec/crates/client/src/certif/realm_keys_bundle.rs
@@ -8,7 +8,9 @@ use libparsec_types::prelude::*;
 
 use crate::InvalidCertificateError;
 
-use super::{encrypt::CertifEncryptForUserError, store::CertificatesStoreReadGuard, CertifOps};
+use super::{
+    encrypt::CertifEncryptForUserError, store::CertificatesStoreReadGuard, CertificateOps,
+};
 
 #[derive(Debug, Clone, Copy)]
 pub enum EncrytionUsage {
@@ -177,7 +179,7 @@ impl From<ConnectionError> for LoadLastKeysBundleError {
 /// provide us with valid keys (and if something is corrupted, an OWNER should do
 /// a healing key rotation soon enough in theory).
 async fn load_last_realm_keys_bundle(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreReadGuard<'_>,
     realm_id: VlobID,
 ) -> Result<Arc<RealmKeys>, LoadLastKeysBundleError> {
@@ -313,7 +315,7 @@ impl From<ConnectionError> for AttemptRealmKeysBundleHealingError {
 // ///
 // /// This method is typically used by a monitor.
 // pub(super) async fn attempt_realm_keys_bundle_healing<'a>(
-//     ops: &CertifOps,
+//     ops: &CertificateOps,
 //     realm_id: VlobID,
 // ) -> Result<KeysBundleHealingOutcome, AttemptRealmKeysBundleHealingError> {
 //     loop {
@@ -331,7 +333,7 @@ impl From<ConnectionError> for AttemptRealmKeysBundleHealingError {
 // TODO: finish key bundle healing !
 #[allow(dead_code)]
 async fn recover_realm_keys_from_previous_bundles(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreReadGuard<'_>,
     realm_id: VlobID,
 ) -> Result<KeysBundleHealingOutcome, AttemptRealmKeysBundleHealingError> {
@@ -511,7 +513,7 @@ pub enum EncryptRealmKeysBundleAccessForUserError {
 }
 
 pub(super) async fn encrypt_realm_keys_bundle_access_for_user(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreReadGuard<'_>,
     realm_id: VlobID,
     user_id: UserID,
@@ -639,7 +641,7 @@ pub enum ValidateKeysBundleError {
 
 #[allow(clippy::too_many_arguments)]
 async fn validate_keys_bundle(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreReadGuard<'_>,
     realm_id: VlobID,
     keys_bundle: &[u8],
@@ -856,7 +858,7 @@ pub enum CertifEncryptForRealmError {
 }
 
 pub(super) async fn encrypt_for_realm(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreReadGuard<'_>,
     usage: EncrytionUsage,
     realm_id: VlobID,
@@ -903,7 +905,7 @@ pub enum CertifDecryptForRealmError {
     CorruptedKey,
     #[error("Cannot decrypt data")]
     CorruptedData,
-    // Note this error is not used here, but in `CertifOps::decrypt_opaque_data_for_realm`
+    // Note this error is not used here, but in `CertificateOps::decrypt_opaque_data_for_realm`
     // that is a wrapper around `decrypt_for_realm`, so it's convenient to have it here
     // in order to avoid yet another error type conversion.
     #[error(transparent)]
@@ -915,7 +917,7 @@ pub enum CertifDecryptForRealmError {
 }
 
 pub(super) async fn decrypt_for_realm(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     store: &mut CertificatesStoreReadGuard<'_>,
     usage: EncrytionUsage,
     realm_id: VlobID,

--- a/libparsec/crates/client/src/certif/realm_rename.rs
+++ b/libparsec/crates/client/src/certif/realm_rename.rs
@@ -6,8 +6,9 @@ use libparsec_protocol::authenticated_cmds;
 use libparsec_types::prelude::*;
 
 use super::{
-    realm_keys_bundle::CertifEncryptForRealmError, store::CertifStoreError, CertifOps,
-    CertificateBasedActionOutcome, InvalidCertificateError, InvalidKeysBundleError, UpTo,
+    realm_keys_bundle::CertifEncryptForRealmError, store::CertifStoreError,
+    CertificateBasedActionOutcome, CertificateOps, InvalidCertificateError, InvalidKeysBundleError,
+    UpTo,
 };
 use crate::{certif::CertifPollServerError, EncrytionUsage, EventTooMuchDriftWithServerClock};
 
@@ -58,7 +59,7 @@ impl From<CertifStoreError> for CertifRenameRealmError {
 }
 
 pub(super) async fn rename_realm(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     realm_id: VlobID,
     new_name: EntryName,
 ) -> Result<CertificateBasedActionOutcome, CertifRenameRealmError> {
@@ -66,7 +67,7 @@ pub(super) async fn rename_realm(
 }
 
 async fn rename_realm_internal(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     realm_id: VlobID,
     new_name: EntryName,
     initial_rename: bool,
@@ -189,7 +190,7 @@ async fn rename_realm_internal(
 }
 
 pub(super) async fn ensure_realm_initial_rename(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     realm_id: VlobID,
     name: EntryName,
 ) -> Result<CertificateBasedActionOutcome, CertifRenameRealmError> {

--- a/libparsec/crates/client/src/certif/realm_share.rs
+++ b/libparsec/crates/client/src/certif/realm_share.rs
@@ -6,7 +6,7 @@ use libparsec_protocol::authenticated_cmds;
 use libparsec_types::prelude::*;
 
 use super::{
-    store::CertifStoreError, CertifOps, CertifPollServerError, CertificateBasedActionOutcome,
+    store::CertifStoreError, CertifPollServerError, CertificateBasedActionOutcome, CertificateOps,
     InvalidCertificateError, InvalidKeysBundleError,
 };
 use crate::{
@@ -69,7 +69,7 @@ impl From<CertifStoreError> for CertifShareRealmError {
 }
 
 pub(super) async fn share_realm(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     realm_id: VlobID,
     recipient: UserID,
     role: Option<RealmRole>,
@@ -142,7 +142,7 @@ enum DoServerCommandOutcome {
 }
 
 async fn unshare_do_server_command(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     realm_id: VlobID,
     recipient: UserID,
     timestamp: DateTime,
@@ -228,7 +228,7 @@ async fn unshare_do_server_command(
 }
 
 async fn share_do_server_command(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     realm_id: VlobID,
     recipient: UserID,
     role: RealmRole,

--- a/libparsec/crates/client/src/certif/store.rs
+++ b/libparsec/crates/client/src/certif/store.rs
@@ -31,7 +31,7 @@ use libparsec_types::prelude::*;
 
 use crate::certif::CertifPollServerError;
 
-use super::{realm_keys_bundle::RealmKeys, CertifOps, InvalidCertificateError};
+use super::{realm_keys_bundle::RealmKeys, CertificateOps, InvalidCertificateError};
 
 #[derive(Debug, Default)]
 enum ScalarCache<T> {
@@ -189,7 +189,7 @@ impl CertificatesStore {
         // don't work).
         // However in practice all our references have a lifetime bound to the
         // parent (i.e. `for_write`) or the grand-parent (i.e.
-        // `CertifOps::add_certificates_batch`) which are going to poll this
+        // `CertificateOps::add_certificates_batch`) which are going to poll this
         // future directly, so the references' lifetimes *are* long enough.
         // TODO: Remove this once async closure are available
         let static_write_guard_mut_ref = unsafe { pretend_static(&mut write_guard) };
@@ -277,7 +277,7 @@ impl CertificatesStore {
     /// the server provides us with the certificates requirements to do the validation).
     pub async fn for_read_with_requirements<T, E, Fut>(
         &self,
-        ops: &CertifOps,
+        ops: &CertificateOps,
         needed_timestamps: &PerTopicLastTimestamps,
         cb: impl FnOnce(&'static mut CertificatesStoreReadGuard) -> Fut,
     ) -> Result<Result<T, E>, CertifForReadWithRequirementsError>

--- a/libparsec/crates/client/src/certif/user_revoke.rs
+++ b/libparsec/crates/client/src/certif/user_revoke.rs
@@ -5,8 +5,8 @@ use libparsec_protocol::authenticated_cmds;
 use libparsec_types::prelude::*;
 
 use super::{
-    store::CertifStoreError, CertifOps, CertificateBasedActionOutcome, InvalidCertificateError,
-    InvalidKeysBundleError,
+    store::CertifStoreError, CertificateBasedActionOutcome, CertificateOps,
+    InvalidCertificateError, InvalidKeysBundleError,
 };
 use crate::EventTooMuchDriftWithServerClock;
 
@@ -59,7 +59,7 @@ impl From<CertifStoreError> for CertifRevokeUserError {
 }
 
 pub(super) async fn revoke_user(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     user: UserID,
 ) -> Result<CertificateBasedActionOutcome, CertifRevokeUserError> {
     if ops.device.user_id == user {
@@ -88,7 +88,7 @@ enum DoServerCommandOutcome {
 }
 
 async fn do_server_command(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     recipient: UserID,
     timestamp: DateTime,
 ) -> Result<DoServerCommandOutcome, CertifRevokeUserError> {

--- a/libparsec/crates/client/src/certif/workspace_bootstrap.rs
+++ b/libparsec/crates/client/src/certif/workspace_bootstrap.rs
@@ -4,9 +4,9 @@ use libparsec_client_connection::ConnectionError;
 use libparsec_types::prelude::*;
 
 use super::{
-    store::CertifStoreError, CertifEnsureRealmCreatedError, CertifOps, CertifPollServerError,
+    store::CertifStoreError, CertifEnsureRealmCreatedError, CertifPollServerError,
     CertifRenameRealmError, CertifRotateRealmKeyError, CertificateBasedActionOutcome,
-    InvalidCertificateError, InvalidKeysBundleError,
+    CertificateOps, InvalidCertificateError, InvalidKeysBundleError,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -54,7 +54,7 @@ impl From<CertifStoreError> for CertifBootstrapWorkspaceError {
 }
 
 pub(super) async fn bootstrap_workspace(
-    ops: &CertifOps,
+    ops: &CertificateOps,
     realm_id: VlobID,
     name: &EntryName,
 ) -> Result<CertificateBasedActionOutcome, CertifBootstrapWorkspaceError> {

--- a/libparsec/crates/client/src/client/mod.rs
+++ b/libparsec/crates/client/src/client/mod.rs
@@ -26,7 +26,7 @@ pub use self::{
     workspace_share::ClientShareWorkspaceError, workspace_start::ClientStartWorkspaceError,
 };
 use crate::{
-    certif::{CertifOps, CertifPollServerError},
+    certif::{CertifPollServerError, CertificateOps},
     config::{ClientConfig, ServerConfig},
     event_bus::EventBus,
     monitors::{
@@ -64,7 +64,7 @@ pub struct Client {
     pub(crate) device: Arc<LocalDevice>,
     pub(crate) event_bus: EventBus,
     pub(crate) cmds: Arc<AuthenticatedCmds>,
-    certificates_ops: Arc<CertifOps>,
+    certificates_ops: Arc<CertificateOps>,
     user_ops: Arc<UserOps>,
     /// Workspace ops gets added or removed from this list when they are started or stopped.
     ///
@@ -103,7 +103,7 @@ impl Client {
 
         // TODO: error handling
         let certificates_ops = Arc::new(
-            CertifOps::start(
+            CertificateOps::start(
                 config.clone(),
                 device.clone(),
                 event_bus.clone(),

--- a/libparsec/crates/client/src/client/workspace_refresh_list.rs
+++ b/libparsec/crates/client/src/client/workspace_refresh_list.rs
@@ -46,7 +46,7 @@ pub async fn refresh_workspaces_list(
     // them after B" problem).
     //
     // The downside is that the user manifest is potentially locked for a long time (as
-    // `CertifOps::list_self_workspaces` may need to reach the server).
+    // `CertificateOps::list_self_workspaces` may need to reach the server).
 
     let mut updater = client.user_ops.for_update_local_workspaces().await;
     let old_local_workspaces = updater.workspaces();

--- a/libparsec/crates/client/src/event_bus.rs
+++ b/libparsec/crates/client/src/event_bus.rs
@@ -217,7 +217,7 @@ impl_events!(
     // TODO: two types of new certificates events:
     //       - poll from scratch
     //       - per-type event: rename, key rotation, share/unshare with self, shamir for self, etc.
-    // The CertifOps has received integrated new certificates from the server.
+    // The CertificateOps has received integrated new certificates from the server.
     NewCertificates {
         // The local certificates storage was empty, hence the server sent all certificates.
         storage_initially_empty: bool,

--- a/libparsec/crates/client/src/monitors/certif_poll.rs
+++ b/libparsec/crates/client/src/monitors/certif_poll.rs
@@ -6,7 +6,7 @@ use libparsec_platform_async::{channel, pretend_future_is_send_on_web};
 use libparsec_platform_storage::certificates::PerTopicLastTimestamps;
 
 use crate::{
-    certif::{CertifOps, CertifPollServerError},
+    certif::{CertifPollServerError, CertificateOps},
     event_bus::*,
 };
 
@@ -16,7 +16,7 @@ use crate::event_bus::{EventBus, EventMissedServerEvents};
 const CERTIF_POLL_MONITOR_NAME: &str = "certif_poll";
 
 pub(crate) async fn start_certif_poll_monitor(
-    certif_ops: Arc<CertifOps>,
+    certif_ops: Arc<CertificateOps>,
     event_bus: EventBus,
 ) -> Monitor {
     let task_future = {
@@ -27,7 +27,7 @@ pub(crate) async fn start_certif_poll_monitor(
 }
 
 fn task_future_factory(
-    certif_ops: Arc<CertifOps>,
+    certif_ops: Arc<CertificateOps>,
     event_bus: EventBus,
 ) -> impl Future<Output = ()> {
     enum Action {
@@ -81,7 +81,7 @@ fn task_future_factory(
                             // choice but to also stop.
                             return;
                         }
-                        // `CertifOps` is already responsible for sending the invalid
+                        // `CertificateOps` is already responsible for sending the invalid
                         // certificate event on the event bus, so there nothing more to do !
                         CertifPollServerError::InvalidCertificate(_) => (),
                         CertifPollServerError::Internal(err) => {

--- a/libparsec/crates/client/src/user/mod.rs
+++ b/libparsec/crates/client/src/user/mod.rs
@@ -13,14 +13,14 @@ use libparsec_client_connection::AuthenticatedCmds;
 use libparsec_types::prelude::*;
 
 use self::store::{UserForUpdateLocalWorkspacesUpdater, UserStore};
-use crate::{certif::CertifOps, event_bus::EventBus, ClientConfig};
+use crate::{certif::CertificateOps, event_bus::EventBus, ClientConfig};
 
 #[derive(Debug)]
 pub struct UserOps {
     device: Arc<LocalDevice>,
     store: UserStore,
     cmds: Arc<AuthenticatedCmds>,
-    certificates_ops: Arc<CertifOps>,
+    certificates_ops: Arc<CertificateOps>,
     event_bus: EventBus,
 }
 
@@ -31,7 +31,7 @@ impl UserOps {
         config: &ClientConfig,
         device: Arc<LocalDevice>,
         cmds: Arc<AuthenticatedCmds>,
-        certificates_ops: Arc<CertifOps>,
+        certificates_ops: Arc<CertificateOps>,
         event_bus: EventBus,
     ) -> Result<Self, anyhow::Error> {
         let store = UserStore::start(&config.data_base_dir, device.clone()).await?;

--- a/libparsec/crates/client/src/workspace/fetch.rs
+++ b/libparsec/crates/client/src/workspace/fetch.rs
@@ -7,8 +7,8 @@ use libparsec_types::prelude::*;
 
 use crate::{
     certif::{
-        CertifOps, CertifValidateManifestError, InvalidCertificateError, InvalidKeysBundleError,
-        InvalidManifestError,
+        CertifValidateManifestError, CertificateOps, InvalidCertificateError,
+        InvalidKeysBundleError, InvalidManifestError,
     },
     CertifValidateBlockError, InvalidBlockAccessError,
 };
@@ -46,7 +46,7 @@ impl From<ConnectionError> for FetchRemoteManifestError {
 
 pub(super) async fn fetch_remote_child_manifest(
     cmds: &AuthenticatedCmds,
-    certificates_ops: &CertifOps,
+    certificates_ops: &CertificateOps,
     realm_id: VlobID,
     vlob_id: VlobID,
 ) -> Result<ChildManifest, FetchRemoteManifestError> {
@@ -87,7 +87,7 @@ pub(super) async fn fetch_remote_child_manifest(
 #[allow(unused)]
 pub(super) async fn fetch_remote_workspace_manifest(
     cmds: &AuthenticatedCmds,
-    certificates_ops: &CertifOps,
+    certificates_ops: &CertificateOps,
     realm_id: VlobID,
 ) -> Result<FolderManifest, FetchRemoteManifestError> {
     let vlob_id = realm_id; // Remember: workspace manifest's ID *is* the realm ID !
@@ -210,7 +210,7 @@ impl From<ConnectionError> for FetchRemoteBlockError {
 
 pub(super) async fn fetch_block(
     cmds: &AuthenticatedCmds,
-    certificates_ops: &CertifOps,
+    certificates_ops: &CertificateOps,
     realm_id: VlobID,
     manifest: &FileManifest,
     access: &BlockAccess,

--- a/libparsec/crates/client/src/workspace/mod.rs
+++ b/libparsec/crates/client/src/workspace/mod.rs
@@ -16,7 +16,7 @@ use libparsec_client_connection::AuthenticatedCmds;
 use libparsec_platform_async::lock::Mutex as AsyncMutex;
 use libparsec_types::prelude::*;
 
-use crate::{certif::CertifOps, event_bus::EventBus, ClientConfig};
+use crate::{certif::CertificateOps, event_bus::EventBus, ClientConfig};
 pub use addr::{WorkspaceDecryptPathAddrError, WorkspaceGeneratePathAddrError};
 use store::WorkspaceStore;
 use transactions::RemoveEntryExpect;
@@ -94,7 +94,7 @@ pub struct WorkspaceOps {
     config: Arc<ClientConfig>,
     device: Arc<LocalDevice>,
     cmds: Arc<AuthenticatedCmds>,
-    certificates_ops: Arc<CertifOps>,
+    certificates_ops: Arc<CertificateOps>,
     event_bus: EventBus,
     store: WorkspaceStore,
     opened_files: Mutex<OpenedFiles>,
@@ -134,7 +134,7 @@ impl WorkspaceOps {
         config: Arc<ClientConfig>,
         device: Arc<LocalDevice>,
         cmds: Arc<AuthenticatedCmds>,
-        certificates_ops: Arc<CertifOps>,
+        certificates_ops: Arc<CertificateOps>,
         event_bus: EventBus,
         realm_id: VlobID,
         workspace_external_info: WorkspaceExternalInfo,

--- a/libparsec/crates/client/src/workspace/store/mod.rs
+++ b/libparsec/crates/client/src/workspace/store/mod.rs
@@ -20,8 +20,8 @@ use libparsec_platform_storage::workspace::{UpdateManifestData, WorkspaceStorage
 use libparsec_types::prelude::*;
 
 use crate::{
-    certif::CertifOps, InvalidBlockAccessError, InvalidCertificateError, InvalidKeysBundleError,
-    InvalidManifestError,
+    certif::CertificateOps, InvalidBlockAccessError, InvalidCertificateError,
+    InvalidKeysBundleError, InvalidManifestError,
 };
 
 use cache::CurrentViewCache;
@@ -109,7 +109,7 @@ pub(super) struct WorkspaceStore {
     realm_id: VlobID,
     device: Arc<LocalDevice>,
     cmds: Arc<AuthenticatedCmds>,
-    certificates_ops: Arc<CertifOps>,
+    certificates_ops: Arc<CertificateOps>,
 
     /// Note cache also contains the update locks.
     current_view_cache: Mutex<CurrentViewCache>,
@@ -125,7 +125,7 @@ impl WorkspaceStore {
         data_base_dir: &Path,
         device: Arc<LocalDevice>,
         cmds: Arc<AuthenticatedCmds>,
-        certificates_ops: Arc<CertifOps>,
+        certificates_ops: Arc<CertificateOps>,
         cache_size: u64,
         realm_id: VlobID,
     ) -> Result<Self, anyhow::Error> {

--- a/libparsec/crates/client/src/workspace/transactions/inbound_sync.rs
+++ b/libparsec/crates/client/src/workspace/transactions/inbound_sync.rs
@@ -82,8 +82,8 @@ use libparsec_types::prelude::*;
 use super::super::WorkspaceOps;
 use crate::{
     certif::{
-        CertifOps, CertifValidateManifestError, InvalidCertificateError, InvalidKeysBundleError,
-        InvalidManifestError,
+        CertifValidateManifestError, CertificateOps, InvalidCertificateError,
+        InvalidKeysBundleError, InvalidManifestError,
     },
     workspace::{
         merge::{MergeLocalFileManifestOutcome, MergeLocalFolderManifestOutcome},
@@ -667,7 +667,7 @@ pub trait RemoteManifest: Sized {
 
     #[allow(clippy::too_many_arguments)]
     async fn validate(
-        certif_ops: &CertifOps,
+        certif_ops: &CertificateOps,
         needed_realm_certificate_timestamp: DateTime,
         needed_common_certificate_timestamp: DateTime,
         realm_id: VlobID,
@@ -701,7 +701,7 @@ impl RemoteManifest for RootManifest {
     }
 
     async fn validate(
-        certif_ops: &CertifOps,
+        certif_ops: &CertificateOps,
         needed_realm_certificate_timestamp: DateTime,
         needed_common_certificate_timestamp: DateTime,
         realm_id: VlobID,
@@ -753,7 +753,7 @@ impl RemoteManifest for ChildManifest {
     }
 
     async fn validate(
-        certif_ops: &CertifOps,
+        certif_ops: &CertificateOps,
         needed_realm_certificate_timestamp: DateTime,
         needed_common_certificate_timestamp: DateTime,
         realm_id: VlobID,

--- a/libparsec/crates/client/src/workspace/transactions/outbound_sync.rs
+++ b/libparsec/crates/client/src/workspace/transactions/outbound_sync.rs
@@ -465,7 +465,7 @@ async fn upload_manifest<M: RemoteManifest>(
                 bad_rep @ (
                     // Got sequester info from certificates
                     Rep::OrganizationNotSequestered
-                    // Already checked the realm exists when we called `CertifOps::encrypt_for_realm`
+                    // Already checked the realm exists when we called `CertificateOps::encrypt_for_realm`
                     | Rep::RealmNotFound
                     // Don't know what to do with this status :/
                     | Rep::UnknownStatus { .. }
@@ -800,7 +800,7 @@ async fn upload_blocks(
 
                 // Unexpected errors :(
                 bad_rep @ (
-                    // Already checked the realm exists when we called `CertifOps::encrypt_for_realm`
+                    // Already checked the realm exists when we called `CertificateOps::encrypt_for_realm`
                     | Rep::RealmNotFound
                     // Don't know what to do with this status :/
                     | Rep::UnknownStatus { .. }

--- a/libparsec/crates/client/tests/unit/certif/utils.rs
+++ b/libparsec/crates/client/tests/unit/certif/utils.rs
@@ -7,14 +7,14 @@ use libparsec_tests_fixtures::prelude::*;
 use libparsec_types::prelude::*;
 
 use crate::{
-    certif::{store::CertificatesStore, CertifOps},
+    certif::{store::CertificatesStore, CertificateOps},
     ClientConfig, EventBus, MountpointMountStrategy, WorkspaceStorageCacheSize,
 };
 
 pub(crate) async fn certificates_ops_factory(
     env: &TestbedEnv,
     device: &Arc<LocalDevice>,
-) -> CertifOps {
+) -> CertificateOps {
     let config = Arc::new(ClientConfig {
         config_dir: env.discriminant_dir.clone(),
         data_base_dir: env.discriminant_dir.clone(),
@@ -27,7 +27,7 @@ pub(crate) async fn certificates_ops_factory(
     let cmds = Arc::new(
         AuthenticatedCmds::new(&config.config_dir, device.clone(), config.proxy.clone()).unwrap(),
     );
-    CertifOps::start(config.clone(), device.clone(), event_bus, cmds)
+    CertificateOps::start(config.clone(), device.clone(), event_bus, cmds)
         .await
         .unwrap()
 }

--- a/libparsec/crates/client/tests/unit/user/utils.rs
+++ b/libparsec/crates/client/tests/unit/user/utils.rs
@@ -7,7 +7,7 @@ use libparsec_tests_fixtures::prelude::*;
 use libparsec_types::prelude::*;
 
 use crate::{
-    certif::CertifOps, user::UserOps, ClientConfig, EventBus, MountpointMountStrategy,
+    certif::CertificateOps, user::UserOps, ClientConfig, EventBus, MountpointMountStrategy,
     WorkspaceStorageCacheSize,
 };
 
@@ -25,7 +25,7 @@ pub(crate) async fn user_ops_factory(env: &TestbedEnv, device: &Arc<LocalDevice>
         AuthenticatedCmds::new(&config.config_dir, device.clone(), config.proxy.clone()).unwrap(),
     );
     let certificates_ops = Arc::new(
-        CertifOps::start(
+        CertificateOps::start(
             config.clone(),
             device.clone(),
             event_bus.clone(),

--- a/libparsec/crates/client/tests/unit/workspace/utils.rs
+++ b/libparsec/crates/client/tests/unit/workspace/utils.rs
@@ -6,7 +6,7 @@ use libparsec_client_connection::{AuthenticatedCmds, ProxyConfig};
 use libparsec_types::prelude::*;
 
 use crate::{
-    certif::CertifOps,
+    certif::CertificateOps,
     workspace::{LocalUserManifestWorkspaceEntry, WorkspaceExternalInfo, WorkspaceOps},
     ClientConfig, EventBus, MountpointMountStrategy, WorkspaceStorageCacheSize,
 };
@@ -29,7 +29,7 @@ pub(crate) async fn workspace_ops_factory(
         AuthenticatedCmds::new(&config.config_dir, device.clone(), config.proxy.clone()).unwrap(),
     );
     let certificates_ops = Arc::new(
-        CertifOps::start(
+        CertificateOps::start(
             config.clone(),
             device.clone(),
             event_bus.clone(),


### PR DESCRIPTION
But why ?

- In the doc sometimes it was CertifOps sometime CertificateOps
- I favored CertificateOps for consistency with other certificate related enums
