### PR TITLE
Fix cannot push package with local version to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -132,6 +132,7 @@ jobs:
         timeout-minutes: 5
 
       - name: Publish wheel on PyPI
+        if: steps.version.outputs.local == ''
         uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # pin v1.9.0
         with:
           user: __token__


### PR DESCRIPTION
Fix the following error, by not push package with local version to PyPI:

```
HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
           The use of local versions in <Version('3.0.0b12.dev19927+8a30e48')> is
           not allowed. See
           https://packaging.python.org/specifications/core-metadata for more
           information.
```

<https://github.com/Scille/parsec-cloud/actions/runs/10067328239/job/27831161231>