### PR TITLE
Fix payloads in libparsec types unit tests

### DIFF
--- a/libparsec/crates/protocol/tests/authenticated_cmds/v4/realm_rotate_key.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v4/realm_rotate_key.rs
@@ -38,7 +38,6 @@ pub fn req() {
         realm_key_rotation_certificate: Bytes::from_static(b"foobar"),
     };
 
-    println!("{:?}", req.dump());
     let expected = authenticated_cmds::AnyCmdReq::RealmRotateKey(req);
 
     let data = authenticated_cmds::AnyCmdReq::load(&raw).unwrap();

--- a/libparsec/crates/types/tests/unit/certif.rs
+++ b/libparsec/crates/types/tests/unit/certif.rs
@@ -1557,7 +1557,6 @@ fn serde_sequester_authority_certificate(alice: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_sequester_service_certificate() {
     // Generated from Parsec v3.0.0-b.11+dev
     // Content:

--- a/libparsec/crates/types/tests/unit/certif.rs
+++ b/libparsec/crates/types/tests/unit/certif.rs
@@ -11,7 +11,6 @@ use crate::prelude::*;
 // default/missing policy
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn debug_format(alice: &Device, bob: &Device, timestamp: DateTime) {
     let user_certificate = UserCertificate {
         author: CertificateSignerOwned::User(alice.device_id),
@@ -745,7 +744,6 @@ fn serde_user_update_certificate(alice: &Device, bob: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_realm_role_certificate(alice: &Device, bob: &Device) {
     // Generated from Parsec v3.0.0-b.11+dev
     // Content:
@@ -828,7 +826,6 @@ fn serde_realm_role_certificate(alice: &Device, bob: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_realm_role_certificate_no_role(alice: &Device, bob: &Device) {
     // Generated from Parsec v3.0.0-b.11+dev
     // Content:
@@ -1498,7 +1495,6 @@ fn serde_shamir_recovery_brief_certificate(alice: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_sequester_authority_certificate(alice: &Device) {
     // Generated from Parsec v3.0.0-b.11+dev
     // Content:
@@ -1612,7 +1608,7 @@ fn serde_sequester_service_certificate() {
     assert_eq!(
         outcome,
         Err(DataError::BadSerialization {
-            format: Some(0),
+            format: None,
             step: "format detection"
         })
     );

--- a/libparsec/crates/types/tests/unit/certif.rs
+++ b/libparsec/crates/types/tests/unit/certif.rs
@@ -26,9 +26,9 @@ fn debug_format(alice: &Device, bob: &Device, timestamp: DateTime) {
         format!("{:?}", user_certificate),
         concat!(
             "UserCertificate {",
-            " author: User(DeviceID(\"alice@dev1\")),",
+            " author: User(DeviceID { nickname: \"alice@dev1\", id: \"de10a11c-ec00-1000-0000-000000000000\" }),",
             " timestamp: DateTime(\"2020-01-01T00:00:00Z\"),",
-            " user_id: UserID(\"bob\"),",
+            " user_id: UserID { nickname: \"bob\", id: \"808c0010-0000-0000-0000-000000000000\" },",
             " human_handle: Real(HumanHandle(\"Boby McBobFace <bob@example.com>\")),",
             " public_key: PublicKey(****),",
             " algorithm: X25519XSalsa20Poly1305,",
@@ -50,9 +50,10 @@ fn debug_format(alice: &Device, bob: &Device, timestamp: DateTime) {
         format!("{:?}", device_certificate),
         concat!(
             "DeviceCertificate {",
-            " author: User(DeviceID(\"alice@dev1\")),",
+            " author: User(DeviceID { nickname: \"alice@dev1\", id: \"de10a11c-ec00-1000-0000-000000000000\" }),",
             " timestamp: DateTime(\"2020-01-01T00:00:00Z\"),",
-            " device_id: DeviceID(\"bob@dev1\"),",
+            " user_id: UserID { nickname: \"bob\", id: \"808c0010-0000-0000-0000-000000000000\" },",
+            " device_id: DeviceID { nickname: \"bob@dev1\", id: \"de10808c-0010-0000-0000-000000000000\" },",
             " device_label: Real(DeviceLabel(\"My dev1 machine\")),",
             " verify_key: VerifyKey(****),",
             " algorithm: Ed25519",
@@ -69,9 +70,9 @@ fn debug_format(alice: &Device, bob: &Device, timestamp: DateTime) {
         format!("{:?}", revoked_user_certificate),
         concat!(
             "RevokedUserCertificate {",
-            " author: DeviceID(\"alice@dev1\"),",
+            " author: DeviceID { nickname: \"alice@dev1\", id: \"de10a11c-ec00-1000-0000-000000000000\" },",
             " timestamp: DateTime(\"2020-01-01T00:00:00Z\"),",
-            " user_id: UserID(\"bob\")",
+            " user_id: UserID { nickname: \"bob\", id: \"808c0010-0000-0000-0000-000000000000\" }",
             " }",
         )
     );
@@ -86,9 +87,9 @@ fn debug_format(alice: &Device, bob: &Device, timestamp: DateTime) {
         format!("{:?}", user_update_certificate),
         concat!(
             "UserUpdateCertificate {",
-            " author: DeviceID(\"alice@dev1\"),",
+            " author: DeviceID { nickname: \"alice@dev1\", id: \"de10a11c-ec00-1000-0000-000000000000\" },",
             " timestamp: DateTime(\"2020-01-01T00:00:00Z\"),",
-            " user_id: UserID(\"bob\"),",
+            " user_id: UserID { nickname: \"bob\", id: \"808c0010-0000-0000-0000-000000000000\" },",
             " new_profile: Outsider",
             " }",
         )
@@ -105,10 +106,10 @@ fn debug_format(alice: &Device, bob: &Device, timestamp: DateTime) {
         format!("{:?}", realm_role_certificate),
         concat!(
             "RealmRoleCertificate {",
-            " author: DeviceID(\"alice@dev1\"),",
+            " author: DeviceID { nickname: \"alice@dev1\", id: \"de10a11c-ec00-1000-0000-000000000000\" },",
             " timestamp: DateTime(\"2020-01-01T00:00:00Z\"),",
             " realm_id: VlobID(60478445-0642-426b-91eb-89242f54fa52),",
-            " user_id: UserID(\"bob\"),",
+            " user_id: UserID { nickname: \"bob\", id: \"808c0010-0000-0000-0000-000000000000\" },",
             " role: Some(Owner)",
             " }",
         )
@@ -125,7 +126,7 @@ fn debug_format(alice: &Device, bob: &Device, timestamp: DateTime) {
         format!("{:?}", realm_name),
         concat!(
             "RealmNameCertificate {",
-            " author: DeviceID(\"alice@dev1\"),",
+            " author: DeviceID { nickname: \"alice@dev1\", id: \"de10a11c-ec00-1000-0000-000000000000\" },",
             " timestamp: DateTime(\"2020-01-01T00:00:00Z\"),",
             " realm_id: VlobID(60478445-0642-426b-91eb-89242f54fa52),",
             " key_index: 42,",
@@ -147,11 +148,11 @@ fn debug_format(alice: &Device, bob: &Device, timestamp: DateTime) {
         format!("{:?}", realm_key_rotation),
         concat!(
             "RealmKeyRotationCertificate {",
-            " author: DeviceID(\"alice@dev1\"),",
+            " author: DeviceID { nickname: \"alice@dev1\", id: \"de10a11c-ec00-1000-0000-000000000000\" },",
             " timestamp: DateTime(\"2020-01-01T00:00:00Z\"),",
             " realm_id: VlobID(60478445-0642-426b-91eb-89242f54fa52),",
             " key_index: 42,",
-            " encryption_algorithm: Xsalsa20Poly1305,",
+            " encryption_algorithm: Blake2bXsalsa20Poly1305,",
             " hash_algorithm: Sha256,",
             " key_canary: [48, 49, 50, 51, 52, 53]",
             " }",
@@ -170,7 +171,7 @@ fn debug_format(alice: &Device, bob: &Device, timestamp: DateTime) {
         format!("{:?}", realm_archiving_certificate),
         concat!(
             "RealmArchivingCertificate {",
-            " author: DeviceID(\"alice@dev1\"),",
+            " author: DeviceID { nickname: \"alice@dev1\", id: \"de10a11c-ec00-1000-0000-000000000000\" },",
             " timestamp: DateTime(\"2020-01-01T00:00:00Z\"),",
             " realm_id: VlobID(60478445-0642-426b-91eb-89242f54fa52),",
             " configuration: DeletionPlanned { deletion_date: DateTime(\"2020-01-01T00:00:00Z\") }",
@@ -194,8 +195,9 @@ fn debug_format(alice: &Device, bob: &Device, timestamp: DateTime) {
             // Ignore `per_recipient_shares` as, as a HashMap, it output is not stable across runs
             concat!(
                 "ShamirRecoveryBriefCertificate {",
-                " author: DeviceID(\"alice@dev1\"),",
+                " author: DeviceID { nickname: \"alice@dev1\", id: \"de10a11c-ec00-1000-0000-000000000000\" },",
                 " timestamp: DateTime(\"2020-01-01T00:00:00Z\"),",
+                " user_id: UserID { nickname: \"alice\", id: \"a11cec00-1000-0000-0000-000000000000\" },",
                 " threshold: 3,",
                 " per_recipient_shares: "
             )
@@ -213,9 +215,10 @@ fn debug_format(alice: &Device, bob: &Device, timestamp: DateTime) {
         format!("{:?}", shamir_recovery_share_certificate),
         concat!(
             "ShamirRecoveryShareCertificate {",
-            " author: DeviceID(\"alice@dev1\"),",
+            " author: DeviceID { nickname: \"alice@dev1\", id: \"de10a11c-ec00-1000-0000-000000000000\" },",
             " timestamp: DateTime(\"2020-01-01T00:00:00Z\"),",
-            " recipient: UserID(\"bob\"),",
+            " user_id: UserID { nickname: \"alice\", id: \"a11cec00-1000-0000-0000-000000000000\" },",
+            " recipient: UserID { nickname: \"bob\", id: \"808c0010-0000-0000-0000-000000000000\" },",
             " ciphered_share: [97, 98, 99, 100]",
             " }",
         )
@@ -273,28 +276,27 @@ fn debug_format(alice: &Device, bob: &Device, timestamp: DateTime) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_user_certificate(alice: &Device, bob: &Device) {
-    // Generated from Parsec v3.0.0-b.6+dev
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
-    //   type: "user_certificate"
-    //   author: "alice@dev1"
-    //   timestamp: ext(1, 1638618643.208821)
-    //   human_handle: ("bob@example.com", "Boby McBobFace")
-    //   user_id: "bob"
-    //   public_key: <bob.public_key as bytes>
+    //   type: user_certificate
+    //   author: ext(2, de10a11cec0010000000000000000000)
+    //   timestamp: ext(1, 1638618643208821) i.e. 2021-12-04T12:50:43.208821Z
+    //   user_id: ext(2, 808c0010000000000000000000000000)
+    //   human_handle: ['bob@example.com', 'Boby McBobFace']
+    //   public_key: 7c999e9980bef37707068b07d975591efc56335be9634ceef7c932a09c891e25
     //   algorithm: X25519_XSALSA20_POLY1305
-    //   profile: "STANDARD"
+    //   profile: STANDARD
     let data = Bytes::from_static(&hex!(
-        "e0b24615251070b6ec25811ae05479d2674368eb299896c8425bbe3a3f5d3818910334"
-        "29f7e39638f8636c7e920268b886279e37f3f2ddae7bdd0e9d3c718704789c01e1001e"
-        "ff89a474797065b0757365725f6365727469666963617465a6617574686f72aa616c69"
-        "63654064657631a974696d657374616d70d70141d86ad584cd5d53a7757365725f6964"
-        "a3626f62ac68756d616e5f68616e646c6592af626f62406578616d706c652e636f6dae"
-        "426f6279204d63426f6246616365aa7075626c69635f6b6579c4207c999e9980bef377"
-        "07068b07d975591efc56335be9634ceef7c932a09c891e25a9616c676f726974686db8"
-        "5832353531395f5853414c534132305f504f4c5931333035a869735f61646d696ec2a7"
-        "70726f66696c65a85354414e444152447ae35f3c"
+        "47450a97d5b15191dd26828a285a76c657d3e62d0079ce598924099039355a6e8ee566"
+        "5b7cfac1764e8406cbd8605f119c4266d746cfdf0ae501ec312152df0cff88a4747970"
+        "65b0757365725f6365727469666963617465a6617574686f72d802de10a11cec001000"
+        "0000000000000000a974696d657374616d70d7010005d250a2269a75a7757365725f69"
+        "64d802808c0010000000000000000000000000ac68756d616e5f68616e646c6592af62"
+        "6f62406578616d706c652e636f6dae426f6279204d63426f6246616365aa7075626c69"
+        "635f6b6579c4207c999e9980bef37707068b07d975591efc56335be9634ceef7c932a0"
+        "9c891e25a9616c676f726974686db85832353531395f5853414c534132305f504f4c59"
+        "31333035a770726f66696c65a85354414e44415244"
     ));
 
     let expected = UserCertificate {
@@ -366,28 +368,27 @@ fn serde_user_certificate(alice: &Device, bob: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_user_certificate_redacted(alice: &Device, bob: &Device) {
-    // Generated from Parsec v3.0.0-b.6+dev
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
-    //   type: "user_certificate"
-    //   author: "alice@dev1"
-    //   timestamp: ext(1, 1638618643.208821)
+    //   type: user_certificate
+    //   author: ext(2, de10a11cec0010000000000000000000)
+    //   timestamp: ext(1, 1638618643208821) i.e. 2021-12-04T12:50:43.208821Z
+    //   user_id: ext(2, 808c0010000000000000000000000000)
     //   human_handle: None
-    //   user_id: "bob"
-    //   public_key: <bob.public_key as bytes>
+    //   public_key: 7c999e9980bef37707068b07d975591efc56335be9634ceef7c932a09c891e25
     //   algorithm: X25519_XSALSA20_POLY1305
-    //   profile: "STANDARD"
-    let data = hex!(
-        "b5bb4b44bfc97e104671044387932a0c60e0d7207c047925828c3063c8e718e4b47197"
-        "373cc97bd3a3edb54d00434bd6b84b357e6f43b214c764239f84392104789c01c2003d"
-        "ff89a474797065b0757365725f6365727469666963617465a6617574686f72aa616c69"
-        "63654064657631a974696d657374616d70d70141d86ad584cd5d53a7757365725f6964"
-        "a3626f62ac68756d616e5f68616e646c65c0aa7075626c69635f6b6579c4207c999e99"
-        "80bef37707068b07d975591efc56335be9634ceef7c932a09c891e25a9616c676f7269"
-        "74686db85832353531395f5853414c534132305f504f4c5931333035a869735f61646d"
-        "696ec2a770726f66696c65a85354414e44415244040d5363"
-    );
+    //   profile: STANDARD
+    let data = Bytes::from_static(&hex!(
+        "66adf9f0d950658ee38d4154b4957c59cd2804bb491a783fb5c60d4b2e033138f390fc"
+        "0c6658ab0b406ad6369544559527168adeb61a7fa5b4598a65e4cce20eff88a4747970"
+        "65b0757365725f6365727469666963617465a6617574686f72d802de10a11cec001000"
+        "0000000000000000a974696d657374616d70d7010005d250a2269a75a7757365725f69"
+        "64d802808c0010000000000000000000000000ac68756d616e5f68616e646c65c0aa70"
+        "75626c69635f6b6579c4207c999e9980bef37707068b07d975591efc56335be9634cee"
+        "f7c932a09c891e25a9616c676f726974686db85832353531395f5853414c534132305f"
+        "504f4c5931333035a770726f66696c65a85354414e44415244"
+    ));
     let data = Bytes::from(data.as_ref().to_vec());
 
     let expected = UserCertificate {
@@ -443,27 +444,28 @@ fn serde_user_certificate_redacted(alice: &Device, bob: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_device_certificate(alice: &Device, bob: &Device) {
-    // Generated from Parsec v3.0.0-b.6+dev
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
-    //   type: "device_certificate"
-    //   author: "alice@dev1"
-    //   timestamp: ext(1, 1638618643.208821)
-    //   device_id: "bob@dev1"
-    //   device_label: "My dev1 machine"
-    //   verify_key: <bob.verify_key>
+    //   type: device_certificate
+    //   author: ext(2, de10a11cec0010000000000000000000)
+    //   timestamp: ext(1, 1638618643208821) i.e. 2021-12-04T12:50:43.208821Z
+    //   user_id: ext(2, a11cec00100000000000000000000000)
+    //   device_id: ext(2, de10808c001000000000000000000000)
+    //   device_label: My dev1 machine
+    //   verify_key: 840d872f4252da2d1c9f81a77db5f0a5b9b60a5cde1eeabf40388ef6bca64909
     //   algorithm: ED25519
-    let data = hex!(
-        "4a3f0aa00d5c4b5b61ccd03c50579e23e6c3f5dae5d0ac783eca2d4d95dd775aea593b"
-        "13d7a22da2591aced48aae8b283edd439afc49f84080a9ea38adde1300789c01ae0051"
-        "ff87a474797065b26465766963655f6365727469666963617465a6617574686f72aa61"
-        "6c6963654064657631a974696d657374616d70d70141d86ad584cd5d53a96465766963"
-        "655f6964a8626f624064657631ac6465766963655f6c6162656caf4d79206465763120"
-        "6d616368696e65aa7665726966795f6b6579c420840d872f4252da2d1c9f81a77db5f0"
-        "a5b9b60a5cde1eeabf40388ef6bca64909a9616c676f726974686da745443235353139"
-        "03864b9d"
-    );
+    let data = Bytes::from_static(&hex!(
+        "dc217cebca09b8b3ed3c3a4a77ea10f183b9949799f6fa59ba2815b8d6a476d02f117b"
+        "6182c056dd0c9e2551831f700aff6bc0543c2c77ec5d12d11edd12880cff88a4747970"
+        "65b26465766963655f6365727469666963617465a6617574686f72d802de10a11cec00"
+        "10000000000000000000a974696d657374616d70d7010005d250a2269a75a775736572"
+        "5f6964d802a11cec00100000000000000000000000a96465766963655f6964d802de10"
+        "808c001000000000000000000000ac6465766963655f6c6162656caf4d792064657631"
+        "206d616368696e65aa7665726966795f6b6579c420840d872f4252da2d1c9f81a77db5"
+        "f0a5b9b60a5cde1eeabf40388ef6bca64909a9616c676f726974686da7454432353531"
+        "39"
+    ));
     let data = Bytes::from(data.as_ref().to_vec());
 
     let expected = DeviceCertificate {
@@ -532,26 +534,27 @@ fn serde_device_certificate(alice: &Device, bob: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_device_certificate_redacted(alice: &Device, bob: &Device) {
-    // Generated from Parsec v3.0.0-b.6+dev
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
-    //   type: "device_certificate"
-    //   author: "alice@dev1"
-    //   timestamp: ext(1, 1638618643.208821)
-    //   device_id: "bob@dev1"
+    //   type: device_certificate
+    //   author: ext(2, de10a11cec0010000000000000000000)
+    //   timestamp: ext(1, 1638618643208821) i.e. 2021-12-04T12:50:43.208821Z
+    //   user_id: ext(2, a11cec00100000000000000000000000)
+    //   device_id: ext(2, de10808c001000000000000000000000)
     //   device_label: None
-    //   verify_key: <bob.verify_key>
+    //   verify_key: 840d872f4252da2d1c9f81a77db5f0a5b9b60a5cde1eeabf40388ef6bca64909
     //   algorithm: ED25519
-    let data = hex!(
-        "40da6782dad5bf04d76980b2e1d69a3810ad19c5512d76dc16958fd442c350ee499a40"
-        "b092ab300570d020dcc7b792cfe4f882688e98d80ba830f9e0d9d46603789c019f0060"
-        "ff87a474797065b26465766963655f6365727469666963617465a6617574686f72aa61"
-        "6c6963654064657631a974696d657374616d70d70141d86ad584cd5d53a96465766963"
-        "655f6964a8626f624064657631ac6465766963655f6c6162656cc0aa7665726966795f"
-        "6b6579c420840d872f4252da2d1c9f81a77db5f0a5b9b60a5cde1eeabf40388ef6bca6"
-        "4909a9616c676f726974686da74544323535313919274663"
-    );
+    let data = Bytes::from_static(&hex!(
+        "6372a56378037182e782b7846be62e06218cee7b107e30403e95bd9db449c8e4e5ba45"
+        "9bf6d80f04540bc127600d09839ae6595d0e445a89b87c0949ec15fc04ff88a4747970"
+        "65b26465766963655f6365727469666963617465a6617574686f72d802de10a11cec00"
+        "10000000000000000000a974696d657374616d70d7010005d250a2269a75a775736572"
+        "5f6964d802a11cec00100000000000000000000000a96465766963655f6964d802de10"
+        "808c001000000000000000000000ac6465766963655f6c6162656cc0aa766572696679"
+        "5f6b6579c420840d872f4252da2d1c9f81a77db5f0a5b9b60a5cde1eeabf40388ef6bc"
+        "a64909a9616c676f726974686da745443235353139"
+    ));
     let data = Bytes::from(data.as_ref().to_vec());
 
     let expected = DeviceCertificate {
@@ -605,21 +608,20 @@ fn serde_device_certificate_redacted(alice: &Device, bob: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_revoked_user_certificate(alice: &Device, bob: &Device) {
-    // Generated from Python implementation (Parsec v2.6.0)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
-    //   type: "revoked_user_certificate"
-    //   author: "alice@dev1"
-    //   timestamp: ext(1, 1638618643.208821)
-    //   user_id: "bob"
-    let data = hex!(
-        "d3bb83c6366f6f232d6ad0e61ec4e45cb818d219aec21c116756ac9b5240f4b50c8658"
-        "b0429e8be08dff45f8a9a9eb8ad7ca1c9c23fe23435d845fd6c9e69605789c6b599658"
-        "5a92915fb42a31273339d52125b5cc7049496541ea8ea2d4b2fcecd494f8d2e2d4a2f8"
-        "e4d4a292ccb4cce4c492d4952599b9a9c52589b905d7191d6f645d6d391b1bbc1cac28"
-        "336571527e1200bd0d243a"
-    );
+    //   type: revoked_user_certificate
+    //   author: ext(2, de10a11cec0010000000000000000000)
+    //   timestamp: ext(1, 1638618643208821) i.e. 2021-12-04T12:50:43.208821Z
+    //   user_id: ext(2, 808c0010000000000000000000000000)
+    let data = Bytes::from_static(&hex!(
+        "f03f69d6098a9b13a2b39624cab76f151740d5f7c1ea875a7cb5bf74579218a53f0962"
+        "d35dab1c682c3f7d45f35c93d4fc8035382df2053aac759556428bdb00ff84a4747970"
+        "65b87265766f6b65645f757365725f6365727469666963617465a6617574686f72d802"
+        "de10a11cec0010000000000000000000a974696d657374616d70d7010005d250a2269a"
+        "75a7757365725f6964d802808c0010000000000000000000000000"
+    ));
     let data = Bytes::from(data.as_ref().to_vec());
 
     let expected = RevokedUserCertificate {
@@ -673,23 +675,22 @@ fn serde_revoked_user_certificate(alice: &Device, bob: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_user_update_certificate(alice: &Device, bob: &Device) {
-    // Generated from Rust implementation (Parsec v3.0.x)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
-    //   type: "user_update_certificate"
-    //   author: "alice@dev1"
-    //   timestamp: ext(1, 1638618643.208821)
-    //   user_id: "bob"
-    //   new_profile: 'OUTSIDER'
-    let data = hex!(
-        "9fcf8d19225f29cb3252f792bdb8c183aadf7904e5d2f167b0ac39aeb4370c3b3193c2"
-        "91d14720bd302ade3ae338bd0f6654c9270696653c4d8b91cdf9fcdc02789c0165009a"
-        "ff85a474797065b7757365725f7570646174655f6365727469666963617465a6617574"
-        "686f72aa616c6963654064657631a974696d657374616d70d70141d86ad584cd5d53a7"
-        "757365725f6964a3626f62ab6e65775f70726f66696c65a84f55545349444552f6972c"
-        "29"
-    );
+    //   type: user_update_certificate
+    //   author: ext(2, de10a11cec0010000000000000000000)
+    //   timestamp: ext(1, 1638618643208821) i.e. 2021-12-04T12:50:43.208821Z
+    //   user_id: ext(2, 808c0010000000000000000000000000)
+    //   new_profile: OUTSIDER
+    let data = Bytes::from_static(&hex!(
+        "ad195fd99016f8aa88f544fd072c8b188cece24338eda7f2b5e4d87f900b53b7335d53"
+        "1049d4184413e52d115bad9e3e7a30bbba83b8f742edfd3a9e472ca900ff85a4747970"
+        "65b7757365725f7570646174655f6365727469666963617465a6617574686f72d802de"
+        "10a11cec0010000000000000000000a974696d657374616d70d7010005d250a2269a75"
+        "a7757365725f6964d802808c0010000000000000000000000000ab6e65775f70726f66"
+        "696c65a84f55545349444552"
+    ));
     let data = Bytes::from(data.as_ref().to_vec());
 
     let expected = UserUpdateCertificate {
@@ -746,32 +747,23 @@ fn serde_user_update_certificate(alice: &Device, bob: &Device) {
 #[rstest]
 #[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_realm_role_certificate(alice: &Device, bob: &Device) {
-    // Generated from Python implementation (Parsec v2.6.0)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
-    //   type: "realm_role_certificate"
-    //   author: "alice@dev1"
-    //   timestamp: ext(1, 1638618643.208821)
-    //   realm_id: ext(2, b"4486e7cf02d747bd9126679ba58e0474")
-    //   user_id: "bob",
-    //   role: "OWNER",
-    let data = hex!(
-        "842251fd775c0cb6cdf19b7d00195713361856192cdea53efdbc79b63d40b1437fad4e"
-        "991c0d00a658fce3d32254ff613c49383fbbc0abd828ab211fc49d090b789c6b5b5252"
-        "5990baad2835312737be283f27353e39b5a824332d3339b1247505443833e506934bdb"
-        "f3f34cd7ddf74e544b9fbdb48fa5647969716a11506671527ed21290bea5fee17eae41"
-        "2b4b3273538b4b12730bae333adec8bada7236367859626949467ed1aac49ccce45487"
-        "94d432430020cc3454"
-    );
+    //   type: realm_role_certificate
+    //   author: ext(2, de10a11cec0010000000000000000000)
+    //   timestamp: ext(1, 1638618643208821) i.e. 2021-12-04T12:50:43.208821Z
+    //   realm_id: ext(2, 4486e7cf02d747bd9126679ba58e0474)
+    //   user_id: ext(2, 808c0010000000000000000000000000)
+    //   role: OWNER
+    let data = Bytes::from_static(&hex!(
+        "4f85b51dfb534eb55ebf7a107fda12d38c17e7404e8632eef16e2183a79beb92ad5f76"
+        "0188b2bb9dbde1da48604f7231a688037bd702df47f9877de23bd11a0cff86a4747970"
+        "65b67265616c6d5f726f6c655f6365727469666963617465a6617574686f72d802de10"
+        "a11cec0010000000000000000000a974696d657374616d70d7010005d250a2269a75a8"
+        "7265616c6d5f6964d8024486e7cf02d747bd9126679ba58e0474a7757365725f6964d8"
+        "02808c0010000000000000000000000000a4726f6c65a54f574e4552"
+    ));
     let data = Bytes::from(data.as_ref().to_vec());
-
-    let certif = RealmRoleCertificate::verify_and_load(
-        &data,
-        &alice.verify_key(),
-        alice.device_id,
-        None,
-        None,
-    )
-    .unwrap();
 
     let expected = RealmRoleCertificate {
         author: alice.device_id,
@@ -780,6 +772,14 @@ fn serde_realm_role_certificate(alice: &Device, bob: &Device) {
         user_id: bob.user_id,
         role: Some(RealmRole::Owner),
     };
+    let certif = RealmRoleCertificate::verify_and_load(
+        &data,
+        &alice.verify_key(),
+        alice.device_id,
+        None,
+        None,
+    )
+    .unwrap();
     p_assert_eq!(certif, expected);
 
     let unsecure_certif = RealmRoleCertificate::unsecure_load(data.clone()).unwrap();
@@ -830,30 +830,22 @@ fn serde_realm_role_certificate(alice: &Device, bob: &Device) {
 #[rstest]
 #[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_realm_role_certificate_no_role(alice: &Device, bob: &Device) {
-    // Generated from Python implementation (Parsec v2.6.0)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
-    //   type: "realm_role_certificate"
-    //   author: "alice@dev1"
-    //   timestamp: ext(1, 1638618643.208821)
-    //   realm_id: ext(2, b"4486e7cf02d747bd9126679ba58e0474")
-    //   user_id: "bob",
-    //   role: None,
-    let data = hex!(
-        "0241a345e65a7271487e7d0145660c7dce22b51ac8c4da05d617226b382b38efcf2d1f"
-        "a5366b8e75abf8689e358de2564d1e02113537d2dcf5cdeb2db800a304789c6b5b5992"
-        "999b5a5c92985b709dd1f146d6d596b3b1c1cb124b4b32f28b5625e66426a73aa4a496"
-        "192e29cacf493db0bcb438b5283e336571527ed29292ca82d46d45a98939b9f120c9f8"
-        "e4d4a292ccb4cce4c492d41510e1cc941b4c2e6dcfcf335d77df3b512d7df6d23e9612"
-        "005ac632e4"
-    );
-    let certif = RealmRoleCertificate::verify_and_load(
-        &data,
-        &alice.verify_key(),
-        alice.device_id,
-        None,
-        None,
-    )
-    .unwrap();
+    //   type: realm_role_certificate
+    //   author: ext(2, de10a11cec0010000000000000000000)
+    //   timestamp: ext(1, 1638618643208821) i.e. 2021-12-04T12:50:43.208821Z
+    //   realm_id: ext(2, 4486e7cf02d747bd9126679ba58e0474)
+    //   user_id: ext(2, 808c0010000000000000000000000000)
+    //   role: None
+    let data = Bytes::from_static(&hex!(
+        "47342b9ff8476003fbaa2d00989a481236197d695cafa134a4fb4626425008f6866686"
+        "a478883d311a8c1b31ff2930a14da8b390199a4d190cefa14f06517f04ff86a4747970"
+        "65b67265616c6d5f726f6c655f6365727469666963617465a6617574686f72d802de10"
+        "a11cec0010000000000000000000a974696d657374616d70d7010005d250a2269a75a8"
+        "7265616c6d5f6964d8024486e7cf02d747bd9126679ba58e0474a7757365725f6964d8"
+        "02808c0010000000000000000000000000a4726f6c65c0"
+    ));
 
     let expected = RealmRoleCertificate {
         author: alice.device_id,
@@ -863,6 +855,14 @@ fn serde_realm_role_certificate_no_role(alice: &Device, bob: &Device) {
         role: None,
         // role: Some(RealmRole::Owner),
     };
+    let certif = RealmRoleCertificate::verify_and_load(
+        &data,
+        &alice.verify_key(),
+        alice.device_id,
+        None,
+        None,
+    )
+    .unwrap();
     p_assert_eq!(certif, expected);
 
     // Also test serialization round trip
@@ -880,24 +880,22 @@ fn serde_realm_role_certificate_no_role(alice: &Device, bob: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_realm_archiving_certificate_available(alice: &Device) {
-    // Generated from Rust implementation (Parsec v2.16.0-rc.4+dev)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
-    //   type: "realm_archiving_certificate"
-    //   author: "alice@dev1"
-    //   timestamp: ext(1, 1577836800.0)
-    //   configuration: {type:"AVAILABLE"}
-    //   realm_id: ext(2, hex!("4486e7cf02d747bd9126679ba58e0474"))
-    //
-    let data = hex!(
-        "5ed2a9a35096161dd741299427e56d5bf56de9a54cfbb6b0e754de9f2cfc699cf25bb9"
-        "2686fe38f1e2ad5a14130852d51a1ee4b74aaaa6c90e914a0011a2e000789c0181007e"
-        "ff85a474797065bb7265616c6d5f617263686976696e675f6365727469666963617465"
-        "a6617574686f72aa616c6963654064657631a974696d657374616d70d70141d782f840"
-        "000000a87265616c6d5f6964d8024486e7cf02d747bd9126679ba58e0474ad636f6e66"
-        "696775726174696f6e81a474797065a9415641494c41424c4539583722"
-    );
+    //   type: realm_archiving_certificate
+    //   author: ext(2, de10a11cec0010000000000000000000)
+    //   timestamp: ext(1, 1577836800000000) i.e. 2020-01-01T01:00:00Z
+    //   realm_id: ext(2, 4486e7cf02d747bd9126679ba58e0474)
+    //   configuration: {'type': 'AVAILABLE'}
+    let data = Bytes::from_static(&hex!(
+        "4a0f7c4399ac2aced8833bdf1c32871374536e82fbd5b3a39f3253e2b7da5da9158d2e"
+        "455b874237079bdd5ad0501e2985d3dc2da96266169a58f16f432d2707ff85a4747970"
+        "65bb7265616c6d5f617263686976696e675f6365727469666963617465a6617574686f"
+        "72d802de10a11cec0010000000000000000000a974696d657374616d70d70100059b08"
+        "c1fa4000a87265616c6d5f6964d8024486e7cf02d747bd9126679ba58e0474ad636f6e"
+        "66696775726174696f6e81a474797065a9415641494c41424c45"
+    ));
     let data = Bytes::from(data.as_ref().to_vec());
 
     let expected = RealmArchivingCertificate {
@@ -960,24 +958,22 @@ fn serde_realm_archiving_certificate_available(alice: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_realm_archiving_certificate_archived(alice: &Device) {
-    // Generated from Rust implementation (Parsec v2.16.0-rc.4+dev)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
-    //   type: "realm_archiving_certificate"
-    //   author: "alice@dev1"
-    //   timestamp: ext(1, 1577836800.0)
-    //   configuration: {type:"ARCHIVED"}
-    //   realm_id: ext(2, hex!("4486e7cf02d747bd9126679ba58e0474"))
-    //
-    let data = hex!(
-        "ca7aaea973705fae5737d382667e6ae535963d470bb6a1e1e073999e5a2ad35d2bb68b"
-        "1181f821e6e0f462062ce9c48bb7e8e3c76ff880ea6cf6afaf0ac13306789c0180007f"
-        "ff85a474797065bb7265616c6d5f617263686976696e675f6365727469666963617465"
-        "a6617574686f72aa616c6963654064657631a974696d657374616d70d70141d782f840"
-        "000000a87265616c6d5f6964d8024486e7cf02d747bd9126679ba58e0474ad636f6e66"
-        "696775726174696f6e81a474797065a84152434849564544024936e6"
-    );
+    //   type: realm_archiving_certificate
+    //   author: ext(2, de10a11cec0010000000000000000000)
+    //   timestamp: ext(1, 1577836800000000) i.e. 2020-01-01T01:00:00Z
+    //   realm_id: ext(2, 4486e7cf02d747bd9126679ba58e0474)
+    //   configuration: {'type': 'ARCHIVED'}
+    let data = Bytes::from_static(&hex!(
+        "abdeb92c23c13f0f9c60d037f8ef8d9421309b67e74545d66df37a99b4a181cda6164e"
+        "5125b70ac4add2b9e5850a644268c519b5cbc0a8def68a0d43df28ca06ff85a4747970"
+        "65bb7265616c6d5f617263686976696e675f6365727469666963617465a6617574686f"
+        "72d802de10a11cec0010000000000000000000a974696d657374616d70d70100059b08"
+        "c1fa4000a87265616c6d5f6964d8024486e7cf02d747bd9126679ba58e0474ad636f6e"
+        "66696775726174696f6e81a474797065a84152434849564544"
+    ));
     let data = Bytes::from(data.as_ref().to_vec());
 
     let expected = RealmArchivingCertificate {
@@ -1040,25 +1036,23 @@ fn serde_realm_archiving_certificate_archived(alice: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_realm_archiving_certificate_deletion_planned(alice: &Device) {
-    // Generated from Rust implementation (Parsec v2.16.0-rc.4+dev)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
-    //   type: "realm_archiving_certificate"
-    //   author: "alice@dev1"
-    //   timestamp: ext(1, 1577836800.0)
-    //   configuration: {type:"DELETION_PLANNED", deletion_date:ext(1, 1580428800.0)}
-    //   realm_id: ext(2, hex!("4486e7cf02d747bd9126679ba58e0474"))
-    //
-    let data = hex!(
-        "ff3f4ed5765c70230f55bfce6c051f00be174cf8bd36b57224ca048c67d063a3f93573"
-        "15c9993d869b79f713325535c8dbe9a341198205af21dad8056489a200789c01a0005f"
-        "ff85a474797065bb7265616c6d5f617263686976696e675f6365727469666963617465"
-        "a6617574686f72aa616c6963654064657631a974696d657374616d70d70141d782f840"
-        "000000a87265616c6d5f6964d8024486e7cf02d747bd9126679ba58e0474ad636f6e66"
-        "696775726174696f6e82a474797065b044454c4554494f4e5f504c414e4e4544ad6465"
-        "6c6574696f6e5f64617465d70141d78cdb80000000ab704333"
-    );
+    //   type: realm_archiving_certificate
+    //   author: ext(2, de10a11cec0010000000000000000000)
+    //   timestamp: ext(1, 1577836800000000) i.e. 2020-01-01T01:00:00Z
+    //   realm_id: ext(2, 4486e7cf02d747bd9126679ba58e0474)
+    //   configuration: {'type': 'DELETION_PLANNED', 'deletion_date': ExtType(code=1, data=b'\x00\x05\x9ddA7\x80\x00')}
+    let data = Bytes::from_static(&hex!(
+        "39c3377a657a32aaf46213497d65276d57391a143ac6f15bd3462ab746cea879a12f6a"
+        "1fcdcb9efdd0d334c472b4086a3b0650569516f369089c8aa4f0d9a805ff85a4747970"
+        "65bb7265616c6d5f617263686976696e675f6365727469666963617465a6617574686f"
+        "72d802de10a11cec0010000000000000000000a974696d657374616d70d70100059b08"
+        "c1fa4000a87265616c6d5f6964d8024486e7cf02d747bd9126679ba58e0474ad636f6e"
+        "66696775726174696f6e82a474797065b044454c4554494f4e5f504c414e4e4544ad64"
+        "656c6574696f6e5f64617465d70100059d6441378000"
+    ));
     let data = Bytes::from(data.as_ref().to_vec());
 
     let expected = RealmArchivingCertificate {
@@ -1123,24 +1117,23 @@ fn serde_realm_archiving_certificate_deletion_planned(alice: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_realm_name_certificate(alice: &Device) {
-    // Generated from Rust implementation (Parsec v3.0.x)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
-    //   type: "realm_name_certificate"
-    //   author: "alice@dev1"
-    //   timestamp: ext(1, 1638618643.208821)
-    //   realm_id: ext(2, hex!("4486e7cf02d747bd9126679ba58e0474"))
+    //   type: realm_name_certificate
+    //   author: ext(2, de10a11cec0010000000000000000000)
+    //   timestamp: ext(1, 1638618643208821) i.e. 2021-12-04T12:50:43.208821Z
+    //   realm_id: ext(2, 4486e7cf02d747bd9126679ba58e0474)
     //   key_index: 42
-    //   encrypted_name: b"12345"
-    let data = hex!(
-        "39ff6b6a3b84921598adc04b9a45cfea198ceb2820740ceab3d6f10172905f530c086b"
-        "5032dfbab0046927917d43a1b5027b9e287ef8e5525fdefcf02851e801789c017f0080"
-        "ff86a474797065b67265616c6d5f6e616d655f6365727469666963617465a661757468"
-        "6f72aa616c6963654064657631a974696d657374616d70d70141d86ad584cd5d53a872"
-        "65616c6d5f6964d8024486e7cf02d747bd9126679ba58e0474a96b65795f696e646578"
-        "2aae656e637279707465645f6e616d65c405313233343524f3372c"
-    );
+    //   encrypted_name: 3132333435
+    let data = Bytes::from_static(&hex!(
+        "59af6356a7348835175d43bfec635376963136b486d4c7812d4c44968e510e5788b9f1"
+        "90f1fb7372233178821dbf211d2a46ba928943d2bdeb58a44afad1ec0cff86a4747970"
+        "65b67265616c6d5f6e616d655f6365727469666963617465a6617574686f72d802de10"
+        "a11cec0010000000000000000000a974696d657374616d70d7010005d250a2269a75a8"
+        "7265616c6d5f6964d8024486e7cf02d747bd9126679ba58e0474a96b65795f696e6465"
+        "782aae656e637279707465645f6e616d65c4053132333435"
+    ));
     let data = Bytes::from(data.as_ref().to_vec());
 
     let expected = RealmNameCertificate {
@@ -1191,28 +1184,27 @@ fn serde_realm_name_certificate(alice: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_realm_key_rotation_certificate(alice: &Device) {
-    // Generated from Rust implementation (Parsec v3.0.x)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
-    //   type: "realm_name_certificate"
-    //   author: "alice@dev1"
-    //   timestamp: ext(1, 1638618643.208821)
-    //   realm_id: ext(2, hex!("4486e7cf02d747bd9126679ba58e0474"))
+    //   type: realm_key_rotation_certificate
+    //   author: ext(2, de10a11cec0010000000000000000000)
+    //   timestamp: ext(1, 1638618643208821) i.e. 2021-12-04T12:50:43.208821Z
+    //   realm_id: ext(2, 4486e7cf02d747bd9126679ba58e0474)
     //   key_index: 42
-    //   encryption_algorithm: "XSALSA20_POLY1305"
-    //   hash_algorithm: "SHA256"
-    //   encrypted_name: b"12345"
-    let data = hex!(
-        "876755790e8e5b0a21808df04ba92eab8c8a72ad0f37f4c9a670020ca69411f9f1de0b"
-        "f05847a7c40c522ddd1be6652f1caac7ab0fa29498782b69fec7e3c10b789c45cdbf0e"
-        "c1501480f1105ec560d252b326120609491706694e6e0fbdf45f6e0fd15dc424315b69"
-        "b483446265b28a49da37f01a5206fb97dfb7de53e0e14d2058b63ec540172e0171d7d1"
-        "190ae223ce8030841999ae88c1e20c1b06cea588b88d3e81ed2539359dbc968fa176fc"
-        "21dc48f3cdd5fb994f5ad76d69bc3b6c0a146532770c5c942fe8301178df0558635770"
-        "32ed735f533b9a2a57f45eb73390aa15e564826ffe83506babb2528f3387810322b817"
-        "25b95a533e97c65008"
-    );
+    //   encryption_algorithm: BLAKE2_XSALSA20_POLY1305
+    //   hash_algorithm: SHA256
+    //   key_canary: 3132333435
+    let data = Bytes::from_static(&hex!(
+        "30ef7b46c6c6c875485a67f3873986fc1b0e4fbed17c54edf45250da169b755c376c69"
+        "567a7e91268559227e21b0ff14083b3efe9af5b7ed3d0e02d05acb1909ff88a4747970"
+        "65be7265616c6d5f6b65795f726f746174696f6e5f6365727469666963617465a66175"
+        "74686f72d802de10a11cec0010000000000000000000a974696d657374616d70d70100"
+        "05d250a2269a75a87265616c6d5f6964d8024486e7cf02d747bd9126679ba58e0474a9"
+        "6b65795f696e6465782ab4656e6372797074696f6e5f616c676f726974686db8424c41"
+        "4b45325f5853414c534132305f504f4c5931333035ae686173685f616c676f72697468"
+        "6da6534841323536aa6b65795f63616e617279c4053132333435"
+    ));
     let data = Bytes::from(data.as_ref().to_vec());
 
     let expected = RealmKeyRotationCertificate {
@@ -1278,24 +1270,24 @@ fn serde_realm_key_rotation_certificate(alice: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_shamir_recovery_share_certificate(alice: &Device, bob: &Device) {
-    // Generated from Rust implementation (Parsec v2.16.1+dev)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
-    //   type: "shamir_recovery_share_certificate"
-    //   author: "alice@dev1"
-    //   timestamp: ext(1, 1577836800.0)
-    //   ciphered_share: hex!("61626364")
-    //   recipient: "bob"
-    //
-    let data = hex!(
-        "59008168d41356fb52c874bc1524c9f06e1bc0f2624ab7f3e61d94a03094bfe63ada1a"
-        "3cfaabbfd861acd84a67a1a3a816567b1aecfdffc9697ad0bb007d9806789c25cc410a"
-        "c2301046e1085ec42378837a923099fc920163c2742c742b781245a80b4fe11d8a37e9"
-        "b281eededb7c8f978d15ff439f288b7a0597013afaf60acf5093b33019de74b354f443"
-        "17617411c37132c9e88d729d77a7f9be74ceb9a9015205577b8612bead131471e37e7b"
-        "0a1c57ffa9303c"
-    );
+    //   type: shamir_recovery_share_certificate
+    //   author: ext(2, de10a11cec0010000000000000000000)
+    //   timestamp: ext(1, 1577836800000000) i.e. 2020-01-01T01:00:00Z
+    //   user_id: ext(2, a11cec00100000000000000000000000)
+    //   recipient: ext(2, 808c0010000000000000000000000000)
+    //   ciphered_share: 61626364
+    let data = Bytes::from_static(&hex!(
+        "b11d8ecf86af5c8c5ed215d63f985ad4d264cf985d4c4d25eeb3aa5059142eaa106f85"
+        "6ef586a5f36bae19a547c850032583558b433396598f39b46aba6a3c00ff86a4747970"
+        "65d9217368616d69725f7265636f766572795f73686172655f63657274696669636174"
+        "65a6617574686f72d802de10a11cec0010000000000000000000a974696d657374616d"
+        "70d70100059b08c1fa4000a7757365725f6964d802a11cec0010000000000000000000"
+        "0000a9726563697069656e74d802808c0010000000000000000000000000ae63697068"
+        "657265645f7368617265c40461626364"
+    ));
     let data = Bytes::from(data.as_ref().to_vec());
 
     let expected = ShamirRecoveryShareCertificate {
@@ -1508,34 +1500,23 @@ fn serde_shamir_recovery_brief_certificate(alice: &Device) {
 #[rstest]
 #[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_sequester_authority_certificate(alice: &Device) {
-    // Generated from Python implementation (Parsec v2.14.1+dev)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
-    //   type: "sequester_authority_certificate"
-    //   author: None
-    //   timestamp: ext(1, 946774800.0)
-    //   verify_key_der: hex!(
-    //     "30819f300d06092a864886f70d010101050003818d0030818902818100b2dc00a3c3b5c689b069f3"
-    //     "f40c494d2a5be313b1034fbf1dfe0eeee0f36cfbcf624400256cc660d5084782738a3045d75b584c"
-    //     "1943bc04c7123d68ac0cef253b4ee8d79bd09da19162dcc083662269b7b62cb38582f8a30219047b"
-    //     "087c11b60184b0493e0c1c8b1d10f9d7e6a2eb5aff66f7ee18303195f3bcc72ab57207ebfd020301"
-    //     "0001"
-    //   )
-    //
-    let data = hex!(
-        "5955d05b6175d010dcb653dd0b56ea4096d8f26f3991a3a4cb22489a8b80c12631ae1d"
-        "041d94cc7f4ae4440cf476ee9c3e5b0539953bba7b46015b4b02765304789c01f5000a"
-        "ff84a474797065bf7365717565737465725f617574686f726974795f63657274696669"
-        "63617465a974696d657374616d70d70141cc375188000000ae7665726966795f6b6579"
-        "5f646572c4a230819f300d06092a864886f70d010101050003818d0030818902818100"
-        "b2dc00a3c3b5c689b069f3f40c494d2a5be313b1034fbf1dfe0eeee0f36cfbcf624400"
-        "256cc660d5084782738a3045d75b584c1943bc04c7123d68ac0cef253b4ee8d79bd09d"
-        "a19162dcc083662269b7b62cb38582f8a30219047b087c11b60184b0493e0c1c8b1d10"
-        "f9d7e6a2eb5aff66f7ee18303195f3bcc72ab57207ebfd0203010001a6617574686f72"
-        "c0b8006a3d"
-    );
+    //   type: sequester_authority_certificate
+    //   timestamp: ext(1, 946774800000000) i.e. 2000-01-02T02:00:00Z
+    //   verify_key_der: 30819f300d06092a864886f70d010101050003818d0030818902818100b2dc00a3c3b5c689b069f3f40c494d2a5be313b1034fbf1dfe0eeee0f36cfbcf624400256cc660d5084782738a3045d75b584c1943bc04c7123d68ac0cef253b4ee8d79bd09da19162dcc083662269b7b62cb38582f8a30219047b087c11b60184b0493e0c1c8b1d10f9d7e6a2eb5aff66f7ee18303195f3bcc72ab57207ebfd0203010001
+    let data = Bytes::from_static(&hex!(
+        "b73d3afa988dbe02cf9b2f2f3f6914a29127fb9ffafa6490087b8f617cbbd8ecc20f81"
+        "f00482e9d240894277a8c7c9a16a8f8beba0d140597a9dd73111310d03ff83a4747970"
+        "65bf7365717565737465725f617574686f726974795f6365727469666963617465a974"
+        "696d657374616d70d70100035d162fa2e400ae7665726966795f6b65795f646572c4a2"
+        "30819f300d06092a864886f70d010101050003818d0030818902818100b2dc00a3c3b5"
+        "c689b069f3f40c494d2a5be313b1034fbf1dfe0eeee0f36cfbcf624400256cc660d508"
+        "4782738a3045d75b584c1943bc04c7123d68ac0cef253b4ee8d79bd09da19162dcc083"
+        "662269b7b62cb38582f8a30219047b087c11b60184b0493e0c1c8b1d10f9d7e6a2eb5a"
+        "ff66f7ee18303195f3bcc72ab57207ebfd0203010001"
+    ));
     let data = Bytes::from(data.as_ref().to_vec());
-    let certif =
-        SequesterAuthorityCertificate::verify_and_load(&data, &alice.verify_key()).unwrap();
 
     let expected = SequesterAuthorityCertificate {
         timestamp: "2000-01-02T01:00:00Z".parse().unwrap(),
@@ -1550,6 +1531,9 @@ fn serde_sequester_authority_certificate(alice: &Device) {
         )
         .unwrap(),
     };
+    let certif =
+        SequesterAuthorityCertificate::verify_and_load(&data, &alice.verify_key()).unwrap();
+
     p_assert_eq!(certif, expected);
 
     let unsecure_certif = SequesterAuthorityCertificate::unsecure_load(data).unwrap();
@@ -1579,33 +1563,24 @@ fn serde_sequester_authority_certificate(alice: &Device) {
 #[rstest]
 #[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_sequester_service_certificate() {
-    // Generated from Python implementation (Parsec v2.14.1+dev)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
-    //   type: "sequester_service_certificate"
-    //   timestamp: ext(1, 946774800.0)
-    //   encryption_key_der: hex!(
-    //     "30819f300d06092a864886f70d010101050003818d0030818902818100b2dc00a3c3b5c689b069f3"
-    //     "f40c494d2a5be313b1034fbf1dfe0eeee0f36cfbcf624400256cc660d5084782738a3045d75b584c"
-    //     "1943bc04c7123d68ac0cef253b4ee8d79bd09da19162dcc083662269b7b62cb38582f8a30219047b"
-    //     "087c11b60184b0493e0c1c8b1d10f9d7e6a2eb5aff66f7ee18303195f3bcc72ab57207ebfd020301"
-    //     "0001"
-    //   )
-    //   service_id: ext(2, hex!("b5eb565343c442b3a26be44573813ff0"))
-    //   service_label: "foo"
-    //
-    let data = hex!(
-        "789c6b5d559c5a5496999c1a9f99728369ebebb060e7234e9b17653f712d6eb4ffb0b2"
-        "243337b5b82431b7e03aa3e319f3c00e060686b5300d398949a9398bd3f2f397945416"
-        "a4ee2d4e2d2c05aa4d2d8a8729484e2d2ac94ccb4c4e2c49dd949a975c54595092999f"
-        "179f9d5a199f925a74649141e37c035e364ead368fb6efbc8c8c8cac0ccc8dbd0c068d"
-        "9d4c8d8d0c9bee302c3ebcf558e786cccf5f783c7db5a21f0b6f64f6df2ffb8fefdd83"
-        "cf39bfcf27b930a8e61c4bb8cae1de54dc65e07a3d3ac247d2790fcb7121db8c353cef"
-        "55adfd5e5c9f7d61eec28949770e34a729656edfa6b3b9b5e9c7622649966a8e1ac16d"
-        "8c2d1b3ced7864ba65057e5e7fb6e875d4ffb4efef240c0ca77ede735c6b6b11fbebbf"
-        "4ccc8c0c8c00ac417d28"
-    );
-
-    let certif = SequesterServiceCertificate::load(&data).unwrap();
+    //   type: sequester_service_certificate
+    //   timestamp: ext(1, 946774800000000) i.e. 2000-01-02T02:00:00Z
+    //   service_id: ext(2, b5eb565343c442b3a26be44573813ff0)
+    //   service_label: foo
+    //   encryption_key_der: 30819f300d06092a864886f70d010101050003818d0030818902818100b2dc00a3c3b5c689b069f3f40c494d2a5be313b1034fbf1dfe0eeee0f36cfbcf624400256cc660d5084782738a3045d75b584c1943bc04c7123d68ac0cef253b4ee8d79bd09da19162dcc083662269b7b62cb38582f8a30219047b087c11b60184b0493e0c1c8b1d10f9d7e6a2eb5aff66f7ee18303195f3bcc72ab57207ebfd0203010001
+    let data = Bytes::from_static(&hex!(
+        "ff85a474797065bd7365717565737465725f736572766963655f636572746966696361"
+        "7465a974696d657374616d70d70100035d162fa2e400aa736572766963655f6964d802"
+        "b5eb565343c442b3a26be44573813ff0ad736572766963655f6c6162656ca3666f6fb2"
+        "656e6372797074696f6e5f6b65795f646572c4a230819f300d06092a864886f70d0101"
+        "01050003818d0030818902818100b2dc00a3c3b5c689b069f3f40c494d2a5be313b103"
+        "4fbf1dfe0eeee0f36cfbcf624400256cc660d5084782738a3045d75b584c1943bc04c7"
+        "123d68ac0cef253b4ee8d79bd09da19162dcc083662269b7b62cb38582f8a30219047b"
+        "087c11b60184b0493e0c1c8b1d10f9d7e6a2eb5aff66f7ee18303195f3bcc72ab57207"
+        "ebfd0203010001"
+    ));
 
     let expected = SequesterServiceCertificate {
         timestamp: "2000-01-02T01:00:00Z".parse().unwrap(),
@@ -1622,6 +1597,8 @@ fn serde_sequester_service_certificate() {
         )
         .unwrap(),
     };
+    let certif = SequesterServiceCertificate::load(&data).unwrap();
+
     p_assert_eq!(certif, expected);
 
     // Also test serialization round trip

--- a/libparsec/crates/types/tests/unit/invite.rs
+++ b/libparsec/crates/types/tests/unit/invite.rs
@@ -6,9 +6,8 @@ use crate::fixtures::{bob, Device};
 use crate::prelude::*;
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_invite_user_data(bob: &Device) {
-    // Generated from Python implementation (Parsec v2.6.0)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
     //   type: "invite_user_data"
     //   requested_device_label: "My dev1 machine"
@@ -16,13 +15,14 @@ fn serde_invite_user_data(bob: &Device) {
     //   public_key: <bob.public_key as bytes>
     //   verify_key: <bob.verify_key as bytes>
     let encrypted = &hex!(
-        "2802b8a233ad8ec183bb7060b81432fab2f7786ce1a9f774798f3c793bed75fc9ac654"
-        "056ba0c42786dd9f95b4eeaeb9ba51fe3e799d93f26f8de11f47bfec8067d844d9d3cc"
-        "1a4665ad94c01890600c1a29b2c058ede68f50c872a3762fb843a5516283d70565bb5f"
-        "089eac347da2524af11775efa56189eba5bdbc3bffca52a8e948a3502419f0694afa48"
-        "1f7f1b8beb149b09182eb258d4ce95dedb6bed0c900dacd1cd3fec67637721351cd449"
-        "e7093477e05e3510fa01cefce2d31af8df499e54d9e15e136b454657b3bf104fb7bc3e"
-        "0d1bd170a1c9cba023bd19693e4ae3c115bfbf01d8ce6fbb414e5db5e752bf05c20a"
+        "e4f5ba3abc4d45355a5977e0bfd07bfdeff13ffe2a82f7079f214250a479d9c0084fb1"
+        "600b3de09b8064419fd14fd36b4ed3acf1778804695d21030b78c903f033e0d8193e93"
+        "88368b386a3939c442c2eb081eb72682c441d3a92a62ceeb99c6d7f7c182bc4e8b4994"
+        "806a49a41ffd8e20b30205517ee33012b9360f52dc20b6f725963ba2cda55a611e1add"
+        "8bf76b4d7b2906a62e0b89871a37f3a267bc0ee21460334b212e1c39ad7b3a3054e15c"
+        "d12b1b2c1bc4a43bd693711f37acc5b2f774b478c8d2a2457b3f24ff3ca84564a6b223"
+        "625c5507cd2710eace856e8c4d9084b294c3cc1147cec211036d4f8c570fd2958f378a"
+        "44b318"
     );
 
     let expected = InviteUserData {
@@ -48,24 +48,25 @@ fn serde_invite_user_data(bob: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_invite_user_confirmation(bob: &Device) {
-    // Generated from Python implementation (Parsec v2.6.0)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
     //   type: "invite_user_confirmation"
-    //   device_id: "bob@dev1"
+    //   user_id: ext(2, 808c0010000000000000000000000000)
+    //   device_id: ext(2, de10808c001000000000000000000000)
     //   device_label: "My dev1 machine"
     //   human_handle: ("bob@example.com", "Boby McBobFace")
     //   profil: "STANDARD"
     //   root_verify_key: hex!("be2976732cec8ca94eedcf0aafd413cd159363e0fadc9e68572c77a1e17d9bbd")
     let encrypted = &hex!(
-        "d49ccfc53ca9eeda99cf7218c7b2cd60996885f7b16059f444530a6da146be4cf7a95c"
-        "638e86ac42ac446bb03da4dd77aba5b7df397d2584cd07741168094bb0f4927aa4fff8"
-        "93a3580ad289c60e3aad326eb7534339fb000553b1f37b52b99d9636f78344ef2f7b5a"
-        "fd621a40f9bca39c4db8fbedfc093628eace16c81714710273c772a0ee4c236a7056c6"
-        "88ad49d69d5a6661d98c6dbc1677d8c4a6dff65c01d5d1a91580e5a45bd638dcf23bef"
-        "fc690cc70382690e9ae76be763ef7c8ef077be06a6d2672aa24537a59545918ad5dd95"
-        "2394d0f9371271ef8b6d71af2dd087725be430f96b"
+        "da506f3f3431ec1f18849c94f4e4e76ce792c147d31a195ed831036ce1ab803930ce29"
+        "ae62ecae189601befa743ec9b73a0a76118bdb5e26a01360bd337ab3cb3b3298932250"
+        "7b6c2c3528b7a26c6eb9ad11fd5057fc0a72b2c93f7b412d76bbce5d992a7cf0c8025f"
+        "b32f2d12c92872fb44e3306fc16f57400f6b303cce8aa7063fa064eb50dfdd5ae3898e"
+        "5e1d2804ebba18a1c6558eb2a92e3ca2088659001963b5aa844fa5de61ea7a06e71598"
+        "8c993ed10a42ab2aa6d5e40455d4aeb6365473c486f1ebb6318e9d8ef047e0407a7736"
+        "d6d3607196afebec66c920c99a3dd17656085d787d6b0f7303ec374cf3275745bfe799"
+        "77160c6001054dd6af082a62a358f72252fd57f5ae83"
     );
 
     let expected = InviteUserConfirmation {
@@ -93,19 +94,18 @@ fn serde_invite_user_confirmation(bob: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_invite_device_data(bob: &Device) {
-    // Generated from Python implementation (Parsec v2.6.0)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
     //   type: "invite_device_data"
     //   requested_device_label: "My dev1 machine"
     //   verify_key: <bob.verify_key as bytes>
     let encrypted = &hex!(
-        "6ffae1baf9f4eec1ef7b29ec88dbe4e006672a30a48871d04a0f5d63965653a8d69a0f"
-        "bf3fa7c6ed1351863080232acc245748e5c970c0fda93b192c6b81e1d8c5126e6960f1"
-        "e0470deded2f42eaca16a793198818b85c03914ef3fd780785278feed85a7243e8274a"
-        "0a98d2fbed573d69b6df31a8d06ac57ca2529ad112cb0d214ab9c1886073b3d81a7e5d"
-        "a402fcea57696dbb25c860"
+        "04040f06a106396d6d53e03abb5cfb77088cda9683bb54e434ca2fad0187c0a78d00ac"
+        "99727b980ba0eba6586a4db4b6575ee37b37178ff9f2b8623d045cf8fa8981a8cf7c76"
+        "0fccf4c324e6da00142bc382c6365fc4255bf57026e83d463b7241d89175edc90d8726"
+        "7a6839b5c867a7b630f30bb13e0f0a01b02c2c0ff107cf98212f0cc87ab903cef8380f"
+        "ad96a704e1907946ed48"
     );
 
     let expected = InviteDeviceData {
@@ -129,12 +129,12 @@ fn serde_invite_device_data(bob: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_invite_device_confirmation(bob: &Device) {
-    // Generated from Python implementation (Parsec v2.6.0)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
     //   type: "invite_device_confirmation"
-    //   device_id: "bob@dev1"
+    //   user_id: ext(2, 808c0010000000000000000000000000)
+    //   device_id: ext(2, de10808c001000000000000000000000)
     //   device_label: "My dev1 machine"
     //   human_handle: ("bob@example.com", "Boby McBobFace")
     //   profil: "STANDARD"
@@ -143,16 +143,18 @@ fn serde_invite_device_confirmation(bob: &Device) {
     //   user_manifest_key: <bob.user_manifest_key as bytes>
     //   root_verify_key: hex!("be2976732cec8ca94eedcf0aafd413cd159363e0fadc9e68572c77a1e17d9bbd")
     let encrypted = &hex!(
-        "b703ea4cfb8aed8c7ba7a434316f0acd43389159bbf66c3a2bedd34d943ed97ed22302"
-        "c76d2b91790f19ca7a87c4dd5526ea493cf388ff5a492c7343409175f17542f29ccf25"
-        "1bf8bb4b503a78c3614535225ffcf974069bd036576f31f2ec1cb498e8716f08a56339"
-        "eb1c784183bf34874963e0f1656d6af6859ffcb58e57ab3e73ce6285de981d3b636f7b"
-        "4dd37070f3f68947ff463d1c9668f30f4e30adc898741c57871d97975be07da4639aba"
-        "d4249e461fed36635bd9240b1bbca9317d239164426eed3d03f86120ecfef81d5c03e3"
-        "18988311db64628e01560546bec8a48633b6024cd417d49dfff774de638d1a14fb133d"
-        "54a69d6c21238417dea12b4f8f8db2fc8d99b20e62c49a6b7efc22b9e4cd2d00dacd66"
-        "e0cf57c12ca375a2e2853794f294af7e7858832b66ec128713ee3c2310fd25d3b1e2c1"
-        "4622d103c9ce636025b4a61ed7ee1d5ac9817b14955b99f5b9b93c65d300"
+        "06733269843fadca366b5f1a4328eeebfbd9ee0c33b11435ddbba1721c317ebcded96b"
+        "e030e5cc768faebd91b09c4370f4153f7bc134b803253b5911377f5558d81c79c173d2"
+        "859f1d52b5baa7ceafd03e8259c45eca8522f05b35c7c5c297ee7303b12b19bd1c9a87"
+        "d76d103098baa2b423c314749416a95b4381f40d9899666f10f4866f618ec91a711ff4"
+        "55738e009854013f4b2772e4d9c69eac81a6c0df27bf0c3e0c98965e29ee4272d23471"
+        "a1537485fe6c03dc29e8dbe7c81903cf54aae45bc9994d1028f4de9e8f57abdedecd16"
+        "30aec2414f714944f864484d87d3fd93c8ae2af9dab9695c60936043452e679d92c55e"
+        "c2b39a5c720ae04579b419d3be360936c535824c7d7f109ba4c72340fda07435b28891"
+        "412a9b2a1164dac3b607fb236c715896ea029ed64aa1c77afab39c2447bc2eba85415e"
+        "26860e463e0b6fde8a77e709d5991db925f6f6c2051388228f5c3a17797fb9000c7502"
+        "80026b4f239c2a4ec112eaf29aaedbf6f9fba0be3af96aa119a4ebbb031d81d880069d"
+        "2210ca4999db6ecf2f5ecc"
     );
 
     let expected = InviteDeviceConfirmation {

--- a/libparsec/crates/types/tests/unit/local_device.rs
+++ b/libparsec/crates/types/tests/unit/local_device.rs
@@ -6,108 +6,113 @@ use crate::prelude::*;
 
 #[rstest]
 #[case::admin(
-    // Generated from v3.0.0-b.6+dev
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
     //   server_url: http://alice_dev1.example.com:9999
     //   organization_id: "CoolOrg"
     //   root_verify_key: hex!("be2976732cec8ca94eedcf0aafd413cd159363e0fadc9e68572c77a1e17d9bbd")
-    //   device_id: "alice@dev1"
+    //   user_id: ext(2, a11cec00100000000000000000000000)
+    //   device_id: ext(2, de10a11cec0010000000000000000000)
     //   device_label: "My dev1 machine"
     //   human_handle: ("alice@example.com", "Alicey McAliceFace")
     //   signing_key: <alice.signing_key as bytes>
     //   private_key: <alice.private_key as bytes>
-    //   profile: "ADMIN"
+    //   initial_profile: "ADMIN"
     //   user_realm_id: ext(2, hex!("a4031e8bcdd84df8ae12bd3d05e6e20f"))
     //   user_realm_key: hex!("26bf35a98c1e54e90215e154af92a1af2d1142cdd0dba25b990426b0b30b0f9a")
     //   local_symkey: hex!("125a78618995e2e0f9a19bc8617083c809c03deb5457d5b82df5bcaec9966cd4")
     &hex!(
-        "a4eeb71ec7b4dccf55fd715b0686d650d22990201076acfc67dc9a506a87ec9e652665"
-        "148f745a5f27eb3c4d6f22e5bd23c3bb02eb64a11c1072f6003317bc7826dbcda57af7"
-        "8f412b4cfaef049c7cc358038f928783db21c5f9ec21017b37232c290c2872db6efc2a"
-        "ff88b530ce5e90d16dfe5ee9b2d6f537f919d306918d9d1224d4574c466b786cc2b932"
-        "f88219a5273b2f016244f04c9bec93f23514295bc7ccbe64a79ef9b00ab6daaabb5e5f"
-        "ad26fc53bca5adb90f865fe1d514f072095878d3b16f4579288626b4963adfb3ac5139"
-        "765fb8154b95188201688cf0356f5e4f3a6f5b9f1f3419906f5cd1af8bb985dd40afc3"
-        "3bcc5ef4a9c7eed5a03fa0133153a1be6bccd652b42e1eb937d79a4347fbdef3dd51bf"
-        "55ca3ee7762f88708143c63d0bff2e0558a8b9948038b1126a6970a68a471ad427c71f"
-        "d0ef0288f5dbbcd7e45d661fff667da685e98250aa76d312b26e7d1de6aa578333b7ab"
-        "90c33edfdbf6e2a22a4680ef7a7058d14db29f47866eec7ecb338f0415e4a13b4c05da"
-        "c6999b9477862ef83ee1aef9c20b8ca6c9fd135ff291cf730b53f23c19aafc4d58d342"
-        "24b330a3786a13dee70c4e304fd1237d5d9a9999ed2c86fc9fb3eb84e92dd92591dacd"
-        "d504c2a63a1acc527351fa1720f507c6d0535ac29d5747c8ce86e700a952c4fe463308"
-        "719f8dfc923d999e789c645b7b43dfc0"
+        "7183aed06c4aca4a681cac2d0005a333f1710b7e0f68b7cb3d283b7470bc78fff39519"
+        "375f7edb40a3e8060b07382f141534cf087ae8e9c545e75acdf2dbadd2aaa8a56cd68d"
+        "72f9e98f645c84a4cc7499ef1a1190c43a8673fc2521c3addc1ac7434962f92286798b"
+        "3783c6de3eb3efde083514911c844b0f2843f51b452b9742737065fff0d11450e8757d"
+        "6c04c0111690eaef205b30a3cf6cc072129d93d41fd4724f3f734fea3e28519550c4cc"
+        "7aee4bdbcc69b92b2aef705043a8ff921b3b8b129270cc5bcd50e0a808535d796f5851"
+        "9766a3899810c451a018b4aaf786e075b4247678a408a996181069f77c8eb0774f5da2"
+        "194fc6b771f7792755a2f21f53d6f8a2bbf1ac1e47424b6f7b57006bb5735c27c9e64e"
+        "9507d5cf167907fc5fa1ddbae9d99db22239a99e674936e4236d96d55596b746601055"
+        "7ad0164a5ffa206934f5e813f9fb4f14a9a1715660a6b07e69253f8efda8bde2bb1d3d"
+        "d54a291f3a31ffae3664884b26b8ef30882abfbd3b4d5ebcc959b83f894d6e70a8d083"
+        "caf59ed69fc4264ec4a6c5cee2039acaf2200444ee923cf01d9b73aceb34ddea057072"
+        "1ad654b8e555608d65c91b311c8ad2806c8178aab75ae00942a755d2a018f88c3bc22f"
+        "ba8768e75d7cb55950114f5ff70161f29eac8c8490d492165a442d7ece078eeb632a71"
+        "aff4a5acbb15ccd586a9fa57ce24a158f1bdeb6990e743bdf734303d5c484e9d8cadd4"
+        "122e23a1cee9a87ebf268c6360068db44398e2aaf26382606bb7e1bee4321a91"
     ),
     UserProfile::Admin,
 )]
 #[case::standard(
-    // Generated from v3.0.0-b.6+dev
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
     //   server_url: http://alice_dev1.example.com:9999
     //   organization_id: "CoolOrg"
     //   root_verify_key: hex!("be2976732cec8ca94eedcf0aafd413cd159363e0fadc9e68572c77a1e17d9bbd")
-    //   device_id: "alice@dev1"
+    //   user_id: ext(2, a11cec00100000000000000000000000)
+    //   device_id: ext(2, de10a11cec0010000000000000000000)
     //   device_label: "My dev1 machine"
     //   human_handle: ("alice@example.com", "Alicey McAliceFace")
     //   signing_key: <alice.signing_key as bytes>
     //   private_key: <alice.private_key as bytes>
-    //   profile: "STANDARD"
+    //   initial_profile: "STANDARD"
     //   user_realm_id: ext(2, hex!("a4031e8bcdd84df8ae12bd3d05e6e20f"))
     //   user_realm_key: hex!("26bf35a98c1e54e90215e154af92a1af2d1142cdd0dba25b990426b0b30b0f9a")
     //   local_symkey: hex!("125a78618995e2e0f9a19bc8617083c809c03deb5457d5b82df5bcaec9966cd4")
     &hex!(
-        "e2cca1b6fc5cb43dabb33a2d77556feb873ac5396a602b4b8547ba6d338d3ecda5506c"
-        "e54242d90920d80c7059ff1082ee9f672978320688329ec7a59bf6abf9eb58b7ac35ba"
-        "e55b6c94549c7544117c8262da043dce90889d5426781a917364e4a27829e39e0270e5"
-        "83dc28426ae8c5100dd3878a7ad7b83aba39b44d74e85f841b795bd21157a1b0035a88"
-        "3e84955e36835a95f56898935b3969ed7153feed771184bb80af5bd6231361de5af61e"
-        "2704e9b1118950c72808e757fd3188b87d6c31443f75c39ca066fbcfda391af749c7d3"
-        "b989742b4e0770ec70545b4ef55ce07a3009a162fa3fba333b51139c9d094f2b8d6438"
-        "d174b27c416e64ce9e39a0bbe30819f47c5e83cf96c1688f24b317573b9a5c379dce3c"
-        "07531f636ef4fc4be8e1811d6d0365230c17d02649e70772117914df06f48b236ab035"
-        "c6d898b413b17ada185387cb0fa40249a1a82f5172e68f4795a419b75a355cdc6ea7d6"
-        "66b9dbd26a2757381a750657dd9e1ee3927d303d9cb64c9aec1ab6d5f17245712469e7"
-        "42e057411716d8cd51cefb4bc8903577e2ea1d8dcfb641c9de86a84470f6a162a71c4d"
-        "874fcd34af9b9fc9ff62ac9b109635cb5544645204ff32effc9b26fd0021e8cdf51947"
-        "a2ca36d5fde110d3565e52e02d84d8590a1fb725a60ffaa80beccdedfd87e80cf9e096"
-        "2e23763d9eaaefef2781e9288bb3e1944bec66"
+        "bfd29c0e21f862421c4171ca3e1c5b4bbe3e580fc7c33b341343efbd671a73aa3a8627"
+        "666685478204f5a7a1f92f6ed96ee8f1473535581e01d1a7c570660df75c68115bd88c"
+        "f91952d59268cd334e59ab25707082ed062a163f3681630c58fcebf655a3ab30eb5c76"
+        "a320ab8fb8d1d91d64b38d13d48cb9812acb822fc0bea3015436c9928435cf98a94f0a"
+        "6fcdbf187390f32ab483c079c6bb7de16578350dea09a3927f08c6da41cf902aa19d5d"
+        "328c7ccc00eb24e99fa799f21f84f20090e248bb1dfd2939b2271304794d872a64fb73"
+        "4ba0df9627834a5ed31a26790aa95f4e84b738dfce0952ec8c3a3e4ed21d0cf5480b4f"
+        "c17750b4ce3a094f4401d04d86c6f6499bb66c99a86882a864ae755673049e0c034bb7"
+        "c35fe7bc2f1f7d5c3baebc2ae1d7012bb93db6fd5fe6432cc566fa081cc9d5a4da33c5"
+        "427c843c4f4883548c70d0c06d775105621eaa0ae993120f6032bf345eb3060e4f484d"
+        "e5376460c56057bcfa554b652456af6e2f199d7345470963370af42d51a80fd0ff09de"
+        "12ac98c14d702f8f48fe0b5bea102316e808c7cd066e2e458a50f53e52b12e48383f6d"
+        "2239f3c7b0d5e2ceeb42e07abbbf0b4eb236904259235163f3bfa90e3ecc77dc7d5e80"
+        "e00ed493073c4062f84e72d796c8df83c8132092eac6bcafa394fc52f182df32d50567"
+        "dae8a9923a8c36bda8fe793b2672de8165b6446baf2bc2d4ce051b56a0cfe984f82e4e"
+        "bb4509bc79de71abae79cfa37139de4c393b41674c2729ec169d0092b8d590fd336dbb"
     ),
     UserProfile::Standard,
 )]
 #[case::outsider(
-    // Generated from v3.0.0-b.6+dev
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
     //   server_url: http://alice_dev1.example.com:9999
     //   organization_id: "CoolOrg"
     //   root_verify_key: hex!("be2976732cec8ca94eedcf0aafd413cd159363e0fadc9e68572c77a1e17d9bbd")
-    //   device_id: "alice@dev1"
+    //   user_id: ext(2, a11cec00100000000000000000000000)
+    //   device_id: ext(2, de10a11cec0010000000000000000000)
     //   device_label: "My dev1 machine"
     //   human_handle: ("alice@example.com", "Alicey McAliceFace")
     //   signing_key: <alice.signing_key as bytes>
     //   private_key: <alice.private_key as bytes>
-    //   profile: "OUTSIDER"
+    //   initial_profile: "OUTSIDER"
     //   user_realm_id: ext(2, hex!("a4031e8bcdd84df8ae12bd3d05e6e20f"))
     //   user_realm_key: hex!("26bf35a98c1e54e90215e154af92a1af2d1142cdd0dba25b990426b0b30b0f9a")
     //   local_symkey: hex!("125a78618995e2e0f9a19bc8617083c809c03deb5457d5b82df5bcaec9966cd4")
     &hex!(
-        "21db4301d0d64f2ab7697fcfde71deeea8acb8b94187bfd985680d8ba6a794340db0cc"
-        "9c9da49114b3f29fdab29b00d13afd4e59c1661dceaa928b7e6777397a8c0695a27c71"
-        "1948f49a339495ea95796059518d8633a214868b01a8f95af6b7784d7a81a7dd01e42a"
-        "1403374c943426b499a4efd2d9082715451dc99886089dfe125c47d24db4029ed544e2"
-        "2cd7be5cd8170b4b165dadcaa28063c18942dc3ea6b002b4dbb8f1c2d4ed2371ae77f7"
-        "1ea6c3e814fba3cc89e490ec117fc6d308643c5de52a6bf337b1070a2fb8b405ae8c20"
-        "41a30d0c0ed16e4981e253bff6d02ce8428fcfbf206d6dcab3f05af1ef0ddefbf9ca5a"
-        "e54d359efb754192eddd5631b22b128a081724bf80845e54c65143d46b64c5474ed345"
-        "b578abcb51087aa895366dfe16726ae7f479594899d344a8e51dba754f08565d9799f3"
-        "751b478bd43c9de56e48a2c18f503229537e604c06517aeadd4bb355eadcf6eea00e67"
-        "e6c5bab563715488dff15006cdfc36ad5a66eed5120fad68f0ae0130d5f15f387528db"
-        "ccd247b2a5505df5eec9290d256b5705dd62eedf9ae1cd1550ff2389988a7ddee8143f"
-        "e5cf047a544571a7ff610f42c278602d5bcd8daa171a8c914fff1f2a1035a2d0355ab0"
-        "d83786afa829e65b3e36c4c99852d6d20ca57ee74156f07c6a2ed0439a3b710b7a6afd"
-        "1e20fbe53b7a6ce1ccb831d8d9ac8680fe7bc7"
+        "cb74876c6136006164a1fb8ba211a0447205edc26469c6834e1332cec1b43680046550"
+        "1c86bbb734908c63c04d369b6d0e1d8eb8de78324cb13c53d219c94c0e6cedae660852"
+        "1a94673f34fbb2f5ea10c1a9630d12c3557bc0cab0e71420e6afdc875be52def609fa5"
+        "2cd18522b947b38638b9aacda8517235a5c1ed3730beb5482c91ebd5c73d75fb3e7d1a"
+        "c1deae0f04e9c6597fcd2b299c6c1503795395ee275a12affad6c816f3e1b7d8375bd6"
+        "bd36f9635237c1963008e9f31d656e83a650f3039582a8df873fa8c7b45116db89d664"
+        "12fc64bb3ebb6411da83de5db0992df311154edc3f1497a9367d947f1a70f58f8230a8"
+        "d8af9b8aa48d767d85478dbbf8ff950ecc7c2bf993fd8e0357f1a401d257ce7aaebbff"
+        "6c622a58fc197d533e0682d1d43798a349b802d385f581455a742defe5171430b9253a"
+        "8a7e8cbf1838953ea9885d02510bd800be3834e16b2b1f30bdc6fa4cffff5c911a2d52"
+        "df15c0b461616fb755ef62b05d9c98c9ef2d3b059062230e7cfa9b82b28584393a656c"
+        "be3700553866b93293e9dc2ce7dbc4eff760ecbeaf59c6a67501cf7e966029601d8a49"
+        "a5a424cfaa440d802fc12f5eed0e4f6e2a76e80ce399a9bbf3d14d5ee97a45369473c4"
+        "e631c154a907112f5d18fc151e832ace8684bbf5530a4e43a2a54b896e7022f6bc9e42"
+        "25f795551d2c414e6560bde08e1c34176cd45a19c16c0ab8d3f665242eb45acda90965"
+        "82fcb754a9268ca37e6719040a3a655bbd899651123118f8568ed00ef1a196f74048aa"
     ),
     UserProfile::Outsider,
 )]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_local_device_data_x(#[case] data: &[u8], #[case] initial_profile: UserProfile) {
     let key = SecretKey::from(hex!(
         "b1b52e16c1b46ab133c8bf576e82d26c887f1e9deae1af80043a258c36fcabf3"

--- a/libparsec/crates/types/tests/unit/local_device_file.rs
+++ b/libparsec/crates/types/tests/unit/local_device_file.rs
@@ -6,17 +6,15 @@ use crate::fixtures::{alice, Device};
 use crate::prelude::*;
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn password_protected_device_file(alice: &Device) {
-    // Generated from Parsec 3.0.0-b.6+dev
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
     //   type: "password"
     //   ciphertext: <encrypted alice local device>
     //   human_handle: ("bob@example.com", "Boby McBobFace")
     //   device_label: "My dev1 machine"
     //   organization_id: "CoolOrg"
-    //   device_id: "alice@dev1"
-    //   slug: "f78292422e#CoolOrg#alice@dev1"
+    //   device_id: ext(2, de10a11cec0010000000000000000000)
     //   algorithm:
     //     type: "ARGON2ID"
     //     salt: hex!("2ae6167f0f7472b8565c390df3af4a8b")
@@ -24,29 +22,27 @@ fn password_protected_device_file(alice: &Device) {
     //     memlimit_kb: 8
     //     parallelism: 1
     let filedata = hex!(
-        "88aa63697068657274657874c502119743c0a4c62a016e8c1afd000197ecdc6a589ccb"
-        "c5a97e323eb2a0ad4304f2e2a04dc56fcdda1bf857ca6ef5c8a63c1485b65d333da166"
-        "f59395ef12381016d5d7edc934d112b6404d113a0549d87b86f673c970dc740e580150"
-        "c6fafc155c217a8e2ab463f10d32c3a4ea20e500cd5ec88f4e0f20f8772cf70b0ffb3d"
-        "0a6fbd35d29d4676a012f08c9cf8f8c3e36b0af29fa9a7371d785ee06f6b5966567e17"
-        "cdb4c2a9789511b6f469b394668a56ca60b2ab3d4843007075d8cde834054db43751dc"
-        "39e2dd3936750a3244f53778645e7daeb3b1030e7edae8bea4a770ce2cfb465a5b5996"
-        "2fdc574859ba3d5989b349501d5d0224f1388bb9a5f68e578319502c4b3b9d8f7f0c06"
-        "5018bc2b3368e3bb96d13cc53e22848bee0b86b4f7daa497bdb308cd3d39daf09f198a"
-        "ceb93f385d4984c8ed36e225d0ef40c60431ec1791e8082f0039eaaa7d8641af4e2dbc"
-        "441a36c71f13d4e214440fcbc25374d370d8d5033f4a45c4c9cb5fe7483d6eeba308b1"
-        "efd9a4f335ef80b3e8353462088622afaf25916d495945065e1db440615986e0a1b4c0"
-        "f8c29f8819c548603a76215e8301508504aa5dbd136233304c75ed6327a4706e9a5074"
-        "e76d9c693a58d0e411eb54a67a910b15e36894c83e8099f4b80027053faf46fde70a84"
-        "69650d6f91560a7dfe1b876d23f22c2668aaefb817cdc47be0f1f8d2a5500014920f51"
-        "adb2f5a1d9a3e543012c3ed270ff12cd481df5a96465766963655f6964aa616c696365"
-        "4064657631ac6465766963655f6c6162656caf4d792064657631206d616368696e65ac"
-        "68756d616e5f68616e646c6592b1616c696365406578616d706c652e636f6db2416c69"
-        "636579204d63416c69636546616365af6f7267616e697a6174696f6e5f6964a7436f6f"
-        "6c4f7267a4736c7567bd6637383239323432326523436f6f6c4f726723616c69636540"
-        "64657631a474797065a870617373776f7264a9616c676f726974686d85a474797065a8"
-        "4152474f4e324944a473616c74c4102ae6167f0f7472b8565c390df3af4a8ba86f7073"
-        "6c696d697401ab6d656d6c696d69745f6b6208ab706172616c6c656c69736d01"
+        "9ba870617373776f7264d70100047c0f0d84c000d70100047cc41a172000b668747470"
+        "733a2f2f7061727365632e696e76616c6964a7436f6f6c4f7267d802a11cec00100000"
+        "000000000000000000d802de10a11cec001000000000000000000092b1616c69636540"
+        "6578616d706c652e636f6db2416c69636579204d63416c69636546616365af4d792064"
+        "657631206d616368696e6595a84152474f4e324944080101c4102ae6167f0f7472b856"
+        "5c390df3af4a8bc502119743c0a4c62a016e8c1afd000197ecdc6a589ccbc5a97e323e"
+        "b2a0ad4304f2e2a04dc56fcdda1bf857ca6ef5c8a63c1485b65d333da166f59395ef12"
+        "381016d5d7edc934d112b6404d113a0549d87b86f673c970dc740e580150c6fafc155c"
+        "217a8e2ab463f10d32c3a4ea20e500cd5ec88f4e0f20f8772cf70b0ffb3d0a6fbd35d2"
+        "9d4676a012f08c9cf8f8c3e36b0af29fa9a7371d785ee06f6b5966567e17cdb4c2a978"
+        "9511b6f469b394668a56ca60b2ab3d4843007075d8cde834054db43751dc39e2dd3936"
+        "750a3244f53778645e7daeb3b1030e7edae8bea4a770ce2cfb465a5b59962fdc574859"
+        "ba3d5989b349501d5d0224f1388bb9a5f68e578319502c4b3b9d8f7f0c065018bc2b33"
+        "68e3bb96d13cc53e22848bee0b86b4f7daa497bdb308cd3d39daf09f198aceb93f385d"
+        "4984c8ed36e225d0ef40c60431ec1791e8082f0039eaaa7d8641af4e2dbc441a36c71f"
+        "13d4e214440fcbc25374d370d8d5033f4a45c4c9cb5fe7483d6eeba308b1efd9a4f335"
+        "ef80b3e8353462088622afaf25916d495945065e1db440615986e0a1b4c0f8c29f8819"
+        "c548603a76215e8301508504aa5dbd136233304c75ed6327a4706e9a5074e76d9c693a"
+        "58d0e411eb54a67a910b15e36894c83e8099f4b80027053faf46fde70a8469650d6f91"
+        "560a7dfe1b876d23f22c2668aaefb817cdc47be0f1f8d2a5500014920f51adb2f5a1d9"
+        "a3e543012c3ed270ff12cd481df5"
     );
     let _password = "P@ssw0rd.";
 
@@ -94,38 +90,38 @@ fn password_protected_device_file(alice: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn keyring_device_file(alice: &Device) {
-    // Generated from Rust implementation (Parsec v3.0.0+dev)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
     //   type: "keyring"
     //   ciphertext: <encrypted alice local device>
     //   human_handle: ("bob@example.com", "Boby McBobFace")
     //   device_label: "My dev1 machine"
     //   organization_id: "CoolOrg"
-    //   device_id: "alice@dev1"
-    //   slug: "f78292422e#CoolOrg#alice@dev1"
+    //   device_id: ext(2, de10a11cec0010000000000000000000)
     //   keyring_user: "keyring_user"
     let filedata = hex!(
-        "99a76b657972696e67c5021141d162cceacbc6845a582ee1497e37469ce46e6e09b33e"
-        "1cd5d68d0e054188e38aa85e2a02d0a344cd986e712274f8824f9464fa5a27f7f2291f"
-        "42cf579b6be44e0733f89a07f45150dfd8096634f685a44db07693e085e3af6f5525c1"
-        "4216f3860adaf612c4a8235e005bc1f9dc31aa24f49383b5afb9f7a2e788bbadb67589"
-        "4a5f316085449b223df957b799140fe9cdfd3fea56fbaa452b250cad39ce4cc6c7ccdf"
-        "e8248e15c7575c4b259f7d3aa93c106b5d99443724b6b2be4e9f55dd3ba5cd29da633a"
-        "a20a643599221b8bfe99c6029f7f2160cd18c89a05d71713d51b57b98f56036a9cab70"
-        "4376cd6a754985345fc6309de5c6e852489406b946e213a71154668ccf9adb089527d2"
-        "8f84ba7b8425d0d13aa697e8ecaa5b6192b7400b1fc589bbb72a7b5dbf1b9942a3837d"
-        "1bb1e86401f329172ed57e140a67ec80ba3a74fc804436588ec8057540529c121887ba"
-        "4e86236d53b1b8ed7f8d8d4798c769e5ddbdf785fbe9872cf5dc201016705f67424dfd"
-        "3a02ddc5be737a64325c80a3b678b3908e1036de6880c897fb87236decde2110eeff74"
-        "53f07b755bb634020d2a06fb3599513cbd0c56f25f2cd7fc10ecf11719ec719d7e36d6"
-        "d79d9f72ec213d9be2113c9e90d9449e1e2b143c608662c9456b7fb34ff1dcbcf8f54e"
-        "f860d6681f6a8c6ef65e7831a381999dfedc98e7b33afae58d4edb101475c29fd9804a"
-        "7bd9adfc99bc2697e16c460e5a4f2dc792b1616c696365406578616d706c652e636f6d"
-        "b2416c69636579204d63416c69636546616365af4d792064657631206d616368696e65"
-        "aa616c6963654064657631a7436f6f6c4f7267bd6637383239323432326523436f6f6c"
-        "4f726723616c6963654064657631a6706172736563ac6b657972696e675f75736572"
+        "9ca76b657972696e67d70100047c0f0d84c000d70100047cc41a172000b66874747073"
+        "3a2f2f7061727365632e696e76616c6964a7436f6f6c4f7267d802a11cec0010000000"
+        "0000000000000000d802de10a11cec001000000000000000000092b1616c6963654065"
+        "78616d706c652e636f6db2416c69636579204d63416c69636546616365af4d79206465"
+        "7631206d616368696e65a6706172736563ac6b657972696e675f75736572c5021141d1"
+        "62cceacbc6845a582ee1497e37469ce46e6e09b33e1cd5d68d0e054188e38aa85e2a02"
+        "d0a344cd986e712274f8824f9464fa5a27f7f2291f42cf579b6be44e0733f89a07f451"
+        "50dfd8096634f685a44db07693e085e3af6f5525c14216f3860adaf612c4a8235e005b"
+        "c1f9dc31aa24f49383b5afb9f7a2e788bbadb675894a5f316085449b223df957b79914"
+        "0fe9cdfd3fea56fbaa452b250cad39ce4cc6c7ccdfe8248e15c7575c4b259f7d3aa93c"
+        "106b5d99443724b6b2be4e9f55dd3ba5cd29da633aa20a643599221b8bfe99c6029f7f"
+        "2160cd18c89a05d71713d51b57b98f56036a9cab704376cd6a754985345fc6309de5c6"
+        "e852489406b946e213a71154668ccf9adb089527d28f84ba7b8425d0d13aa697e8ecaa"
+        "5b6192b7400b1fc589bbb72a7b5dbf1b9942a3837d1bb1e86401f329172ed57e140a67"
+        "ec80ba3a74fc804436588ec8057540529c121887ba4e86236d53b1b8ed7f8d8d4798c7"
+        "69e5ddbdf785fbe9872cf5dc201016705f67424dfd3a02ddc5be737a64325c80a3b678"
+        "b3908e1036de6880c897fb87236decde2110eeff7453f07b755bb634020d2a06fb3599"
+        "513cbd0c56f25f2cd7fc10ecf11719ec719d7e36d6d79d9f72ec213d9be2113c9e90d9"
+        "449e1e2b143c608662c9456b7fb34ff1dcbcf8f54ef860d6681f6a8c6ef65e7831a381"
+        "999dfedc98e7b33afae58d4edb101475c29fd9804a7bd9adfc99bc2697e16c460e5a4f"
+        "2dc7"
     );
 
     let expected = DeviceFileKeyring {
@@ -168,39 +164,36 @@ fn keyring_device_file(alice: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn recovery_device_file(alice: &Device) {
-    // Generated from Python implementation (Parsec v2.6.0)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
     //   type: "recovery"
     //   ciphertext: <encrypted alice local device>
     //   human_handle: ("bob@example.com", "Boby McBobFace")
     //   device_label: "My dev1 machine"
     //   organization_id: "CoolOrg"
-    //   device_id: "alice@dev1"
-    //   slug: "f78292422e#CoolOrg#alice@dev1"
+    //   device_id: ext(2, de10a11cec0010000000000000000000)
     let filedata = hex!(
-        "87aa63697068657274657874c5021141d162cceacbc6845a582ee1497e37469ce46e6e"
-        "09b33e1cd5d68d0e054188e38aa85e2a02d0a344cd986e712274f8824f9464fa5a27f7"
-        "f2291f42cf579b6be44e0733f89a07f45150dfd8096634f685a44db07693e085e3af6f"
-        "5525c14216f3860adaf612c4a8235e005bc1f9dc31aa24f49383b5afb9f7a2e788bbad"
-        "b675894a5f316085449b223df957b799140fe9cdfd3fea56fbaa452b250cad39ce4cc6"
-        "c7ccdfe8248e15c7575c4b259f7d3aa93c106b5d99443724b6b2be4e9f55dd3ba5cd29"
-        "da633aa20a643599221b8bfe99c6029f7f2160cd18c89a05d71713d51b57b98f56036a"
-        "9cab704376cd6a754985345fc6309de5c6e852489406b946e213a71154668ccf9adb08"
-        "9527d28f84ba7b8425d0d13aa697e8ecaa5b6192b7400b1fc589bbb72a7b5dbf1b9942"
-        "a3837d1bb1e86401f329172ed57e140a67ec80ba3a74fc804436588ec8057540529c12"
-        "1887ba4e86236d53b1b8ed7f8d8d4798c769e5ddbdf785fbe9872cf5dc201016705f67"
-        "424dfd3a02ddc5be737a64325c80a3b678b3908e1036de6880c897fb87236decde2110"
-        "eeff7453f07b755bb634020d2a06fb3599513cbd0c56f25f2cd7fc10ecf11719ec719d"
-        "7e36d6d79d9f72ec213d9be2113c9e90d9449e1e2b143c608662c9456b7fb34ff1dcbc"
-        "f8f54ef860d6681f6a8c6ef65e7831a381999dfedc98e7b33afae58d4edb101475c29f"
-        "d9804a7bd9adfc99bc2697e16c460e5a4f2dc7a96465766963655f6964aa616c696365"
-        "4064657631ac6465766963655f6c6162656caf4d792064657631206d616368696e65ac"
-        "68756d616e5f68616e646c6592b1616c696365406578616d706c652e636f6db2416c69"
-        "636579204d63416c69636546616365af6f7267616e697a6174696f6e5f6964a7436f6f"
-        "6c4f7267a4736c7567bd6637383239323432326523436f6f6c4f726723616c69636540"
-        "64657631a474797065a87265636f76657279"
+        "9aa87265636f76657279d70100047c0f0d84c000d70100047cc41a172000b668747470"
+        "733a2f2f7061727365632e696e76616c6964a7436f6f6c4f7267d802a11cec00100000"
+        "000000000000000000d802de10a11cec001000000000000000000092b1616c69636540"
+        "6578616d706c652e636f6db2416c69636579204d63416c69636546616365af4d792064"
+        "657631206d616368696e65c5021141d162cceacbc6845a582ee1497e37469ce46e6e09"
+        "b33e1cd5d68d0e054188e38aa85e2a02d0a344cd986e712274f8824f9464fa5a27f7f2"
+        "291f42cf579b6be44e0733f89a07f45150dfd8096634f685a44db07693e085e3af6f55"
+        "25c14216f3860adaf612c4a8235e005bc1f9dc31aa24f49383b5afb9f7a2e788bbadb6"
+        "75894a5f316085449b223df957b799140fe9cdfd3fea56fbaa452b250cad39ce4cc6c7"
+        "ccdfe8248e15c7575c4b259f7d3aa93c106b5d99443724b6b2be4e9f55dd3ba5cd29da"
+        "633aa20a643599221b8bfe99c6029f7f2160cd18c89a05d71713d51b57b98f56036a9c"
+        "ab704376cd6a754985345fc6309de5c6e852489406b946e213a71154668ccf9adb0895"
+        "27d28f84ba7b8425d0d13aa697e8ecaa5b6192b7400b1fc589bbb72a7b5dbf1b9942a3"
+        "837d1bb1e86401f329172ed57e140a67ec80ba3a74fc804436588ec8057540529c1218"
+        "87ba4e86236d53b1b8ed7f8d8d4798c769e5ddbdf785fbe9872cf5dc201016705f6742"
+        "4dfd3a02ddc5be737a64325c80a3b678b3908e1036de6880c897fb87236decde2110ee"
+        "ff7453f07b755bb634020d2a06fb3599513cbd0c56f25f2cd7fc10ecf11719ec719d7e"
+        "36d6d79d9f72ec213d9be2113c9e90d9449e1e2b143c608662c9456b7fb34ff1dcbcf8"
+        "f54ef860d6681f6a8c6ef65e7831a381999dfedc98e7b33afae58d4edb101475c29fd9"
+        "804a7bd9adfc99bc2697e16c460e5a4f2dc7"
     );
     let _recovery_password = "F4D4-ZGIQ-3DYH-WPFF-QPIM-DWXJ-VFKA-Z7FT-K444-EU2Q-7DAI-QPGW-NNWQ";
 
@@ -242,9 +235,9 @@ fn recovery_device_file(alice: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
+
 fn smartcard_device_file(alice: &Device) {
-    // Generated from Python implementation (Parsec v2.15.0+dev)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
     //   type: "smartcard"
     //   certificate_id: "foo"
@@ -265,37 +258,32 @@ fn smartcard_device_file(alice: &Device) {
     //     "dedba44fcb6224654859605a2bbeb979e7d73f233724ab4846b38c94ce603de796f866d0d90fb0ba"
     //     "dd037a135cca4d018e"
     //   )
-    //   device_id: "alice@dev1"
+    //   device_id: ext(2, de10a11cec0010000000000000000000)
     //   device_label: "My dev1 machine"
     //   encrypted_key: hex!("666f6f")
     //   human_handle: ["alice@example.com", "Alicey McAliceFace"]
     //   organization_id: "CoolOrg"
-    //   slug: "f78292422e#CoolOrg#alice@dev1"
-    //
     let raw = hex!(
-        "8aae63657274696669636174655f6964a3666f6fb063657274696669636174655f7368"
-        "6131c403666f6faa63697068657274657874c50211a73aff77a2aa692b4393e094bfd2"
-        "c2ccad4b0a8d010960caf27165b787fb412ed2aeeb99f492a87063e368cebe38dc1f20"
-        "c65273cb3254480cc9e4b519a53241205b531b41edfa749419b83aeb0fb46cc2e21ae2"
-        "5782a1ab8fd3a32ca3b8fca4a0ffc8a301b62aca6612d87e7f34a89b6e747ec82d3873"
-        "4d7943e17009d091d699871aaf964b8426292d0a405ea3e868dca65028dae317a0311a"
-        "f3a958f86541edaef33d49e05056ccb038cc9f7dae40a336dd207eea4341229ba7efa3"
-        "9aa0df28d0d33d91fba49dd63f3814c162fff9083674acd6cc8b621b869c801d0a5274"
-        "74e7da6cd51053803529542d39c9e6794353be278c39ec06cb20560a01e80db86a20df"
-        "80808f2115ff28afdc2cf9da5099218d4c873dfcbf78e88e4e63ddfcf883de5527b4b2"
-        "34ca63c286a7aa12de2fc6337dd1709f6f5922e3d9f1029ce2b66d2fb856edb1c701f3"
-        "2c33fa4ca5d0789f52ce2091c48270324f5f631000f6ded1f0c5e1ae94831f488faeff"
-        "93d8e0c2e26411b499dea920a14733fbea42dd95a8ec13726f33c45f0c19f6e6b9b37a"
-        "dde46ce49465ebad63bfd8106e2d1fb7bc2ff3fea5c86d713226e098aca0ea48fe4180"
-        "e801eac583e96fd9fae329358f54f57d46c22f845e3d083f6d6deaf09d821eaaadbbd9"
-        "45ac6f8131b70427794db0dedba44fcb6224654859605a2bbeb979e7d73f233724ab48"
-        "46b38c94ce603de796f866d0d90fb0badd037a135cca4d018ea96465766963655f6964"
-        "aa616c6963654064657631ac6465766963655f6c6162656caf4d792064657631206d61"
-        "6368696e65ad656e637279707465645f6b6579c403666f6fac68756d616e5f68616e64"
-        "6c6592b1616c696365406578616d706c652e636f6db2416c69636579204d63416c6963"
-        "6546616365af6f7267616e697a6174696f6e5f6964a7436f6f6c4f7267a4736c7567bd"
-        "6637383239323432326523436f6f6c4f726723616c6963654064657631a474797065a9"
-        "736d61727463617264"
+        "9da9736d61727463617264d70100047c0f0d84c000d70100047cc41a172000b6687474"
+        "70733a2f2f7061727365632e696e76616c6964a7436f6f6c4f7267d802a11cec001000"
+        "00000000000000000000d802de10a11cec001000000000000000000092b1616c696365"
+        "406578616d706c652e636f6db2416c69636579204d63416c69636546616365af4d7920"
+        "64657631206d616368696e65a3666f6fc403666f6fc403666f6fc50211a73aff77a2aa"
+        "692b4393e094bfd2c2ccad4b0a8d010960caf27165b787fb412ed2aeeb99f492a87063"
+        "e368cebe38dc1f20c65273cb3254480cc9e4b519a53241205b531b41edfa749419b83a"
+        "eb0fb46cc2e21ae25782a1ab8fd3a32ca3b8fca4a0ffc8a301b62aca6612d87e7f34a8"
+        "9b6e747ec82d38734d7943e17009d091d699871aaf964b8426292d0a405ea3e868dca6"
+        "5028dae317a0311af3a958f86541edaef33d49e05056ccb038cc9f7dae40a336dd207e"
+        "ea4341229ba7efa39aa0df28d0d33d91fba49dd63f3814c162fff9083674acd6cc8b62"
+        "1b869c801d0a527474e7da6cd51053803529542d39c9e6794353be278c39ec06cb2056"
+        "0a01e80db86a20df80808f2115ff28afdc2cf9da5099218d4c873dfcbf78e88e4e63dd"
+        "fcf883de5527b4b234ca63c286a7aa12de2fc6337dd1709f6f5922e3d9f1029ce2b66d"
+        "2fb856edb1c701f32c33fa4ca5d0789f52ce2091c48270324f5f631000f6ded1f0c5e1"
+        "ae94831f488faeff93d8e0c2e26411b499dea920a14733fbea42dd95a8ec13726f33c4"
+        "5f0c19f6e6b9b37adde46ce49465ebad63bfd8106e2d1fb7bc2ff3fea5c86d713226e0"
+        "98aca0ea48fe4180e801eac583e96fd9fae329358f54f57d46c22f845e3d083f6d6dea"
+        "f09d821eaaadbbd945ac6f8131b70427794db0dedba44fcb6224654859605a2bbeb979"
+        "e7d73f233724ab4846b38c94ce603de796f866d0d90fb0badd037a135cca4d018e"
     );
     let expected = DeviceFile::Smartcard(DeviceFileSmartcard {
         encrypted_key: b"foo".as_ref().into(),
@@ -332,7 +320,6 @@ fn smartcard_device_file(alice: &Device) {
     });
 
     let device = DeviceFile::load(&raw).unwrap();
-
     p_assert_eq!(device, expected);
 
     // Also test roundtrip
@@ -344,7 +331,6 @@ fn smartcard_device_file(alice: &Device) {
 }
 
 #[test]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn available_device() {
     let org: OrganizationID = "CoolOrg".parse().unwrap();
 
@@ -354,15 +340,14 @@ fn available_device() {
         protected_on: "2010-01-10T00:00:00Z".parse().unwrap(),
         server_url: "https://parsec.invalid".to_string(),
         organization_id: org.clone(),
-        user_id: "9c50250fa3b644e29f77eeefa53dc37d".parse().unwrap(),
-        device_id: "9fd3863a3eb240cfaec64904efe5bed3".parse().unwrap(),
+        user_id: "alice".parse().unwrap(),
+        device_id: "alice@dev1".parse().unwrap(),
         human_handle: HumanHandle::new("john@example.com", "John Doe").unwrap(),
         device_label: "MyPc".parse().unwrap(),
         ty: DeviceFileType::Password,
     };
-
     p_assert_eq!(
         available.device_id.hex(),
-        "57f426e7a3cd5dc4a5d19fb8a83addb9112a65d12a13e2f72dd1fdfb9a8a4971"
+        "de10a11cec0010000000000000000000"
     );
 }

--- a/libparsec/crates/types/tests/unit/local_manifest.rs
+++ b/libparsec/crates/types/tests/unit/local_manifest.rs
@@ -224,14 +224,14 @@ fn serde_local_file_manifest_invalid_blocksize() {
 #[case::folder_manifest(Box::new(|alice: &Device| {
     let now = "2021-12-04T11:50:43.208821Z".parse().unwrap();
     (
-        // Generated from Parsec v3.0.0-b.6+dev
+        // Generated from Parsec v3.0.0-b.11+dev
         // Content:
         //   type: "local_folder_manifest"
         //   parent: ext(2, hex!("40c8fe8cd69742479f418f1a6d54ea7a"))
         //   updated: ext(1, 1638618643.208821)
         //   base: {
         //     type: "folder_manifest"
-        //     author: "alice@dev1"
+        //     author: ext(2, de10a11cec0010000000000000000000)
         //     timestamp: ext(1, 1638618643.208821)
         //     id: ext(2, hex!("87c6b5fd3b454c94bab51d6af1c6930b"))
         //     parent: ext(2, hex!("07748fbf67a646428427865fd730bf3e"))
@@ -246,19 +246,20 @@ fn serde_local_file_manifest_invalid_blocksize() {
         //   need_sync: true
         //   speculative: false
         &hex!(
-            "9c8a25134ade10150c12d5c9b9f4d47dfd32c887102d9aeecde2bd7f752651e3c5cdf0"
-            "ef6bbd9b7c395437af73696b27bfd6fd2e8b0d5dd7269969e1bc3a1e8aa124be6218a1"
-            "4e7432abc5d263c641b8b4742d4a3470d415323f967e3825e4aafc02b7aafe7ddd62ff"
-            "f0910b66fe1133889a7a583fd1b945eec325f99b0ca5003bf4658355c188625fb1bb13"
-            "87b19533eace14045191e35197566ddb1c650bbe6abc4d95ed354242ce55f15e53e354"
-            "186eb15c44a0bc78abf94a723613ab3bb58e1186e1c157488c18a615ccb623df06561c"
-            "e5919b10c726812366bdac8cda53c8337157848f6ad9dfd531bce00b9c0b19a855a3ee"
-            "4ecb1cb6f9b74302674e996d3ddf3530483044754e4767cb6ecfc74ff25519e3bc5593"
-            "2bbf94f74bf4664167af157f170d5d5978307018f35edffcab17c1cd617f0d17a3136b"
-            "9ed5275ae56349567ce1f7ea5f65a3c4740c259fe50de67b067488548354969ee16f1c"
-            "ca6cc763194414a469b875b98e6e82d2a95a0f9d2701844fe8781227a59a607bab8b5d"
-            "ce7b8bd2c17590c15718a129a6ee7c6691eff49c4c33e56b5c94d66d005292f68e556e"
-            "7d99ce68645d7fda63803581e29f1909e06f67a2783afd77bff4a18a"
+            "ab892bdf53c956853286db81fc065764581d7b4814f826665d7703f67be19079cf886b"
+            "d620679ec8e2c686b6ba432968aa3ed1a034e5a0551cf0632446e55bea7338829d2ba4"
+            "987d3cd5de8f885403fcddac91e50c2829c3e71556616d40f62e47087ab2fc59a67e58"
+            "f277f0606b5f1e2867dffac5324a41029b77ec028acc9115531cc5cd683f95ec5bd83c"
+            "a9533a6a2194ff2e763f05370509c137bb6e39263dc2ea879127d40eba075d8b05e167"
+            "295b218c1e31f914065147d64d3baf2c386c78f97a57e0d857bc8c947432eaf0d90055"
+            "e1297e99c89cf723c6306e4de954b71974026b31826a8657463aedaec5741d1ddec006"
+            "a914d636276f0d80ddb77841d7308ac776bc50cf4daa7a62cd0c0fbfe7b79a8dbd1d63"
+            "6b820a8760a233da7b1be6520469c4a09def3aaebc4679a4617b2cce451163372bab55"
+            "e9e948f7ad5fd5355a8585d58bd058306d90a445dc6b0a2c192d6af176a95db3a8fd51"
+            "63e9937bc85751afbc80a159bf01446c36484db99c873be3ee7d7e71b9cebede27b438"
+            "93265e1636549948bc084b1e45dff4a32af757905bf10e70c8527429ee857716ef0d5a"
+            "8e194dbd7af90f6820b9c21fdfff3e8291fa814cba96c6ac12a19a089a2e1ca622fad6"
+            "40"
         )[..],
         LocalFolderManifest {
             parent: VlobID::from_hex("40c8fe8cd69742479f418f1a6d54ea7a").unwrap(),
@@ -288,14 +289,14 @@ fn serde_local_file_manifest_invalid_blocksize() {
 #[case::folder_manifest_speculative(Box::new(|alice: &Device| {
     let now = "2021-12-04T11:50:43.208821Z".parse().unwrap();
     (
-        // Generated from Parsec v3.0.0-b.6+dev
+        // Generated from Parsec v3.0.0-b.11+dev
         // Content:
         //   type: "local_folder_manifest"
         //   parent: ext(2, hex!("40c8fe8cd69742479f418f1a6d54ea7a"))
         //   updated: ext(1, 1638618643.208821)
         //   base: {
         //     type: "folder_manifest"
-        //     author: "alice@dev1"
+        //     author: ext(2, de10a11cec0010000000000000000000)
         //     timestamp: ext(1, 1638618643.208821)
         //     id: ext(2, hex!("87c6b5fd3b454c94bab51d6af1c6930b"))
         //     parent: ext(2, hex!("07748fbf67a646428427865fd730bf3e"))
@@ -310,17 +311,17 @@ fn serde_local_file_manifest_invalid_blocksize() {
         //   need_sync: true
         //   speculative: true
         &hex!(
-            "c9478625a33eb9516ae53b2b38428ed093ad36091db5305fb70c1cb39810677baed3b0"
-            "0ee5b142f1cc3957809ba360af76282b41eb4834262e6afe1b2ec8adcf7d866bfcb4dd"
-            "6e2b91bc7316a20250e37a3063d9220dd3b5b93c45dbc7e1a1fbad032c5f6215a10431"
-            "ff8ce49dc4692a84794b61a2e2d7c4180b60386eca4789a2fd02e699d889af23a360ad"
-            "6a4db25baa9bbcdae8b59542a77770d3488d39d0a1b87f04c3d79dc26397930f7dddcb"
-            "1ce7cc31d166150fd7689737235b27a8e1b4136a526523e897f628fb5fbc8df021abbd"
-            "7021d02560f048a55e01209ad8c761ef1397ed3360b68fc56911a129c56e9495a62a76"
-            "3fef4be06d9c529d1f4a5088532ad92050d3ca2a4023045c81ebf255bc59349c7fc1f9"
-            "fa50717fb7a70e4d09544ffd9c89a4ead4cd8eebff83656be1b7ea43bae784e58c940d"
-            "63eb7c6c2fa6d95cdc7c35dc1441939196a7d3c2fcca21b6e4a9787da43b7f3e7a732c"
-            "5e55cf055f3b954d96a54bfe1c0f"
+            "c731bca8d0cb4aa5a0865a9f107a155ce56771464fb32779c461b10fa0926a190fb100"
+            "9bc7381c6d7e60ac6a6e591bf32d8c643642e80cef1dcc39425052798d569658d277a9"
+            "679278e37338485e9bea40e68eb00baccd004895af85170c1c7d629c3a865ad0541a96"
+            "44d3c9dd47d7118d4381028d080b799b5689414dc4b73f94a27eaec8dc2a87cb2ff27d"
+            "660883818415e6d5643b130c860cf0e3d7cfa0d2b668857b0cab7e073a88b547ec01d7"
+            "d6f799aa39003c86e1f2c53c3836f4f7214055dc6492e2771dc437b848e6ee7f0adc71"
+            "2d94ac5b44b98bd5b2f1b16ed301e8791899f88689bb015e1cd167f077ba2c557bf482"
+            "5989515d78a067a00edb00476246110e4f6e9b065315299c6e965151b663b8e025ac54"
+            "4f7843b8dc66cea69bdac349c096c5c6c7ea5a76561ca6979e3fe235b07a30d5c8f1ad"
+            "93d88b255e5c599722600107d25dbb6135d28bce8e37044e0d888cd3d202f06b5e7154"
+            "c8a1e8030cfa03e6828a150f1a260e974e53bee1bdd5"
         )[..],
         LocalFolderManifest {
             parent: VlobID::from_hex("40c8fe8cd69742479f418f1a6d54ea7a").unwrap(),
@@ -370,7 +371,7 @@ fn serde_local_folder_manifest(
 #[case::need_sync(Box::new(|alice: &Device| {
     let now = "2021-12-04T11:50:43.208821Z".parse().unwrap();
     (
-        // Generated from Parsec v3.0.0-b.6+dev
+        // Generated from Parsec v3.0.0-b.11+dev
         // Content:
         //   type: "local_user_manifest"
         //   updated: ext(1, 1638618643.208821)
@@ -404,28 +405,28 @@ fn serde_local_folder_manifest(
         //   ]
         //   base: {
         //     type: "user_manifest"
-        //     author: "alice@dev1"
+        //     device_id: ext(2, de10a11cec0010000000000000000000)
         //     timestamp: ext(1, 1638618643.208821)
         //     created: ext(1, 1638618643.208821)}
         //     updated: ext(1, 1638618643.208821)
         //     version: 42
         //   }
         &hex!(
-            "be56b2c031af53f2f006834cb117acbfa1814633a0738b1f33dfddff3a63a3b64deec4"
-            "031f9739365ca4971cb40cc209ab167e9cfb69db0922429ae4f0e595d9f4f8eed7846d"
-            "7b553ac83256c69a5b46603b43ebe0ee4c70349806a461e180f7d7d12bc483c744195f"
-            "fd7a8cb3fd77674371bc8574433ee46e1c18f8a652ff37c435cc5f4d1e380c5902e831"
-            "f4e48c8e4a9798c13f5072eaa2730e5b5b06c1ab565ca81eea197e830817a5f1aacd87"
-            "f054eeaeb7786a1b94caab10e984f6caa926ec6998478fc27da61a2e853ebf10ca65b0"
-            "6610ebf508093dbb38dfccd60d48ae191ae547ad09be84780ff28129b67c509a2bc93f"
-            "e6def7c76b8773f34bc7a3ada6c9754ce24dc46f3df055f234bc46345e958cbd82a48b"
-            "86766f90973b1f854ad19f693e8d203367b9e7dcb7dc43c62849bbc2c3a8d027471206"
-            "3de8398cca20d52543d71a276304fbbe2e7820430f74e39bc0ab6637c4da8e300467ea"
-            "4ce5c418d06348ec06ae293e9331e89c6cb429be6ab8ecd0125a1ff516276a3f096601"
-            "e8d94614c5368f07221067f8b5b0475ad464f7594a5daa53c4fb4310168701fa4df404"
-            "1b7004bef61551d27a444dba384a66c2622d38e1a73fc5b5db1433bb4b731d170db881"
-            "56d4cb30723c72f19621b7302fc75f9b3eba2592b5723f67b28d8ff16e76c38418eb93"
-            "9af38a2dc18a102be2ec06d979b87f333f7a9d92a92257c149"
+            "e1ddd0d0c31cc06de56514b4d2dd684a074d24e8a1843163900c1042bc7330c947eabf"
+            "5d41e986ae4d5bc7e603356774a87fb9ee43ee447a3cb17c730cbf85d729b2645f968f"
+            "193c9edaac1636c7445f1eb510348f1d7868a7e4fe10a6d24b2e2818f3237b8eeb2310"
+            "b8075fa062451786efc1902106d0d67c9f5985ad066acdb005c94d4d987c2b0ffb4f61"
+            "8b54260d8aab4f49f1acc1bcd67ced2ff5f52f62a3477449f9051719cced881b1bef8f"
+            "ffb3d906ac75b0cd55940b474ca96df8fc4b51447a7d96a4666401556300becc49e86c"
+            "2610f4f838e784b5bf41e880cb76f53c77267167f4000b5ba5c2b868d4dc082faf341c"
+            "74a9df66481e0aca6bf8e308a3ad62962edf345458ddab102951b1458059b9b2a9391e"
+            "564a283e66669641e4be87263fe79fe827eeddf25ce48ac1ac5e2598b5b2b559dbab91"
+            "0efcd702b8ab07555d0757e7070a1ef07738fe9df2c2fc3a54658c6d3798fc53bd6603"
+            "6b0dfb9815a3f4283c8460d4c1aa6923324146937edb4957184a0c77aac5ac6dcdde57"
+            "25fb3b85f0a47d4996a57af35757eef2fc6a1d258eca5d968cf60331379679c75f5816"
+            "9eb959da3ee7f9913ac1c6b325c1a759b3d09dab65007d97e817bd28c688a51e85ff57"
+            "87ef8de336742c196b73e2f2d9eba53905c736b8e5f5c77a7872fdd8d6270ffbc5fbf8"
+            "e672c5b4ed0fc260b42369da4c436e8387048223c7ef22404008fef6a98e40b882"
         )[..],
         LocalUserManifest {
             updated: now,
@@ -461,7 +462,7 @@ fn serde_local_folder_manifest(
 #[case::synced(Box::new(|alice: &Device| {
     let now = "2021-12-04T11:50:43.208821Z".parse().unwrap();
     (
-        // Generated from Parsec v3.0.0-b.6+dev
+        // Generated from Parsec v3.0.0-b.11+dev
         // Content:
         //   type: "local_user_manifest"
         //   updated: ext(1, 1638618643.208821)
@@ -482,7 +483,7 @@ fn serde_local_folder_manifest(
         //   ]
         //   base: {
         //     type: "user_manifest"
-        //     author: "alice@dev1"
+        //     device_id: ext(2, de10a11cec0010000000000000000000)
         //     timestamp: ext(1, 1638618643.208821)
         //     id: ext(2, hex!("87c6b5fd3b454c94bab51d6af1c6930b"))
         //     version: 42
@@ -490,17 +491,17 @@ fn serde_local_folder_manifest(
         //     updated: ext(1, 1638618643.208821)
         //   }
         &hex!(
-            "6645e8c8e9415a69cc47a284dbd6ac1bdc9c66347374b118ba361f9e63cf868edd651d"
-            "2f110e8fa3b466a003d7eb0416bf0bc15e6e1cc3699d799b765b919c8f19fc3d3dad8f"
-            "a4a1faa0f31f0de7ecc81c120d8b49641c9b21d466db4c204ab5b943e9e91efba84099"
-            "9d128a85968103af838ceccb2a102d5ac14216c86df6cf22e1a59b5504dcac1d05f940"
-            "d00bd9d5d3ff403be15c7422eb62392c6892fe47eeb453f04300f0306405ef463d2794"
-            "8df84b63d5d47e5e78f693c9ec6cd1ffd77e7df72b8c3144c3fb8bc42bf53173ed32ff"
-            "edac9e779b09732211400b64407c81c7c5d64fe5465af0cf8f37278ad7c4def9a6d824"
-            "a2cb2d4e9b2acbba52ad0c33815ecf01b260e94ad5e4f53eee295f43454d01efe5335f"
-            "d02b666d759b7ad25edf1c53a640c008d2af20ddf21e3793b36f6ad0fc44f46caaac25"
-            "1438520389da2ef61210288e52e1a1b31d6e7565c9491e3b7873416ec5cd26c74e4c63"
-            "6102749d37e9b3424b2ee9a61461c0"
+            "39679fb1d1b531e046a667e8c10030ad219218864cd6df033755b48330fc51088fd218"
+            "e167f8035456d89129b4959225401a00759d828ce8f3f8139e309cbf29e9223f73633c"
+            "abf15620478aafadd9cbfd51b22438a3b5c66036b7d8e5b3eb83c5aebcb2f02c8b5c2e"
+            "25b22e8963847346b21c564164f1d049ea556f7d3bbbe0e0ff7a60f742ceef2bb9789c"
+            "4ad2a33cfb4467ee5eafcb529f17d69e9d78042c45fffb6e3dce20bfcf8166f5749284"
+            "f21f3ad776aef0a7f58ea215408478e24132cb330ad7f9f81ce14ce055e8b7a3421678"
+            "959a9031a2613e6aa1c3756d90fe6ade7c621df8f63e500babcd0ca432764ab6b760f6"
+            "f67358bf369de860dc0719d42f78b68666cdc526674961d90df8060c29d0d1ce41abfa"
+            "5d976156ab8e95113aaf35e3f3c00d372a3a3f506fd346d99d1424bf6150293646b050"
+            "46147340166b046654d8c95a82e06864e2baf28e1e050198083a2c7eb09544e7863ed2"
+            "892a99fb2df4932550a763c347abdcce4d78256b230831"
         )[..],
         LocalUserManifest {
             updated: now,
@@ -529,7 +530,7 @@ fn serde_local_folder_manifest(
 #[case::speculative(Box::new(|alice: &Device| {
     let now = "2021-12-04T11:50:43.208821Z".parse().unwrap();
     (
-        // Generated from Parsec v3.0.0-b.6+dev
+        // Generated from Parsec v3.0.0-b.11+dev
         // Content:
         //   type: "local_user_manifest"
         //   updated: ext(1, 1638618643.208821)
@@ -538,7 +539,7 @@ fn serde_local_folder_manifest(
         //   local_workspaces: []
         //   base: {
         //     type: "user_manifest"
-        //     author: "alice@dev1"
+        //     device_id: ext(2, de10a11cec0010000000000000000000)
         //     timestamp: ext(1, 1638618643.208821)
         //     id: ext(2, hex!("87c6b5fd3b454c94bab51d6af1c6930b"))
         //     version: 0
@@ -546,14 +547,14 @@ fn serde_local_folder_manifest(
         //     updated: ext(1, 1638618643.208821)
         //   }
         &hex!(
-            "6cf0e1fd8dc90c25e5d27a4179b9953ff5dc4b8f0dc29c005e1c9fe442a7ad83836815"
-            "064ceaa35d4dca7ca13095a7ff2ce70b9203f6697e99509bc76e7efee269ab46ca486b"
-            "9fb954d28dc2a1bb48e49bafa0f88dd3ab2da9883d69263da18898382c640610ab9748"
-            "65036f903a63a64a3ef964ceea4006210a6f1cfffeb33c7d1c575eb35d93fdb1df0cde"
-            "d890c39241495805472c1f9ee43aa5f6abb7d13ccfb6540c44d1e2dffc6ec0c6887907"
-            "ad810f88dd27cbc95a178680f3e2f00e4f51775b3bd73228dd48eee64b8edf50464606"
-            "f0335c3152db0b1bb57235c6e8d9c1ddd269c81a2873426267cccb72869517f97cb134"
-            "2e3f2c22c7f7513f6181"
+            "63bd4da3423a061d0719d5c550bde6d4a6402d694d5ddb20cff209ddf57c1608812660"
+            "69b80b8993a588480e129e9393c357701681d51adc85825cab244f7bdadc1d636b40af"
+            "a544bff9b92048e9a2ef35617db6468e89b3e7cc35102c639d1782375e1379f3fe171b"
+            "f44a1552525bf0f9c5e011253a2ca50f3b0de0c161ac37417edfdbdec2912aeeb386d3"
+            "3a2a10a1705493600a20dbc326cfd4ed25dbe299a6ea1f2fa28da5b91f2f97f91d2291"
+            "0c6488b0064e418a6848de7f47611271aa86f900d0704a2436302411e57c0994b0829b"
+            "65278f92da9f5b2cb6d40e11dcf81fba6c5fca5a9bf5f9fbc9bfae74f247e553bf6bd2"
+            "eb1567bd99711d7986135498a1aadb5c7f07"
         )[..],
         LocalUserManifest {
             updated: now,
@@ -571,7 +572,6 @@ fn serde_local_folder_manifest(
         }
     )
 }))]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_local_user_manifest(
     alice: &Device,
     #[case] generate_data_and_expected: AliceLocalUserManifest,
@@ -581,7 +581,6 @@ fn serde_local_user_manifest(
         "b1b52e16c1b46ab133c8bf576e82d26c887f1e9deae1af80043a258c36fcabf3"
     ));
 
-    println!("{:?}", expected.dump_and_encrypt(&key));
     let manifest = LocalUserManifest::decrypt_and_load(data, &key).unwrap();
 
     p_assert_eq!(manifest, expected);

--- a/libparsec/crates/types/tests/unit/local_manifest.rs
+++ b/libparsec/crates/types/tests/unit/local_manifest.rs
@@ -174,7 +174,6 @@ fn serde_local_file_manifest_ok(alice: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_local_file_manifest_invalid_blocksize() {
     // Generated from Parsec v3.0.0-b.6+dev
     // Content:
@@ -344,7 +343,6 @@ fn serde_local_file_manifest_invalid_blocksize() {
         }
     )
 }))]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_local_folder_manifest(
     alice: &Device,
     #[case] generate_data_and_expected: AliceLocalFolderManifest,

--- a/libparsec/crates/types/tests/unit/manifest.rs
+++ b/libparsec/crates/types/tests/unit/manifest.rs
@@ -347,12 +347,11 @@ fn invalid_load(alice: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_file_manifest_ok(alice: &Device) {
-    // Generated from Parsec v3.0.0-b.6+dev
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
     //   type: "file_manifest"
-    //   author: "alice@dev1"
+    //   author: ext(2, de10a11cec0010000000000000000000)
     //   timestamp: ext(1, 1638618643.208821)
     //   id: ext(2, hex!("87c6b5fd3b454c94bab51d6af1c6930b"))
     //   version: 42
@@ -376,19 +375,19 @@ fn serde_file_manifest_ok(alice: &Device) {
     //   parent: ext(2, hex!("07748fbf67a646428427865fd730bf3e"))
     //   size: 700
     let data = hex!(
-        "09f77ead3e78f15e5c8d1475c11f704861682b7601250493fb4c7ae5b1387ba9a48c3d"
-        "fcd94bd1ba97a0a4c3928e95628588163cbdf9f6024cbbd19749841f7661d346d6dd0c"
-        "cc6f95750ca8755d5ada11c7e716453699815ff75c5c39267c5238f6e02171c50bd32d"
-        "271506b5a1834ff37a218b882503a607c8f8f4e26f834c2af620d733a130e3328ee2b7"
-        "0adeb43319a1a1e047ba2f699362ac236d92bc88ca18dbc67cbaff476b9cf1a0e9ffcc"
-        "d5e0ccebc97ee468191a513655d028ca1a973a26b510c38d26007f0f00fd8b71c3db89"
-        "7fcec1a3b3f2cc82bbb8319ef2e63ff8a12dbf5c3971352a40af512a69f4263085db6e"
-        "0700efc4da802a82585d1c306b311873e5cd01c92e84deb91d9d6bbab1f1cd0464e54d"
-        "7a0a9a29b2cf23bf7b00dc543c5c93ef1638d9dbdd86c29be5bc88b977ea34d55dbc39"
-        "5eb0b027d7985d67d96c927b8f1ddf5f3f15d1d45fb4ef6bcd622813b73ab1f243cd6b"
-        "2a893d2fa90a5f41f7ca285a3f4bcf4a51faad93c4ecb171dde9e0bbb4670d365e5b1c"
-        "e04a13b108ce22d4483fa634e1345aeedac2581cbc99d11fd5aef880539fc5cd0f2f75"
-        "007a47b609f30349dcbae2e7"
+        "b1c255a968225dc9dfb30e7f8d942895b66ade79c5924c1f425579c6dd27750f3de61e"
+        "41a2f132e1c0d994493c16ff4df9f8972211519c1b92bf04b88fd4a6d03cbcd2125492"
+        "28a7402f7fa1b15161a2c521f6aa6058c52b344ee39bff593e17da2b61c90bd67f4d73"
+        "a9abe43140d920dd287a832a28d2319d6d47a3545921df48b96963f61767882e301ed6"
+        "a0fe605ade9e86b264cdc9afda41ec217a2e200a663659a350d4560d62086ba5824e55"
+        "7ad1f76f3b50148dbcdb7fd3c27f7b53587f76c5bdca9c2d62879143528a8b7392a67a"
+        "4b6e27d4d5765620e9b2d89f6a7019df8c17d373aec46d32207d8f27435e11de179e8d"
+        "c146bbd0d673bf40379b45390d95eb84793ef52b3500c529dd3ea542cd00713b61030f"
+        "924a0d55f5bb40746596942944f5d875eafce6bcfe0921561397899a95dbd9248f29fb"
+        "a2cd24ffec9df96d095afb3aebde0aaed3238ec4d480d9958ad1e202a62034c2e7c23e"
+        "ab0906a4cd0ca62cb569702adff82bdc9047f0a798dc038af88c5dfdf402d306202e14"
+        "9997de859ad44a92e8216b266ea1e8e88b0120f6a816b90c6cd85ff9d8cb435ad6bbb1"
+        "251654931c5c68f10b9894ba6cc6cc5c3b2f1f88f5dcbb5f581073762e"
     );
     let now = "2021-12-04T11:50:43.208821Z".parse().unwrap();
     let key = SecretKey::from(hex!(
@@ -508,12 +507,11 @@ fn serde_file_manifest_invalid_blocksize(alice: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_folder_manifest(alice: &Device) {
-    // Generated from Python implementation (Parsec v2.6.0)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
     //   type: "folder_manifest"
-    //   author: "alice@dev1"
+    //   author: ext(2, de10a11cec0010000000000000000000)
     //   timestamp: ext(1, 1638618643.208821)
     //   id: ext(2, hex!("87c6b5fd3b454c94bab51d6af1c6930b"))
     //   parent: ext(2, hex!("07748fbf67a646428427865fd730bf3e"))
@@ -525,15 +523,16 @@ fn serde_folder_manifest(alice: &Device) {
     //     "wksp2": hex!("d7e3af6a03e1414db0f4682901e9aa4b")
     //   }
     let data = hex!(
-        "afc13ea5d28a0da5f17662d5110dd75d983f22efc1c09ddce90fb3ff8fef001aad8317"
-        "957874a52cf75882123b1030891e5b46052d5bddfd1885de9fc784e07afa0d415fe7e0"
-        "ffde9416d1285a8738a0e634fc1185e441886db61aa8fce5b588f502604fe26d28e295"
-        "23f424b65465dcde840192a68b1668376ac86e1949c7613f65e1f760cc031df2306ae5"
-        "73d0178d7a388515ffe241562e167af7eb7484a3b0608438a08ff3449759d2622847ef"
-        "c05698d772b0fff9f529b1c3582b1137f7121bc2f3dcdb4de32dc3f8daac75602273de"
-        "7b7d8b87451c517c1d1476422c51d72375520808e85eb64c0f6a6f2de5ca564df7cca2"
-        "86530c527b4bad7594f9e3dad1f40845af2dbe8fbb97201f3c617d5d63824ff36ce61f"
-        "ccd31ac8d5cb3c2f1609236a266b46ae9d01b508"
+        "816426b30ff69bbfda1232fc85708987c8556a9a25a32d6f3031282abd8a7040a9d2e2"
+        "eed40f839e0ef0af0c416585e49e685e9df1e15e1d11b6991689a8e1102a98325a6d7d"
+        "3cbf5d129053e0e99e77074b9858f7990b8993c0c79defab4768d4407e7facbc1efa42"
+        "2cbc9242dddd389019a418367afe4f4c35295dd24480f80270a2e6e2e22c62439ce8cd"
+        "2cf3fa44afa66bb4dc554c6a9d422ce46836f070aca9919ca89555a385c9d1ccf64897"
+        "5cc72838e452cdcd74428d00802bc204e1d4dd5cf9b272b827d5333c73da27e3ea3d96"
+        "6f311889ee3e6804be13d16105c534fde987b80c58e3910001f7e3076abe2e634215fb"
+        "4ae259131c8e5c4070165713301cd7027d0759f6dc1822c91bd30d90c2e7a954983a17"
+        "dc08014817994b6a7ff7e42037409218cd3126a9fbf43962f91422664c44ec9e3bb5ec"
+        "300cfe5b269e"
     );
     let now = "2021-12-04T11:50:43.208821Z".parse().unwrap();
     let key = SecretKey::from(hex!(
@@ -594,25 +593,24 @@ fn serde_folder_manifest(alice: &Device) {
 }
 
 #[rstest]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_user_manifest(alice: &Device) {
-    // Generated from Rust implementation (Parsec v3.0.0-alpha)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
     //   type: "user_manifest"
-    //   author: "alice@dev1"
+    //   author: ext(2, de10a11cec0010000000000000000000)
     //   timestamp: ext(1, 1638618643.208821)
     //   id: ext(2, hex!("87c6b5fd3b454c94bab51d6af1c6930b"))
     //   version: 42
     //   created: ext(1, 1638618643.208821)
     //   updated: ext(1, 1638618643.208821)
     let data = hex!(
-        "a7f9f9e4d8e30951e7977a4d142f7f6bd623f7590dff7da3059fcf851cb172f23f4eac"
-        "f275d78de986ee2cd64049c54cff626ad777f7928ab5a47f751db9f7896bf64c8b10e2"
-        "45e40e6f847f52f503d4d0c9ad812642d5bbf71e2c7d80bc5159c191279b2f9e47a83b"
-        "ba7f85d8431d77570a93de678d5a3268c76aaede7790945c653d487c958f689172c25c"
-        "1f160c872dc30bb1c4e63157b981d2698ddb5b8253c140e54e3028017d8bd461fcc662"
-        "4a26e7daa6be4ef396cc587f368a523bc585e3b606ddf72be6c7f8eaf12f6b2410d783"
-        "59782a9b508148cd30fcada6bd0f3f1cec49bd30afc6e1fa2a1fb3a0b8"
+        "92c7286c12e48b9790d55713dd33a0c447ae96b1ee03537ce46c64eac982d957483dd9"
+        "9f7725220c2bed5c76f02caca992daec30e8fe9c46986f61555e8c7009a9895b8ab0bb"
+        "843cb63c96f02f756fafdee6d991b18fd0090003de20e12a96e23f19298f78d0e451dd"
+        "a7559776a519fa5bdd3adb398ccc6fa3222a293c19ac80dd400c6fb61d667848c2071b"
+        "6acfe752d20bb6e8a1cd1dd91616c29bf2a19367c197ea8e5dd3b09f2ca886ff8b9c85"
+        "9b726fe2bcd9fc6eb56c14067b8383c462c55fe1eff51c6d60f99105820d99bcf70f47"
+        "3cca12385f6b184ce9b737d36f1b6489791a4a4183cccf4fa094"
     );
     let now = "2021-12-04T11:50:43.208821Z".parse().unwrap();
     let key = SecretKey::from(hex!(

--- a/libparsec/crates/types/tests/unit/pki.rs
+++ b/libparsec/crates/types/tests/unit/pki.rs
@@ -8,24 +8,24 @@ use crate::fixtures::{alice, Device};
 use crate::prelude::*;
 
 #[test]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_pki_enrollment_answer_payload() {
-    // Generated from Python implementation (Parsec v2.13.0+dev)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
     //   type: "pki_enrollment_answer_payload"
-    //   device_id: "alice@dev1"
+    //   user_id: ext(2, a11cec00100000000000000000000000)
+    //   device_id: ext(2, de10a11cec0010000000000000000000)
     //   device_label: "My dev1 machine"
     //   human_handle: ["alice@example.com", "Alicey McAliceFace"]
     //   profile: "ADMIN"
     //   root_verify_key: hex!("be2976732cec8ca94eedcf0aafd413cd159363e0fadc9e68572c77a1e17d9bbd")
-    //
     let raw = &hex!(
-        "789c6b5b99925a96999c1a9f99b22a3107c87000f20dd717e5e797c497a51665a655c6"
-        "67a7561e51d8a75956acf3a667a5dfdbf35cebaf089f159d9cfce0d79d7919e13ae50b"
-        "1fd6cedebb066a4c4e62526ace7adf4a0590310ab989c9199979a9cb0b8af2d3327352"
-        "973abaf87afa2d29a92c48dd5b909d199f9a57949f93939b9a57129f98575c9e5a145f"
-        "905899939f98b226a33437312f3e23312f252775d24688c3522b12730b7252f592f373"
-        "373982442a157c93c10cb7c4e45400b9cd57ac"
+        "ff87a474797065bd706b695f656e726f6c6c6d656e745f616e737765725f7061796c6f"
+        "6164a7757365725f6964d802a11cec00100000000000000000000000a9646576696365"
+        "5f6964d802de10a11cec0010000000000000000000ac6465766963655f6c6162656caf"
+        "4d792064657631206d616368696e65ac68756d616e5f68616e646c6592b1616c696365"
+        "406578616d706c652e636f6db2416c69636579204d63416c69636546616365a770726f"
+        "66696c65a541444d494eaf726f6f745f7665726966795f6b6579c420be2976732cec8c"
+        "a94eedcf0aafd413cd159363e0fadc9e68572c77a1e17d9bbd"
     );
     let expected = PkiEnrollmentAnswerPayload {
         user_id: "alice".parse().unwrap(),
@@ -53,19 +53,18 @@ fn serde_pki_enrollment_answer_payload() {
 
 #[rstest]
 #[case(
-    // Generated from Python implementation (Parsec v2.13.0+dev)
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
     //   type: "pki_enrollment_submit_payload"
     //   public_key: hex!("e1b20b860a78ef778d0c776121c7027cd90ce04b4d2f1a291a48d911f145724d")
     //   requested_device_label: "My dev1 machine"
     //   verify_key: hex!("845415cd821748005054dba8d456ac18ad3e71acdf980e19d6a925191362c9f9")
-    //
     &hex!(
-        "789c6bd956945a589a5a5c929a129f925a96999c1a9f9398949ab3deb75201c83754c8"
-        "4d4ccec8cc4b5d55509a9493991c9f9d5a7944e1e126ee36ae8af7e5bd3ce5898ac799"
-        "6a6ef23cf0f6d597d294f2b829f8d1b5c87755596a51665a2544714b88e8d926710f86"
-        "8090db2bae84ad91586b57b8e6fe0c3ec96b2b552585934efe5c52525990bab7203b33"
-        "3e35af283f27273735af24beb8342937b324be20b132273f3105007e8d4634"
+        "ff84a474797065bd706b695f656e726f6c6c6d656e745f7375626d69745f7061796c6f"
+        "6164aa7665726966795f6b6579c420845415cd821748005054dba8d456ac18ad3e71ac"
+        "df980e19d6a925191362c9f9aa7075626c69635f6b6579c420e1b20b860a78ef778d0c"
+        "776121c7027cd90ce04b4d2f1a291a48d911f145724db67265717565737465645f6465"
+        "766963655f6c6162656caf4d792064657631206d616368696e65"
     )[..],
     PkiEnrollmentSubmitPayload {
         public_key: PublicKey::from(hex!("e1b20b860a78ef778d0c776121c7027cd90ce04b4d2f1a291a48d911f145724d")),
@@ -73,11 +72,12 @@ fn serde_pki_enrollment_answer_payload() {
         verify_key: VerifyKey::try_from(hex!("845415cd821748005054dba8d456ac18ad3e71acdf980e19d6a925191362c9f9")).unwrap()
     }
 )]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_pki_enrollment_submit_payload(
     #[case] raw: &[u8],
     #[case] expected: PkiEnrollmentSubmitPayload,
 ) {
+    println!("***expected: {:?}", expected.dump());
+
     let data = PkiEnrollmentSubmitPayload::load(raw).unwrap();
     p_assert_eq!(data, expected);
 
@@ -90,21 +90,21 @@ fn serde_pki_enrollment_submit_payload(
 
 #[rstest]
 #[case::full(
-    // Generated from Parsec v3.0.0-b.6+dev
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
-    //   type: "local_pending_enrollment"
-    //   server_url: http://parsec.example.com
-    //   organization_id: "my_org"
+    //   type: local_pending_enrollment
+    //   server_url: https://parsec.example.com/
+    //   organization_id: my_org
     //   ciphertext: hex!("666f6f")
     //   encrypted_key: hex!("666f6f")
-    //   enrollment_id: ext(2, hex!("d4e678ea63cc4025a0739c6c46476794"))
+    //   enrollment_id: ext(2, d4e678ea63cc4025a0739c6c46476794)
     //   submit_payload: {
     //     type: "pki_enrollment_submit_payload"
     //     public_key: hex!("e1b20b860a78ef778d0c776121c7027cd90ce04b4d2f1a291a48d911f145724d")
     //     requested_device_label: "My dev1 machine"
     //     verify_key: hex!("845415cd821748005054dba8d456ac18ad3e71acdf980e19d6a925191362c9f9")
     //   }
-    //   submitted_on: ext(1, 946771200.0)
+    //   submitted_on: ext(1, 946771200000000) i.e. 2000-01-02T01:00:00Z
     //   x509_certificate: {
     //     type: "x509_certificate"
     //     certificate_id: "foo"
@@ -113,23 +113,22 @@ fn serde_pki_enrollment_submit_payload(
     //     issuer: {foo:"bar"}
     //     subject: {foo:"bar"}
     //   }
-    //
     &hex!(
-        "89a474797065b86c6f63616c5f70656e64696e675f656e726f6c6c6d656e74aa736572"
-        "7665725f75726cbb68747470733a2f2f7061727365632e6578616d706c652e636f6d2f"
-        "af6f7267616e697a6174696f6e5f6964a66d795f6f7267b0783530395f636572746966"
-        "696361746586a474797065b0783530395f6365727469666963617465a6697373756572"
-        "81a3666f6fa3626172a77375626a65637481a3666f6fa3626172b46465725f78353039"
-        "5f6365727469666963617465c403666f6fb063657274696669636174655f73686131c4"
-        "03666f6fae63657274696669636174655f6964a3666f6fac7375626d69747465645f6f"
-        "6ed70141cc374a80000000ad656e726f6c6c6d656e745f6964d802d4e678ea63cc4025"
-        "a0739c6c46476794ae7375626d69745f7061796c6f616484a474797065bd706b695f65"
-        "6e726f6c6c6d656e745f7375626d69745f7061796c6f6164aa7665726966795f6b6579"
-        "c420845415cd821748005054dba8d456ac18ad3e71acdf980e19d6a925191362c9f9aa"
-        "7075626c69635f6b6579c420e1b20b860a78ef778d0c776121c7027cd90ce04b4d2f1a"
-        "291a48d911f145724db67265717565737465645f6465766963655f6c6162656caf4d79"
-        "2064657631206d616368696e65ad656e637279707465645f6b6579c403666f6faa6369"
-        "7068657274657874c403666f6f"
+        "ff89a474797065b86c6f63616c5f70656e64696e675f656e726f6c6c6d656e74aa7365"
+        "727665725f75726cbb68747470733a2f2f7061727365632e6578616d706c652e636f6d"
+        "2faf6f7267616e697a6174696f6e5f6964a66d795f6f7267b0783530395f6365727469"
+        "66696361746586a474797065b0783530395f6365727469666963617465a66973737565"
+        "7281a3666f6fa3626172a77375626a65637481a3666f6fa3626172b46465725f783530"
+        "395f6365727469666963617465c403666f6fb063657274696669636174655f73686131"
+        "c403666f6fae63657274696669636174655f6964a3666f6fac7375626d69747465645f"
+        "6f6ed70100035d15590f4000ad656e726f6c6c6d656e745f6964d802d4e678ea63cc40"
+        "25a0739c6c46476794ae7375626d69745f7061796c6f616484a474797065bd706b695f"
+        "656e726f6c6c6d656e745f7375626d69745f7061796c6f6164aa7665726966795f6b65"
+        "79c420845415cd821748005054dba8d456ac18ad3e71acdf980e19d6a925191362c9f9"
+        "aa7075626c69635f6b6579c420e1b20b860a78ef778d0c776121c7027cd90ce04b4d2f"
+        "1a291a48d911f145724db67265717565737465645f6465766963655f6c6162656caf4d"
+        "792064657631206d616368696e65ad656e637279707465645f6b6579c403666f6faa63"
+        "697068657274657874c403666f6f"
     )[..],
     Box::new(|alice: &Device| {
         LocalPendingEnrollment {
@@ -157,21 +156,21 @@ fn serde_pki_enrollment_submit_payload(
     })
 )]
 #[case::without(
-    // Generated from Parsec v3.0.0-b.6+dev
+    // Generated from Parsec v3.0.0-b.11+dev
     // Content:
-    //   type: "local_pending_enrollment"
-    //   server_url: http://parsec.example.com
-    //   organization_id: "my_org"
+    //   type: local_pending_enrollment
+    //   server_url: https://parsec.example.com/
+    //   organization_id: my_org
     //   ciphertext: hex!("666f6f")
     //   encrypted_key: hex!("666f6f")
-    //   enrollment_id: ext(2, hex!("d4e678ea63cc4025a0739c6c46476794"))
+    //    enrollment_id: ext(2, d4e678ea63cc4025a0739c6c46476794)
     //   submit_payload: {
     //     type: "pki_enrollment_submit_payload"
     //     public_key: hex!("e1b20b860a78ef778d0c776121c7027cd90ce04b4d2f1a291a48d911f145724d")
     //     requested_device_label: "My dev1 machine"
     //     verify_key: hex!("845415cd821748005054dba8d456ac18ad3e71acdf980e19d6a925191362c9f9")
     //   }
-    //   submitted_on: ext(1, 946771200.0)
+    //   submitted_on: ext(1, 946771200000000) i.e. 2000-01-02T01:00:00Z
     //   x509_certificate: {
     //     type: "x509_certificate"
     //     certificate_id: None
@@ -180,23 +179,22 @@ fn serde_pki_enrollment_submit_payload(
     //     issuer: {foo:"bar"}
     //     subject: {foo:"bar"}
     //   }
-    //
     &hex!(
-        "89a474797065b86c6f63616c5f70656e64696e675f656e726f6c6c6d656e74aa736572"
-        "7665725f75726cbb68747470733a2f2f7061727365632e6578616d706c652e636f6d2f"
-        "af6f7267616e697a6174696f6e5f6964a66d795f6f7267b0783530395f636572746966"
-        "696361746586a474797065b0783530395f6365727469666963617465a6697373756572"
-        "81a3666f6fa3626172a77375626a65637481a3666f6fa3626172b46465725f78353039"
-        "5f6365727469666963617465c403666f6fb063657274696669636174655f73686131c4"
-        "03666f6fae63657274696669636174655f6964c0ac7375626d69747465645f6f6ed701"
-        "41cc374a80000000ad656e726f6c6c6d656e745f6964d802d4e678ea63cc4025a0739c"
-        "6c46476794ae7375626d69745f7061796c6f616484a474797065bd706b695f656e726f"
-        "6c6c6d656e745f7375626d69745f7061796c6f6164aa7665726966795f6b6579c42084"
-        "5415cd821748005054dba8d456ac18ad3e71acdf980e19d6a925191362c9f9aa707562"
-        "6c69635f6b6579c420e1b20b860a78ef778d0c776121c7027cd90ce04b4d2f1a291a48"
-        "d911f145724db67265717565737465645f6465766963655f6c6162656caf4d79206465"
-        "7631206d616368696e65ad656e637279707465645f6b6579c403666f6faa6369706865"
-        "7274657874c403666f6f"
+        "ff89a474797065b86c6f63616c5f70656e64696e675f656e726f6c6c6d656e74aa7365"
+        "727665725f75726cbb68747470733a2f2f7061727365632e6578616d706c652e636f6d"
+        "2faf6f7267616e697a6174696f6e5f6964a66d795f6f7267b0783530395f6365727469"
+        "66696361746586a474797065b0783530395f6365727469666963617465a66973737565"
+        "7281a3666f6fa3626172a77375626a65637481a3666f6fa3626172b46465725f783530"
+        "395f6365727469666963617465c403666f6fb063657274696669636174655f73686131"
+        "c403666f6fae63657274696669636174655f6964c0ac7375626d69747465645f6f6ed7"
+        "0100035d15590f4000ad656e726f6c6c6d656e745f6964d802d4e678ea63cc4025a073"
+        "9c6c46476794ae7375626d69745f7061796c6f616484a474797065bd706b695f656e72"
+        "6f6c6c6d656e745f7375626d69745f7061796c6f6164aa7665726966795f6b6579c420"
+        "845415cd821748005054dba8d456ac18ad3e71acdf980e19d6a925191362c9f9aa7075"
+        "626c69635f6b6579c420e1b20b860a78ef778d0c776121c7027cd90ce04b4d2f1a291a"
+        "48d911f145724db67265717565737465645f6465766963655f6c6162656caf4d792064"
+        "657631206d616368696e65ad656e637279707465645f6b6579c403666f6faa63697068"
+        "657274657874c403666f6f"
     )[..],
     Box::new(|alice: &Device| {
         LocalPendingEnrollment {
@@ -223,7 +221,6 @@ fn serde_pki_enrollment_submit_payload(
         }
     })
 )]
-#[ignore = "TODO: scheme has changed, must regenerate the dump"]
 fn serde_local_pending_enrollment(
     alice: &Device,
     #[case] raw: &[u8],

--- a/libparsec/crates/types/tests/unit/pki.rs
+++ b/libparsec/crates/types/tests/unit/pki.rs
@@ -76,8 +76,6 @@ fn serde_pki_enrollment_submit_payload(
     #[case] raw: &[u8],
     #[case] expected: PkiEnrollmentSubmitPayload,
 ) {
-    println!("***expected: {:?}", expected.dump());
-
     let data = PkiEnrollmentSubmitPayload::load(raw).unwrap();
     p_assert_eq!(data, expected);
 


### PR DESCRIPTION
This PR fixes all impacted payloads in `libparsec_types` unit tests.

Only the following are still to be fixed. They involve _invalid_ payloads that are expected to fail with BadSerialization at some step ("msgpack+validation", "zstd"). But I don't know how to generate these payloads since there is no `expected` value:
- `libparsec/crates/platform_device_loader/tests/list.rs::list_devices`
- `libparsec/crates/types/tests/unit/manifest.rs::dump_load`
- `libparsec/crates/types/tests/unit/manifest.rs::invalid_load`
- `libparsec/crates/types/tests/unit/manifest.rs::serde_file_manifest_invalid_blocksize`

Closes #7669