### PR TITLE
Use macro to define share option over multiple struct

### DIFF
--- a/cli/src/cancel_invitation.rs
+++ b/cli/src/cancel_invitation.rs
@@ -7,19 +7,20 @@ use libparsec::{
 
 use crate::utils::*;
 
-#[derive(clap::Parser)]
-pub struct CancelInvitation {
-    #[clap(flatten)]
-    config: ConfigWithDeviceSharedOpts,
-    /// Invitation token
-    #[arg(short, long, value_parser = InvitationToken::from_hex)]
-    token: InvitationToken,
-}
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = config_dir, device]
+    pub struct CancelInvitation {
+        /// Invitation token
+        #[arg(short, long, value_parser = InvitationToken::from_hex)]
+        token: InvitationToken,
+    }
+);
 
 pub async fn cancel_invitation(cancel_invitation: CancelInvitation) -> anyhow::Result<()> {
     let CancelInvitation {
-        config: ConfigWithDeviceSharedOpts { config_dir, device },
         token,
+        device,
+        config_dir,
     } = cancel_invitation;
     log::trace!(
         "Cancelling invitation (confdir={}, device={})",

--- a/cli/src/create_organization.rs
+++ b/cli/src/create_organization.rs
@@ -6,14 +6,14 @@ use libparsec::{OrganizationID, ParsecAddr, ParsecOrganizationBootstrapAddr};
 
 use crate::utils::*;
 
-#[derive(clap::Parser)]
-pub struct CreateOrganization {
-    /// OrganizationID
-    #[arg(short, long)]
-    organization_id: OrganizationID,
-    #[clap(flatten)]
-    server: ServerSharedOpts,
-}
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = addr, token]
+    pub struct CreateOrganization {
+        /// OrganizationID
+        #[arg(short, long)]
+        organization_id: OrganizationID,
+    }
+);
 
 #[derive(serde::Deserialize)]
 #[serde(untagged)]
