### PR TITLE
Use test and testing feature flag instead of unused when needed.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,6 +1918,7 @@ dependencies = [
 name = "libparsec_client"
 version = "3.0.0-b.11+dev"
 dependencies = [
+ "libparsec_client",
  "libparsec_client_connection",
  "libparsec_platform_async",
  "libparsec_platform_device_loader",
@@ -2071,6 +2072,7 @@ dependencies = [
  "js-sys",
  "lazy_static",
  "libparsec_platform_async",
+ "libparsec_platform_storage",
  "libparsec_testbed",
  "libparsec_tests_fixtures",
  "libparsec_tests_lite",

--- a/libparsec/crates/client/Cargo.toml
+++ b/libparsec/crates/client/Cargo.toml
@@ -27,6 +27,8 @@ libparsec_tests_lite = { workspace = true }
 libparsec_tests_fixtures = { workspace = true, features = ["default"] }
 proptest = { workspace = true, features = ["default"] }
 proptest-state-machine = { workspace = true }
+libparsec_platform_storage = { workspace = true, features = ["expose-test-methods"] }
+libparsec_client = {path = ".",features = ["expose-test-methods"]}
 
 [target.'cfg(any(not(target_arch = "wasm32"), target_os = "linux"))'.dependencies]
 # TODO: `use-zstd-in-serialization-format` is a temporary feature to disable the
@@ -34,3 +36,6 @@ proptest-state-machine = { workspace = true }
 #       MacOS/Windows/Ubuntu 20.04).
 #       TL;DR: ALWAYS ENABLE `use-zstd-in-serialization-format` FOR PRODUCTION !!!
 libparsec_types = { workspace = true, features = ["use-zstd-in-serialization-format"] }
+
+[features]
+expose-test-methods = []

--- a/libparsec/crates/client/README.md
+++ b/libparsec/crates/client/README.md
@@ -1,0 +1,6 @@
+# Libparsec client
+
+
+## Features
+
+`expose-test-methods`: Exposes internal methods that should be used only while testing.

--- a/libparsec/crates/client/src/certif/store.rs
+++ b/libparsec/crates/client/src/certif/store.rs
@@ -131,6 +131,7 @@ impl CertificatesStore {
     }
 
     /// Only used for debugging tests
+    #[cfg(any(test, feature = "testing"))]
     #[allow(unused)]
     pub async fn debug_dump(&self) -> anyhow::Result<String> {
         let mut output = "{\n".to_owned();

--- a/libparsec/crates/client/src/lib.rs
+++ b/libparsec/crates/client/src/lib.rs
@@ -1,5 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
+#![doc = include_str!("../README.md")]
 mod certif;
 mod client;
 mod config;

--- a/libparsec/crates/platform_storage/Cargo.toml
+++ b/libparsec/crates/platform_storage/Cargo.toml
@@ -41,7 +41,7 @@ serde-wasm-bindgen = { workspace = true }
 libparsec_tests_lite = { workspace = true }
 # Note `libparsec_tests_fixtures` enables our `test-with-testbed` feature
 libparsec_tests_fixtures = { workspace = true, default-features = false, features = ["test-with-platform-storage-testbed"] }
-libparsec_platform_storage = {path = ".",features = ["expose-test-methods"]}
+libparsec_platform_storage = { path = ".", features = ["expose-test-methods"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { workspace = true }

--- a/libparsec/crates/platform_storage/Cargo.toml
+++ b/libparsec/crates/platform_storage/Cargo.toml
@@ -13,6 +13,8 @@ workspace = true
 
 [features]
 test-with-testbed = ["libparsec_testbed"]
+# to access methods that must only be used during tests
+expose-test-methods = []
 
 [dependencies]
 libparsec_types = { workspace = true }
@@ -39,6 +41,7 @@ serde-wasm-bindgen = { workspace = true }
 libparsec_tests_lite = { workspace = true }
 # Note `libparsec_tests_fixtures` enables our `test-with-testbed` feature
 libparsec_tests_fixtures = { workspace = true, default-features = false, features = ["test-with-platform-storage-testbed"] }
+libparsec_platform_storage = {path = ".",features = ["expose-test-methods"]}
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { workspace = true }

--- a/libparsec/crates/platform_storage/src/certificates.rs
+++ b/libparsec/crates/platform_storage/src/certificates.rs
@@ -655,7 +655,7 @@ impl CertificatesStorage {
     }
 
     /// Only used for debugging tests
-    #[allow(unused)]
+    #[cfg(any(test, feature = "expose-test-methods"))]
     pub async fn debug_dump(&mut self) -> anyhow::Result<String> {
         self.platform.debug_dump().await
     }
@@ -723,7 +723,7 @@ impl<'a> CertificatesStorageUpdater<'a> {
     }
 
     /// Only used for debugging tests
-    #[allow(unused)]
+    #[cfg(any(test, feature = "expose-test-methods"))]
     pub async fn debug_dump(&mut self) -> anyhow::Result<String> {
         self.platform.debug_dump().await
     }

--- a/libparsec/crates/platform_storage/src/native/certificates.rs
+++ b/libparsec/crates/platform_storage/src/native/certificates.rs
@@ -551,6 +551,8 @@ impl<'a> PlatformCertificatesStorageForUpdateGuard<'a> {
     }
 
     /// Only used for debugging tests
+    #[cfg(any(test, feature = "expose-test-methods"))]
+    #[allow(unused)]
     pub async fn debug_dump(&mut self) -> anyhow::Result<String> {
         let rows = sqlx::query(
             "SELECT \
@@ -705,6 +707,8 @@ impl PlatformCertificatesStorage {
     }
 
     /// Only used for debugging tests
+    #[cfg(any(test, feature = "expose-test-methods"))]
+    #[allow(unused)]
     pub async fn debug_dump(&mut self) -> anyhow::Result<String> {
         let mut update = self.for_update().await?;
         update.debug_dump().await

--- a/libparsec/crates/platform_storage/src/native/user.rs
+++ b/libparsec/crates/platform_storage/src/native/user.rs
@@ -206,7 +206,7 @@ impl PlatformUserStorage {
     }
 
     /// Only used for debugging tests
-    #[allow(unused)]
+    #[cfg(feature = "expose-test-methods")]
     pub async fn debug_dump(&mut self) -> anyhow::Result<String> {
         let checkpoint = self.get_realm_checkpoint().await?;
 

--- a/libparsec/crates/platform_storage/src/native/workspace.rs
+++ b/libparsec/crates/platform_storage/src/native/workspace.rs
@@ -304,7 +304,7 @@ impl PlatformWorkspaceStorage {
     }
 
     /// Only used for debugging tests
-    #[allow(unused)]
+    #[cfg(any(test, feature = "expose-test-methods"))]
     pub async fn debug_dump(&mut self) -> anyhow::Result<String> {
         let checkpoint = self.get_realm_checkpoint().await?;
         let mut output = format!("checkpoint: {checkpoint}\n");

--- a/libparsec/crates/platform_storage/src/user.rs
+++ b/libparsec/crates/platform_storage/src/user.rs
@@ -78,7 +78,7 @@ impl UserStorage {
     }
 
     /// Only used for debugging tests
-    #[allow(unused)]
+    #[cfg(feature = "expose-test-methods")]
     pub async fn debug_dump(&mut self) -> anyhow::Result<String> {
         self.platform.debug_dump().await
     }

--- a/libparsec/crates/platform_storage/src/web/certificates.rs
+++ b/libparsec/crates/platform_storage/src/web/certificates.rs
@@ -277,6 +277,7 @@ impl<'a> PlatformCertificatesStorageForUpdateGuard<'a> {
     }
 
     /// Only used for debugging tests
+    #[cfg(any(test, feature = "expose-test-methods"))]
     pub async fn debug_dump(&mut self) -> anyhow::Result<String> {
         todo!()
     }
@@ -364,6 +365,7 @@ impl PlatformCertificatesStorage {
     }
 
     /// Only used for debugging tests
+    #[cfg(any(test, feature = "expose-test-methods"))]
     pub async fn debug_dump(&mut self) -> anyhow::Result<String> {
         let mut update = self.for_update().await?;
         update.debug_dump().await

--- a/libparsec/crates/platform_storage/src/web/model.rs
+++ b/libparsec/crates/platform_storage/src/web/model.rs
@@ -392,6 +392,7 @@ impl Chunk {
             .map(|x| x.into_iter().nth(0))
     }
 
+    #[cfg(feature = "expose-test-methods")]
     pub(super) async fn get_chunks(tx: &IdbTransaction<'_>) -> anyhow::Result<Vec<Self>> {
         super::db::get_values(tx, Self::STORE, Self::INDEX_IS_BLOCK, 0.into()).await
     }

--- a/libparsec/crates/platform_storage/src/web/user.rs
+++ b/libparsec/crates/platform_storage/src/web/user.rs
@@ -147,6 +147,7 @@ impl PlatformUserStorage {
         }
     }
 
+    #[cfg(feature = "expose-test-methods")]
     pub async fn debug_dump(&mut self) -> anyhow::Result<String> {
         todo!();
     }

--- a/libparsec/crates/platform_storage/src/web/workspace.rs
+++ b/libparsec/crates/platform_storage/src/web/workspace.rs
@@ -306,7 +306,7 @@ impl PlatformWorkspaceStorage {
     }
 
     /// Only used for debugging tests
-    #[allow(unused)]
+    #[cfg(feature = "expose-test-methods")]
     pub async fn debug_dump(&mut self) -> anyhow::Result<String> {
         let checkpoint = self.get_realm_checkpoint().await?;
         let mut output = format!("checkpoint: {checkpoint}\n");

--- a/libparsec/crates/platform_storage/src/workspace.rs
+++ b/libparsec/crates/platform_storage/src/workspace.rs
@@ -176,7 +176,7 @@ impl WorkspaceStorage {
     }
 
     /// Only used for debugging tests
-    #[allow(unused)]
+    #[cfg(feature = "expose-test-methods")]
     pub async fn debug_dump(&mut self) -> anyhow::Result<String> {
         self.platform.debug_dump().await
     }


### PR DESCRIPTION
The idea is to hide behind compilation flags the functions that are used only in tests.