### PR TITLE
Fix typo `snapcraft upload` command in `publish.yml`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           set -x
           for channel in $(cat ${{ runner.temp }}/snap-release-channels); do
-            snapcraft upload --releases=$channel snap/Parsec_${{ steps.version.outputs.full }}_linux_*.snap
+            snapcraft upload --release=$channel snap/Parsec_${{ steps.version.outputs.full }}_linux_*.snap
           done
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_CREDENTIALS }}

--- a/misc/snapcraft_releases.py
+++ b/misc/snapcraft_releases.py
@@ -1,6 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 """
-For a given Parsec version, this script outputs the `<channel>` value intended to be used in the `--releases=<channel>` option for `snapcraft upload`.
+For a given Parsec version, this script outputs the `<channel>` value intended to be used in the `--release=<channel>` option for `snapcraft upload`.
 
 - A channel is formed with <track>/<risk-level>/<branch>
 - Parsec currently has 4 tracks: latest, v2, v3, nigthly


### PR DESCRIPTION
The option `--release=` does not take a `s`
