### PR TITLE
Remove psutil stubs

### DIFF
--- a/server/parsec/stubs/psutil/__init__.pyi
+++ b/server/parsec/stubs/psutil/__init__.pyi
@@ -1,5 +1,0 @@
-# Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
-
-from __future__ import annotations
-
-def pid_exists(pid: int) -> bool: ...


### PR DESCRIPTION
No longer needed since they were added to typeshed library which seems to be bundled with type checkers (such as pyright).