### PR TITLE
[parsec-cli] Read some options from env variables

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,7 @@ testenv = []
 libparsec = { workspace = true }
 
 anyhow = { workspace = true }
-clap = { workspace = true, features = ["default", "derive"] }
+clap = { workspace = true, features = ["default", "derive", "env"] }
 env_logger = { workspace = true, features = ["auto-color", "humantime", "regex"] }
 log = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }

--- a/cli/src/bootstrap_organization.rs
+++ b/cli/src/bootstrap_organization.rs
@@ -33,6 +33,12 @@ pub async fn bootstrap_organization_req(
     human_handle: HumanHandle,
     password: Password,
 ) -> anyhow::Result<AvailableDevice> {
+    log::trace!(
+        "Bootstrapping organization (confdir={}, datadir={})",
+        client_config.config_dir.display(),
+        client_config.data_base_dir.display()
+    );
+
     let on_event_callback = Arc::new(|_| ());
 
     Ok(libparsec::bootstrap_organization(
@@ -57,6 +63,7 @@ pub async fn bootstrap_organization(
         addr,
         device_label,
     } = bootstrap_organization;
+    log::trace!("Bootstrapping organization (addr={addr})");
 
     let human_handle = HumanHandle::new(&email, &label)
         .map_err(|e| anyhow::anyhow!("Cannot create human handle: {e}"))?;

--- a/cli/src/bootstrap_organization.rs
+++ b/cli/src/bootstrap_organization.rs
@@ -1,6 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
 use std::sync::Arc;
 
 use libparsec::{
@@ -10,7 +9,7 @@ use libparsec::{
 
 use crate::utils::*;
 
-#[derive(Args)]
+#[derive(clap::Parser)]
 pub struct BootstrapOrganization {
     /// Bootstrap address
     /// (e.g: parsec3://127.0.0.1:6770/Org?no_ssl=true&action=bootstrap_organization&token=59961ba6dcc9b018d2fdc9da1c0c762b716a27cff30594562dc813e4b765871a)

--- a/cli/src/cancel_invitation.rs
+++ b/cli/src/cancel_invitation.rs
@@ -21,6 +21,11 @@ pub async fn cancel_invitation(cancel_invitation: CancelInvitation) -> anyhow::R
         config: ConfigWithDeviceSharedOpts { config_dir, device },
         token,
     } = cancel_invitation;
+    log::trace!(
+        "Cancelling invitation (confdir={}, device={})",
+        config_dir.display(),
+        device.as_deref().unwrap_or("N/A")
+    );
 
     load_cmds_and_run(config_dir, device, |cmds, _| async move {
         let mut handle = start_spinner("Deleting invitation".into());

--- a/cli/src/cancel_invitation.rs
+++ b/cli/src/cancel_invitation.rs
@@ -1,23 +1,16 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
-use std::path::PathBuf;
-
 use libparsec::{
     authenticated_cmds::latest::invite_cancel::{self, InviteCancelRep},
-    get_default_config_dir, InvitationToken,
+    InvitationToken,
 };
 
 use crate::utils::*;
 
-#[derive(Args)]
+#[derive(clap::Parser)]
 pub struct CancelInvitation {
-    /// Parsec config directory
-    #[arg(short, long, default_value_os_t = get_default_config_dir())]
-    config_dir: PathBuf,
-    /// Device ID
-    #[arg(short, long)]
-    device: Option<String>,
+    #[clap(flatten)]
+    config: ConfigWithDeviceSharedOpts,
     /// Invitation token
     #[arg(short, long, value_parser = InvitationToken::from_hex)]
     token: InvitationToken,
@@ -25,8 +18,7 @@ pub struct CancelInvitation {
 
 pub async fn cancel_invitation(cancel_invitation: CancelInvitation) -> anyhow::Result<()> {
     let CancelInvitation {
-        config_dir,
-        device,
+        config: ConfigWithDeviceSharedOpts { config_dir, device },
         token,
     } = cancel_invitation;
 

--- a/cli/src/claim_invitation.rs
+++ b/cli/src/claim_invitation.rs
@@ -1,6 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
 use std::sync::Arc;
 
 use libparsec::{
@@ -15,7 +14,7 @@ use libparsec::{
 
 use crate::utils::*;
 
-#[derive(Args)]
+#[derive(clap::Parser)]
 pub struct ClaimInvitation {
     /// Server invitation address (e.g.: parsec3://127.0.0.1:41905/Org?no_ssl=true&action=claim_user&token=4e45cc21e7604af196173ff6c9184a1f)
     #[arg(short, long)]

--- a/cli/src/claim_invitation.rs
+++ b/cli/src/claim_invitation.rs
@@ -22,6 +22,7 @@ pub struct ClaimInvitation {
 }
 
 pub async fn claim_invitation(claim_invitation: ClaimInvitation) -> anyhow::Result<()> {
+    log::trace!("Claiming invitation (addr={})", claim_invitation.addr);
     let ctx = step0(claim_invitation.addr).await?;
 
     match ctx {

--- a/cli/src/create_organization.rs
+++ b/cli/src/create_organization.rs
@@ -71,6 +71,7 @@ pub async fn create_organization(create_organization: CreateOrganization) -> any
         organization_id,
         server: ServerSharedOpts { addr, token },
     } = create_organization;
+    log::trace!("Creating organization \"{organization_id}\" (addr={addr})");
 
     let mut handle = start_spinner("Creating organization".into());
 

--- a/cli/src/create_organization.rs
+++ b/cli/src/create_organization.rs
@@ -1,23 +1,18 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
 use reqwest::Client;
 
 use libparsec::{OrganizationID, ParsecAddr, ParsecOrganizationBootstrapAddr};
 
 use crate::utils::*;
 
-#[derive(Args)]
+#[derive(clap::Parser)]
 pub struct CreateOrganization {
     /// OrganizationID
     #[arg(short, long)]
     organization_id: OrganizationID,
-    /// Server address (e.g: parsec3://127.0.0.1:6770?no_ssl=true)
-    #[arg(short, long)]
-    addr: ParsecAddr,
-    /// Administration token
-    #[arg(short, long)]
-    token: String,
+    #[clap(flatten)]
+    server: ServerSharedOpts,
 }
 
 #[derive(serde::Deserialize)]
@@ -74,8 +69,7 @@ pub async fn create_organization_req(
 pub async fn create_organization(create_organization: CreateOrganization) -> anyhow::Result<()> {
     let CreateOrganization {
         organization_id,
-        addr,
-        token,
+        server: ServerSharedOpts { addr, token },
     } = create_organization;
 
     let mut handle = start_spinner("Creating organization".into());

--- a/cli/src/create_workspace.rs
+++ b/cli/src/create_workspace.rs
@@ -18,6 +18,11 @@ pub async fn create_workspace(create_workspace: CreateWorkspace) -> anyhow::Resu
         config: ConfigWithDeviceSharedOpts { config_dir, device },
         name,
     } = create_workspace;
+    log::trace!(
+        "Creating workspace {name} (confdir={}, device={})",
+        config_dir.display(),
+        device.as_deref().unwrap_or("N/A")
+    );
 
     load_client_and_run(config_dir, device, |client| async move {
         let mut handle = start_spinner("Creating workspace".into());

--- a/cli/src/create_workspace.rs
+++ b/cli/src/create_workspace.rs
@@ -1,20 +1,13 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
-use std::path::PathBuf;
-
-use libparsec::{get_default_config_dir, EntryName};
+use libparsec::EntryName;
 
 use crate::utils::*;
 
-#[derive(Args)]
+#[derive(clap::Args)]
 pub struct CreateWorkspace {
-    /// Parsec config directory
-    #[arg(short, long, default_value_os_t = get_default_config_dir())]
-    config_dir: PathBuf,
-    /// Device ID
-    #[arg(short, long)]
-    device: Option<String>,
+    #[clap(flatten)]
+    config: ConfigWithDeviceSharedOpts,
     /// New workspace name
     #[arg(short, long)]
     name: EntryName,
@@ -22,8 +15,7 @@ pub struct CreateWorkspace {
 
 pub async fn create_workspace(create_workspace: CreateWorkspace) -> anyhow::Result<()> {
     let CreateWorkspace {
-        config_dir,
-        device,
+        config: ConfigWithDeviceSharedOpts { config_dir, device },
         name,
     } = create_workspace;
 

--- a/cli/src/export_recovery_device.rs
+++ b/cli/src/export_recovery_device.rs
@@ -1,20 +1,15 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
 use std::path::PathBuf;
 
-use libparsec::{get_default_config_dir, save_recovery_device};
+use libparsec::save_recovery_device;
 
 use crate::utils::*;
 
-#[derive(Args)]
+#[derive(clap::Parser)]
 pub struct ExportRecoveryDevice {
-    /// Parsec config directory
-    #[arg(short, long, default_value_os_t = get_default_config_dir())]
-    config_dir: PathBuf,
-    /// Device ID
-    #[arg(short, long)]
-    device: Option<String>,
+    #[clap(flatten)]
+    config: ConfigWithDeviceSharedOpts,
     /// Recovery device output
     #[arg(short, long)]
     output: PathBuf,
@@ -24,8 +19,7 @@ pub async fn export_recovery_device(
     export_recovery_device: ExportRecoveryDevice,
 ) -> anyhow::Result<()> {
     let ExportRecoveryDevice {
-        config_dir,
-        device,
+        config: ConfigWithDeviceSharedOpts { config_dir, device },
         output,
     } = export_recovery_device;
 

--- a/cli/src/export_recovery_device.rs
+++ b/cli/src/export_recovery_device.rs
@@ -22,6 +22,12 @@ pub async fn export_recovery_device(
         config: ConfigWithDeviceSharedOpts { config_dir, device },
         output,
     } = export_recovery_device;
+    log::trace!(
+        "Exporting recovery device at {} (confdir={}, device={})",
+        output.display(),
+        config_dir.display(),
+        device.as_deref().unwrap_or("N/A")
+    );
 
     load_device_and_run(config_dir, device, |device| async move {
         let mut handle = start_spinner("Saving recovery device file".into());

--- a/cli/src/greet_invitation.rs
+++ b/cli/src/greet_invitation.rs
@@ -1,11 +1,9 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
-use std::{path::PathBuf, sync::Arc};
+use std::sync::Arc;
 
 use libparsec::{
     authenticated_cmds::latest::invite_list::{self, InviteListItem},
-    get_default_config_dir,
     internal::{
         DeviceGreetInProgress1Ctx, DeviceGreetInProgress2Ctx, DeviceGreetInProgress3Ctx,
         DeviceGreetInProgress4Ctx, DeviceGreetInitialCtx, EventBus, UserGreetInProgress1Ctx,
@@ -17,14 +15,10 @@ use libparsec::{
 
 use crate::utils::*;
 
-#[derive(Args)]
+#[derive(clap::Parser)]
 pub struct GreetInvitation {
-    /// Parsec config directory
-    #[arg(short, long, default_value_os_t = get_default_config_dir())]
-    config_dir: PathBuf,
-    /// Device ID
-    #[arg(short, long)]
-    device: Option<String>,
+    #[clap(flatten)]
+    config: ConfigWithDeviceSharedOpts,
     /// Invitation token
     #[arg(short, long, value_parser = InvitationToken::from_hex)]
     token: InvitationToken,
@@ -32,8 +26,7 @@ pub struct GreetInvitation {
 
 pub async fn greet_invitation(greet_invitation: GreetInvitation) -> anyhow::Result<()> {
     let GreetInvitation {
-        config_dir,
-        device,
+        config: ConfigWithDeviceSharedOpts { config_dir, device },
         token,
     } = greet_invitation;
 

--- a/cli/src/greet_invitation.rs
+++ b/cli/src/greet_invitation.rs
@@ -29,6 +29,11 @@ pub async fn greet_invitation(greet_invitation: GreetInvitation) -> anyhow::Resu
         config: ConfigWithDeviceSharedOpts { config_dir, device },
         token,
     } = greet_invitation;
+    log::trace!(
+        "Greeting invitation (confdir={}, device={})",
+        config_dir.display(),
+        device.as_deref().unwrap_or("N/A")
+    );
 
     load_cmds_and_run(config_dir, device, |cmds, device| async move {
         let invitation = step0(&cmds, token).await?;

--- a/cli/src/import_recovery_device.rs
+++ b/cli/src/import_recovery_device.rs
@@ -26,6 +26,11 @@ pub async fn import_recovery_device(
         input,
         passphrase,
     } = import_recovery_device;
+    log::trace!(
+        "Importing recovery device from {} (confdir={})",
+        input.display(),
+        config_dir.display(),
+    );
 
     let mut handle = start_spinner("Loading recovery device file".into());
 

--- a/cli/src/import_recovery_device.rs
+++ b/cli/src/import_recovery_device.rs
@@ -1,17 +1,15 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
 use std::path::{Path, PathBuf};
 
-use libparsec::{get_default_config_dir, load_recovery_device, DeviceAccessStrategy};
+use libparsec::{load_recovery_device, DeviceAccessStrategy};
 
 use crate::utils::*;
 
-#[derive(Args)]
+#[derive(clap::Parser)]
 pub struct ImportRecoveryDevice {
-    /// Parsec config directory
-    #[arg(short, long, default_value_os_t = get_default_config_dir())]
-    config_dir: PathBuf,
+    #[clap(flatten)]
+    config: ConfigSharedOpts,
     /// Recovery file
     #[arg(short, long)]
     input: PathBuf,
@@ -24,9 +22,9 @@ pub async fn import_recovery_device(
     import_recovery_device: ImportRecoveryDevice,
 ) -> anyhow::Result<()> {
     let ImportRecoveryDevice {
+        config: ConfigSharedOpts { config_dir },
         input,
         passphrase,
-        config_dir,
     } = import_recovery_device;
 
     let mut handle = start_spinner("Loading recovery device file".into());

--- a/cli/src/invite_device.rs
+++ b/cli/src/invite_device.rs
@@ -17,6 +17,11 @@ pub async fn invite_device(invite_device: InviteDevice) -> anyhow::Result<()> {
     let InviteDevice {
         config: ConfigWithDeviceSharedOpts { config_dir, device },
     } = invite_device;
+    log::trace!(
+        "Inviting a device (confdir={}, device={})",
+        config_dir.display(),
+        device.as_deref().unwrap_or("N/A")
+    );
 
     load_cmds_and_run(config_dir, device, |cmds, device| async move {
         let mut handle = start_spinner("Creating device invitation".into());

--- a/cli/src/invite_device.rs
+++ b/cli/src/invite_device.rs
@@ -1,27 +1,22 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
-use std::path::PathBuf;
-
 use libparsec::{
     authenticated_cmds::latest::invite_new_device::{self, InviteNewDeviceRep},
-    get_default_config_dir, InvitationType, ParsecInvitationAddr,
+    InvitationType, ParsecInvitationAddr,
 };
 
 use crate::utils::*;
 
-#[derive(Args)]
+#[derive(clap::Parser)]
 pub struct InviteDevice {
-    /// Parsec config directory
-    #[arg(short, long, default_value_os_t = get_default_config_dir())]
-    config_dir: PathBuf,
-    /// Device ID
-    #[arg(short, long)]
-    device: Option<String>,
+    #[clap(flatten)]
+    config: ConfigWithDeviceSharedOpts,
 }
 
 pub async fn invite_device(invite_device: InviteDevice) -> anyhow::Result<()> {
-    let InviteDevice { config_dir, device } = invite_device;
+    let InviteDevice {
+        config: ConfigWithDeviceSharedOpts { config_dir, device },
+    } = invite_device;
 
     load_cmds_and_run(config_dir, device, |cmds, device| async move {
         let mut handle = start_spinner("Creating device invitation".into());

--- a/cli/src/invite_user.rs
+++ b/cli/src/invite_user.rs
@@ -1,23 +1,16 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
-use std::path::PathBuf;
-
 use libparsec::{
     authenticated_cmds::latest::invite_new_user::{self, InviteNewUserRep},
-    get_default_config_dir, InvitationType, ParsecInvitationAddr,
+    InvitationType, ParsecInvitationAddr,
 };
 
 use crate::utils::*;
 
-#[derive(Args)]
+#[derive(clap::Parser)]
 pub struct InviteUser {
-    /// Parsec config directory
-    #[arg(short, long, default_value_os_t = get_default_config_dir())]
-    config_dir: PathBuf,
-    /// Greeter device ID
-    #[arg(short, long)]
-    device: Option<String>,
+    #[clap(flatten)]
+    config: ConfigWithDeviceSharedOpts,
     /// Claimer email (i.e.: The invitee)
     #[arg(short, long)]
     email: String,
@@ -28,8 +21,7 @@ pub struct InviteUser {
 
 pub async fn invite_user(invite_user: InviteUser) -> anyhow::Result<()> {
     let InviteUser {
-        config_dir,
-        device,
+        config: ConfigWithDeviceSharedOpts { config_dir, device },
         email,
         send_email,
     } = invite_user;

--- a/cli/src/invite_user.rs
+++ b/cli/src/invite_user.rs
@@ -25,6 +25,11 @@ pub async fn invite_user(invite_user: InviteUser) -> anyhow::Result<()> {
         email,
         send_email,
     } = invite_user;
+    log::trace!(
+        "Inviting an user (confdir={}, device={})",
+        config_dir.display(),
+        device.as_deref().unwrap_or("N/A")
+    );
 
     load_cmds_and_run(config_dir, device, |cmds, device| async move {
         let mut handle = start_spinner("Creating user invitation".into());

--- a/cli/src/list_devices.rs
+++ b/cli/src/list_devices.rs
@@ -1,23 +1,19 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
-use std::path::PathBuf;
-
-use libparsec::{get_default_config_dir, list_available_devices};
+use libparsec::list_available_devices;
 
 use crate::utils::*;
 
-#[derive(Args)]
+#[derive(clap::Parser)]
 pub struct ListDevices {
-    /// Parsec config directory
-    #[arg(short, long, default_value_os_t = get_default_config_dir())]
-    config_dir: PathBuf,
+    #[clap(flatten)]
+    config: ConfigSharedOpts,
 }
 
 pub async fn list_devices(list_devices: ListDevices) -> anyhow::Result<()> {
-    let config_dir = list_devices.config_dir;
-    let config_dir_str = config_dir.to_string_lossy();
+    let config_dir = list_devices.config.config_dir;
     let devices = list_available_devices(&config_dir).await;
+    let config_dir_str = config_dir.to_string_lossy();
 
     if devices.is_empty() {
         println!("No devices found in {YELLOW}{config_dir_str}{RESET}");

--- a/cli/src/list_devices.rs
+++ b/cli/src/list_devices.rs
@@ -12,6 +12,7 @@ pub struct ListDevices {
 
 pub async fn list_devices(list_devices: ListDevices) -> anyhow::Result<()> {
     let config_dir = list_devices.config.config_dir;
+    log::trace!("Listing devices under {}", config_dir.display());
     let devices = list_available_devices(&config_dir).await;
     let config_dir_str = config_dir.to_string_lossy();
 

--- a/cli/src/list_invitations.rs
+++ b/cli/src/list_invitations.rs
@@ -1,27 +1,22 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
-use std::path::PathBuf;
-
 use libparsec::{
     authenticated_cmds::latest::invite_list::{self, InviteListItem, InviteListRep},
-    get_default_config_dir, InvitationStatus,
+    InvitationStatus,
 };
 
 use crate::utils::*;
 
-#[derive(Args)]
+#[derive(clap::Parser)]
 pub struct ListInvitations {
-    /// Parsec config directory
-    #[arg(short, long, default_value_os_t = get_default_config_dir())]
-    config_dir: PathBuf,
-    /// Device ID
-    #[arg(short, long)]
-    device: Option<String>,
+    #[clap(flatten)]
+    config: ConfigWithDeviceSharedOpts,
 }
 
 pub async fn list_invitations(list_invitations: ListInvitations) -> anyhow::Result<()> {
-    let ListInvitations { config_dir, device } = list_invitations;
+    let ListInvitations {
+        config: ConfigWithDeviceSharedOpts { config_dir, device },
+    } = list_invitations;
 
     load_cmds_and_run(config_dir, device, |cmds, _| async move {
         let mut handle = start_spinner("Listing invitations".into());

--- a/cli/src/list_invitations.rs
+++ b/cli/src/list_invitations.rs
@@ -17,6 +17,11 @@ pub async fn list_invitations(list_invitations: ListInvitations) -> anyhow::Resu
     let ListInvitations {
         config: ConfigWithDeviceSharedOpts { config_dir, device },
     } = list_invitations;
+    log::trace!(
+        "Listing invitations (confdir={}, device={})",
+        config_dir.display(),
+        device.as_deref().unwrap_or("N/A")
+    );
 
     load_cmds_and_run(config_dir, device, |cmds, _| async move {
         let mut handle = start_spinner("Listing invitations".into());

--- a/cli/src/list_users.rs
+++ b/cli/src/list_users.rs
@@ -16,6 +16,11 @@ pub async fn list_users(list_users: ListUsers) -> anyhow::Result<()> {
         config: ConfigWithDeviceSharedOpts { config_dir, device },
         skip_revoked,
     } = list_users;
+    log::trace!(
+        "Listing users (confdir={}, device={}, skip_revoked={skip_revoked})",
+        config_dir.display(),
+        device.as_deref().unwrap_or("N/A")
+    );
 
     load_client_and_run(config_dir, device, |client| async move {
         client.poll_server_for_new_certificates().await?;

--- a/cli/src/list_users.rs
+++ b/cli/src/list_users.rs
@@ -1,20 +1,11 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
-use std::path::PathBuf;
-
-use libparsec::get_default_config_dir;
-
 use crate::utils::*;
 
-#[derive(Args)]
+#[derive(clap::Parser)]
 pub struct ListUsers {
-    /// Parsec config directory
-    #[arg(short, long, default_value_os_t = get_default_config_dir())]
-    config_dir: PathBuf,
-    /// Device ID
-    #[arg(short, long)]
-    device: Option<String>,
+    #[clap(flatten)]
+    config: ConfigWithDeviceSharedOpts,
     /// Skip revoked users
     #[arg(short, long, default_value_t)]
     skip_revoked: bool,
@@ -22,8 +13,7 @@ pub struct ListUsers {
 
 pub async fn list_users(list_users: ListUsers) -> anyhow::Result<()> {
     let ListUsers {
-        config_dir,
-        device,
+        config: ConfigWithDeviceSharedOpts { config_dir, device },
         skip_revoked,
     } = list_users;
 

--- a/cli/src/list_workspaces.rs
+++ b/cli/src/list_workspaces.rs
@@ -12,6 +12,11 @@ pub async fn list_workspaces(list_workspaces: ListWorkspaces) -> anyhow::Result<
     let ListWorkspaces {
         config: ConfigWithDeviceSharedOpts { config_dir, device },
     } = list_workspaces;
+    log::trace!(
+        "Listing workspaces (confdir={}, device={})",
+        config_dir.display(),
+        device.as_deref().unwrap_or("N/A")
+    );
 
     load_client_and_run(config_dir, device, |client| async move {
         client.poll_server_for_new_certificates().await?;

--- a/cli/src/list_workspaces.rs
+++ b/cli/src/list_workspaces.rs
@@ -1,24 +1,17 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
-use std::path::PathBuf;
-
-use libparsec::get_default_config_dir;
-
 use crate::utils::*;
 
-#[derive(Args)]
+#[derive(clap::Parser)]
 pub struct ListWorkspaces {
-    /// Parsec config directory
-    #[arg(short, long, default_value_os_t = get_default_config_dir())]
-    config_dir: PathBuf,
-    /// Device ID
-    #[arg(short, long)]
-    device: Option<String>,
+    #[clap(flatten)]
+    config: ConfigWithDeviceSharedOpts,
 }
 
 pub async fn list_workspaces(list_workspaces: ListWorkspaces) -> anyhow::Result<()> {
-    let ListWorkspaces { config_dir, device } = list_workspaces;
+    let ListWorkspaces {
+        config: ConfigWithDeviceSharedOpts { config_dir, device },
+    } = list_workspaces;
 
     load_client_and_run(config_dir, device, |client| async move {
         client.poll_server_for_new_certificates().await?;

--- a/cli/src/remove_device.rs
+++ b/cli/src/remove_device.rs
@@ -1,24 +1,17 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
-use std::path::PathBuf;
-
-use libparsec::get_default_config_dir;
-
 use crate::utils::*;
 
-#[derive(Args)]
+#[derive(clap::Parser)]
 pub struct RemoveDevice {
-    /// Parsec config directory
-    #[arg(short, long, default_value_os_t = get_default_config_dir())]
-    config_dir: PathBuf,
-    /// Device ID
-    #[arg(short, long)]
-    device: Option<String>,
+    #[clap(flatten)]
+    config: ConfigWithDeviceSharedOpts,
 }
 
 pub async fn remove_device(remove_device: RemoveDevice) -> anyhow::Result<()> {
-    let RemoveDevice { config_dir, device } = remove_device;
+    let RemoveDevice {
+        config: ConfigWithDeviceSharedOpts { config_dir, device },
+    } = remove_device;
 
     load_device_file_and_run(config_dir, device, |device| async move {
         let short_id = &device.device_id.hex()[..3];

--- a/cli/src/remove_device.rs
+++ b/cli/src/remove_device.rs
@@ -12,6 +12,11 @@ pub async fn remove_device(remove_device: RemoveDevice) -> anyhow::Result<()> {
     let RemoveDevice {
         config: ConfigWithDeviceSharedOpts { config_dir, device },
     } = remove_device;
+    log::trace!(
+        "Removing device {device} (confdir={})",
+        config_dir.display(),
+        device = device.as_deref().unwrap_or("N/A")
+    );
 
     load_device_file_and_run(config_dir, device, |device| async move {
         let short_id = &device.device_id.hex()[..3];

--- a/cli/src/run_testenv.rs
+++ b/cli/src/run_testenv.rs
@@ -16,7 +16,7 @@ use libparsec::{
     DeviceAccessStrategy, DeviceCertificate, DeviceID, DeviceLabel, HumanHandle, LocalDevice,
     MaybeRedacted, OrganizationID, ParsecAddr, PrivateKeyAlgorithm, ProxyConfig, SigningKey,
     SigningKeyAlgorithm, UserCertificate, UserProfile, PARSEC_BASE_CONFIG_DIR,
-    PARSEC_BASE_DATA_DIR, PARSEC_HOME_DIR, PARSEC_SCHEME,
+    PARSEC_BASE_DATA_DIR, PARSEC_BASE_HOME_DIR, PARSEC_SCHEME,
 };
 
 use crate::{
@@ -356,7 +356,7 @@ fn get_env_variables(tmp_dir: &Path) -> (&'static str, Vec<(&'static str, String
         "set",
         vec![
             (
-                PARSEC_HOME_DIR,
+                PARSEC_BASE_HOME_DIR,
                 format!("{dir}\\cache", dir = tmp_dir.display()),
             ),
             (
@@ -375,7 +375,7 @@ fn get_env_variables(tmp_dir: &Path) -> (&'static str, Vec<(&'static str, String
         "export",
         vec![
             (
-                PARSEC_HOME_DIR,
+                PARSEC_BASE_HOME_DIR,
                 format!("{dir}/cache", dir = tmp_dir.display()),
             ),
             (

--- a/cli/src/run_testenv.rs
+++ b/cli/src/run_testenv.rs
@@ -15,7 +15,7 @@ use libparsec::{
     load_device, AuthenticatedCmds, Bytes, CertificateSignerOwned, ClientConfig, DateTime,
     DeviceAccessStrategy, DeviceCertificate, DeviceID, DeviceLabel, HumanHandle, LocalDevice,
     MaybeRedacted, OrganizationID, ParsecAddr, PrivateKeyAlgorithm, ProxyConfig, SigningKey,
-    SigningKeyAlgorithm, UserCertificate, UserProfile, PARSEC_CONFIG_DIR, PARSEC_DATA_DIR,
+    SigningKeyAlgorithm, UserCertificate, UserProfile, PARSEC_BASE_DATA_DIR, PARSEC_CONFIG_DIR,
     PARSEC_HOME_DIR, PARSEC_SCHEME,
 };
 
@@ -360,7 +360,7 @@ fn get_env_variables(tmp_dir: &Path) -> (&'static str, Vec<(&'static str, String
                 format!("{dir}\\cache", dir = tmp_dir.display()),
             ),
             (
-                PARSEC_DATA_DIR,
+                PARSEC_BASE_DATA_DIR,
                 format!("{dir}\\share", dir = tmp_dir.display()),
             ),
             (
@@ -379,7 +379,7 @@ fn get_env_variables(tmp_dir: &Path) -> (&'static str, Vec<(&'static str, String
                 format!("{dir}/cache", dir = tmp_dir.display()),
             ),
             (
-                PARSEC_DATA_DIR,
+                PARSEC_BASE_DATA_DIR,
                 format!("{dir}/share", dir = tmp_dir.display()),
             ),
             (

--- a/cli/src/run_testenv.rs
+++ b/cli/src/run_testenv.rs
@@ -15,8 +15,8 @@ use libparsec::{
     load_device, AuthenticatedCmds, Bytes, CertificateSignerOwned, ClientConfig, DateTime,
     DeviceAccessStrategy, DeviceCertificate, DeviceID, DeviceLabel, HumanHandle, LocalDevice,
     MaybeRedacted, OrganizationID, ParsecAddr, PrivateKeyAlgorithm, ProxyConfig, SigningKey,
-    SigningKeyAlgorithm, UserCertificate, UserProfile, PARSEC_BASE_DATA_DIR, PARSEC_CONFIG_DIR,
-    PARSEC_HOME_DIR, PARSEC_SCHEME,
+    SigningKeyAlgorithm, UserCertificate, UserProfile, PARSEC_BASE_CONFIG_DIR,
+    PARSEC_BASE_DATA_DIR, PARSEC_HOME_DIR, PARSEC_SCHEME,
 };
 
 use crate::{
@@ -364,7 +364,7 @@ fn get_env_variables(tmp_dir: &Path) -> (&'static str, Vec<(&'static str, String
                 format!("{dir}\\share", dir = tmp_dir.display()),
             ),
             (
-                PARSEC_CONFIG_DIR,
+                PARSEC_BASE_CONFIG_DIR,
                 format!("{dir}\\config", dir = tmp_dir.display()),
             ),
         ],
@@ -383,7 +383,7 @@ fn get_env_variables(tmp_dir: &Path) -> (&'static str, Vec<(&'static str, String
                 format!("{dir}/share", dir = tmp_dir.display()),
             ),
             (
-                PARSEC_CONFIG_DIR,
+                PARSEC_BASE_CONFIG_DIR,
                 format!("{dir}/config", dir = tmp_dir.display()),
             ),
         ],

--- a/cli/src/run_testenv.rs
+++ b/cli/src/run_testenv.rs
@@ -1,6 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
 use std::{
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
@@ -32,7 +31,7 @@ const AVAILABLE_PORT_COUNT: u16 = u16::MAX - RESERVED_PORT_OFFSET;
 const LAST_SERVER_PID: &str = "LAST_SERVER_ID";
 pub const TESTBED_SERVER_URL: &str = "TESTBED_SERVER_URL";
 
-#[derive(Args)]
+#[derive(clap::Parser)]
 pub struct RunTestenv {
     /// Sourced script file
     #[arg(long)]

--- a/cli/src/share_workspace.rs
+++ b/cli/src/share_workspace.rs
@@ -26,6 +26,11 @@ pub async fn share_workspace(share_workspace: ShareWorkspace) -> anyhow::Result<
         user_id,
         role,
     } = share_workspace;
+    log::trace!(
+        "Sharing workspace {workspace_id} to {user_id} with role {role} (confdir={}, device={})",
+        config_dir.display(),
+        device.as_deref().unwrap_or("N/A")
+    );
 
     load_client_and_run(config_dir, device, |client| async move {
         let mut handle = start_spinner("Sharing workspace".into());

--- a/cli/src/share_workspace.rs
+++ b/cli/src/share_workspace.rs
@@ -1,20 +1,13 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
-use std::path::PathBuf;
-
-use libparsec::{get_default_config_dir, RealmRole, UserID, VlobID};
+use libparsec::{RealmRole, UserID, VlobID};
 
 use crate::utils::*;
 
-#[derive(Args)]
+#[derive(clap::Parser)]
 pub struct ShareWorkspace {
-    /// Parsec config directory
-    #[arg(short, long, default_value_os_t = get_default_config_dir())]
-    config_dir: PathBuf,
-    /// Device ID
-    #[arg(short, long)]
-    device: Option<String>,
+    #[clap(flatten)]
+    config: ConfigWithDeviceSharedOpts,
     /// Workspace id
     #[arg(short, long, value_parser = VlobID::from_hex)]
     workspace_id: VlobID,
@@ -28,8 +21,7 @@ pub struct ShareWorkspace {
 
 pub async fn share_workspace(share_workspace: ShareWorkspace) -> anyhow::Result<()> {
     let ShareWorkspace {
-        config_dir,
-        device,
+        config: ConfigWithDeviceSharedOpts { config_dir, device },
         workspace_id,
         user_id,
         role,

--- a/cli/src/stats_organization.rs
+++ b/cli/src/stats_organization.rs
@@ -39,6 +39,7 @@ pub async fn stats_organization(stats_organization: StatsOrganization) -> anyhow
         organization_id,
         server: ServerSharedOpts { addr, token },
     } = stats_organization;
+    log::trace!("Retrieving stats for organization {organization_id} (addr={addr})");
 
     let rep = stats_organization_req(&organization_id, &addr, &token).await?;
 

--- a/cli/src/stats_organization.rs
+++ b/cli/src/stats_organization.rs
@@ -1,22 +1,19 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
 use reqwest::Client;
 use serde_json::Value;
 
 use libparsec::{OrganizationID, ParsecAddr};
 
-#[derive(Args)]
+use crate::utils::ServerSharedOpts;
+
+#[derive(clap::Parser)]
 pub struct StatsOrganization {
     /// OrganizationID
     #[arg(short, long)]
     organization_id: OrganizationID,
-    /// Server address (e.g: parsec3://127.0.0.1:6770?no_ssl=true)
-    #[arg(short, long)]
-    addr: ParsecAddr,
-    /// Administration token
-    #[arg(short, long)]
-    token: String,
+    #[clap(flatten)]
+    server: ServerSharedOpts,
 }
 
 pub async fn stats_organization_req(
@@ -40,8 +37,7 @@ pub async fn stats_organization_req(
 pub async fn stats_organization(stats_organization: StatsOrganization) -> anyhow::Result<()> {
     let StatsOrganization {
         organization_id,
-        addr,
-        token,
+        server: ServerSharedOpts { addr, token },
     } = stats_organization;
 
     let rep = stats_organization_req(&organization_id, &addr, &token).await?;

--- a/cli/src/stats_server.rs
+++ b/cli/src/stats_server.rs
@@ -74,6 +74,7 @@ pub async fn stats_server(stats_organization: StatsServer) -> anyhow::Result<()>
         format,
         end_date,
     } = stats_organization;
+    log::trace!("Retrieving server's stats (addr={addr}, format={format})");
 
     let rep = stats_server_req(&addr, &token, format, end_date).await?;
 

--- a/cli/src/stats_server.rs
+++ b/cli/src/stats_server.rs
@@ -1,19 +1,16 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
 use reqwest::{Client, Response};
 use serde_json::Value;
 
 use libparsec::{DateTime, ParsecAddr};
 
-#[derive(Args)]
+use crate::utils::ServerSharedOpts;
+
+#[derive(clap::Parser)]
 pub struct StatsServer {
-    /// Server address (e.g: parsec3://127.0.0.1:6770?no_ssl=true)
-    #[arg(short, long)]
-    addr: ParsecAddr,
-    /// Administration token
-    #[arg(short, long)]
-    token: String,
+    #[clap(flatten)]
+    server: ServerSharedOpts,
     /// Output format (json/csv)
     #[arg(short, long, default_value_t = Format::Json)]
     format: Format,
@@ -73,8 +70,7 @@ pub async fn stats_server_req(
 
 pub async fn stats_server(stats_organization: StatsServer) -> anyhow::Result<()> {
     let StatsServer {
-        addr,
-        token,
+        server: ServerSharedOpts { addr, token },
         format,
         end_date,
     } = stats_organization;

--- a/cli/src/status_organization.rs
+++ b/cli/src/status_organization.rs
@@ -39,6 +39,7 @@ pub async fn status_organization(status_organization: StatusOrganization) -> any
         organization_id,
         server: ServerSharedOpts { addr, token },
     } = status_organization;
+    log::trace!("Retrieving status of organization {organization_id} (addr={addr})");
 
     let rep = status_organization_req(&organization_id, &addr, &token).await?;
 

--- a/cli/src/status_organization.rs
+++ b/cli/src/status_organization.rs
@@ -1,22 +1,19 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use clap::Args;
 use reqwest::Client;
 use serde_json::Value;
 
 use libparsec::{OrganizationID, ParsecAddr};
 
-#[derive(Args)]
+use crate::utils::ServerSharedOpts;
+
+#[derive(clap::Parser)]
 pub struct StatusOrganization {
     /// OrganizationID
     #[arg(short, long)]
     organization_id: OrganizationID,
-    /// Server address (e.g: parsec3://127.0.0.1:6770?no_ssl=true)
-    #[arg(short, long)]
-    addr: ParsecAddr,
-    /// Administration token
-    #[arg(short, long)]
-    token: String,
+    #[clap(flatten)]
+    server: ServerSharedOpts,
 }
 
 pub async fn status_organization_req(
@@ -40,8 +37,7 @@ pub async fn status_organization_req(
 pub async fn status_organization(status_organization: StatusOrganization) -> anyhow::Result<()> {
     let StatusOrganization {
         organization_id,
-        addr,
-        token,
+        server: ServerSharedOpts { addr, token },
     } = status_organization;
 
     let rep = status_organization_req(&organization_id, &addr, &token).await?;

--- a/cli/src/tests.rs
+++ b/cli/src/tests.rs
@@ -15,7 +15,7 @@ use libparsec::{
     },
     get_default_config_dir, tmp_path, AuthenticatedCmds, ClientConfig, HumanHandle, InvitationType,
     LocalDevice, OrganizationID, ParsecAddr, ParsecInvitationAddr, ProxyConfig, TmpPath,
-    PARSEC_BASE_DATA_DIR, PARSEC_CONFIG_DIR, PARSEC_HOME_DIR,
+    PARSEC_BASE_CONFIG_DIR, PARSEC_BASE_DATA_DIR, PARSEC_HOME_DIR,
 };
 
 use crate::{
@@ -41,7 +41,7 @@ fn set_env(tmp_dir: &str, url: &ParsecAddr) {
     std::env::set_var(TESTBED_SERVER_URL, url.to_url().to_string());
     std::env::set_var(PARSEC_HOME_DIR, format!("{tmp_dir}/cache"));
     std::env::set_var(PARSEC_BASE_DATA_DIR, format!("{tmp_dir}/share"));
-    std::env::set_var(PARSEC_CONFIG_DIR, format!("{tmp_dir}/config"));
+    std::env::set_var(PARSEC_BASE_CONFIG_DIR, format!("{tmp_dir}/config"));
 }
 
 fn unique_org_id() -> OrganizationID {

--- a/cli/src/tests.rs
+++ b/cli/src/tests.rs
@@ -15,7 +15,7 @@ use libparsec::{
     },
     get_default_config_dir, tmp_path, AuthenticatedCmds, ClientConfig, HumanHandle, InvitationType,
     LocalDevice, OrganizationID, ParsecAddr, ParsecInvitationAddr, ProxyConfig, TmpPath,
-    PARSEC_CONFIG_DIR, PARSEC_DATA_DIR, PARSEC_HOME_DIR,
+    PARSEC_BASE_DATA_DIR, PARSEC_CONFIG_DIR, PARSEC_HOME_DIR,
 };
 
 use crate::{
@@ -40,7 +40,7 @@ fn get_testenv_config() -> TestenvConfig {
 fn set_env(tmp_dir: &str, url: &ParsecAddr) {
     std::env::set_var(TESTBED_SERVER_URL, url.to_url().to_string());
     std::env::set_var(PARSEC_HOME_DIR, format!("{tmp_dir}/cache"));
-    std::env::set_var(PARSEC_DATA_DIR, format!("{tmp_dir}/share"));
+    std::env::set_var(PARSEC_BASE_DATA_DIR, format!("{tmp_dir}/share"));
     std::env::set_var(PARSEC_CONFIG_DIR, format!("{tmp_dir}/config"));
 }
 

--- a/cli/src/tests.rs
+++ b/cli/src/tests.rs
@@ -94,6 +94,7 @@ fn version() {
 #[rstest::rstest]
 #[tokio::test]
 async fn list_devices(tmp_path: TmpPath) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let tmp_path_str = tmp_path.to_str().unwrap();
     let config = get_testenv_config();
     let (url, _, _) = run_local_organization(&tmp_path, None, config)
@@ -116,6 +117,7 @@ async fn list_devices(tmp_path: TmpPath) {
 #[rstest::rstest]
 #[tokio::test]
 async fn create_organization(tmp_path: TmpPath) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let tmp_path_str = tmp_path.to_str().unwrap();
     let config = get_testenv_config();
     let (url, _, _) = run_local_organization(&tmp_path, None, config)
@@ -141,6 +143,7 @@ async fn create_organization(tmp_path: TmpPath) {
 #[rstest::rstest]
 #[tokio::test]
 async fn bootstrap_organization(tmp_path: TmpPath) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let tmp_path_str = tmp_path.to_str().unwrap();
     let config = get_testenv_config();
     let (url, _, _) = run_local_organization(&tmp_path, None, config)
@@ -176,6 +179,7 @@ async fn bootstrap_organization(tmp_path: TmpPath) {
 #[rstest::rstest]
 #[tokio::test]
 async fn invite_device(tmp_path: TmpPath) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let tmp_path_str = tmp_path.to_str().unwrap();
     let config = get_testenv_config();
     let (url, [alice, ..], _) = run_local_organization(&tmp_path, None, config)
@@ -193,6 +197,7 @@ async fn invite_device(tmp_path: TmpPath) {
 #[rstest::rstest]
 #[tokio::test]
 async fn invite_user(tmp_path: TmpPath) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let tmp_path_str = tmp_path.to_str().unwrap();
     let config = get_testenv_config();
     let (url, [alice, ..], _) = run_local_organization(&tmp_path, None, config)
@@ -216,6 +221,7 @@ async fn invite_user(tmp_path: TmpPath) {
 #[rstest::rstest]
 #[tokio::test]
 async fn cancel_invitation(tmp_path: TmpPath) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let tmp_path_str = tmp_path.to_str().unwrap();
     let config = get_testenv_config();
     let (url, [alice, ..], _) = run_local_organization(&tmp_path, None, config)
@@ -266,6 +272,7 @@ async fn cancel_invitation(tmp_path: TmpPath) {
 #[rstest::rstest]
 #[tokio::test]
 async fn stats_organization(tmp_path: TmpPath) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let tmp_path_str = tmp_path.to_str().unwrap();
     let config = get_testenv_config();
     let (url, _, org_id) = run_local_organization(&tmp_path, None, config)
@@ -317,6 +324,7 @@ async fn stats_organization(tmp_path: TmpPath) {
 #[rstest::rstest]
 #[tokio::test]
 async fn export_recovery_device(tmp_path: TmpPath) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let tmp_path_str = tmp_path.to_str().unwrap();
     let config = get_testenv_config();
     let (url, [alice, ..], _) = run_local_organization(&tmp_path, None, config)
@@ -344,6 +352,7 @@ async fn export_recovery_device(tmp_path: TmpPath) {
 #[rstest::rstest]
 #[tokio::test]
 async fn import_recovery_device(tmp_path: TmpPath) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let tmp_path_str = tmp_path.to_str().unwrap();
     let config = get_testenv_config();
     let (url, [alice, ..], _) = run_local_organization(&tmp_path, None, config)
@@ -373,6 +382,7 @@ async fn import_recovery_device(tmp_path: TmpPath) {
 #[rstest::rstest]
 #[tokio::test]
 async fn stats_server(tmp_path: TmpPath) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let tmp_path_str = tmp_path.to_str().unwrap();
     let config = get_testenv_config();
     let (url, _, _) = run_local_organization(&tmp_path, None, config)
@@ -423,6 +433,7 @@ async fn stats_server(tmp_path: TmpPath) {
 #[rstest::rstest]
 #[tokio::test]
 async fn status_organization(tmp_path: TmpPath) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let tmp_path_str = tmp_path.to_str().unwrap();
     let config = get_testenv_config();
     let (url, _, org_id) = run_local_organization(&tmp_path, None, config)
@@ -460,6 +471,7 @@ async fn status_organization(tmp_path: TmpPath) {
 #[rstest::rstest]
 #[tokio::test]
 async fn list_invitations(tmp_path: TmpPath) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let tmp_path_str = tmp_path.to_str().unwrap();
     let config = get_testenv_config();
     let (url, [alice, ..], _) = run_local_organization(&tmp_path, None, config)
@@ -513,6 +525,7 @@ async fn list_invitations(tmp_path: TmpPath) {
 #[rstest::rstest]
 #[tokio::test]
 async fn create_workspace(tmp_path: TmpPath) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let tmp_path_str = tmp_path.to_str().unwrap();
     let config = get_testenv_config();
     let (url, [alice, ..], _) = run_local_organization(&tmp_path, None, config)
@@ -543,6 +556,7 @@ async fn create_workspace(tmp_path: TmpPath) {
 #[rstest::rstest]
 #[tokio::test]
 async fn list_users(tmp_path: TmpPath) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let tmp_path_str = tmp_path.to_str().unwrap();
     let config = get_testenv_config();
     let (url, [alice, ..], _) = run_local_organization(&tmp_path, None, config)
@@ -570,6 +584,7 @@ async fn list_users(tmp_path: TmpPath) {
 // and the cli invocation process have different values for `alice.device_id.hex()` !
 #[ignore = "TODO: fix this test !"]
 async fn share_workspace(tmp_path: TmpPath) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let tmp_path_str = tmp_path.to_str().unwrap();
     let config = get_testenv_config();
     let (url, [alice, _, bob], _) = run_local_organization(&tmp_path, None, config)
@@ -627,6 +642,7 @@ async fn share_workspace(tmp_path: TmpPath) {
 #[rstest::rstest]
 #[tokio::test]
 async fn invite_device_dance(tmp_path: TmpPath) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let tmp_path_str = tmp_path.to_str().unwrap();
     let config = get_testenv_config();
     let (url, [alice, ..], _) = run_local_organization(&tmp_path, None, config)
@@ -728,6 +744,7 @@ async fn invite_device_dance(tmp_path: TmpPath) {
 #[rstest::rstest]
 #[tokio::test]
 async fn invite_user_dance(tmp_path: TmpPath) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let tmp_path_str = tmp_path.to_str().unwrap();
     let config = get_testenv_config();
     let (url, [alice, ..], _) = run_local_organization(&tmp_path, None, config)
@@ -843,6 +860,7 @@ async fn invite_user_dance(tmp_path: TmpPath) {
 // and the cli invocation process have different values for `alice.device_id.hex()` !
 #[ignore = "TODO: fix this test !"]
 async fn remove_device(tmp_path: TmpPath) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let tmp_path_str = tmp_path.to_str().unwrap();
     let config = get_testenv_config();
     let (url, [alice, ..], _) = run_local_organization(&tmp_path, None, config)

--- a/cli/src/tests.rs
+++ b/cli/src/tests.rs
@@ -15,7 +15,7 @@ use libparsec::{
     },
     get_default_config_dir, tmp_path, AuthenticatedCmds, ClientConfig, HumanHandle, InvitationType,
     LocalDevice, OrganizationID, ParsecAddr, ParsecInvitationAddr, ProxyConfig, TmpPath,
-    PARSEC_BASE_CONFIG_DIR, PARSEC_BASE_DATA_DIR, PARSEC_HOME_DIR,
+    PARSEC_BASE_CONFIG_DIR, PARSEC_BASE_DATA_DIR, PARSEC_BASE_HOME_DIR,
 };
 
 use crate::{
@@ -39,7 +39,7 @@ fn get_testenv_config() -> TestenvConfig {
 
 fn set_env(tmp_dir: &str, url: &ParsecAddr) {
     std::env::set_var(TESTBED_SERVER_URL, url.to_url().to_string());
-    std::env::set_var(PARSEC_HOME_DIR, format!("{tmp_dir}/cache"));
+    std::env::set_var(PARSEC_BASE_HOME_DIR, format!("{tmp_dir}/cache"));
     std::env::set_var(PARSEC_BASE_DATA_DIR, format!("{tmp_dir}/share"));
     std::env::set_var(PARSEC_BASE_CONFIG_DIR, format!("{tmp_dir}/config"));
 }

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -10,17 +10,21 @@ use libparsec::{
 };
 use spinners::{Spinner, Spinners, Stream};
 
+/// Environment variable to set the Parsec config directory
+/// Should not be confused with [`libparsec::PARSEC_BASE_CONFIG_DIR`]
+pub const PARSEC_CONFIG_DIR: &str = "PARSEC_CONFIG_DIR";
+
 #[derive(clap::Parser)]
 pub(crate) struct ConfigSharedOpts {
     /// Parsec config directory
-    #[arg(short, long, default_value_os_t = libparsec::get_default_config_dir(), env = libparsec::PARSEC_CONFIG_DIR)]
+    #[arg(short, long, default_value_os_t = libparsec::get_default_config_dir(), env = PARSEC_CONFIG_DIR)]
     pub(crate) config_dir: PathBuf,
 }
 
 #[derive(clap::Parser)]
 pub(crate) struct ConfigWithDeviceSharedOpts {
     /// Parsec config directory
-    #[arg(short, long, default_value_os_t = libparsec::get_default_config_dir(), env = libparsec::PARSEC_CONFIG_DIR)]
+    #[arg(short, long, default_value_os_t = libparsec::get_default_config_dir(), env = PARSEC_CONFIG_DIR)]
     pub(crate) config_dir: PathBuf,
     /// Device ID
     #[arg(short, long, env = "PARSEC_DEVICE_ID")]

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -10,6 +10,33 @@ use libparsec::{
 };
 use spinners::{Spinner, Spinners, Stream};
 
+#[derive(clap::Parser)]
+pub(crate) struct ConfigSharedOpts {
+    /// Parsec config directory
+    #[arg(short, long, default_value_os_t = libparsec::get_default_config_dir(), env = libparsec::PARSEC_CONFIG_DIR)]
+    pub(crate) config_dir: PathBuf,
+}
+
+#[derive(clap::Parser)]
+pub(crate) struct ConfigWithDeviceSharedOpts {
+    /// Parsec config directory
+    #[arg(short, long, default_value_os_t = libparsec::get_default_config_dir(), env = libparsec::PARSEC_CONFIG_DIR)]
+    pub(crate) config_dir: PathBuf,
+    /// Device ID
+    #[arg(short, long, env = "PARSEC_DEVICE_ID")]
+    pub(crate) device: Option<String>,
+}
+
+#[derive(clap::Parser, Clone)]
+pub(crate) struct ServerSharedOpts {
+    /// Server address (e.g: parsec3://127.0.0.1:6770?no_ssl=true)
+    #[arg(short, long, env = "PARSEC_SERVER_ADDR")]
+    pub(crate) addr: libparsec::ParsecAddr,
+    /// Administration token
+    #[arg(short, long, env = "PARSEC_ADMINISTRATION_TOKEN")]
+    pub(crate) token: String,
+}
+
 pub const GREEN: &str = "\x1B[92m";
 pub const RED: &str = "\x1B[91m";
 pub const RESET: &str = "\x1B[39m";

--- a/libparsec/crates/platform_device_loader/src/lib.rs
+++ b/libparsec/crates/platform_device_loader/src/lib.rs
@@ -27,7 +27,7 @@ pub const ARGON2ID_DEFAULT_PARALLELISM: u32 = 1;
 pub(crate) const DEVICE_FILE_EXT: &str = "keys";
 
 pub const PARSEC_CONFIG_DIR: &str = "PARSEC_CONFIG_DIR";
-pub const PARSEC_DATA_DIR: &str = "PARSEC_DATA_DIR";
+pub const PARSEC_BASE_DATA_DIR: &str = "PARSEC_BASE_DATA_DIR";
 pub const PARSEC_HOME_DIR: &str = "PARSEC_HOME_DIR";
 
 pub fn get_default_data_base_dir() -> PathBuf {
@@ -37,7 +37,7 @@ pub fn get_default_data_base_dir() -> PathBuf {
     }
     #[cfg(not(target_arch = "wasm32"))]
     {
-        let mut path = if let Ok(data_dir) = std::env::var(PARSEC_DATA_DIR) {
+        let mut path = if let Ok(data_dir) = std::env::var(PARSEC_BASE_DATA_DIR) {
             PathBuf::from(data_dir)
         } else {
             dirs::data_dir().expect("Could not determine base data directory")

--- a/libparsec/crates/platform_device_loader/src/lib.rs
+++ b/libparsec/crates/platform_device_loader/src/lib.rs
@@ -28,7 +28,7 @@ pub(crate) const DEVICE_FILE_EXT: &str = "keys";
 
 pub const PARSEC_BASE_CONFIG_DIR: &str = "PARSEC_BASE_CONFIG_DIR";
 pub const PARSEC_BASE_DATA_DIR: &str = "PARSEC_BASE_DATA_DIR";
-pub const PARSEC_HOME_DIR: &str = "PARSEC_HOME_DIR";
+pub const PARSEC_BASE_HOME_DIR: &str = "PARSEC_BASE_HOME_DIR";
 
 pub fn get_default_data_base_dir() -> PathBuf {
     #[cfg(target_arch = "wasm32")]
@@ -73,7 +73,7 @@ pub fn get_default_mountpoint_base_dir() -> PathBuf {
     }
     #[cfg(not(target_arch = "wasm32"))]
     {
-        let mut path = if let Ok(home_dir) = std::env::var(PARSEC_HOME_DIR) {
+        let mut path = if let Ok(home_dir) = std::env::var(PARSEC_BASE_HOME_DIR) {
             PathBuf::from(home_dir)
         } else {
             dirs::home_dir().expect("Could not determine home directory")

--- a/libparsec/crates/platform_device_loader/src/lib.rs
+++ b/libparsec/crates/platform_device_loader/src/lib.rs
@@ -26,7 +26,7 @@ pub const ARGON2ID_DEFAULT_PARALLELISM: u32 = 1;
 
 pub(crate) const DEVICE_FILE_EXT: &str = "keys";
 
-pub const PARSEC_CONFIG_DIR: &str = "PARSEC_CONFIG_DIR";
+pub const PARSEC_BASE_CONFIG_DIR: &str = "PARSEC_BASE_CONFIG_DIR";
 pub const PARSEC_BASE_DATA_DIR: &str = "PARSEC_BASE_DATA_DIR";
 pub const PARSEC_HOME_DIR: &str = "PARSEC_HOME_DIR";
 
@@ -55,7 +55,7 @@ pub fn get_default_config_dir() -> PathBuf {
     }
     #[cfg(not(target_arch = "wasm32"))]
     {
-        let mut path = if let Ok(config_dir) = std::env::var(PARSEC_CONFIG_DIR) {
+        let mut path = if let Ok(config_dir) = std::env::var(PARSEC_BASE_CONFIG_DIR) {
             PathBuf::from(config_dir)
         } else {
             dirs::config_dir().expect("Could not determine base config directory")

--- a/libparsec/src/config.rs
+++ b/libparsec/src/config.rs
@@ -7,7 +7,7 @@ pub use libparsec_client::{
 };
 pub use libparsec_platform_device_loader::{
     get_default_config_dir, get_default_data_base_dir, get_default_mountpoint_base_dir,
-    PARSEC_BASE_DATA_DIR, PARSEC_CONFIG_DIR, PARSEC_HOME_DIR,
+    PARSEC_BASE_CONFIG_DIR, PARSEC_BASE_DATA_DIR, PARSEC_HOME_DIR,
 };
 pub use libparsec_types::prelude::*;
 

--- a/libparsec/src/config.rs
+++ b/libparsec/src/config.rs
@@ -7,7 +7,7 @@ pub use libparsec_client::{
 };
 pub use libparsec_platform_device_loader::{
     get_default_config_dir, get_default_data_base_dir, get_default_mountpoint_base_dir,
-    PARSEC_CONFIG_DIR, PARSEC_DATA_DIR, PARSEC_HOME_DIR,
+    PARSEC_BASE_DATA_DIR, PARSEC_CONFIG_DIR, PARSEC_HOME_DIR,
 };
 pub use libparsec_types::prelude::*;
 

--- a/libparsec/src/config.rs
+++ b/libparsec/src/config.rs
@@ -7,7 +7,7 @@ pub use libparsec_client::{
 };
 pub use libparsec_platform_device_loader::{
     get_default_config_dir, get_default_data_base_dir, get_default_mountpoint_base_dir,
-    PARSEC_BASE_CONFIG_DIR, PARSEC_BASE_DATA_DIR, PARSEC_HOME_DIR,
+    PARSEC_BASE_CONFIG_DIR, PARSEC_BASE_DATA_DIR, PARSEC_BASE_HOME_DIR,
 };
 pub use libparsec_types::prelude::*;
 


### PR DESCRIPTION
- Add `env` feature to clap dependency
- Use `env` feature to read some options from env variables:

  - `PARSEC_SERVER_ADDR` for server address
  - `PARSEC_ADMINISTRATION_TOKEN` for administration token
  - `PARSEC_CONFIG_DIR` for Parsec config directory
  - `PARSEC_DEVICE_ID` for device ID