@@ -69,7 +69,8 @@ pub async fn create_organization_req(
 pub async fn create_organization(create_organization: CreateOrganization) -> anyhow::Result<()> {
     let CreateOrganization {
         organization_id,
-        server: ServerSharedOpts { addr, token },
+        token,
+        addr,
     } = create_organization;
     log::trace!("Creating organization \"{organization_id}\" (addr={addr})");
 

--- a/cli/src/create_workspace.rs
+++ b/cli/src/create_workspace.rs
@@ -4,19 +4,20 @@ use libparsec::EntryName;
 
 use crate::utils::*;
 
-#[derive(clap::Args)]
-pub struct CreateWorkspace {
-    #[clap(flatten)]
-    config: ConfigWithDeviceSharedOpts,
-    /// New workspace name
-    #[arg(short, long)]
-    name: EntryName,
-}
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = config_dir, device]
+    pub struct CreateWorkspace {
+        /// New workspace name
+        #[arg(short, long)]
+        name: EntryName,
+    }
+);
 
 pub async fn create_workspace(create_workspace: CreateWorkspace) -> anyhow::Result<()> {
     let CreateWorkspace {
-        config: ConfigWithDeviceSharedOpts { config_dir, device },
         name,
+        device,
+        config_dir,
     } = create_workspace;
     log::trace!(
         "Creating workspace {name} (confdir={}, device={})",

--- a/cli/src/export_recovery_device.rs
+++ b/cli/src/export_recovery_device.rs
@@ -6,21 +6,22 @@ use libparsec::save_recovery_device;
 
 use crate::utils::*;
 
-#[derive(clap::Parser)]
-pub struct ExportRecoveryDevice {
-    #[clap(flatten)]
-    config: ConfigWithDeviceSharedOpts,
-    /// Recovery device output
-    #[arg(short, long)]
-    output: PathBuf,
-}
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = config_dir, device]
+    pub struct ExportRecoveryDevice {
+        /// Recovery device output
+        #[arg(short, long)]
+        output: PathBuf,
+    }
+);
 
 pub async fn export_recovery_device(
     export_recovery_device: ExportRecoveryDevice,
 ) -> anyhow::Result<()> {
     let ExportRecoveryDevice {
-        config: ConfigWithDeviceSharedOpts { config_dir, device },
         output,
+        device,
+        config_dir,
     } = export_recovery_device;
     log::trace!(
         "Exporting recovery device at {} (confdir={}, device={})",

--- a/cli/src/greet_invitation.rs
+++ b/cli/src/greet_invitation.rs
@@ -15,19 +15,20 @@ use libparsec::{
 
 use crate::utils::*;
 
-#[derive(clap::Parser)]
-pub struct GreetInvitation {
-    #[clap(flatten)]
-    config: ConfigWithDeviceSharedOpts,
-    /// Invitation token
-    #[arg(short, long, value_parser = InvitationToken::from_hex)]
-    token: InvitationToken,
-}
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = config_dir, device]
+    pub struct GreetInvitation {
+        /// Invitation token
+        #[arg(short, long, value_parser = InvitationToken::from_hex)]
+        token: InvitationToken,
+    }
+);
 
 pub async fn greet_invitation(greet_invitation: GreetInvitation) -> anyhow::Result<()> {
     let GreetInvitation {
-        config: ConfigWithDeviceSharedOpts { config_dir, device },
         token,
+        device,
+        config_dir,
     } = greet_invitation;
     log::trace!(
         "Greeting invitation (confdir={}, device={})",

--- a/cli/src/import_recovery_device.rs
+++ b/cli/src/import_recovery_device.rs
@@ -6,25 +6,25 @@ use libparsec::{load_recovery_device, DeviceAccessStrategy};
 
 use crate::utils::*;
 
-#[derive(clap::Parser)]
-pub struct ImportRecoveryDevice {
-    #[clap(flatten)]
-    config: ConfigSharedOpts,
-    /// Recovery file
-    #[arg(short, long)]
-    input: PathBuf,
-    /// Passphrase
-    #[arg(short, long)]
-    passphrase: String,
-}
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = config_dir]
+    pub struct ImportRecoveryDevice {
+        /// Recovery file
+        #[arg(short, long)]
+        input: PathBuf,
+        /// Passphrase
+        #[arg(short, long)]
+        passphrase: String,
+    }
+);
 
 pub async fn import_recovery_device(
     import_recovery_device: ImportRecoveryDevice,
 ) -> anyhow::Result<()> {
     let ImportRecoveryDevice {
-        config: ConfigSharedOpts { config_dir },
         input,
         passphrase,
+        config_dir,
     } = import_recovery_device;
     log::trace!(
         "Importing recovery device from {} (confdir={})",

--- a/cli/src/invite_device.rs
+++ b/cli/src/invite_device.rs
@@ -7,16 +7,13 @@ use libparsec::{
 
 use crate::utils::*;
 
-#[derive(clap::Parser)]
-pub struct InviteDevice {
-    #[clap(flatten)]
-    config: ConfigWithDeviceSharedOpts,
-}
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = config_dir, device]
+    pub struct InviteDevice {}
+);
 
 pub async fn invite_device(invite_device: InviteDevice) -> anyhow::Result<()> {
-    let InviteDevice {
-        config: ConfigWithDeviceSharedOpts { config_dir, device },
-    } = invite_device;
+    let InviteDevice { device, config_dir } = invite_device;
     log::trace!(
         "Inviting a device (confdir={}, device={})",
         config_dir.display(),

--- a/cli/src/invite_user.rs
+++ b/cli/src/invite_user.rs
@@ -7,23 +7,24 @@ use libparsec::{
 
 use crate::utils::*;
 
-#[derive(clap::Parser)]
-pub struct InviteUser {
-    #[clap(flatten)]
-    config: ConfigWithDeviceSharedOpts,
-    /// Claimer email (i.e.: The invitee)
-    #[arg(short, long)]
-    email: String,
-    /// Send email to the invitee
-    #[arg(short, long, default_value_t)]
-    send_email: bool,
-}
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = config_dir, device]
+    pub struct InviteUser {
+        /// Claimer email (i.e.: The invitee)
+        #[arg(short, long)]
+        email: String,
+        /// Send email to the invitee
+        #[arg(short, long, default_value_t)]
+        send_email: bool,
+    }
+);
 
 pub async fn invite_user(invite_user: InviteUser) -> anyhow::Result<()> {
     let InviteUser {
-        config: ConfigWithDeviceSharedOpts { config_dir, device },
         email,
         send_email,
+        device,
+        config_dir,
     } = invite_user;
     log::trace!(
         "Inviting an user (confdir={}, device={})",

--- a/cli/src/list_devices.rs
+++ b/cli/src/list_devices.rs
@@ -4,14 +4,13 @@ use libparsec::list_available_devices;
 
 use crate::utils::*;
 
-#[derive(clap::Parser)]
-pub struct ListDevices {
-    #[clap(flatten)]
-    config: ConfigSharedOpts,
-}
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = config_dir]
+    pub struct ListDevices {}
+);
 
 pub async fn list_devices(list_devices: ListDevices) -> anyhow::Result<()> {
-    let config_dir = list_devices.config.config_dir;
+    let config_dir = list_devices.config_dir;
     log::trace!("Listing devices under {}", config_dir.display());
     let devices = list_available_devices(&config_dir).await;
     let config_dir_str = config_dir.to_string_lossy();

--- a/cli/src/list_invitations.rs
+++ b/cli/src/list_invitations.rs
@@ -7,16 +7,13 @@ use libparsec::{
 
 use crate::utils::*;
 
-#[derive(clap::Parser)]
-pub struct ListInvitations {
-    #[clap(flatten)]
-    config: ConfigWithDeviceSharedOpts,
-}
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = config_dir, device]
+    pub struct ListInvitations {}
+);
 
 pub async fn list_invitations(list_invitations: ListInvitations) -> anyhow::Result<()> {
-    let ListInvitations {
-        config: ConfigWithDeviceSharedOpts { config_dir, device },
-    } = list_invitations;
+    let ListInvitations { device, config_dir } = list_invitations;
     log::trace!(
         "Listing invitations (confdir={}, device={})",
         config_dir.display(),

--- a/cli/src/list_users.rs
+++ b/cli/src/list_users.rs
@@ -2,19 +2,20 @@
 
 use crate::utils::*;
 
-#[derive(clap::Parser)]
-pub struct ListUsers {
-    #[clap(flatten)]
-    config: ConfigWithDeviceSharedOpts,
-    /// Skip revoked users
-    #[arg(short, long, default_value_t)]
-    skip_revoked: bool,
-}
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = config_dir, device]
+    pub struct ListUsers {
+        /// Skip revoked users
+        #[arg(short, long, default_value_t)]
+        skip_revoked: bool,
+    }
+);
 
 pub async fn list_users(list_users: ListUsers) -> anyhow::Result<()> {
     let ListUsers {
-        config: ConfigWithDeviceSharedOpts { config_dir, device },
         skip_revoked,
+        device,
+        config_dir,
     } = list_users;
     log::trace!(
         "Listing users (confdir={}, device={}, skip_revoked={skip_revoked})",

--- a/cli/src/list_workspaces.rs
+++ b/cli/src/list_workspaces.rs
@@ -2,16 +2,13 @@
 
 use crate::utils::*;
 
-#[derive(clap::Parser)]
-pub struct ListWorkspaces {
-    #[clap(flatten)]
-    config: ConfigWithDeviceSharedOpts,
-}
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = config_dir, device]
+    pub struct ListWorkspaces {}
+);
 
 pub async fn list_workspaces(list_workspaces: ListWorkspaces) -> anyhow::Result<()> {
-    let ListWorkspaces {
-        config: ConfigWithDeviceSharedOpts { config_dir, device },
-    } = list_workspaces;
+    let ListWorkspaces { device, config_dir } = list_workspaces;
     log::trace!(
         "Listing workspaces (confdir={}, device={})",
         config_dir.display(),

--- a/cli/src/macro_opts.rs
+++ b/cli/src/macro_opts.rs
@@ -1,0 +1,155 @@
+/// This macros builds a Clap argument parser by combining the provided structure
+/// with common CLI options.
+///
+/// Available common CLI options:
+/// - `config_dir` (add `config_dir: std::path::PathBuf`)
+/// - `device` (add `device: Option<String>`)
+/// - `addr` (add `addr: libparsec::ParsecAddr`)
+/// - `token` (add `token: String`)
+///
+/// Example:
+///
+/// ```rust
+/// crate::clap_parser_with_shared_opts_builder!(
+///     #[with = config_dir]
+///     pub struct ListUsers {
+///         #[arg(short, long, default_value_t)]
+///         skip_revoked: bool,
+///     }
+/// );
+/// ```
+///
+/// Becomes:
+///
+/// ```rust no_run
+/// #[derive(clap::Parser)]
+/// pub struct ListUsers {
+///     #[arg(short, long, default_value_t)]
+///     skip_revoked: bool,
+///     #[doc = "Parsec config directory"]
+///     #[arg(short, long, default_value_os_t = libparsec::get_default_config_dir(), env = $crate::utils::PARSEC_CONFIG_DIR)]
+///     pub(crate) config_dir: std::path::PathBuf,
+/// }
+/// ```
+#[macro_export]
+macro_rules! clap_parser_with_shared_opts_builder {
+    // Config dir option
+    (
+        #[with = config_dir $(,$modifier:ident)*]
+        $(#[$struct_attr:meta])*
+        $visibility:vis struct $name:ident {
+            $(
+                $(#[$field_attr:meta])*
+                $field_vis:vis $field:ident: $field_type:ty,
+            )*
+        }
+    ) => {
+        $crate::clap_parser_with_shared_opts_builder!(
+            #[with = $($modifier),*]
+            $(#[$struct_attr])*
+            $visibility struct $name {
+                #[doc = "Parsec config directory"]
+                #[arg(short, long, default_value_os_t = libparsec::get_default_config_dir(), env = $crate::utils::PARSEC_CONFIG_DIR)]
+                pub(crate) config_dir: std::path::PathBuf,
+                $(
+                    $(#[$field_attr])*
+                    $field_vis $field: $field_type,
+                )*
+            }
+        );
+    };
+    // Device option
+    (
+        #[with = device $(,$modifier:ident)*]
+        $(#[$struct_attr:meta])*
+        $visibility:vis struct $name:ident {
+            $(
+                $(#[$field_attr:meta])*
+                $field_vis:vis $field:ident: $field_type:ty,
+            )*
+        }
+    ) => {
+        $crate::clap_parser_with_shared_opts_builder!(
+            #[with = $($modifier),*]
+            $(#[$struct_attr])*
+            $visibility struct $name {
+                #[doc = "Device ID"]
+                #[arg(short, long, env = "PARSEC_DEVICE_ID")]
+                pub(crate) device: Option<String>,
+                $(
+                    $(#[$field_attr])*
+                    $field_vis $field: $field_type,
+                )*
+            }
+        );
+    };
+    // Server addr option
+    (
+        #[with = addr $(,$modifier:ident)*]
+        $(#[$struct_attr:meta])*
+        $visibility:vis struct $name:ident {
+            $(
+                $(#[$field_attr:meta])*
+                $field_vis:vis $field:ident: $field_type:ty,
+            )*
+        }
+    ) => {
+        $crate::clap_parser_with_shared_opts_builder!(
+            #[with = $($modifier),*]
+            $(#[$struct_attr])*
+            $visibility struct $name {
+                #[doc = "Server address (e.g: parsec3://127.0.0.1:6770?no_ssl=true)"]
+                #[arg(short, long, env = "PARSEC_SERVER_ADDR")]
+                pub(crate) addr: libparsec::ParsecAddr,
+                $(
+                    $(#[$field_attr])*
+                    $field_vis $field: $field_type,
+                )*
+            }
+        );
+    };
+    // Server administration token option
+    (
+        #[with = token $(,$modifier:ident)*]
+        $(#[$struct_attr:meta])*
+        $visibility:vis struct $name:ident {
+            $(
+                $(#[$field_attr:meta])*
+                $field_vis:vis $field:ident: $field_type:ty,
+            )*
+        }
+    ) => {
+        $crate::clap_parser_with_shared_opts_builder!(
+            #[with = $($modifier),*]
+            $(#[$struct_attr])*
+            $visibility struct $name {
+                #[doc = "Administration token"]
+                #[arg(short, long, env = "PARSEC_ADMINISTRATION_TOKEN")]
+                pub(crate) token: String,
+                $(
+                    $(#[$field_attr])*
+                    $field_vis $field: $field_type,
+                )*
+            }
+        );
+    };
+    (
+        #[with =]
+        $(#[$struct_attr:meta])*
+        $visibility:vis struct $name:ident {
+            $(
+                $(#[$field_attr:meta])*
+                $field_vis:vis $field:ident: $field_type:ty,
+            )*
+        }
+    ) => {
+        $(#[$struct_attr])*
+        #[derive(clap::Parser)]
+        $visibility struct $name {
+            $(
+                $(#[$field_attr])*
+                $field_vis $field: $field_type,
+            )*
+        }
+    };
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,6 +14,7 @@ mod list_devices;
 mod list_invitations;
 mod list_users;
 mod list_workspaces;
+mod macro_opts;
 mod remove_device;
 #[cfg(feature = "testenv")]
 mod run_testenv;

--- a/cli/src/remove_device.rs
+++ b/cli/src/remove_device.rs
@@ -2,16 +2,13 @@
 
 use crate::utils::*;
 
-#[derive(clap::Parser)]
-pub struct RemoveDevice {
-    #[clap(flatten)]
-    config: ConfigWithDeviceSharedOpts,
-}
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = config_dir, device]
+    pub struct RemoveDevice {}
+);
 
 pub async fn remove_device(remove_device: RemoveDevice) -> anyhow::Result<()> {
-    let RemoveDevice {
-        config: ConfigWithDeviceSharedOpts { config_dir, device },
-    } = remove_device;
+    let RemoveDevice { device, config_dir } = remove_device;
     log::trace!(
         "Removing device {device} (confdir={})",
         config_dir.display(),

--- a/cli/src/shamir_setup.rs
+++ b/cli/src/shamir_setup.rs
@@ -1,33 +1,28 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::collections::HashMap;
 
-use clap::Args;
-use libparsec::{get_default_config_dir, UserID, UserProfile};
+use libparsec::{UserID, UserProfile};
 
 use crate::utils::{load_client_and_run, start_spinner};
 
-#[derive(Args)]
-pub struct ShamirSetupCreate {
-    /// Parsec config directory
-    #[arg(short, long, default_value_os_t = get_default_config_dir())]
-    config_dir: PathBuf,
-    /// Device ID
-    #[arg(short, long)]
-    device: Option<String>,
-    /// Share recipients, if missing organization's admins will be used instead
-    /// Author must not be included as recipient.
-    /// User email is expected
-    #[arg(short, long,  num_args = 1..)]
-    recipients: Option<Vec<String>>,
-    /// Share weights. Requires Share recipient list.
-    /// Must have the same length as recipients.
-    /// Defaults to one per recipient.
-    #[arg(short, long, requires = "recipients",  num_args = 1..)]
-    weights: Option<Vec<u8>>,
-    /// Threshold number of shares required to proceed with recovery.
-    /// Default to sum of weights. Must be lesser or equal to sum of weights.
-    #[arg(short, long)]
-    threshold: Option<u8>,
-}
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = config_dir, device]
+    pub struct ShamirSetupCreate {
+        /// Share recipients, if missing organization's admins will be used instead
+        /// Author must not be included as recipient.
+        /// User email is expected
+        #[arg(short, long,  num_args = 1..)]
+        recipients: Option<Vec<String>>,
+        /// Share weights. Requires Share recipient list.
+        /// Must have the same length as recipients.
+        /// Defaults to one per recipient.
+        #[arg(short, long, requires = "recipients",  num_args = 1..)]
+        weights: Option<Vec<u8>>,
+        /// Threshold number of shares required to proceed with recovery.
+        /// Default to sum of weights. Must be lesser or equal to sum of weights.
+        #[arg(short, long)]
+        threshold: Option<u8>,
+    }
+);
 
 pub async fn shamir_setup_create(shamir_setup: ShamirSetupCreate) -> anyhow::Result<()> {
     let ShamirSetupCreate {

--- a/cli/src/share_workspace.rs
+++ b/cli/src/share_workspace.rs
@@ -4,27 +4,28 @@ use libparsec::{RealmRole, UserID, VlobID};
 
 use crate::utils::*;
 
-#[derive(clap::Parser)]
-pub struct ShareWorkspace {
-    #[clap(flatten)]
-    config: ConfigWithDeviceSharedOpts,
-    /// Workspace id
-    #[arg(short, long, value_parser = VlobID::from_hex)]
-    workspace_id: VlobID,
-    /// Recipient id
-    #[arg(short, long, value_parser = UserID::from_hex)]
-    user_id: UserID,
-    /// Role (owner/manager/contributor/reader)
-    #[arg(short, long)]
-    role: RealmRole,
-}
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = config_dir, device]
+    pub struct ShareWorkspace {
+        /// Workspace id
+        #[arg(short, long, value_parser = VlobID::from_hex)]
+        workspace_id: VlobID,
+        /// Recipient id
+        #[arg(short, long, value_parser = UserID::from_hex)]
+        user_id: UserID,
+        /// Role (owner/manager/contributor/reader)
+        #[arg(short, long)]
+        role: RealmRole,
+    }
+);
 
 pub async fn share_workspace(share_workspace: ShareWorkspace) -> anyhow::Result<()> {
     let ShareWorkspace {
-        config: ConfigWithDeviceSharedOpts { config_dir, device },
         workspace_id,
         user_id,
         role,
+        device,
+        config_dir,
     } = share_workspace;
     log::trace!(
         "Sharing workspace {workspace_id} to {user_id} with role {role} (confdir={}, device={})",

--- a/cli/src/stats_organization.rs
+++ b/cli/src/stats_organization.rs
@@ -5,16 +5,14 @@ use serde_json::Value;
 
 use libparsec::{OrganizationID, ParsecAddr};
 
-use crate::utils::ServerSharedOpts;
-
-#[derive(clap::Parser)]
-pub struct StatsOrganization {
-    /// OrganizationID
-    #[arg(short, long)]
-    organization_id: OrganizationID,
-    #[clap(flatten)]
-    server: ServerSharedOpts,
-}
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = addr, token]
+    pub struct StatsOrganization {
+        /// OrganizationID
+        #[arg(short, long)]
+        organization_id: OrganizationID,
+    }
+);
 
 pub async fn stats_organization_req(
     organization_id: &OrganizationID,
@@ -37,7 +35,8 @@ pub async fn stats_organization_req(
 pub async fn stats_organization(stats_organization: StatsOrganization) -> anyhow::Result<()> {
     let StatsOrganization {
         organization_id,
-        server: ServerSharedOpts { addr, token },
+        token,
+        addr,
     } = stats_organization;
     log::trace!("Retrieving stats for organization {organization_id} (addr={addr})");
 

--- a/cli/src/stats_server.rs
+++ b/cli/src/stats_server.rs
@@ -5,19 +5,17 @@ use serde_json::Value;
 
 use libparsec::{DateTime, ParsecAddr};
 
-use crate::utils::ServerSharedOpts;
-
-#[derive(clap::Parser)]
-pub struct StatsServer {
-    #[clap(flatten)]
-    server: ServerSharedOpts,
-    /// Output format (json/csv)
-    #[arg(short, long, default_value_t = Format::Json)]
-    format: Format,
-    /// Ignore everything after this date (e.g: 2024-01-01T00:00:00-00:00)
-    #[arg(short, long)]
-    end_date: Option<DateTime>,
-}
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = addr, token]
+    pub struct StatsServer {
+        /// Output format (json/csv)
+        #[arg(short, long, default_value_t = Format::Json)]
+        format: Format,
+        /// Ignore everything after this date (e.g: 2024-01-01T00:00:00-00:00)
+        #[arg(short, long)]
+        end_date: Option<DateTime>,
+    }
+);
 
 #[derive(Clone, Copy)]
 pub enum Format {
@@ -70,9 +68,10 @@ pub async fn stats_server_req(
 
 pub async fn stats_server(stats_organization: StatsServer) -> anyhow::Result<()> {
     let StatsServer {
-        server: ServerSharedOpts { addr, token },
         format,
         end_date,
+        token,
+        addr,
     } = stats_organization;
     log::trace!("Retrieving server's stats (addr={addr}, format={format})");
 

--- a/cli/src/status_organization.rs
+++ b/cli/src/status_organization.rs
@@ -5,16 +5,14 @@ use serde_json::Value;
 
 use libparsec::{OrganizationID, ParsecAddr};
 
-use crate::utils::ServerSharedOpts;
-
-#[derive(clap::Parser)]
-pub struct StatusOrganization {
-    /// OrganizationID
-    #[arg(short, long)]
-    organization_id: OrganizationID,
-    #[clap(flatten)]
-    server: ServerSharedOpts,
-}
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = addr, token]
+    pub struct StatusOrganization {
+        /// OrganizationID
+        #[arg(short, long)]
+        organization_id: OrganizationID,
+    }
+);
 
 pub async fn status_organization_req(
     organization_id: &OrganizationID,
@@ -37,7 +35,8 @@ pub async fn status_organization_req(
 pub async fn status_organization(status_organization: StatusOrganization) -> anyhow::Result<()> {
     let StatusOrganization {
         organization_id,
-        server: ServerSharedOpts { addr, token },
+        token,
+        addr,
     } = status_organization;
     log::trace!("Retrieving status of organization {organization_id} (addr={addr})");
 

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -14,33 +14,6 @@ use spinners::{Spinner, Spinners, Stream};
 /// Should not be confused with [`libparsec::PARSEC_BASE_CONFIG_DIR`]
 pub const PARSEC_CONFIG_DIR: &str = "PARSEC_CONFIG_DIR";
 
-#[derive(clap::Parser)]
-pub(crate) struct ConfigSharedOpts {
-    /// Parsec config directory
-    #[arg(short, long, default_value_os_t = libparsec::get_default_config_dir(), env = PARSEC_CONFIG_DIR)]
-    pub(crate) config_dir: PathBuf,
-}
-
-#[derive(clap::Parser)]
-pub(crate) struct ConfigWithDeviceSharedOpts {
-    /// Parsec config directory
-    #[arg(short, long, default_value_os_t = libparsec::get_default_config_dir(), env = PARSEC_CONFIG_DIR)]
-    pub(crate) config_dir: PathBuf,
-    /// Device ID
-    #[arg(short, long, env = "PARSEC_DEVICE_ID")]
-    pub(crate) device: Option<String>,
-}
-
-#[derive(clap::Parser, Clone)]
-pub(crate) struct ServerSharedOpts {
-    /// Server address (e.g: parsec3://127.0.0.1:6770?no_ssl=true)
-    #[arg(short, long, env = "PARSEC_SERVER_ADDR")]
-    pub(crate) addr: libparsec::ParsecAddr,
-    /// Administration token
-    #[arg(short, long, env = "PARSEC_ADMINISTRATION_TOKEN")]
-    pub(crate) token: String,
-}
-
 pub const GREEN: &str = "\x1B[92m";
 pub const RED: &str = "\x1B[91m";
 pub const RESET: &str = "\x1B[39m";


### PR DESCRIPTION
Previously we used the structs `*SharedOpts` to share the same configuration for multiple commands. But I don't find that flexible enough, so I created a macro to define the shared options over multiple structs.

The advantage of the struct is already flattened
