### PR TITLE
Expected payload cooker script to simplify rewrite of libparsec_type's tests

### DIFF
--- a/libparsec/crates/types/tests/unit/certif.rs
+++ b/libparsec/crates/types/tests/unit/certif.rs
@@ -306,6 +306,10 @@ fn serde_user_certificate(alice: &Device, bob: &Device) {
         algorithm: PrivateKeyAlgorithm::X25519XSalsa20Poly1305,
         profile: bob.profile,
     };
+    println!(
+        "***expected: {:?}",
+        expected.dump_and_sign(&alice.signing_key)
+    );
 
     let certif = UserCertificate::verify_and_load(
         &data,

--- a/misc/test_expected_payload_cooker.py
+++ b/misc/test_expected_payload_cooker.py
@@ -1,0 +1,149 @@
+# Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import binascii
+import datetime
+import re
+import struct
+import sys
+import textwrap
+
+try:
+    import msgpack  # type: ignore
+except ImportError:
+    raise SystemExit("msgpack not installed. Run `pip install msgpack`")
+try:
+    import zstandard  # type: ignore
+except ImportError:
+    raise SystemExit("zstandard not installed. Run `pip install zstandard`")
+try:
+    import nacl.exceptions  # type: ignore
+    import nacl.secret  # type: ignore
+except ImportError:
+    raise SystemExit("pynacl not installed. Run `pip install pynacl`")
+
+
+TAG = "***expected:"
+
+# Expected failure header: `FAIL [   0.004s] libparsec_types certif::tests::serde_user_certificate_redacted`
+FAILING_TEST_HEADER_PATTERN = re.compile(r"\W*FAIL \[[ 0-9.]+s\] ([ \w::]+)")
+TAG_PATTERN = re.compile(r"\W*\*\*\*expected: \[([ 0-9,]*)\]")
+
+
+KEY_CANDIDATES = [
+    binascii.unhexlify("b1b52e16c1b46ab133c8bf576e82d26c887f1e9deae1af80043a258c36fcabf3")
+]
+
+
+def decode_expected_raw(raw: bytes) -> dict[str, object]:
+    def attempt_decrypt(raw: bytes) -> bytes | None:
+        for key in KEY_CANDIDATES:
+            key = nacl.secret.SecretBox(key)
+            try:
+                return key.decrypt(raw)
+            except nacl.exceptions.CryptoError:
+                continue
+
+    def attempt_decompression(raw: bytes) -> bytes | None:
+        try:
+            return zstandard.decompress(raw)
+        except ValueError:
+            return None
+
+    def attempt_deserialization(raw: bytes) -> dict[str, object] | None:
+        if raw[0] == 0xFF:
+            try:
+                return msgpack.unpackb(raw[1:])
+            except ValueError:
+                pass
+
+        # First byte is the version
+        if raw[0] != 0x00:
+            return None
+
+        try:
+            decompressed = zstandard.decompress(raw[1:])
+        except ValueError:
+            return None
+
+        try:
+            return msgpack.unpackb(decompressed)
+        except ValueError:
+            return None
+
+    # First attempt: consider the data is not signed nor encrypted
+    deserialized = attempt_deserialization(raw)
+    if deserialized is not None:
+        return deserialized
+
+    # Second attempt: consider the data is only signed
+    raw_without_signature = raw[64:]
+    deserialized = attempt_deserialization(raw_without_signature)
+    if deserialized is not None:
+        return deserialized
+
+    # Last attempt: consider the data is signed and encrypted
+    decrypted = attempt_decrypt(raw)
+    assert decrypted is not None
+    decrypted_without_signature = decrypted[64:]
+    decompressed = attempt_decompression(decrypted_without_signature)
+    assert decompressed is not None
+    deserialized = attempt_deserialization(decompressed)
+    assert deserialized is not None
+    return deserialized
+
+
+def cook_msgpack_type(value):
+    if isinstance(value, bytes):
+        return value.hex()
+
+    if isinstance(value, msgpack.ExtType):
+        match value.code:
+            # DateTime
+            case 1:
+                ts = struct.unpack(">q", value.data)[0]
+                dt = datetime.datetime.fromtimestamp(ts / 1000000).isoformat() + "Z"
+                return f"ext(1, {ts}) i.e. {dt}"
+            # UUID
+            case 2:
+                return f"ext(2, {value.data.hex()})"
+
+            case _:
+                pass
+
+    return value
+
+
+current_test = None
+
+lines = sys.stdin.readlines()
+
+for line in lines:
+    m = FAILING_TEST_HEADER_PATTERN.match(line)
+    if m:
+        current_test = m.group(1)
+
+    m = TAG_PATTERN.match(line)
+    if not m:
+        continue
+
+    expected_raw = bytes(bytearray([int(c.strip()) for c in m.group(1).split(",")]))
+    expected_decoded = decode_expected_raw(expected_raw)
+
+    txt = []
+    txt.append("    // Generated from Parsec v3.0.0-b.11+dev")
+    txt.append("    // Content:")
+
+    for k, v in expected_decoded.items():
+        txt.append(f"    //   {k}: {cook_msgpack_type(v)}")
+
+    txt.append("    let data = Bytes::from_static(&hex!(")
+    for part in textwrap.wrap(expected_raw.hex()):
+        txt.append(f'        "{part}",')
+    txt.append("    ));")
+
+    print()
+    print(
+        f"===================================== {current_test} ========================================"
+    )
+    print()
+    print("\n".join(txt))


### PR DESCRIPTION
```
$ git diff
diff --git a/libparsec/crates/types/tests/unit/certif.rs b/libparsec/crates/types/tests/unit/certif.rs
index e090c98d5..2023dea8b 100644
--- a/libparsec/crates/types/tests/unit/certif.rs
+++ b/libparsec/crates/types/tests/unit/certif.rs
@@ -306,6 +306,7 @@ fn serde_user_certificate(alice: &Device, bob: &Device) {
         algorithm: PrivateKeyAlgorithm::X25519XSalsa20Poly1305,
         profile: bob.profile,
     };
+    println!("***expected: {:?}", expected.dump_and_sign(&alice.signing_key));
 
     let certif = UserCertificate::verify_and_load(
         &data,

$ cargo nextest r -p libparsec_types certif::tests::serde_user_certificate --run-ignored ignored-only 2>&1 | python misc/test_expected_payload_cooker.py

===================================== libparsec_types certif::tests::serde_user_certificate ========================================

    // Generated from Parsec v3.0.0-b.11+dev
    // Content:
    //   type: user_certificate
    //   author: ext(2, de10a11cec0010000000000000000000)
    //   timestamp: ext(1, 1638618643208821) i.e. 2021-12-04T12:50:43.208821Z
    //   user_id: ext(2, 808c0010000000000000000000000000)
    //   human_handle: ['bob@example.com', 'Boby McBobFace']
    //   public_key: 7c999e9980bef37707068b07d975591efc56335be9634ceef7c932a09c891e25
    //   algorithm: X25519_XSALSA20_POLY1305
    //   profile: STANDARD
    let data = Bytes::from_static(&hex!(
        "47450a97d5b15191dd26828a285a76c657d3e62d0079ce598924099039355a6e8ee566",
        "5b7cfac1764e8406cbd8605f119c4266d746cfdf0ae501ec312152df0cff88a4747970",
        "65b0757365725f6365727469666963617465a6617574686f72d802de10a11cec001000",
        "0000000000000000a974696d657374616d70d7010005d250a2269a75a7757365725f69",
        "64d802808c0010000000000000000000000000ac68756d616e5f68616e646c6592af62",
        "6f62406578616d706c652e636f6dae426f6279204d63426f6246616365aa7075626c69",
        "635f6b6579c4207c999e9980bef37707068b07d975591efc56335be9634ceef7c932a0",
        "9c891e25a9616c676f726974686db85832353531395f5853414c534132305f504f4c59",
        "31333035a770726f66696c65a85354414e44415244",
    ));
```