### PR TITLE
[MS] Handle bootstrap links

### DIFF
--- a/client/electron/src/setup.ts
+++ b/client/electron/src/setup.ts
@@ -478,7 +478,7 @@ export class ElectronCapacitorApp {
           const arg = process.argv.at(i);
 
           // We're only interested in potential Parsec links
-          if (arg.startsWith('parsec://')) {
+          if (arg.startsWith('parsec3://')) {
             this.sendEvent(WindowToPageChannel.OpenLink, arg);
             break;
           } else if (arg === '--log-debug') {

--- a/client/src/common/validators.ts
+++ b/client/src/common/validators.ts
@@ -126,6 +126,15 @@ export const claimLinkValidator: IValidator = async function (value: string) {
   return { validity: Validity.Invalid, reason: reason ? reason : '' };
 };
 
+export const claimAndBootstrapLinkValidator: IValidator = async function (value: string) {
+  const result = await bootstrapLinkValidator(value);
+
+  if (result.validity === Validity.Valid) {
+    return result;
+  }
+  return await claimLinkValidator(value);
+};
+
 export const fileLinkValidator: IValidator = async function (value: string) {
   value = value.trim();
   if (value.length === 0) {
@@ -182,6 +191,30 @@ export const claimDeviceLinkValidator: IValidator = async function (value: strin
     reason = 'validators.claimDeviceLink.missingToken';
   } else {
     reason = 'validators.claimDeviceLink.invalidToken';
+  }
+  return { validity: Validity.Invalid, reason: reason ? reason : '' };
+};
+
+export const bootstrapLinkValidator: IValidator = async function (value: string) {
+  value = value.trim();
+  if (value.length === 0) {
+    return { validity: Validity.Intermediate };
+  }
+  const result = await parseParsecAddr(value);
+  if (result.ok) {
+    return result.value.tag === ParsedParsecAddrTag.OrganizationBootstrap ? { validity: Validity.Valid } : { validity: Validity.Invalid };
+  }
+  let reason = '';
+  if (!value.startsWith('parsec3://')) {
+    reason = 'validators.bootstrapLink.invalidProtocol';
+  } else if (!value.includes('a=')) {
+    reason = 'validators.bootstrapLink.missingAction';
+  } else if (value.includes('a=') && !value.includes('a=bootstrap_organization')) {
+    reason = 'validators.bootstrapLink.invalidAction';
+  } else if (!value.includes('token=')) {
+    reason = 'validators.bootstrapLink.missingToken';
+  } else {
+    reason = 'validators.bootstrapLink.invalidToken';
   }
   return { validity: Validity.Invalid, reason: reason ? reason : '' };
 };

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -1108,6 +1108,9 @@
             "missingToken": "Link does not include a token.",
             "invalidToken": "Link contains an invalid token."
         },
+        "link": {
+            "invalid": "This link is invalid."
+        },
         "userInfo": {
             "name": "Name contains invalid characters.",
             "email": "Wrong email address format."

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -1101,6 +1101,13 @@
             "missingToken": "Link does not include a token.",
             "invalidToken": "Link contains an invalid token."
         },
+        "bootstrapLink": {
+            "invalidProtocol": "Link should start with 'parsec3://'.",
+            "missingAction": "Link does not include an action.",
+            "invalidAction": "Link contains an invalid action.",
+            "missingToken": "Link does not include a token.",
+            "invalidToken": "Link contains an invalid token."
+        },
         "userInfo": {
             "name": "Name contains invalid characters.",
             "email": "Wrong email address format."

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -1101,6 +1101,13 @@
             "missingToken": "Le lien n'inclut pas de jeton.",
             "invalidToken": "Le lien contient un jeton invalide."
         },
+        "bootstrapLink": {
+            "invalidProtocol": "Le lien doit commencer par 'parsec3://'.",
+            "missingAction": "Le lien n'inclut pas d'action.",
+            "invalidAction": "Le lien contient une action invalide.",
+            "missingToken": "Le lien n'inclut pas de jeton.",
+            "invalidToken": "Le lien contient un jeton invalide."
+        },
         "userInfo": {
             "name": "Le nom contient des caractères invalides.",
             "email": "Le format de l'adresse email est invalide."

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -1108,6 +1108,9 @@
             "missingToken": "Le lien n'inclut pas de jeton.",
             "invalidToken": "Le lien contient un jeton invalide."
         },
+        "link": {
+            "invalid": "Ce lien n'est pas valide."
+        },
         "userInfo": {
             "name": "Le nom contient des caractères invalides.",
             "email": "Le format de l'adresse email est invalide."

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -19,7 +19,7 @@ import { IonicVue, isPlatform, modalController } from '@ionic/vue';
 /* Theme variables */
 import '@/theme/global.scss';
 
-import { claimLinkValidator, fileLinkValidator } from '@/common/validators';
+import { bootstrapLinkValidator, claimLinkValidator, fileLinkValidator } from '@/common/validators';
 import appEnUS from '@/locales/en-US.json';
 import appFrFR from '@/locales/fr-FR.json';
 import { getLoggedInDevices, getOrganizationHandle, isElectron, listAvailableDevices, logout, needsMocks, parseFileLink } from '@/parsec';
@@ -206,6 +206,8 @@ async function setupApp(): Promise<void> {
         await handleJoinLink(link);
       } else if ((await fileLinkValidator(link)).validity === Validity.Valid) {
         await handleFileLink(link, currentInformationManager);
+      } else if ((await bootstrapLinkValidator(link)).validity === Validity.Valid) {
+        await handleBootstrapLink(link);
       } else {
         await currentInformationManager.present(
           new Information({
@@ -319,6 +321,13 @@ async function handleJoinLink(link: string): Promise<void> {
     await switchOrganization(null, true);
   }
   await navigateTo(Routes.Home, { query: { claimLink: link } });
+}
+
+async function handleBootstrapLink(link: string): Promise<void> {
+  if (!currentRouteIs(Routes.Home)) {
+    await switchOrganization(null, true);
+  }
+  await navigateTo(Routes.Home, { query: { bootstrapLink: link } });
 }
 
 async function handleFileLink(link: string, informationManager: InformationManager): Promise<void> {

--- a/client/src/router/types.ts
+++ b/client/src/router/types.ts
@@ -143,6 +143,7 @@ export interface Query {
   documentPath?: FsPath;
   deviceId?: DeviceID;
   claimLink?: string;
+  bootstrapLink?: string;
   fileLink?: ParsecWorkspacePathAddr;
   openInvite?: true;
   workspaceName?: WorkspaceName;

--- a/client/src/views/home/OrganizationListPage.vue
+++ b/client/src/views/home/OrganizationListPage.vue
@@ -44,13 +44,13 @@
               :label="'HomePage.noDevices.invitationLink'"
               :placeholder="'JoinOrganization.linkFormPlaceholder'"
               v-model="link"
-              @on-enter-keyup="$emit('joinOrganizationWithLinkClick', link)"
-              :validator="claimLinkValidator"
+              @on-enter-keyup="onLinkClick"
+              :validator="claimAndBootstrapLinkValidator"
               class="invitation-link__input"
               ref="linkRef"
             />
             <ion-button
-              @click="$emit('joinOrganizationWithLinkClick', link)"
+              @click="onLinkClick(link)"
               size="large"
               fill="default"
               id="join-organization-button"
@@ -159,7 +159,7 @@
 </template>
 
 <script setup lang="ts">
-import { claimLinkValidator } from '@/common/validators';
+import { claimAndBootstrapLinkValidator, bootstrapLinkValidator } from '@/common/validators';
 import {
   formatTimeSince,
   MsImage,
@@ -200,6 +200,7 @@ const emits = defineEmits<{
   (e: 'createOrganizationClick'): void;
   (e: 'joinOrganizationClick'): void;
   (e: 'joinOrganizationWithLinkClick', link: string): void;
+  (e: 'bootstrapOrganizationWithLinkClick', link: string): void;
 }>();
 
 enum SortCriteria {
@@ -237,6 +238,14 @@ const msSorterLabels = {
 };
 
 const isPopoverOpen = ref(false);
+
+async function onLinkClick(link: string): Promise<void> {
+  if (await bootstrapLinkValidator(link)) {
+    emits('bootstrapOrganizationWithLinkClick', link);
+  } else {
+    emits('joinOrganizationWithLinkClick', link);
+  }
+}
 
 async function togglePopover(event: Event): Promise<void> {
   isPopoverOpen.value = !isPopoverOpen.value;

--- a/client/src/views/home/SummaryStep.vue
+++ b/client/src/views/home/SummaryStep.vue
@@ -12,6 +12,7 @@
           {{ organization }}
         </ion-text>
         <ion-button
+          v-show="!bootstrapOnly"
           fill="clear"
           class="summary-item__button"
           @click="$emit('update-request', OrgInfo.Organization)"
@@ -69,6 +70,7 @@
           {{ serverMode === ServerMode.SaaS ? $msTranslate('CreateOrganization.saas') : serverAddr }}
         </ion-text>
         <ion-button
+          v-show="!bootstrapOnly"
           fill="clear"
           class="summary-item__button"
           @click="$emit('update-request', OrgInfo.ServerMode)"
@@ -132,6 +134,7 @@ defineProps<{
   serverMode: ServerMode;
   serverAddr: string;
   authentication: DeviceSaveStrategyTag;
+  bootstrapOnly?: boolean;
 }>();
 </script>
 

--- a/client/tests/pw/e2e/bootstrap_organization.spec.ts
+++ b/client/tests/pw/e2e/bootstrap_organization.spec.ts
@@ -1,0 +1,130 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { Locator } from '@playwright/test';
+import { expect } from '@tests/pw/helpers/assertions';
+import { msTest } from '@tests/pw/helpers/fixtures';
+import { fillInputModal, fillIonInput } from '@tests/pw/helpers/utils';
+
+// cspell:disable-next-line
+const BOOTSTRAP_LINK = 'parsec3://localhost:6770/MyOrg?no_ssl=true&a=bootstrap_organization&p=xBCy2YVGB31DPzcxGZbGVUt7';
+
+enum Steps {
+  OrgName = 'org-name',
+  UserInfo = 'user-info',
+  Server = 'org-server',
+  Authentication = 'org-password',
+  Summary = 'org-summary',
+  Creation = 'org-loading',
+  Created = 'org-created',
+}
+
+const TITLES = new Map([
+  [Steps.OrgName, { title: 'Create an organization', subtitle: 'Choose your organization name.' }],
+  [Steps.UserInfo, { title: 'Enter your personal information', subtitle: 'Fill in your name and email.' }],
+  [Steps.Server, { title: 'Choose the server you need', subtitle: 'Choose your desired server type.' }],
+  [Steps.Authentication, { title: 'Authentication', subtitle: 'Lastly, choose an authentication method.' }],
+  [Steps.Summary, { title: 'Overview of your organization', subtitle: 'Verify that the information is correct.' }],
+  [Steps.Creation, {}],
+  [Steps.Created, { title: 'Your organization has been created!' }],
+]);
+
+async function ensureCurrentStepIs(modal: Locator, step: Steps): Promise<void> {
+  const expectedTitle = (TITLES.get(step) as { title?: string; subtitle?: string }).title;
+  const expectedSubtitle = (TITLES.get(step) as { title?: string; subtitle?: string }).subtitle;
+
+  if (expectedTitle) {
+    const modalTitle = modal.locator('.modal-header__title');
+    await expect(modalTitle).toHaveText(expectedTitle);
+  }
+  if (expectedSubtitle) {
+    const modalSubtitle = modal.locator('.modal-header__text');
+    await expect(modalSubtitle).toHaveText(expectedSubtitle);
+  }
+
+  for (const stepCls in Steps) {
+    const block = modal.locator('.modal-content').locator(`.${stepCls}`);
+    if (stepCls === step) {
+      await expect(block).toBeVisible();
+    } else {
+      await expect(block).toBeHidden();
+    }
+  }
+}
+
+msTest('Opens the create organization modal', async ({ home }) => {
+  await home.locator('#create-organization-button').click();
+  await expect(home.locator('.homepage-popover')).toBeVisible();
+  await expect(home.locator('.create-organization-modal')).toBeHidden();
+  await home.locator('.homepage-popover').getByRole('listitem').nth(1).click();
+  await expect(home.locator('.text-input-modal')).toBeVisible();
+  await fillInputModal(home, BOOTSTRAP_LINK);
+  const modal = home.locator('.create-organization-modal');
+  await expect(modal).toBeVisible();
+});
+
+msTest('Go through the organization bootstrapping process', async ({ home }) => {
+  await home.locator('#create-organization-button').click();
+  await expect(home.locator('.homepage-popover')).toBeVisible();
+  await expect(home.locator('.create-organization-modal')).toBeHidden();
+  await home.locator('.homepage-popover').getByRole('listitem').nth(1).click();
+  await fillInputModal(home, BOOTSTRAP_LINK);
+
+  const createOrgModal = home.locator('.create-organization-modal');
+  const nextButton = createOrgModal.locator('#next-button');
+  const modalContent = createOrgModal.locator('.modal-content');
+
+  await ensureCurrentStepIs(createOrgModal, Steps.OrgName);
+  await expect(modalContent.locator('#org-name-input').locator('ion-input').locator('input')).toBeDisabled();
+  await expect(modalContent.locator('#org-name-input').locator('ion-input').locator('input')).toHaveValue('MyOrg');
+  await expect(nextButton).not.toHaveDisabledAttribute();
+  await nextButton.click();
+
+  await ensureCurrentStepIs(createOrgModal, Steps.UserInfo);
+  await expect(nextButton).toHaveDisabledAttribute();
+  await fillIonInput(modalContent.locator('.user-info').locator('ion-input').nth(0), 'Banjo');
+  await expect(nextButton).toHaveDisabledAttribute();
+  await fillIonInput(modalContent.locator('.user-info').locator('ion-input').nth(1), 'banjo@rare');
+  await expect(nextButton).not.toHaveDisabledAttribute();
+  await nextButton.click();
+
+  await ensureCurrentStepIs(createOrgModal, Steps.Authentication);
+  await expect(nextButton).toHaveDisabledAttribute();
+  const authRadios = modalContent.locator('.choose-auth-page').locator('ion-radio');
+  await expect(authRadios.nth(0)).toContainText('Use System Authentication');
+  await expect(authRadios.nth(1)).toContainText('Use Password');
+  await expect(authRadios.nth(0)).not.toBeChecked();
+  await expect(authRadios.nth(0)).toHaveDisabledAttribute();
+  await expect(authRadios.nth(1)).toBeChecked();
+  await expect(nextButton).toHaveDisabledAttribute();
+  const passwordInputs = modalContent.locator('.choose-password').locator('ion-input');
+  await fillIonInput(passwordInputs.nth(0), 'AVeryL0ngP@ssw0rd');
+  await fillIonInput(passwordInputs.nth(1), 'AVeryL0ngP@ssw0rd');
+  await expect(nextButton).toBeEnabled();
+  await nextButton.click();
+
+  await ensureCurrentStepIs(createOrgModal, Steps.Summary);
+  const summaryItems = modalContent.locator('.summary-list').getByRole('listitem');
+  await expect(summaryItems).toHaveCount(5);
+
+  await expect(summaryItems.locator('.summary-item__label')).toHaveText([
+    'Organization',
+    'Full name',
+    'Email',
+    'Server choice',
+    'Authentication method',
+  ]);
+  await expect(summaryItems.locator('.summary-item__text')).toHaveText(['MyOrg', 'Banjo', 'banjo@rare', 'localhost', 'Password']);
+
+  await expect(summaryItems.nth(0).locator('.summary-item__button')).toBeHidden();
+  await expect(summaryItems.nth(1).locator('.summary-item__button')).toBeVisible();
+  await expect(summaryItems.nth(2).locator('.summary-item__button')).toBeVisible();
+  await expect(summaryItems.nth(3).locator('.summary-item__button')).toBeHidden();
+  await expect(summaryItems.nth(4).locator('.summary-item__button')).toBeVisible();
+
+  await nextButton.click();
+  await ensureCurrentStepIs(createOrgModal, Steps.Creation);
+
+  await ensureCurrentStepIs(createOrgModal, Steps.Created);
+  await nextButton.click();
+  await expect(createOrgModal).toBeHidden();
+});

--- a/client/tests/pw/e2e/documents_list.spec.ts
+++ b/client/tests/pw/e2e/documents_list.spec.ts
@@ -19,7 +19,7 @@ async function toggleViewMode(page: Page): Promise<void> {
 
 const FILE_MATCHER = /^File_[a-z0-9_.]+$/;
 const DIR_MATCHER = /^Dir_[a-z_]+$/;
-const TIME_MATCHER = /^(now|(\d{1,2}|one) minutes? ago)$/;
+const TIME_MATCHER = /^(now|< 1 minute|(\d{1,2}|one) minutes? ago)$/;
 const SIZE_MATCHER = /^[0-9.]+ (K|M|G)?B$/;
 
 msTest('Documents page default state', async ({ documents }) => {

--- a/client/tests/pw/e2e/home_page.spec.ts
+++ b/client/tests/pw/e2e/home_page.spec.ts
@@ -75,11 +75,6 @@ msTest('Check join link', async ({ home }) => {
       expectedError: 'Link does not include an action.',
     },
     {
-      // cspell:disable-next-line
-      link: 'parsec3://parsec.cloud/Test?a=bootstrap_organization&p=xBBHJlEjlpxNZYTCvBWWDPIS',
-      expectedError: 'Link contains an invalid action.',
-    },
-    {
       link: 'parsec3://parsec.cloud/Test?a=claim_user',
       expectedError: 'Link does not include a token.',
     },

--- a/client/tests/pw/e2e/home_page.spec.ts
+++ b/client/tests/pw/e2e/home_page.spec.ts
@@ -67,20 +67,20 @@ msTest('Check join link', async ({ home }) => {
     {
       // cspell:disable-next-line
       link: 'http://parsec.cloud/Test?a=claim_user&p=xBBHJlEjlpxNZYTCvBWWDPIS',
-      expectedError: "Link should start with 'parsec3://'.",
+      expectedError: 'This link is invalid.',
     },
     {
       // cspell:disable-next-line
       link: 'parsec3://parsec.cloud/Test?p=xBBHJlEjlpxNZYTCvBWWDPIS',
-      expectedError: 'Link does not include an action.',
+      expectedError: 'This link is invalid.',
     },
     {
       link: 'parsec3://parsec.cloud/Test?a=claim_user',
-      expectedError: 'Link does not include a token.',
+      expectedError: 'This link is invalid.',
     },
     {
       link: 'parsec3://parsec.cloud/Test?a=claim_user&p=abcde',
-      expectedError: 'Link contains an invalid token.',
+      expectedError: 'This link is invalid.',
     },
     {
       // cspell:disable-next-line


### PR DESCRIPTION
Closes #7639

This updates the `join links` to also handle bootstrap. It's a bit misnamed but it's not a very used case so it's probably alright. Once the link's been parsed, we use the create organization process with some steps disabled.
It should handle all cases:
- passing the link as the argument, both at startup and when clicking on a link with the app already opened
- using the input + join button when the homepage displays the "no devices" page
- using the `Create or join` > `Join organization` button when the homepage has some devices

To get a bootstrap link, with a testbed server running:
`cargo run create-organization --addr parsec3://127.0.0.1:6770?no_ssl=true --token s3cr3t --organization-id MyOrg`

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
 