### PR TITLE
Fix upload snapcraft in a single command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,9 +108,13 @@ jobs:
         timeout-minutes: 2
 
       - name: Get releases for snapcraft
+        id: snapcraft-channels
         run: |
           set -o pipefail
-          python misc/snapcraft_releases.py ${{ inputs.nightly && '--nightly' || '' }} ${{ steps.version.outputs.full }} | tee ${{ runner.temp }}/snap-release-channels
+          (
+            echo -n "channels=";
+            python misc/snapcraft_releases.py ${{ inputs.nightly && '--nightly' || '' }} ${{ steps.version.outputs.full }}
+          ) | tee $GITHUB_OUTPUT
         timeout-minutes: 1
 
       - name: Check that snapcraft credential is not empty
@@ -126,15 +130,10 @@ jobs:
         timeout-minutes: 2
 
       - name: Upload Snap
-        run: |
-          set -x
-          for channel in $(cat ${{ runner.temp }}/snap-release-channels); do
-            snapcraft upload --release=$channel snap/Parsec_${{ steps.version.outputs.full }}_linux_*.snap
-          done
+        run: snapcraft upload --release="${{ steps.snapcraft-channels.outputs.channels }}" snap/Parsec_${{ steps.version.outputs.full }}_linux_*.snap
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_CREDENTIALS }}
-        # Each upload takes ~2min, we could have up to 4 channels to upload so: `2 * 4 = 8min` (plus a little spare)
-        timeout-minutes: 10
+        timeout-minutes: 3
 
       - name: Publish wheel on PyPI
         if: steps.version.outputs.local == ''

--- a/misc/snapcraft_releases.py
+++ b/misc/snapcraft_releases.py
@@ -11,15 +11,9 @@ E.g.
 $ python misc/snapcraft_releases.py 2.0.0
 v2/stable
 $ python misc/snapcraft_releases.py 3.0.0-b.0
-v3/beta
-latest/beta
+v3/beta,latest/beta
 $ python misc/snapcraft_releases.py 3.0.0-b.0 --nightly
-v3/edge
-latest/edge
-nightly/stable
-nightly/beta
-nightly/edge
-nightly/candidate
+v3/edge,latest/edge,nightly/stable
 """
 
 import logging
@@ -119,11 +113,11 @@ if __name__ == "__main__":
     if args.nightly:
         # Update channels "<tracks>/edge"
         release_channels.extend(map(lambda track: f"{track}/{RiskLevel.Edge}", tracks_for_version))
-        # Update channels "nightly/<risk>"
-        release_channels.extend(map(lambda risk: f"{Track.Nightly}/{risk}", ALL_RISK_LEVEL))
+        # Update channels "nightly/stable"
+        release_channels.append(f"{Track.Nightly}/{RiskLevel.Stable}")
     else:
         risk = get_risk_level_for_version(version)
         release_channels.extend(map(lambda track: f"{track}/{risk}", tracks_for_version))
 
     log.debug(" ".join(release_channels))
-    print(*release_channels, sep="\n")
+    print(*release_channels, sep=",")


### PR DESCRIPTION
The previous way was not working because snapcraft prevent uploading the same file to multiple channels in multiple steps. The `--release` allows to specify multiple channels with a comma separated list.

Additionally, only the channel `nightly/stable` will be used for the nightly track.