### PR TITLE
Rename chunk to chunk view when applicable

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -200,6 +200,7 @@ getfileattr
 getfileinfo
 getplugin
 GetRandom
+ghijklmnopqrstu
 gifv
 gloo
 gradlew

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -63,7 +63,7 @@ jobs:
       TESTBED_SERVER: http://localhost:6777
     services:
       parsec-testbed-server:
-        image: ghcr.io/scille/parsec-cloud/parsec-testbed-server:3.0.0-b.6.dev.19913.e644062
+        image: ghcr.io/scille/parsec-cloud/parsec-testbed-server:3.0.0-b.6.dev.19914.1a7577b
         ports:
           - 6777:6777
     steps:

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -36,7 +36,7 @@ jobs:
     # https://github.com/Scille/parsec-cloud/pkgs/container/parsec-cloud%2Fparsec-testbed-server
     services:
       parsec-testbed-server:
-        image: ghcr.io/scille/parsec-cloud/parsec-testbed-server:3.0.0-b.6.dev.19913.e644062
+        image: ghcr.io/scille/parsec-cloud/parsec-testbed-server:3.0.0-b.6.dev.19914.1a7577b
         ports:
           - 6777:6777
     steps:

--- a/libparsec/crates/client/src/workspace/store/cache.rs
+++ b/libparsec/crates/client/src/workspace/store/cache.rs
@@ -16,6 +16,7 @@ use super::per_manifest_update_lock::PerManifestUpdateLock;
 /// than a typical kernel read (512ko vs 4ko), so it's a big win to just keep the
 /// chunks currently being read in memory.
 /// To approximate that, we just keep the last 16 chunks read in memory.
