### PR TITLE
Add `apply_prevent_sync_pattern` to `WorkspaceStore`

### DIFF
--- a/libparsec/crates/types/src/local_manifest.rs
+++ b/libparsec/crates/types/src/local_manifest.rs
@@ -663,6 +663,7 @@ impl_transparent_data_format_conversion!(
 );
 
 impl_local_manifest_dump!(LocalFolderManifest);
+impl_local_manifest_load!(LocalFolderManifest);
 
 impl LocalFolderManifest {
     pub fn new(author: DeviceID, parent: VlobID, timestamp: DateTime) -> Self {

--- a/libparsec/crates/types/src/local_manifest.rs
+++ b/libparsec/crates/types/src/local_manifest.rs
@@ -20,6 +20,7 @@ use std::{
     cmp::Ordering,
     collections::{hash_map::RandomState, HashMap, HashSet},
     num::NonZeroU64,
+    ops::{Deref, DerefMut},
     sync::Arc,
 };
 
@@ -1191,6 +1192,20 @@ impl LocalWorkspaceManifest {
     /// - After any modification (hence the need for this method to be public)
     fn check_data_integrity(&self) -> DataResult<()> {
         self.0.check_data_integrity_as_root()
+    }
+}
+
+impl Deref for LocalWorkspaceManifest {
+    type Target = LocalFolderManifest;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for LocalWorkspaceManifest {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 


### PR DESCRIPTION
The goal of this PR is to port the method `WorkspaceFS.apply_prevent_sync_pattern` that was used in `v2`:

https://github.com/Scille/parsec-cloud/blob/d397c035d1369e498a48dea26837d93b7291dfe4/parsec/core/fs/workspacefs/workspacefs.py#L1075-L1103