### PR TITLE
Fix patch vite snap

### DIFF
--- a/.github/workflows/package-client.yml
+++ b/.github/workflows/package-client.yml
@@ -167,7 +167,7 @@ jobs:
         run: >-
           sed -i
           -e s'/if (process.env.VITE_SENTRY_AUTH_TOKEN)/if (true)/'
-          -e s'/authToken: process.env.VITE_SENTRY_AUTH_TOKEN/authToken: "${{ secrets.SENTRY_AUTH_TOKEN }}"/'
+          -e s';authToken: process.env.VITE_SENTRY_AUTH_TOKEN;authToken: "${{ secrets.SENTRY_AUTH_TOKEN }}";'
           vite.config.ts
         working-directory: client
 


### PR DESCRIPTION
The `sed` command was failing because the secret `SENTRY_AUTH_TOKEN` likely contains a `/` character. I've changed the delimiter to `;` to avoid this issue.