### PR TITLE
`SidebarMenu`: Popover side position & elements not clickable behind logo

### DIFF
--- a/client/src/components/workspaces/utils.ts
+++ b/client/src/components/workspaces/utils.ts
@@ -124,7 +124,6 @@ export async function openWorkspaceContextMenu(
     translucent: true,
     showBackdrop: false,
     dismissOnSelect: true,
-    side: fromSidebar ? 'right' : 'bottom',
     componentProps: {
       workspaceName: workspace.currentName,
       clientProfile: clientProfile,

--- a/client/src/theme/components/popovers.scss
+++ b/client/src/theme/components/popovers.scss
@@ -42,11 +42,6 @@
   --width: var(--popover-option-width);
 }
 
-.workspace-context-menu-sidebar {
-  --offset-x: 1.25rem;
-  --offset-y: -0.5rem;
-}
-
 #workspace-context-menu,
 #file-context-menu,
 #user-context-menu,

--- a/client/src/views/sidebar-menu/SidebarMenuPage.vue
+++ b/client/src/views/sidebar-menu/SidebarMenuPage.vue
@@ -475,13 +475,13 @@ async function openOrganizationChoice(event: Event): Promise<void> {
 
 .sidebar,
 .sidebar ion-content {
-  --background: var(--parsec-color-light-primary-800);
   --padding-end: 0;
   --padding-start: 0;
   --padding-top: 0;
 }
 
 .sidebar {
+  --background: var(--parsec-color-light-primary-800);
   border: none;
   user-select: none;
   border-radius: 0 0.5rem 0.5rem 0;
@@ -492,22 +492,23 @@ async function openOrganizationChoice(event: Event): Promise<void> {
     gap: 1.5rem;
   }
 
-  // logo parsec
-  &::after {
-    content: url('@/assets/images/background/logo-icon-white.svg');
-    opacity: 0.03;
-    width: 100%;
-    max-width: 270px;
-    max-height: 170px;
-    position: absolute;
-    bottom: 16px;
-    right: -60px;
-    z-index: 0;
-  }
-
   .sidebar-content {
+    --background: transparent;
     position: relative;
     z-index: 12;
+
+    // logo parsec
+    &::before {
+      content: url('@/assets/images/background/logo-icon-white.svg');
+      opacity: 0.03;
+      width: 100%;
+      max-width: 270px;
+      max-height: 170px;
+      position: absolute;
+      bottom: 16px;
+      right: -60px;
+      z-index: 0;
+    }
   }
 
   .organization-workspaces {


### PR DESCRIPTION
## Describe your changes

Depending on the side position of the popover when `...` is clicked in a workspace element, we can't tell whether the popover is open from the top or the bottom to customise the position with a class. The quickest solution was therefore to let the global behaviour of ionic. 

## Checklist

Before you submit this pull request, please make sure to:

- [ ] Keep changes in the pull request as small as possible
   <!-- Move unrelated changes to a new pull request -->
- [ ] Ensure the commit history is sanitized
   <!-- Commits should have a meaningful title and contain a coherent set of changes
        Squash commits that are only relevant to the branch context -->
- [ ] Give a meaningful title to your PR
- [ ] Describe your changes
   <!-- Give some context about the changes
        Draw attention to the details that should not be overlooked -->
- [ ] Link any related issue in the description
   <!-- You can add `closes #<IssueID>` to close the issue when the PR is merged -->
- [ ] Link any dependent pull request in the description

closes #7713 