+/// More practical information in this issue: https://github.com/Scille/parsec-cloud/issues/7111
 #[derive(Debug)]
 pub(super) struct ChunksCache {
     items: [Option<(ChunkID, Bytes)>; 16],

--- a/libparsec/crates/client/src/workspace/store/mod.rs
+++ b/libparsec/crates/client/src/workspace/store/mod.rs
@@ -344,7 +344,7 @@ impl WorkspaceStore {
 
     pub async fn get_chunk_or_block_local_only(
         &self,
-        chunk: &Chunk,
+        chunk: &ChunkView,
     ) -> Result<Bytes, ReadChunkOrBlockLocalOnlyError> {
         {
             let cache = self.current_view_cache.lock().expect("Mutex is poisoned");
@@ -391,7 +391,7 @@ impl WorkspaceStore {
 
     pub async fn get_chunk_or_block(
         &self,
-        chunk: &Chunk,
+        chunk: &ChunkView,
         remote_manifest: &FileManifest,
     ) -> Result<Bytes, ReadChunkOrBlockError> {
         let outcome = self.get_chunk_or_block_local_only(chunk).await;

--- a/libparsec/crates/client/src/workspace/transactions/fd_flush.rs
+++ b/libparsec/crates/client/src/workspace/transactions/fd_flush.rs
@@ -131,11 +131,11 @@ async fn reshape(
         let mut buf_size = 0;
         let mut local_miss = false;
         let start = reshape.destination().start;
-        for chunk in reshape.source().iter() {
-            let outcome = ops.store.get_chunk_or_block_local_only(chunk).await;
+        for chunk_view in reshape.source().iter() {
+            let outcome = ops.store.get_chunk_or_block_local_only(chunk_view).await;
             match outcome {
                 Ok(chunk_data) => {
-                    chunk
+                    chunk_view
                         .copy_between_start_and_stop(&chunk_data, start, &mut buf, &mut buf_size)
                         .expect("write on vec cannot fail");
                 }

--- a/libparsec/crates/client/tests/unit/workspace/file_operations.rs
+++ b/libparsec/crates/client/tests/unit/workspace/file_operations.rs
@@ -39,14 +39,14 @@ impl Storage {
         self.0.remove(&chunk_id);
     }
 
-    fn read_chunk(&self, chunk: &Chunk) -> &[u8] {
+    fn read_chunk(&self, chunk: &ChunkView) -> &[u8] {
         let data = self.read_chunk_data(chunk.id);
         let start = (chunk.start - chunk.raw_offset) as usize;
         let stop = (chunk.stop.get() - chunk.raw_offset) as usize;
         data.get(start..stop).unwrap()
     }
 
-    fn write_chunk(&mut self, chunk: &Chunk, content: &[u8], offset: i64) {
+    fn write_chunk(&mut self, chunk: &ChunkView, content: &[u8], offset: i64) {
         let data = padded_data(
             content,
             offset,
@@ -55,7 +55,7 @@ impl Storage {
         self.write_chunk_data(chunk.id, data)
     }
 
-    fn build_data(&self, chunks: &[Chunk], size: u64, offset: u64) -> Vec<u8> {
+    fn build_data(&self, chunks: &[ChunkView], size: u64, offset: u64) -> Vec<u8> {
         let start = offset as usize;
         let mut result: Vec<u8> = vec![0; size as usize];
         for chunk in chunks {

--- a/libparsec/crates/client/tests/unit/workspace/inbound_sync_file.rs
+++ b/libparsec/crates/client/tests/unit/workspace/inbound_sync_file.rs
@@ -146,7 +146,7 @@ async fn non_placeholder(
                         manifest.need_sync = true;
                         manifest.blocks.clear();
                         manifest.size = 3;
-                        manifest.blocks.push(vec![Chunk {
+                        manifest.blocks.push(vec![ChunkView {
                             id: wksp1_bar_txt_new_chunk_id,
                             start: 0,
                             stop: 3.try_into().unwrap(),

--- a/libparsec/crates/client/tests/unit/workspace/remove_entry.rs
+++ b/libparsec/crates/client/tests/unit/workspace/remove_entry.rs
@@ -162,7 +162,7 @@ async fn remove_file_with_local_changes(
 
     // Local changes
 
-    let changes_chunk = {
+    let changes_chunk_view = {
         let fd = ops
             .open_file_by_id(wksp1_foo_egg_txt_id, OpenOptions::read_write())
             .await
@@ -193,7 +193,7 @@ async fn remove_file_with_local_changes(
     );
     p_assert_eq!(
         ops.store
-            .get_chunk_or_block_local_only(&changes_chunk)
+            .get_chunk_or_block_local_only(&changes_chunk_view)
             .await
             .unwrap(),
         b"xxxxx".as_ref()
@@ -229,7 +229,7 @@ async fn remove_file_with_local_changes(
     );
     p_assert_matches!(
         ops.store
-            .get_chunk_or_block_local_only(&changes_chunk)
+            .get_chunk_or_block_local_only(&changes_chunk_view)
             .await
             .unwrap_err(),
         ReadChunkOrBlockLocalOnlyError::ChunkNotFound

--- a/libparsec/crates/serialization_format/src/protocol_python_bindings.rs
+++ b/libparsec/crates/serialization_format/src/protocol_python_bindings.rs
@@ -834,7 +834,7 @@ fn quote_type_as_fn_getter_ret_type(ty: &FieldType) -> TokenStream {
         FieldType::WorkspaceManifest => quote! { crate::data::WorkspaceManifest },
         FieldType::UserManifest => quote! { crate::data::UserManifest },
         FieldType::ActiveUsersLimit => quote! { crate::protocol::ActiveUsersLimit },
-        FieldType::Chunk => quote! { crate::data::Chunk },
+        FieldType::ChunkView => quote! { crate::data::ChunkView },
         FieldType::UsersPerProfileDetailItem => quote! { crate::data::UsersPerProfileDetailItem },
         FieldType::PkiEnrollmentSubmitPayload => quote! { crate::data::PkiEnrollmentSubmitPayload },
         FieldType::X509Certificate => quote! { crate::data::X509Certificate },
@@ -968,7 +968,7 @@ fn quote_type_as_fn_getter_conversion(field_path: &TokenStream, ty: &FieldType) 
         FieldType::ActiveUsersLimit => {
             quote! { crate::protocol::ActiveUsersLimit(#field_path.to_owned()) }
         }
-        FieldType::Chunk => quote! { crate::data::Chunk(#field_path.to_owned()) },
+        FieldType::ChunkView => quote! { crate::data::ChunkView(#field_path.to_owned()) },
         FieldType::UsersPerProfileDetailItem => {
             quote! { crate::data::UsersPerProfileDetailItem(#field_path.to_owned()) }
         }
@@ -1054,7 +1054,7 @@ fn quote_type_as_fn_new_param(ty: &FieldType) -> TokenStream {
         FieldType::WorkspaceManifest => quote! { crate::data::WorkspaceManifest },
         FieldType::UserManifest => quote! { crate::data::UserManifest },
         FieldType::ActiveUsersLimit => quote! { crate::protocol::ActiveUsersLimit },
-        FieldType::Chunk => quote! { crate::data::Chunk },
+        FieldType::ChunkView => quote! { crate::data::ChunkView },
         FieldType::UsersPerProfileDetailItem => quote! { crate::data::UsersPerProfileDetailItem },
         FieldType::PkiEnrollmentSubmitPayload => quote! { crate::data::PkiEnrollmentSubmitPayload },
         FieldType::X509Certificate => quote! { crate::data::X509Certificate },
@@ -1177,7 +1177,7 @@ fn internal_quote_field_as_fn_new_conversion(field_name: &Ident, ty: &FieldType)
         | FieldType::WorkspaceManifest
         | FieldType::UserManifest
         | FieldType::ActiveUsersLimit
-        | FieldType::Chunk
+        | FieldType::ChunkView
         | FieldType::UsersPerProfileDetailItem
         | FieldType::PkiEnrollmentSubmitPayload
         | FieldType::X509Certificate => quote! { #field_name.0 },

--- a/libparsec/crates/serialization_format/src/types.rs
+++ b/libparsec/crates/serialization_format/src/types.rs
@@ -247,7 +247,7 @@ generate_field_type_enum!(
     WorkspaceManifest => libparsec_types::WorkspaceManifest,
     UserManifest => libparsec_types::UserManifest,
     ActiveUsersLimit => libparsec_types::ActiveUsersLimit,
-    Chunk => libparsec_types::Chunk,
+    ChunkView => libparsec_types::ChunkView,
     UsersPerProfileDetailItem => libparsec_types::UsersPerProfileDetailItem,
     PkiEnrollmentSubmitPayload => PkiEnrollmentSubmitPayload,
     X509Certificate => libparsec_types::X509Certificate,

--- a/libparsec/crates/testbed/src/template/crc_hash.rs
+++ b/libparsec/crates/testbed/src/template/crc_hash.rs
@@ -466,11 +466,11 @@ impl CrcHash for BlockAccess {
         digest.crc_hash(hasher);
     }
 }
-impl CrcHash for Chunk {
+impl CrcHash for ChunkView {
     fn crc_hash(&self, hasher: &mut crc32fast::Hasher) {
         hasher.update(b"Chunk");
 
-        let Chunk {
+        let ChunkView {
             id,
             start,
             stop,

--- a/libparsec/crates/testbed/src/template/crc_hash.rs
+++ b/libparsec/crates/testbed/src/template/crc_hash.rs
@@ -468,8 +468,7 @@ impl CrcHash for BlockAccess {
 }
 impl CrcHash for ChunkView {
     fn crc_hash(&self, hasher: &mut crc32fast::Hasher) {
-        // TODO: change to `ChunkView``
-        hasher.update(b"Chunk");
+        hasher.update(b"ChunkView");
 
         let ChunkView {
             id,

--- a/libparsec/crates/testbed/src/template/crc_hash.rs
+++ b/libparsec/crates/testbed/src/template/crc_hash.rs
@@ -468,6 +468,7 @@ impl CrcHash for BlockAccess {
 }
 impl CrcHash for ChunkView {
     fn crc_hash(&self, hasher: &mut crc32fast::Hasher) {
+        // TODO: change to `ChunkView``
         hasher.update(b"Chunk");
 
         let ChunkView {

--- a/libparsec/crates/types/schema/local_manifest/local_file_manifest.json5
+++ b/libparsec/crates/types/schema/local_manifest/local_file_manifest.json5
@@ -29,7 +29,7 @@
         },
         {
             "name": "blocks",
-            "type": "List<List<Chunk>>"
+            "type": "List<List<ChunkView>>"
         }
     ]
 }

--- a/libparsec/crates/types/tests/unit/local_manifest.rs
+++ b/libparsec/crates/types/tests/unit/local_manifest.rs
@@ -131,7 +131,7 @@ fn serde_local_file_manifest_ok(alice: &Device) {
             size: 700,
         },
         blocks: vec![vec![
-            Chunk {
+            ChunkView {
                 id: ChunkID::from_hex("ad67b6b5b9ad4653bf8e2b405bb6115f").unwrap(),
                 access: Some(BlockAccess {
                     id: BlockID::from_hex("b82954f1138b4d719b7f5bd78915d20f").unwrap(),
@@ -147,7 +147,7 @@ fn serde_local_file_manifest_ok(alice: &Device) {
                 start: 0,
                 stop: NonZeroU64::new(250).unwrap(),
             },
-            Chunk {
+            ChunkView {
                 id: ChunkID::from_hex("2f99258022a94555b3109e81d34bdf97").unwrap(),
                 access: None,
                 raw_offset: 250,
@@ -593,7 +593,7 @@ fn serde_local_user_manifest(
 
 #[rstest]
 fn chunk_new() {
-    let chunk = Chunk::new(1, NonZeroU64::try_from(5).unwrap());
+    let chunk = ChunkView::new(1, NonZeroU64::try_from(5).unwrap());
 
     p_assert_eq!(chunk.start, 1);
     p_assert_eq!(chunk.stop, NonZeroU64::try_from(5).unwrap());
@@ -604,12 +604,12 @@ fn chunk_new() {
     p_assert_eq!(chunk, 1);
     assert!(chunk < 2);
     assert!(chunk > 0);
-    p_assert_ne!(chunk, Chunk::new(1, NonZeroU64::try_from(5).unwrap()));
+    p_assert_ne!(chunk, ChunkView::new(1, NonZeroU64::try_from(5).unwrap()));
 }
 
 #[rstest]
 fn chunk_promote_as_block() {
-    let chunk = Chunk::new(1, NonZeroU64::try_from(5).unwrap());
+    let chunk = ChunkView::new(1, NonZeroU64::try_from(5).unwrap());
     let id = chunk.id;
     let block = {
         let mut block = chunk.clone();
@@ -640,11 +640,11 @@ fn chunk_promote_as_block() {
         digest: HashDigest::from_data(b"<data>"),
     };
 
-    let mut block = Chunk::from_block_access(block_access);
+    let mut block = ChunkView::from_block_access(block_access);
     let err = block.promote_as_block(b"<data>").unwrap_err();
     p_assert_eq!(err, ChunkPromoteAsBlockError::AlreadyPromotedAsBlock);
 
-    let mut chunk = Chunk {
+    let mut chunk = ChunkView {
         id,
         start: 0,
         stop: NonZeroU64::try_from(1).unwrap(),
@@ -659,7 +659,7 @@ fn chunk_promote_as_block() {
 
 #[rstest]
 fn chunk_is_block() {
-    let chunk = Chunk {
+    let chunk = ChunkView {
         id: ChunkID::default(),
         start: 0,
         stop: NonZeroU64::try_from(1).unwrap(),
@@ -747,7 +747,7 @@ fn local_file_manifest_is_reshaped(timestamp: DateTime) {
     assert!(lfm.is_reshaped());
 
     let block = {
-        let mut block = Chunk {
+        let mut block = ChunkView {
             id: ChunkID::default(),
             start: 0,
             stop: NonZeroU64::try_from(1).unwrap(),
@@ -815,7 +815,7 @@ fn local_file_manifest_from_remote(timestamp: DateTime, #[case] input: (u64, Vec
         lfm.blocks,
         blocks
             .into_iter()
-            .map(|block| vec![Chunk::from_block_access(block)])
+            .map(|block| vec![ChunkView::from_block_access(block)])
             .collect::<Vec<_>>()
     );
 }
@@ -830,7 +830,7 @@ fn local_file_manifest_to_remote(timestamp: DateTime) {
     let mut lfm = LocalFileManifest::new(author, parent, t1);
 
     let block = {
-        let mut block = Chunk {
+        let mut block = ChunkView {
             id: ChunkID::default(),
             start: 0,
             stop: NonZeroU64::try_from(1).unwrap(),

--- a/libparsec/crates/types/tests/unit/local_manifest.rs
+++ b/libparsec/crates/types/tests/unit/local_manifest.rs
@@ -593,26 +593,29 @@ fn serde_local_user_manifest(
 
 #[rstest]
 fn chunk_new() {
-    let chunk = ChunkView::new(1, NonZeroU64::try_from(5).unwrap());
+    let chunk_view = ChunkView::new(1, NonZeroU64::try_from(5).unwrap());
 
-    p_assert_eq!(chunk.start, 1);
-    p_assert_eq!(chunk.stop, NonZeroU64::try_from(5).unwrap());
-    p_assert_eq!(chunk.raw_offset, 1);
-    p_assert_eq!(chunk.raw_size, NonZeroU64::try_from(4).unwrap());
-    p_assert_eq!(chunk.access, None);
+    p_assert_eq!(chunk_view.start, 1);
+    p_assert_eq!(chunk_view.stop, NonZeroU64::try_from(5).unwrap());
+    p_assert_eq!(chunk_view.raw_offset, 1);
+    p_assert_eq!(chunk_view.raw_size, NonZeroU64::try_from(4).unwrap());
+    p_assert_eq!(chunk_view.access, None);
 
-    p_assert_eq!(chunk, 1);
-    assert!(chunk < 2);
-    assert!(chunk > 0);
-    p_assert_ne!(chunk, ChunkView::new(1, NonZeroU64::try_from(5).unwrap()));
+    p_assert_eq!(chunk_view, 1);
+    assert!(chunk_view < 2);
+    assert!(chunk_view > 0);
+    p_assert_ne!(
+        chunk_view,
+        ChunkView::new(1, NonZeroU64::try_from(5).unwrap())
+    );
 }
 
 #[rstest]
 fn chunk_promote_as_block() {
-    let chunk = ChunkView::new(1, NonZeroU64::try_from(5).unwrap());
-    let id = chunk.id;
+    let chunk_view = ChunkView::new(1, NonZeroU64::try_from(5).unwrap());
+    let id = chunk_view.id;
     let block = {
-        let mut block = chunk.clone();
+        let mut block = chunk_view.clone();
         block.promote_as_block(b"<data>").unwrap();
         block
     };
@@ -642,9 +645,9 @@ fn chunk_promote_as_block() {
 
     let mut block = ChunkView::from_block_access(block_access);
     let err = block.promote_as_block(b"<data>").unwrap_err();
-    p_assert_eq!(err, ChunkPromoteAsBlockError::AlreadyPromotedAsBlock);
+    p_assert_eq!(err, ChunkViewPromoteAsBlockError::AlreadyPromotedAsBlock);
 
-    let mut chunk = ChunkView {
+    let mut chunk_view = ChunkView {
         id,
         start: 0,
         stop: NonZeroU64::try_from(1).unwrap(),
@@ -653,13 +656,13 @@ fn chunk_promote_as_block() {
         access: None,
     };
 
-    let err = chunk.promote_as_block(b"<data>").unwrap_err();
-    p_assert_eq!(err, ChunkPromoteAsBlockError::NotAligned);
+    let err = chunk_view.promote_as_block(b"<data>").unwrap_err();
+    p_assert_eq!(err, ChunkViewPromoteAsBlockError::NotAligned);
 }
 
 #[rstest]
 fn chunk_is_block() {
-    let chunk = ChunkView {
+    let chunk_view = ChunkView {
         id: ChunkID::default(),
         start: 0,
         stop: NonZeroU64::try_from(1).unwrap(),
@@ -668,11 +671,11 @@ fn chunk_is_block() {
         access: None,
     };
 
-    assert!(chunk.is_aligned_with_raw_data());
-    assert!(!chunk.is_block());
+    assert!(chunk_view.is_aligned_with_raw_data());
+    assert!(!chunk_view.is_block());
 
     let mut block = {
-        let mut block = chunk.clone();
+        let mut block = chunk_view.clone();
         block.promote_as_block(b"<data>").unwrap();
         block
     };

--- a/server/packaging/testbed-server/README.md
+++ b/server/packaging/testbed-server/README.md
@@ -36,7 +36,7 @@ For example, `https://github.com/Scille/parsec-cloud/blob/master/.github/workflo
 ```yaml
     services:
       parsec-testbed-server:
-        image: ghcr.io/scille/parsec-cloud/parsec-testbed-server:3.0.0-b.6.dev.19913.e644062
+        image: ghcr.io/scille/parsec-cloud/parsec-testbed-server:3.0.0-b.6.dev.19914.1a7577b
 ```
 
 ## Build and Publish a new testbed server Docker image


### PR DESCRIPTION
And add an explanation in the docstrings:
```rust
/*
 * ChunkView
 */

#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
/// Represents the content of a file manifest over a specific range of addresses.
///
/// It is called a `ChunkView` because it is implemented as a view over an
/// underlying chunk of data. Example:
///
/// File addressing:            raw offset            raw offset + raw size
/// Underlying chunk data: |--------|abcdefghijklmnopqrstuvwxyz|-------------|
/// Specific chunk view:   |--------------|ghijklmnopqrstu|------------------|
/// File addressing:                    start           stop
///

``` 