### PR TITLE
Add SQLFluff linter  

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -623,6 +623,7 @@ SPHINXBUILD
 SPHINXOPTS
 splashscreen
 sqldrivers
+sqlfluff
 sqlx
 SRCDIR
 SRSC

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,6 +97,14 @@ repos:
       - id: shellcheck
         args: [--exclude=SC1090, --severity=warning]
 
+  # SQLFluff, The SQL Linter for Humans
+  #
+  # See https://docs.sqlfluff.com/en/stable/index.html
+  - repo: https://github.com/sqlfluff/sqlfluff
+    rev: 3.1.0
+    hooks:
+      - id: sqlfluff-lint
+
   ########
   # Python
 

--- a/libparsec/crates/platform_storage/src/native/sql/.sqlfluff
+++ b/libparsec/crates/platform_storage/src/native/sql/.sqlfluff
@@ -14,3 +14,23 @@ dialect = sqlite
 # lines for the moment.
 # Set to zero or negative to disable checks.
 max_line_length = 120
+
+# The default configuration for capitalisation rules is "consistent"
+# which will auto-detect the setting from the rest of the file. This
+# is less desirable in a new project and you may find this (slightly
+# more strict) setting more useful.
+# Typically we find users rely on syntax highlighting rather than
+# capitalisation to distinguish between keywords and identifiers.
+# Clearly, if your organisation has already settled on uppercase
+# formatting for any of these syntax elements then set them to "upper".
+# See https://stackoverflow.com/questions/608196/why-should-i-capitalize-my-sql-keywords-is-there-a-good-reason
+[sqlfluff:rules:capitalisation.keywords]
+capitalisation_policy = upper
+[sqlfluff:rules:capitalisation.identifiers]
+extended_capitalisation_policy = lower
+[sqlfluff:rules:capitalisation.functions]
+extended_capitalisation_policy = upper
+[sqlfluff:rules:capitalisation.literals]
+capitalisation_policy = upper
+[sqlfluff:rules:capitalisation.types]
+extended_capitalisation_policy = upper

--- a/libparsec/crates/platform_storage/src/native/sql/.sqlfluff
+++ b/libparsec/crates/platform_storage/src/native/sql/.sqlfluff
@@ -1,0 +1,16 @@
+[sqlfluff]
+
+# Supported dialects https://docs.sqlfluff.com/en/stable/dialects.html
+# Or run 'sqlfluff dialects'
+dialect = sqlite
+
+# Comma separated list of rules to exclude, or None
+# See https://docs.sqlfluff.com/en/stable/configuration.html#enabling-and-disabling-rules
+# exclude_rules =
+
+# The standard max_line_length is 80 in line with the convention of
+# other tools and several style guides.
+# We set it to something a little longer to avoid having to fix
+# lines for the moment.
+# Set to zero or negative to disable checks.
+max_line_length = 120

--- a/libparsec/crates/platform_storage/src/native/sql/create-temp-unreferenced-chunks-table.sql
+++ b/libparsec/crates/platform_storage/src/native/sql/create-temp-unreferenced-chunks-table.sql
@@ -1,5 +1,5 @@
 -- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-CREATE TEMP TABLE unreferenced_chunks(
+CREATE TEMP TABLE unreferenced_chunks (
     chunk_id BLOB PRIMARY KEY -- UUID
 ) STRICT;

--- a/libparsec/crates/platform_storage/src/native/sql/create-vlobs-table.sql
+++ b/libparsec/crates/platform_storage/src/native/sql/create-vlobs-table.sql
@@ -5,5 +5,5 @@ CREATE TABLE IF NOT EXISTS vlobs (
     base_version INTEGER NOT NULL,
     remote_version INTEGER NOT NULL,
     need_sync INTEGER NOT NULL, -- Boolean
-    blob BLOB NOT NULL
+    blob BLOB NOT NULL --noqa: references.keywords
 ) STRICT;

--- a/server/parsec/components/postgresql/migrations/.sqlfluff
+++ b/server/parsec/components/postgresql/migrations/.sqlfluff
@@ -14,3 +14,23 @@ dialect = postgres
 # lines for the moment.
 # Set to zero or negative to disable checks.
 max_line_length = 120
+
+# The default configuration for capitalisation rules is "consistent"
+# which will auto-detect the setting from the rest of the file. This
+# is less desirable in a new project and you may find this (slightly
+# more strict) setting more useful.
+# Typically we find users rely on syntax highlighting rather than
+# capitalisation to distinguish between keywords and identifiers.
+# Clearly, if your organisation has already settled on uppercase
+# formatting for any of these syntax elements then set them to "upper".
+# See https://stackoverflow.com/questions/608196/why-should-i-capitalize-my-sql-keywords-is-there-a-good-reason
+[sqlfluff:rules:capitalisation.keywords]
+capitalisation_policy = upper
+[sqlfluff:rules:capitalisation.identifiers]
+extended_capitalisation_policy = lower
+[sqlfluff:rules:capitalisation.functions]
+extended_capitalisation_policy = upper
+[sqlfluff:rules:capitalisation.literals]
+capitalisation_policy = upper
+[sqlfluff:rules:capitalisation.types]
+extended_capitalisation_policy = upper

--- a/server/parsec/components/postgresql/migrations/.sqlfluff
+++ b/server/parsec/components/postgresql/migrations/.sqlfluff
@@ -1,0 +1,16 @@
+[sqlfluff]
+
+# Supported dialects https://docs.sqlfluff.com/en/stable/dialects.html
+# Or run 'sqlfluff dialects'
+dialect = postgres
+
+# Comma separated list of rules to exclude, or None
+# See https://docs.sqlfluff.com/en/stable/configuration.html#enabling-and-disabling-rules
+# exclude_rules =
+
+# The standard max_line_length is 80 in line with the convention of
+# other tools and several style guides.
+# We set it to something a little longer to avoid having to fix
+# lines for the moment.
+# Set to zero or negative to disable checks.
+max_line_length = 120

--- a/server/parsec/components/postgresql/migrations/README.md
+++ b/server/parsec/components/postgresql/migrations/README.md
@@ -1,0 +1,24 @@
+# About Parsec data model
+
+## Data model
+
+The `datamodel.sql` script provides a full, up-to-date, overview of Parsec
+data model. It is used mainly as a reference and to test migrations scripts,
+but it is NOT used to initialize the database.
+
+## Migrations
+
+The SQL scripts named `xxxx_<name>.sql` are migrations scripts that are applied
+in ascending order to initialize the database.
+
+So to get a brand new database:
+
+1. Apply `0001_initial.sql`
+2. Apply `0002_add_field_X.sql`
+3. and so on...
+
+## Tests
+
+Migrations are tested by applying them to a brand new database, dumping the
+resulting database schemas and comparing them with `datamodel.sql` to
+ensure consistency (see `./server/tests/test_migrations.py`).


### PR DESCRIPTION
Changes in this PR:

- Adds `sqlfluff` linter to `.pre-commit-config.yaml`
- Adds `.sqlfluff` config files for `postgres` and `sqlite` dialects
- Fixes linting issues in existing SQL files
- Adds README about Parsec data model and migrations

More info: https://docs.sqlfluff.com/en/stable/index.html