### PR TITLE
Allow to run CLI tests without testenv feature

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -57,6 +57,7 @@ botocore
 broadcastable
 browserslistrc
 Bsas
+bufread
 BUILDDIR
 BUILDKIT
 buildscript

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -159,11 +159,11 @@ jobs:
         timeout-minutes: 10
 
       - name: Build CLI binary
-        run: cargo build ${{ env.CARGO_CI_FLAGS }} --package parsec_cli --features testenv
+        run: cargo build ${{ env.CARGO_CI_FLAGS }} --package parsec_cli
         timeout-minutes: 5
 
       - name: Test CLI
-        run: cargo nextest run ${{ env.CARGO_NEXTEST_CI_FLAGS }} --package parsec_cli --features testenv
+        run: cargo nextest run ${{ env.CARGO_NEXTEST_CI_FLAGS }} --package parsec_cli
         timeout-minutes: 10
 
       - name: Retrieve clippy args

--- a/cli/src/cancel_invitation.rs
+++ b/cli/src/cancel_invitation.rs
@@ -8,7 +8,7 @@ use libparsec::{
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device]
+    #[with = config_dir, device, password_stdin]
     pub struct CancelInvitation {
         /// Invitation token
         #[arg(short, long, value_parser = InvitationToken::from_hex)]
@@ -21,6 +21,7 @@ pub async fn cancel_invitation(cancel_invitation: CancelInvitation) -> anyhow::R
         token,
         device,
         config_dir,
+        password_stdin,
     } = cancel_invitation;
     log::trace!(
         "Cancelling invitation (confdir={}, device={})",
@@ -28,7 +29,7 @@ pub async fn cancel_invitation(cancel_invitation: CancelInvitation) -> anyhow::R
         device.as_deref().unwrap_or("N/A")
     );
 
