### PR TITLE
Fix snap install command in docs

### DIFF
--- a/docs/userguide/installation.rst
+++ b/docs/userguide/installation.rst
@@ -63,7 +63,7 @@ If you are familiar with Snap, you may notice that Parsec snap is provided in cl
 
     .. code-block:: shell
 
-        snap install --channel=v3/stable --name parsec-v3 --classic
+        snap install parsec_v3 --classic --channel=v3
 
 macOS
 -----


### PR DESCRIPTION
- `parsec-v3` --> `parsec_v3` : the syntax for name is `<snap>_<identifier>` (so `parsec_v3`, `parsec_v3beta`... are all accepted).
- No need to specify `--name`, that is for installing a local snap file
- `--channel=v3/stable` --> `--channel=v3` for consistency with previous command
