### PR TITLE
Fix typo in organization create dialog title

### DIFF
--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -152,7 +152,7 @@
         "organizationActionSheet": "Organization",
         "keyringFailed": "Could not log in",
         "noDevices": {
-            "titleCreateOrga": "New to Parsec Cloud ?",
+            "titleCreateOrga": "New to Parsec?",
             "titleInvitation": "You have received an invitation link?",
             "invitationLink": "Enter the invitation link",
             "invitationJoin": "Join",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -152,7 +152,7 @@
         "organizationActionSheet": "Organisation",
         "keyringFailed": "Impossible de se connecter",
         "noDevices": {
-            "titleCreateOrga": "Vous débutez sur Parsec Cloud ?",
+            "titleCreateOrga": "Vous débutez sur Parsec ?",
             "titleInvitation": "Vous avez reçu un lien d'invitation ?",
             "invitationLink": "Saisissez le lien d'invitation",
             "invitationJoin": "Rejoindre",


### PR DESCRIPTION
Remove space before question mark (EN).

Also remove "Cloud" (both EN and FR) to be consistent with app logo and title: only "Parsec" is displayed.