-    load_cmds_and_run(config_dir, device, |cmds, _| async move {
+    load_cmds_and_run(&config_dir, device, password_stdin, |cmds, _| async move {
         let mut handle = start_spinner("Deleting invitation".into());
 
         let rep = cmds.send(invite_cancel::Req { token }).await?;

--- a/cli/src/create_workspace.rs
+++ b/cli/src/create_workspace.rs
@@ -5,7 +5,7 @@ use libparsec::EntryName;
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device]
+    #[with = config_dir, device, password_stdin]
     pub struct CreateWorkspace {
         /// New workspace name
         #[arg(short, long)]
@@ -18,6 +18,7 @@ pub async fn create_workspace(create_workspace: CreateWorkspace) -> anyhow::Resu
         name,
         device,
         config_dir,
+        password_stdin,
     } = create_workspace;
     log::trace!(
         "Creating workspace {name} (confdir={}, device={})",
@@ -25,7 +26,7 @@ pub async fn create_workspace(create_workspace: CreateWorkspace) -> anyhow::Resu
         device.as_deref().unwrap_or("N/A")
     );
 
-    load_client_and_run(config_dir, device, |client| async move {
+    load_client_and_run(&config_dir, device, password_stdin, |client| async move {
         let mut handle = start_spinner("Creating workspace".into());
 
         let id = client.create_workspace(name).await?.simple();

--- a/cli/src/export_recovery_device.rs
+++ b/cli/src/export_recovery_device.rs
@@ -7,7 +7,7 @@ use libparsec::save_recovery_device;
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device]
+    #[with = config_dir, device, password_stdin]
     pub struct ExportRecoveryDevice {
         /// Recovery device output
         #[arg(short, long)]
@@ -22,6 +22,7 @@ pub async fn export_recovery_device(
         output,
         device,
         config_dir,
+        password_stdin,
     } = export_recovery_device;
     log::trace!(
         "Exporting recovery device at {} (confdir={}, device={})",
@@ -30,7 +31,7 @@ pub async fn export_recovery_device(
         device.as_deref().unwrap_or("N/A")
     );
 
-    load_device_and_run(config_dir, device, |device| async move {
+    load_device_and_run(&config_dir, device, password_stdin, |device| async move {
         let mut handle = start_spinner("Saving recovery device file".into());
 
         // TODO save recovery device instead of local device

--- a/cli/src/greet_invitation.rs
+++ b/cli/src/greet_invitation.rs
@@ -16,7 +16,7 @@ use libparsec::{
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device]
+    #[with = config_dir, device, password_stdin]
     pub struct GreetInvitation {
         /// Invitation token
         #[arg(short, long, value_parser = InvitationToken::from_hex)]
@@ -29,6 +29,7 @@ pub async fn greet_invitation(greet_invitation: GreetInvitation) -> anyhow::Resu
         token,
         device,
         config_dir,
+        password_stdin,
     } = greet_invitation;
     log::trace!(
         "Greeting invitation (confdir={}, device={})",
@@ -36,32 +37,45 @@ pub async fn greet_invitation(greet_invitation: GreetInvitation) -> anyhow::Resu
         device.as_deref().unwrap_or("N/A")
     );
 
-    load_cmds_and_run(config_dir, device, |cmds, device| async move {
-        let invitation = step0(&cmds, token).await?;
+    load_cmds_and_run(
+        &config_dir,
+        device,
+        password_stdin,
+        |cmds, device| async move {
+            let invitation = step0(&cmds, token).await?;
 
-        match invitation {
-            InviteListItem::User { .. } => {
-                let ctx =
-                    UserGreetInitialCtx::new(device, Arc::new(cmds), EventBus::default(), token);
+            match invitation {
+                InviteListItem::User { .. } => {
+                    let ctx = UserGreetInitialCtx::new(
+                        device,
+                        Arc::new(cmds),
+                        EventBus::default(),
+                        token,
+                    );
 
-                let ctx = step1_user(ctx).await?;
-                let ctx = step2_user(ctx).await?;
-                let ctx = step3_user(ctx).await?;
-                let ctx = step4_user(ctx).await?;
-                step5_user(ctx).await
+                    let ctx = step1_user(ctx).await?;
+                    let ctx = step2_user(ctx).await?;
+                    let ctx = step3_user(ctx).await?;
+                    let ctx = step4_user(ctx).await?;
+                    step5_user(ctx).await
+                }
+                InviteListItem::Device { .. } => {
+                    let ctx = DeviceGreetInitialCtx::new(
+                        device,
+                        Arc::new(cmds),
+                        EventBus::default(),
+                        token,
+                    );
+
+                    let ctx = step1_device(ctx).await?;
+                    let ctx = step2_device(ctx).await?;
+                    let ctx = step3_device(ctx).await?;
+                    let ctx = step4_device(ctx).await?;
+                    step5_device(ctx).await
+                }
             }
-            InviteListItem::Device { .. } => {
-                let ctx =
-                    DeviceGreetInitialCtx::new(device, Arc::new(cmds), EventBus::default(), token);
-
-                let ctx = step1_device(ctx).await?;
-                let ctx = step2_device(ctx).await?;
-                let ctx = step3_device(ctx).await?;
-                let ctx = step4_device(ctx).await?;
-                step5_device(ctx).await
-            }
-        }
-    })
+        },
+    )
     .await
 }
 

--- a/cli/src/import_recovery_device.rs
+++ b/cli/src/import_recovery_device.rs
@@ -7,7 +7,7 @@ use libparsec::{load_recovery_device, DeviceAccessStrategy};
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir]
+    #[with = config_dir, password_stdin]
     pub struct ImportRecoveryDevice {
         /// Recovery file
         #[arg(short, long)]
@@ -25,6 +25,7 @@ pub async fn import_recovery_device(
         input,
         passphrase,
         config_dir,
+        password_stdin,
     } = import_recovery_device;
     log::trace!(
         "Importing recovery device from {} (confdir={})",
@@ -39,7 +40,13 @@ pub async fn import_recovery_device(
 
     handle.stop_with_newline();
 
-    let password = choose_password()?;
+    let password = choose_password(if password_stdin {
+        ReadPasswordFrom::Stdin
+    } else {
+        ReadPasswordFrom::Tty {
+            prompt: "Enter password for the new device:",
+        }
+    })?;
 
     let key_file = libparsec::get_default_key_file(&config_dir, &device);
 

--- a/cli/src/list_invitations.rs
+++ b/cli/src/list_invitations.rs
@@ -8,19 +8,23 @@ use libparsec::{
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device]
+    #[with = config_dir, device, password_stdin]
     pub struct ListInvitations {}
 );
 
 pub async fn list_invitations(list_invitations: ListInvitations) -> anyhow::Result<()> {
-    let ListInvitations { device, config_dir } = list_invitations;
+    let ListInvitations {
+        device,
+        config_dir,
+        password_stdin,
+    } = list_invitations;
     log::trace!(
         "Listing invitations (confdir={}, device={})",
         config_dir.display(),
         device.as_deref().unwrap_or("N/A")
     );
 
-    load_cmds_and_run(config_dir, device, |cmds, _| async move {
+    load_cmds_and_run(&config_dir, device, password_stdin, |cmds, _| async move {
         let mut handle = start_spinner("Listing invitations".into());
 
         let rep = cmds.send(invite_list::Req).await?;

--- a/cli/src/list_users.rs
+++ b/cli/src/list_users.rs
@@ -3,7 +3,7 @@
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device]
+    #[with = config_dir, device, password_stdin]
     pub struct ListUsers {
         /// Skip revoked users
         #[arg(short, long, default_value_t)]
@@ -16,6 +16,7 @@ pub async fn list_users(list_users: ListUsers) -> anyhow::Result<()> {
         skip_revoked,
         device,
         config_dir,
+        password_stdin,
     } = list_users;
     log::trace!(
         "Listing users (confdir={}, device={}, skip_revoked={skip_revoked})",
@@ -23,7 +24,7 @@ pub async fn list_users(list_users: ListUsers) -> anyhow::Result<()> {
         device.as_deref().unwrap_or("N/A")
     );
 
-    load_client_and_run(config_dir, device, |client| async move {
+    load_client_and_run(&config_dir, device, password_stdin, |client| async move {
         client.poll_server_for_new_certificates().await?;
         let users = client.list_users(skip_revoked, None, None).await?;
 

--- a/cli/src/list_workspaces.rs
+++ b/cli/src/list_workspaces.rs
@@ -3,19 +3,23 @@
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device]
+    #[with = config_dir, device, password_stdin]
     pub struct ListWorkspaces {}
 );
 
 pub async fn list_workspaces(list_workspaces: ListWorkspaces) -> anyhow::Result<()> {
-    let ListWorkspaces { device, config_dir } = list_workspaces;
+    let ListWorkspaces {
+        device,
+        config_dir,
+        password_stdin,
+    } = list_workspaces;
     log::trace!(
         "Listing workspaces (confdir={}, device={})",
         config_dir.display(),
         device.as_deref().unwrap_or("N/A")
     );
 
-    load_client_and_run(config_dir, device, |client| async move {
+    load_client_and_run(&config_dir, device, password_stdin, |client| async move {
         client.poll_server_for_new_certificates().await?;
         client.refresh_workspaces_list().await?;
         let workspaces = client.list_workspaces().await;

--- a/cli/src/macro_opts.rs
+++ b/cli/src/macro_opts.rs
@@ -83,6 +83,32 @@ macro_rules! clap_parser_with_shared_opts_builder {
             }
         );
     };
+    // Password stdin option
+    (
+        #[with = password_stdin $(,$modifier:ident)*]
+        $(#[$struct_attr:meta])*
+        $visibility:vis struct $name:ident {
+            $(
+                $(#[$field_attr:meta])*
+                $field_vis:vis $field:ident: $field_type:ty,
+            )*
+        }
+    ) => {
+        $crate::clap_parser_with_shared_opts_builder!(
+            #[with = $($modifier),*]
+            $(#[$struct_attr])*
+            $visibility struct $name {
+                #[doc = "Read the password from stdin instead of TTY"]
+                #[doc = "Note: this flag need to be explicitly set, that why it does not have a env var"]
+                #[arg(long, default_value_t)]
+                pub(crate) password_stdin: bool,
+                $(
+                    $(#[$field_attr])*
+                    $field_vis $field: $field_type,
+                )*
+            }
+        );
+    };
     // Server addr option
     (
         #[with = addr $(,$modifier:ident)*]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,14 +16,14 @@ mod list_users;
 mod list_workspaces;
 mod macro_opts;
 mod remove_device;
-#[cfg(feature = "testenv")]
+#[cfg(any(test, feature = "testenv"))]
 mod run_testenv;
 mod shamir_setup;
 mod share_workspace;
 mod stats_organization;
 mod stats_server;
 mod status_organization;
-#[cfg(all(test, feature = "testenv"))]
+#[cfg(test)]
 mod tests;
 mod utils;
 

--- a/cli/src/remove_device.rs
+++ b/cli/src/remove_device.rs
@@ -10,9 +10,9 @@ crate::clap_parser_with_shared_opts_builder!(
 pub async fn remove_device(remove_device: RemoveDevice) -> anyhow::Result<()> {
     let RemoveDevice { device, config_dir } = remove_device;
     log::trace!(
-        "Removing device {device} (confdir={})",
+        "Removing device {} (confdir={})",
+        device.as_deref().unwrap_or("N/A"),
         config_dir.display(),
-        device = device.as_deref().unwrap_or("N/A")
     );
 
     load_device_file_and_run(config_dir, device, |device| async move {

--- a/cli/src/run_testenv.rs
+++ b/cli/src/run_testenv.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 pub const DEFAULT_ADMINISTRATION_TOKEN: &str = "s3cr3t";
-const DEFAULT_DEVICE_PASSWORD: &str = "test";
+pub(crate) const DEFAULT_DEVICE_PASSWORD: &str = "test";
 const RESERVED_PORT_OFFSET: u16 = 1024;
 const AVAILABLE_PORT_COUNT: u16 = u16::MAX - RESERVED_PORT_OFFSET;
 const LAST_SERVER_PID: &str = "LAST_SERVER_ID";
@@ -449,6 +449,7 @@ fn wait_testbed_server_to_be_ready(child: &mut std::process::Child) {
     }
 }
 
+#[cfg(feature = "testenv")]
 pub async fn run_testenv(run_testenv: RunTestenv) -> anyhow::Result<()> {
     let RunTestenv {
         main_process_id,

--- a/cli/src/shamir_setup.rs
+++ b/cli/src/shamir_setup.rs
@@ -5,7 +5,7 @@ use libparsec::{UserID, UserProfile};
 use crate::utils::{load_client_and_run, start_spinner};
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device]
+    #[with = config_dir, device, password_stdin]
     pub struct ShamirSetupCreate {
         /// Share recipients, if missing organization's admins will be used instead
         /// Author must not be included as recipient.
@@ -26,13 +26,15 @@ crate::clap_parser_with_shared_opts_builder!(
 
 pub async fn shamir_setup_create(shamir_setup: ShamirSetupCreate) -> anyhow::Result<()> {
     let ShamirSetupCreate {
-        config_dir,
-        device,
         recipients,
         weights,
         threshold,
+        password_stdin,
+        device,
+        config_dir,
     } = shamir_setup;
-    load_client_and_run(config_dir, device, |client| async move {
+
+    load_client_and_run(&config_dir, device, password_stdin, |client| async move {
         let mut handle = start_spinner("Creating shamir setup".into());
 
         let users = client.list_users(true, None, None).await?;

--- a/cli/src/share_workspace.rs
+++ b/cli/src/share_workspace.rs
@@ -5,7 +5,7 @@ use libparsec::{RealmRole, UserID, VlobID};
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device]
+    #[with = config_dir, device, password_stdin]
     pub struct ShareWorkspace {
         /// Workspace id
         #[arg(short, long, value_parser = VlobID::from_hex)]
@@ -26,6 +26,7 @@ pub async fn share_workspace(share_workspace: ShareWorkspace) -> anyhow::Result<
         role,
         device,
         config_dir,
+        password_stdin,
     } = share_workspace;
     log::trace!(
         "Sharing workspace {workspace_id} to {user_id} with role {role} (confdir={}, device={})",
@@ -33,7 +34,7 @@ pub async fn share_workspace(share_workspace: ShareWorkspace) -> anyhow::Result<
         device.as_deref().unwrap_or("N/A")
     );
 
-    load_client_and_run(config_dir, device, |client| async move {
+    load_client_and_run(&config_dir, device, password_stdin, |client| async move {
         let mut handle = start_spinner("Sharing workspace".into());
 
         client


### PR DESCRIPTION
Simplify testing and working on the CLI as you no longer need to recompile it with `testenv` feature for testing.

- Add option `password-stdin` to allow the user to indicate the password should be read from stdin instead of TTY.
- Pass directly `ConfigWithDeviceSharedOpts` instead of passing each args.
- Update `invite_{user,device}_dance` to use `cargo_bin("parsec_cli")` over raw cargo command.
