### PR TITLE
Fix empty secret when publish workflow is called by releaser

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,11 @@ on:
         required: false
         description: Whether to publish the package as a nightly release
         default: true
+    secrets:
+      SNAPCRAFT_CREDENTIALS:
+        required: true
+      PYPI_CREDENTIALS:
+        required: true
   release:
     types:
       - published
@@ -109,7 +114,7 @@ jobs:
         timeout-minutes: 1
 
       - name: Check that snapcraft credential is not empty
-        run: test $(printenv SNAPCRAFT_STORE_CREDENTIALS | wc -c | tee /dev/stderr) -ne 0
+        run: test $(printenv SNAPCRAFT_STORE_CREDENTIALS | wc -c | tee /dev/stderr) -gt 10
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_CREDENTIALS }}
         timeout-minutes: 1

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -228,3 +228,6 @@ jobs:
     with:
       release_tag: ${{ github.event_name == 'schedule' && 'nightly' || github.ref_name }}
       nightly: ${{ github.event_name == 'schedule' || github.event_name == 'pull_request' || github.ref == 'refs/tags/nightly' }}
+    secrets:
+      SNAPCRAFT_CREDENTIALS: ${{ secrets.SNAPCRAFT_CREDENTIALS }}
+      PYPI_CREDENTIALS: ${{ secrets.PYPI_CREDENTIALS }}


### PR DESCRIPTION
The releaser workflow should provide the secrets used in the publish workflow, otherwise they will be empty.