### PR TITLE
Add missing dependency `builder-util-runtime` for electron

### DIFF
--- a/client/electron/package-lock.json
+++ b/client/electron/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@capacitor-community/electron": "^5.0.1",
                 "@sentry/electron": "^5.2.0",
+                "builder-util-runtime": "9.2.4",
                 "chokidar": "~3.6.0",
                 "electron-log": "^5.1.2",
                 "electron-serve": "~1.3.0",
@@ -2030,7 +2031,6 @@
             "version": "9.2.4",
             "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.4.tgz",
             "integrity": "sha512-upp+biKpN/XZMLim7aguUyW8s0FUpDvOtK6sbanMFDAMBzpHDqdhgVYm6zc9HJ6nWo7u2Lxk60i2M6Jd3aiNrA==",
-            "dev": true,
             "dependencies": {
                 "debug": "^4.3.4",
                 "sax": "^1.2.4"

--- a/client/electron/package.json
+++ b/client/electron/package.json
@@ -23,6 +23,7 @@
     "dependencies": {
         "@capacitor-community/electron": "^5.0.1",
         "@sentry/electron": "^5.2.0",
+        "builder-util-runtime": "9.2.4",
         "chokidar": "~3.6.0",
         "electron-log": "^5.1.2",
         "electron-serve": "~1.3.0",


### PR DESCRIPTION
That package is used in `src/updater.ts` for generating errors and handling xml files.