### PR TITLE
Change snap grade to stable

### DIFF
--- a/client/electron/snap/snapcraft.yaml
+++ b/client/electron/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ base: core22
 version: 3.0.0-b.11+dev
 summary: Secure cloud framework
 description: Parsec is an open-source cloud-based application that allow simple yet cryptographically secure file hosting.
-grade: devel
+grade: stable
 confinement: classic
 type: app
 


### PR DESCRIPTION
The stable grade allow the snap to be published to the stable channel.