### PR TITLE
[Shamir] get_certificates returns shamir certificates.

### DIFF
--- a/docs/rfcs/1000-shamir-based-recovery.md
+++ b/docs/rfcs/1000-shamir-based-recovery.md
@@ -329,14 +329,11 @@ This secret contains both:
 
 ## 2 - Get the Shamir recovery setup
 
-This enables two use cases:
+The shamir related certificates are retrieved by the `get_certificates` route, with other certificates depending on the timestamp.
+If the user has authored a shamir setup, they will get the corresponding brief.
+If they are a share recipient, they will get their share and the associated brief.
 
-1) A User retrieving its own Shamir recovery setup. Useful for displaying it to
-   the user and to ensure the setup is still valid (i.e. no recipient has been
-   revoked)
-2) A user retrieving all the Shamir recovery information they are a part of.
-
-Authenticated API:
+> TODO: what happens with shamir deletion certificates.
 
 ```json5
 [
@@ -345,53 +342,34 @@ Authenticated API:
             4
         ],
         "req": {
-            "cmd": "shamir_recovery_self_info"
+            "cmd": "certificate_get",
+            "fields": [
+                {
+                    // Skip the certificates before (or at) this timestamp
+                    "name": "shamir_recovery_after",
+                    "type": "RequiredOption<DateTime>"
+                },
+                // <-------------- Other fields omitted --------->
+
+            ]
         },
         "reps": [
             {
                 "status": "ok",
                 "fields": [
+                    // Certificates are provided in-order (i.e. with growing timestamps)
                     {
-                        // `None` means no configuration
-                        // Otherwise, contains a `ShamirRecoveryBriefCertificate`
-                        "name": "self_info",
-                        "type": "RequiredOption<Bytes>"
-                    }
+                        "name": "shamir_recovery_certificates",
+                        "type": "List<Bytes>"
+                    },
+                    // <-------------- Other fields omitted --------->
+
                 ]
             }
         ]
     }
 ]
-```
 
-```json5
-[
-    {
-        "major_versions": [
-            4
-        ],
-        "req": {
-            "cmd": "shamir_recovery_others_list",
-        },
-        "reps": [
-            {
-                "status": "ok",
-                "fields": [
-                    {
-                        // Contains a list of `ShamirRecoveryBriefCertificate`
-                        "name": "brief_certificates",
-                        "type": "List<Bytes>"
-                    },
-                    {
-                        // Contains a list of `ShamirRecoveryShareCertificate`
-                        "name": "share_certificates",
-                        "type": "List<Bytes>"
-                    }
-                ]
-            },
-        ],
-    }
-]
 ```
 
 ## 3 - Use the Shamir recovery

--- a/server/parsec/components/memory/datamodel.py
+++ b/server/parsec/components/memory/datamodel.py
@@ -432,3 +432,5 @@ class MemoryShamirSetup:
     # The shares provided as a `ShamirRecoveryShareCertificate` since
     # each share is aimed at a specific recipient.
     shares: dict[UserID, bytes]
+    # keep raw brief
+    brief_bytes: bytes

--- a/server/parsec/components/memory/shamir.py
+++ b/server/parsec/components/memory/shamir.py
@@ -112,7 +112,7 @@ class MemoryShamirComponent(BaseShamirComponent):
 
         if self._data.organizations[organization_id].shamir_setup.get(author) is None:
             self._data.organizations[organization_id].shamir_setup[author] = MemoryShamirSetup(
-                setup.ciphered_data, setup.reveal_token, brief, shares
+                setup.ciphered_data, setup.reveal_token, brief, shares, setup.brief
             )
         else:
             return ShamirAddOrDeleteRecoverySetupStoreBadOutcome.ALREADY_SET

--- a/server/parsec/components/memory/user.py
+++ b/server/parsec/components/memory/user.py
@@ -570,7 +570,7 @@ class MemoryUserComponent(BaseUserComponent):
 
         shamir_recovery_certificates: list[bytes] = []
 
-        for user_id, shamir in org.shamir_setup.items():
+        for user_id, shamir in sorted(org.shamir_setup.items(), key=lambda x: x[1].brief.timestamp):
             # filter on timestamp
             if shamir_recovery_after is not None and shamir.brief.timestamp < shamir_recovery_after:
                 continue


### PR DESCRIPTION
Fix #7362 and #7360

In v2, certificates were queried when needed. In v3 all certificates are pulled regularly, so here we don't implement  shared_recovery_device_info and list_shared_recovery_devices routes but we add the shamir certificates to the get_certificates.