### PR TITLE
Improve typing in platform storage

### DIFF
--- a/libparsec/crates/platform_storage/src/web/workspace.rs
+++ b/libparsec/crates/platform_storage/src/web/workspace.rs
@@ -16,7 +16,7 @@ use crate::{
         model::{RealmCheckpoint, Vlob},
         DB_VERSION,
     },
-    workspace::{PopulateManifestOutcome, UpdateManifestData},
+    workspace::{PopulateManifestOutcome, RawEncryptedManifest, UpdateManifestData},
 };
 
 use super::{db, model::PreventSyncPattern};
@@ -130,7 +130,10 @@ impl PlatformWorkspaceStorage {
             .collect::<Result<Vec<_>, _>>()
     }
 
-    pub async fn get_manifest(&mut self, entry_id: VlobID) -> anyhow::Result<Option<Vec<u8>>> {
+    pub async fn get_manifest(
+        &mut self,
+        entry_id: VlobID,
+    ) -> anyhow::Result<Option<RawEncryptedManifest>> {
         let transaction = Vlob::read(&self.conn)?;
 
         Ok(

--- a/libparsec/crates/platform_storage/src/workspace.rs
+++ b/libparsec/crates/platform_storage/src/workspace.rs
@@ -24,10 +24,12 @@ pub struct WorkspaceStorage {
 
 pub struct UpdateManifestData {
     pub entry_id: VlobID,
-    pub encrypted: Vec<u8>,
+    pub encrypted: RawEncryptedManifest,
     pub need_sync: bool,
     pub base_version: VersionInt,
 }
+
+pub type RawEncryptedManifest = Vec<u8>;
 
 pub enum PopulateManifestOutcome {
     Stored,
@@ -133,7 +135,10 @@ impl WorkspaceStorage {
         self.platform.get_outbound_need_sync(limit).await
     }
 
-    pub async fn get_manifest(&mut self, entry_id: VlobID) -> anyhow::Result<Option<Vec<u8>>> {
+    pub async fn get_manifest(
+        &mut self,
+        entry_id: VlobID,
+    ) -> anyhow::Result<Option<RawEncryptedManifest>> {
         self.platform.get_manifest(entry_id).await
     }
 


### PR DESCRIPTION
- Rename `UpdateManifestData` to `ManifestData`
- Add type alias for encrypted manifest