### PR TITLE
Add suffix `.unsigned` to windows & macos artifacts

### DIFF
--- a/.github/workflows/package-client.yml
+++ b/.github/workflows/package-client.yml
@@ -351,7 +351,7 @@ jobs:
         shell: bash
         run: |
           arch=$(uname -m)
-          app_file="Parsec_${{ steps.version.outputs.full }}_${{ matrix.os_alias }}_${arch}.${{ matrix.extension }}"
+          app_file="Parsec_${{ steps.version.outputs.full }}_${{ matrix.os_alias }}_${arch}${{ matrix.platform == 'linux' && '' || '.unsigned'}}.${{ matrix.extension }}"
           latest_file="latest-${{ matrix.os_alias }}-${arch}.yml"
 
           cat << EOF | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -116,11 +116,11 @@ jobs:
           cp ${CP_ARGS} artifacts/Linux-X64-electron-app-AppImage/latest-linux-*.yml release-files
 
           # DMG
-          cp ${CP_ARGS} artifacts/macOS-X64-electron-app-dmg/Parsec_${{ needs.version.outputs.full }}_mac_*.dmg{,.blockmap} release-files
+          cp ${CP_ARGS} artifacts/macOS-X64-electron-app-dmg/Parsec_${{ needs.version.outputs.full }}_mac_*.unsigned.dmg{,.blockmap} release-files
           cp ${CP_ARGS} artifacts/macOS-X64-electron-app-dmg/latest-mac-*.yml release-files
 
           # EXE
-          cp ${CP_ARGS} artifacts/Windows-X64-electron-app-exe/Parsec_${{ needs.version.outputs.full }}_win_*.exe{,.blockmap} release-files
+          cp ${CP_ARGS} artifacts/Windows-X64-electron-app-exe/Parsec_${{ needs.version.outputs.full }}_win_*.unsigned.exe{,.blockmap} release-files
           cp ${CP_ARGS} artifacts/Windows-X64-electron-app-exe/latest-win-*.yml release-files
 
           # CLI

--- a/client/electron/package.js
+++ b/client/electron/package.js
@@ -82,10 +82,15 @@ const fs = require('node:fs');
 fs.mkdirSync('build/assets', { recursive: true });
 fs.writeFileSync('build/assets/publishConfig.json', JSON.stringify(publishConfig));
 
-const signOptions = {
+const SIGN_OPTIONS = {
   certificateSubjectName: 'Scille',
   certificateSha1: '9EB59B224218EE4B9C436CBD327BE60940592013',
 };
+
+const UNSIGNED_ARTIFACT_NAME =
+  OPTS.sign || OPTS.platform === 'linux'
+    ? 'Parsec_${buildVersion}_${os}_${env.BUILD_MACHINE_ARCH}.${ext}'
+    : 'Parsec_${buildVersion}_${os}_${env.BUILD_MACHINE_ARCH}.unsigned.${ext}';
 
 /**
  * @type {import('electron-builder').Configuration}
@@ -93,7 +98,7 @@ const signOptions = {
  */
 const options = {
   appId: 'cloud.parsec.parsec-v3',
-  artifactName: 'Parsec_${buildVersion}_${os}_${env.BUILD_MACHINE_ARCH}.${ext}',
+  artifactName: UNSIGNED_ARTIFACT_NAME,
   buildVersion: '3.0.0-b.12+dev',
   protocols: {
     name: 'Parsec-v3',
@@ -120,7 +125,7 @@ const options = {
 
   win: {
     target: 'nsis',
-    ...(OPTS.sign ? signOptions : {}),
+    ...(OPTS.sign ? SIGN_OPTIONS : {}),
     extraResources: [
       {
         from: 'node_modules/regedit/vbs',


### PR DESCRIPTION
Add this suffix to indicate that the artifacts are not signed.
