### PR TITLE
[CLI] Fix method calculating the short device id size 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +559,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +611,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -762,6 +801,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +870,12 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -814,6 +915,27 @@ dependencies = [
  "salsa20",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1474,6 +1596,16 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crunchy",
 ]
 
 [[package]]
@@ -2746,6 +2878,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2899,7 +3037,9 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "criterion",
  "env_logger",
+ "itertools 0.12.1",
  "libparsec",
  "libparsec_client_connection",
  "libparsec_platform_ipc",
@@ -3074,6 +3214,34 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "plotters"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "polling"
@@ -3351,6 +3519,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -4435,6 +4623,16 @@ checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,13 +53,15 @@ resolver = "2"
 #
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table
 [workspace.package]
-publish = false
 authors = ["@Scille/parsec-dev", "@Scille/rust-code-owners"]
 edition = "2021"
 homepage = "https://parsec.cloud"
 license = "BUSL-1.1"
-version = "3.0.1-a.0"
+publish = false
 repository = "https://github.com/Scille/parsec-cloud"
+# We use the same version for all crates.
+# This comment is used to prevent `taplo` from adding multiple spaces between the version and the comment.
+version = "3.0.1-a.0" # __PARSEC_VERSION__
 
 [workspace.lints.clippy]
 undocumented_unsafe_blocks = "deny"
@@ -82,22 +84,22 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 # check the default feature and making sure they are actually needed ;-)
 [workspace.dependencies]
 libparsec = { path = "libparsec", default-features = false }
-libparsec_protocol = { path = "libparsec/crates/protocol", default-features = false }
+libparsec_client = { path = "libparsec/crates/client", default-features = false }
+libparsec_client_connection = { path = "libparsec/crates/client_connection", default-features = false }
 libparsec_crypto = { path = "libparsec/crates/crypto", default-features = false }
-libparsec_types = { path = "libparsec/crates/types", default-features = false }
+libparsec_platform_async = { path = "libparsec/crates/platform_async", default-features = false }
 libparsec_platform_device_loader = { path = "libparsec/crates/platform_device_loader", default-features = false }
+libparsec_platform_http_proxy = { path = "libparsec/crates/platform_http_proxy", default-features = false }
 libparsec_platform_ipc = { path = "libparsec/crates/platform_ipc", default-features = false }
 libparsec_platform_mountpoint = { path = "libparsec/crates/platform_mountpoint", default-features = false }
 libparsec_platform_storage = { path = "libparsec/crates/platform_storage", default-features = false }
+libparsec_protocol = { path = "libparsec/crates/protocol", default-features = false }
 libparsec_serialization_format = { path = "libparsec/crates/serialization_format", default-features = false }
 libparsec_testbed = { path = "libparsec/crates/testbed", default-features = false }
 libparsec_tests_fixtures = { path = "libparsec/crates/tests_fixtures", default-features = false }
-libparsec_client_connection = { path = "libparsec/crates/client_connection", default-features = false }
-libparsec_platform_async = { path = "libparsec/crates/platform_async", default-features = false }
-libparsec_platform_http_proxy = { path = "libparsec/crates/platform_http_proxy", default-features = false }
-libparsec_client = { path = "libparsec/crates/client", default-features = false }
-libparsec_tests_macros = { path = "libparsec/crates/tests_macros", default-features = false }
 libparsec_tests_lite = { path = "libparsec/crates/tests_lite", default-features = false }
+libparsec_tests_macros = { path = "libparsec/crates/tests_macros", default-features = false }
+libparsec_types = { path = "libparsec/crates/types", default-features = false }
 libparsec_zstd = { path = "libparsec/crates/zstd", default-features = false }
 
 # Third parties
@@ -105,8 +107,8 @@ android_logger = { version = "0.13", default-features = false }
 anyhow = { version = "1.0.89", default-features = false }
 argon2 = { version = "0.5.3", default-features = false }
 assert_cmd = { version = "2.0.16", default-features = false }
-async-lock = { version = "3.4.0", default-features = false }
 async-broadcast = { version = "0.5.1", default-features = false }
+async-lock = { version = "3.4.0", default-features = false }
 base32 = { version = "0.4.0", default-features = false }
 base64 = { version = "0.22.1", default-features = false }
 blake2 = { version = "0.10.6", default-features = false }
@@ -137,8 +139,8 @@ generic-array = { version = "0.14.7", default-features = false }
 getrandom = { package = "getrandom", version = "0.2.15", default-features = false }
 glob = { version = "0.3.1", default-features = false }
 gloo-timers = { version = "0.3.0", default-features = false }
-hex-literal = { version = "0.4.1", default-features = false }
 hex = { version = "0.4.3", default-features = false }
+hex-literal = { version = "0.4.1", default-features = false }
 indexed_db_futures = { version = "0.5.0", default-features = false }
 instant = { version = "0.1.13", default-features = false }
 itertools = { version = "0.12.1", default-features = false }
@@ -155,59 +157,72 @@ neon = { version = "1.0.0", default-features = false }
 once_cell = { version = "1.20.0", default-features = false }
 openssl = { version = "0.10.66", default-features = false }
 paste = { version = "1.0.15", default-features = false }
-pin-project-lite = { version = "0.2.14", default-features = false }
 percent-encoding = { version = "2.3.1", default-features = false }
+pin-project-lite = { version = "0.2.14", default-features = false }
 # Utility crate to find system artifacts
 pkg-config = { version = "0.3.30", default-features = false }
 predicates = { version = "3.1.2", default-features = false }
 pretty_assertions = { version = "1.4.1", default-features = false }
+proc-macro2 = { version = "1.0.86", default-features = false }
 proptest = { version = "1.5.0", default-features = false }
 proptest-state-machine = { version = "0.3.0", default-features = false }
-proc-macro2 = { version = "1.0.86", default-features = false }
 pyo3 = { version = "0.21.2", default-features = false }
 quote = { version = "1.0.37", default-features = false }
 rand = { version = "0.8.5", default-features = false }
 regex = { version = "1.10.6", default-features = false }
 regex-syntax = { version = "0.8.4", default-features = false }
+reqwest = { version = "0.12.5", default-features = false }
 reqwest-eventsource = { version = "0.6.0", default-features = false }
-reqwest = { version = "0.12.7", default-features = false }
 rmp-serde = { version = "1.3.0", default-features = false }
 rpassword = { version = "7.3.1", default-features = false }
 rsa = { version = "0.8.2", default-features = false }
-rstest_reuse = { version = "0.6.0", default-features = false }
 rstest = { version = "0.18.2", default-features = false }
+rstest_reuse = { version = "0.6.0", default-features = false }
 ruzstd = { version = "0.7.2", default-features = true }
 sentry = { version = "0.34.0", default-features = false }
 sentry-log = { version = "0.34.0", default-features = false }
+serde = { version = "1.0.206", default-features = false }
+serde-wasm-bindgen = { version = "0.6.4", default-features = false }
 serde_bytes = { version = "0.11.15", default-features = false }
 serde_json = { version = "1.0.128", default-features = false }
 serde_test = { version = "1.0.177", default-features = false }
-serde = { version = "1.0.210", default-features = false }
-serde-wasm-bindgen = { version = "0.6.4", default-features = false }
 serde_with = { version = "3.9.0", default-features = false }
 sha1 = { version = "0.10.6", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
 sharks = "0.5.0"
 sodiumoxide = { version = "0.2.7", default-features = false }
+spinners = { version = "4.1.1", default-features = false }
 sqlx = { version = "0.7.2", default-features = false }
 syn = { version = "2.0.77", default-features = false }
-spinners = { version = "4.1.1", default-features = false }
 thiserror = { version = "1.0.64", default-features = false }
 tokio = { version = "1.40.0", default-features = false }
 unicode-normalization = { version = "0.1.24", default-features = false }
 url = { version = "2.5.2", default-features = false }
 uuid = { version = "1.6.1", default-features = false }
+wasm-bindgen = { version = "0.2.92", default-features = false }
 wasm-bindgen-futures = { version = "0.4.43", default-features = false }
 wasm-bindgen-test = { version = "0.3.43", default-features = false }
-wasm-bindgen = { version = "0.2.92", default-features = false }
 web-sys = { version = "0.3.70", default-features = false }
 widestring = { version = "1.1.0", default-features = false }
 windows-sys = { version = "0.59.0", default-features = false }
-winfsp_wrs_build = { version = "0.3.0", default-features = false }
 winfsp_wrs = { version = "0.3.0", default-features = false }
+winfsp_wrs_build = { version = "0.3.0", default-features = false }
 x25519-dalek = { version = "2.0.1", default-features = false }
 zeroize = { version = "1.8.1", default-features = false }
 zstd = { version = "0.13.2", default-features = false }
+
+[workspace.dependencies.criterion]
+default-features = false
+version = "0.5.1"
+# We specify a set of features here instead of defining them in every other crates,
+# since we will use the same set of features.
+features = [
+    "cargo_bench_support", # Allow to use cargo bench
+    "plotters",            # Provide a dashboard to visualize the benchmark results
+    "rayon",               # Allow to run benchmarks in parallel
+    "html_reports",        # Generate HTML reports
+    "csv_output",          # Generate CSV reports
+]
 
 # Rust unoptimized code is really slow with crypto algorithm and regex compilation,
 # hence we optimize our 3rd party dependencies.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,6 +9,10 @@ repository.workspace = true
 version.workspace = true
 autotests = false
 
+[[bench]]
+name = "minimal_short_id"
+harness = false
+
 [features]
 testenv = []
 
@@ -29,6 +33,7 @@ spinners = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 url = { workspace = true, optional = true }
 uuid = { workspace = true }
+itertools = { workspace = true }
 
 [dev-dependencies]
 libparsec = { workspace = true, features = ["cli-tests"] }
@@ -37,6 +42,8 @@ assert_cmd = { workspace = true }
 predicates = { workspace = true, features = ["regex"] }
 rstest = { workspace = true }
 uuid = { workspace = true, features = ["v6", "std", "rng"] }
+
+criterion = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winfsp_wrs_build = { workspace = true }

--- a/cli/benches/minimal_short_id.rs
+++ b/cli/benches/minimal_short_id.rs
@@ -1,0 +1,17 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use parsec_cli::utils::get_minimal_short_id_size;
+
+fn minimal_short_id_size_bench(c: &mut Criterion) {
+    for sample_size in [1, 10, 100, 1_000, 10_000] {
+        let ids = vec![libparsec::DeviceID::default(); sample_size];
+        c.bench_with_input(
+            BenchmarkId::new("get_minimal_short_id_size", sample_size),
+            &ids,
+            |b, ids| b.iter(|| get_minimal_short_id_size(ids.iter())),
+        );
+    }
+}
+
+criterion_group!(benches, minimal_short_id_size_bench);
+criterion_main!(benches);

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,0 +1,12 @@
+pub mod commands;
+pub mod macro_opts;
+
+#[cfg(test)]
+#[path = "../tests/integration/mod.rs"]
+mod integration_tests;
+#[cfg(any(test, feature = "testenv"))]
+pub mod testenv_utils;
+#[cfg(test)]
+#[path = "../tests/unit/mod.rs"]
+mod unit_tests;
+pub mod utils;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,16 +1,8 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-mod commands;
-mod macro_opts;
-#[cfg(any(test, feature = "testenv"))]
-mod testenv_utils;
-#[cfg(test)]
-#[path = "../tests/integration/mod.rs"]
-mod tests;
-mod utils;
+use parsec_cli::commands::*;
 
 use clap::{Parser, Subcommand};
-pub use commands::*;
 
 /// Parsec cli
 #[derive(Parser)]

--- a/cli/src/testenv_utils.rs
+++ b/cli/src/testenv_utils.rs
@@ -15,7 +15,9 @@ use libparsec::{
 };
 
 use crate::{
-    organization::{bootstrap::bootstrap_organization_req, create::create_organization_req},
+    commands::organization::{
+        bootstrap::bootstrap_organization_req, create::create_organization_req,
+    },
     utils::{RESET, YELLOW},
 };
 

--- a/cli/tests/integration/device/export_recovery_device.rs
+++ b/cli/tests/integration/device/export_recovery_device.rs
@@ -1,7 +1,9 @@
 use libparsec::{tmp_path, TmpPath};
 
-use crate::testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD};
-use crate::tests::bootstrap_cli_test;
+use crate::{
+    integration_tests::bootstrap_cli_test,
+    testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
+};
 
 #[rstest::rstest]
 #[tokio::test]

--- a/cli/tests/integration/device/import_recovery_device.rs
+++ b/cli/tests/integration/device/import_recovery_device.rs
@@ -1,7 +1,9 @@
 use libparsec::{tmp_path, TmpPath};
 
-use crate::testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD};
-use crate::tests::bootstrap_cli_test;
+use crate::{
+    integration_tests::bootstrap_cli_test,
+    testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
+};
 
 #[rstest::rstest]
 #[tokio::test]

--- a/cli/tests/integration/device/list.rs
+++ b/cli/tests/integration/device/list.rs
@@ -1,7 +1,9 @@
 use libparsec::{tmp_path, TmpPath};
 
-use crate::tests::bootstrap_cli_test;
-use crate::utils::{GREEN, RESET, YELLOW};
+use crate::{
+    integration_tests::bootstrap_cli_test,
+    utils::{GREEN, RESET, YELLOW},
+};
 
 #[rstest::rstest]
 #[tokio::test]

--- a/cli/tests/integration/device/remove.rs
+++ b/cli/tests/integration/device/remove.rs
@@ -3,9 +3,10 @@ use std::io::{BufReader, Write};
 use assert_cmd::cargo::CommandCargoExt;
 use libparsec::{tmp_path, TmpPath};
 
-use crate::testenv_utils::TestOrganization;
-
-use crate::tests::{bootstrap_cli_test, wait_for};
+use crate::{
+    integration_tests::{bootstrap_cli_test, wait_for},
+    testenv_utils::TestOrganization,
+};
 
 #[rstest::rstest]
 #[tokio::test]

--- a/cli/tests/integration/device_option.rs
+++ b/cli/tests/integration/device_option.rs
@@ -6,6 +6,7 @@ use predicates::prelude::PredicateBooleanExt;
 use super::bootstrap_cli_test;
 use crate::{
     testenv_utils::TestOrganization,
+    utils::get_minimal_short_id_size,
     utils::{RESET, YELLOW},
 };
 
@@ -36,7 +37,7 @@ async fn device_not_found(tmp_path: TmpPath) {
     });
 
     let mut available_devices_string_list = String::new();
-    format_device::<4>(&devices, &mut available_devices_string_list).unwrap();
+    format_devices(&devices, &mut available_devices_string_list).unwrap();
 
     crate::assert_cmd_failure!(
         with_password = "a password",
@@ -51,12 +52,14 @@ async fn device_not_found(tmp_path: TmpPath) {
     );
 }
 
-fn format_device<const SHORT_ID_LEN: usize>(
+fn format_devices(
     devices: &[Arc<LocalDevice>],
     mut writer: impl std::fmt::Write,
 ) -> std::fmt::Result {
+    let short_id_size = get_minimal_short_id_size(devices.iter().map(|d| &d.device_id));
+
     for device in devices {
-        let short_id = &device.device_id.hex()[..SHORT_ID_LEN];
+        let short_id = &device.device_id.hex()[..short_id_size];
         let organization_id = &device.organization_id();
         let human_handle = &device.human_handle;
         let device_label = &device.device_label;
@@ -86,7 +89,7 @@ async fn missing_option(tmp_path: TmpPath) {
     devices.sort_by_cached_key(|d| d.device_id.hex());
 
     let mut available_devices_string_list = String::new();
-    format_device::<4>(&devices, &mut available_devices_string_list).unwrap();
+    format_devices(&devices, &mut available_devices_string_list).unwrap();
 
     crate::assert_cmd_failure!("user", "list").stderr(
         predicates::str::contains("Error: Missing option '--device'")
@@ -164,7 +167,7 @@ async fn multiple_device_found(tmp_path: TmpPath) {
     devices.sort_by_cached_key(|d| d.device_id.hex());
 
     let mut available_devices_string_list = String::new();
-    format_device::<3>(&devices, &mut available_devices_string_list).unwrap();
+    format_devices(&devices, &mut available_devices_string_list).unwrap();
 
     crate::assert_cmd_failure!("user", "list", "--device", first_dev_id_prefix).stderr(
         predicates::str::contains(format!(

--- a/cli/tests/integration/invitations/cancel.rs
+++ b/cli/tests/integration/invitations/cancel.rs
@@ -3,8 +3,10 @@ use libparsec::{
     InvitationType, ParsecInvitationAddr, ProxyConfig, TmpPath,
 };
 
-use crate::testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD};
-use crate::tests::bootstrap_cli_test;
+use crate::{
+    integration_tests::bootstrap_cli_test,
+    testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
+};
 
 #[rstest::rstest]
 #[tokio::test]

--- a/cli/tests/integration/invitations/device.rs
+++ b/cli/tests/integration/invitations/device.rs
@@ -7,8 +7,8 @@ use libparsec::{
     InvitationType, ParsecInvitationAddr, ProxyConfig, TmpPath,
 };
 
-use crate::tests::{bootstrap_cli_test, wait_for};
 use crate::{
+    integration_tests::{bootstrap_cli_test, wait_for},
     testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
     utils::YELLOW,
 };

--- a/cli/tests/integration/invitations/list.rs
+++ b/cli/tests/integration/invitations/list.rs
@@ -3,8 +3,8 @@ use libparsec::{
     InvitationType, ParsecInvitationAddr, ProxyConfig, TmpPath,
 };
 
-use crate::tests::bootstrap_cli_test;
 use crate::{
+    integration_tests::bootstrap_cli_test,
     testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
     utils::{RESET, YELLOW},
 };

--- a/cli/tests/integration/invitations/user.rs
+++ b/cli/tests/integration/invitations/user.rs
@@ -7,8 +7,8 @@ use libparsec::{
     InvitationType, ParsecInvitationAddr, ProxyConfig, TmpPath,
 };
 
-use crate::tests::{bootstrap_cli_test, wait_for};
 use crate::{
+    integration_tests::{bootstrap_cli_test, wait_for},
     testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
     utils::YELLOW,
 };

--- a/cli/tests/integration/organization/bootstrap.rs
+++ b/cli/tests/integration/organization/bootstrap.rs
@@ -1,8 +1,8 @@
 use libparsec::{tmp_path, TmpPath};
 
-use crate::tests::{bootstrap_cli_test, unique_org_id};
 use crate::{
-    organization::create::create_organization_req,
+    commands::organization::create::create_organization_req,
+    integration_tests::{bootstrap_cli_test, unique_org_id},
     testenv_utils::{DEFAULT_ADMINISTRATION_TOKEN, DEFAULT_DEVICE_PASSWORD, TESTBED_SERVER},
 };
 

--- a/cli/tests/integration/organization/create.rs
+++ b/cli/tests/integration/organization/create.rs
@@ -1,7 +1,9 @@
 use libparsec::{tmp_path, TmpPath};
 
-use crate::testenv_utils::{DEFAULT_ADMINISTRATION_TOKEN, TESTBED_SERVER};
-use crate::tests::{bootstrap_cli_test, unique_org_id};
+use crate::{
+    integration_tests::{bootstrap_cli_test, unique_org_id},
+    testenv_utils::{DEFAULT_ADMINISTRATION_TOKEN, TESTBED_SERVER},
+};
 
 #[rstest::rstest]
 #[tokio::test]

--- a/cli/tests/integration/organization/stats.rs
+++ b/cli/tests/integration/organization/stats.rs
@@ -1,7 +1,6 @@
 use libparsec::{tmp_path, TmpPath};
 
-use crate::testenv_utils::DEFAULT_ADMINISTRATION_TOKEN;
-use crate::tests::bootstrap_cli_test;
+use crate::{integration_tests::bootstrap_cli_test, testenv_utils::DEFAULT_ADMINISTRATION_TOKEN};
 
 #[rstest::rstest]
 #[tokio::test]

--- a/cli/tests/integration/organization/status.rs
+++ b/cli/tests/integration/organization/status.rs
@@ -1,7 +1,6 @@
 use libparsec::{tmp_path, TmpPath};
 
-use crate::testenv_utils::DEFAULT_ADMINISTRATION_TOKEN;
-use crate::tests::bootstrap_cli_test;
+use crate::{integration_tests::bootstrap_cli_test, testenv_utils::DEFAULT_ADMINISTRATION_TOKEN};
 
 #[rstest::rstest]
 #[tokio::test]

--- a/cli/tests/integration/server/stats.rs
+++ b/cli/tests/integration/server/stats.rs
@@ -1,7 +1,6 @@
 use libparsec::{tmp_path, TmpPath};
 
-use crate::testenv_utils::DEFAULT_ADMINISTRATION_TOKEN;
-use crate::tests::bootstrap_cli_test;
+use crate::{integration_tests::bootstrap_cli_test, testenv_utils::DEFAULT_ADMINISTRATION_TOKEN};
 
 #[rstest::rstest]
 #[tokio::test]

--- a/cli/tests/integration/user/list.rs
+++ b/cli/tests/integration/user/list.rs
@@ -1,8 +1,8 @@
 use libparsec::{tmp_path, TmpPath};
 use predicates::prelude::PredicateBooleanExt;
 
-use crate::tests::bootstrap_cli_test;
 use crate::{
+    integration_tests::bootstrap_cli_test,
     testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
     utils::{GREEN, RESET},
 };

--- a/cli/tests/integration/workspace/create.rs
+++ b/cli/tests/integration/workspace/create.rs
@@ -1,7 +1,7 @@
 use libparsec::{tmp_path, RealmRole, TmpPath};
 
-use crate::tests::bootstrap_cli_test;
 use crate::{
+    integration_tests::bootstrap_cli_test,
     testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
     utils::start_client,
 };

--- a/cli/tests/integration/workspace/import.rs
+++ b/cli/tests/integration/workspace/import.rs
@@ -1,7 +1,7 @@
 use libparsec::{tmp_path, TmpPath};
 
-use crate::tests::bootstrap_cli_test;
 use crate::{
+    integration_tests::bootstrap_cli_test,
     testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
     utils::start_client,
 };

--- a/cli/tests/integration/workspace/share.rs
+++ b/cli/tests/integration/workspace/share.rs
@@ -1,7 +1,7 @@
 use libparsec::{tmp_path, RealmRole, TmpPath};
 
-use crate::tests::bootstrap_cli_test;
 use crate::{
+    integration_tests::bootstrap_cli_test,
     testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
     utils::start_client,
 };

--- a/cli/tests/integration/workspace/sync.rs
+++ b/cli/tests/integration/workspace/sync.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use libparsec::{internal::Client, tmp_path, EntryName, EntryStat, LocalDevice, TmpPath, VlobID};
 
 use crate::{
+    integration_tests::bootstrap_cli_test,
     testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
-    tests::bootstrap_cli_test,
     utils::{start_client, StartedClient},
 };
 

--- a/cli/tests/unit/mod.rs
+++ b/cli/tests/unit/mod.rs
@@ -1,0 +1,1 @@
+mod utils;

--- a/cli/tests/unit/utils.rs
+++ b/cli/tests/unit/utils.rs
@@ -1,0 +1,53 @@
+use libparsec::*;
+use uuid::Uuid;
+
+use crate::utils::MINIMAL_SHORT_ID_SIZE;
+
+#[rstest::rstest]
+#[case::single_device(
+    &["fdf1e92d-809b-4c5b-82e7-59700c1d2aa3".parse::<Uuid>().unwrap().into()],
+    MINIMAL_SHORT_ID_SIZE
+)]
+#[case::first_chart_is_enough(
+    &[
+        "fdf1e92d-809b-4c5b-82e7-59700c1d2aa3".parse::<Uuid>().unwrap().into(),
+        "1fedcc12-0a31-4543-b98f-3fc438efda8f".parse::<Uuid>().unwrap().into(),
+    ],
+    MINIMAL_SHORT_ID_SIZE
+)]
+#[case::conflict_until_second_group(
+    &[
+        "fdf1e92d-809b-4c5b-82e7-59700c1d2aa3".parse::<Uuid>().unwrap().into(),
+        "fdf1e92d-0a31-4543-b98f-3fc438efda8f".parse::<Uuid>().unwrap().into(),
+    ],
+    9
+)]
+#[case::conflict_until_last_char(
+    &[
+        "1fedcc12-0a31-4543-b98f-3fc438efda8b".parse::<Uuid>().unwrap().into(),
+        "1fedcc12-0a31-4543-b98f-3fc438efda8f".parse::<Uuid>().unwrap().into(),
+    ],
+    32
+)]
+#[case::conflict_until_second_char(
+    &[
+        "1fedcc12-0a31-4543-b98f-3fc438efda8f".parse::<Uuid>().unwrap().into(),
+        "10c840c5-b566-491d-85c5-56153d8facef".parse::<Uuid>().unwrap().into(),
+        "cb40cb35-76ca-4533-9f2c-c9eb588cda31".parse::<Uuid>().unwrap().into(),
+        "eb427366-56af-4137-b4e6-daf652d6bfcb".parse::<Uuid>().unwrap().into(),
+    ],
+    MINIMAL_SHORT_ID_SIZE // Given that 2 is lower than `MINIMAL_SHORT_ID_SIZE``
+)]
+#[case::identical_id_short_circuit(
+    &[
+        "1fedcc12-0a31-4543-b98f-3fc438efda8b".parse::<Uuid>().unwrap().into(),
+        "1fedcc12-0a31-4543-b98f-3fc438efda8b".parse::<Uuid>().unwrap().into(),
+    ],
+    32
+)]
+fn test_get_minimal_sort_id_len(#[case] ids: &[DeviceID], #[case] expected_size: usize) {
+    assert_eq!(
+        crate::utils::get_minimal_short_id_size(ids.iter()),
+        expected_size
+    );
+}

--- a/misc/version_updater.py
+++ b/misc/version_updater.py
@@ -419,7 +419,12 @@ FILES_WITH_VERSION_INFO: dict[Path, dict[Tool, RawRegexes]] = {
     },
     ROOT_DIR / "Cargo.toml": {
         Tool.License: [TOML_LICENSE_FIELD],
-        Tool.Parsec: [ReplaceRegex(r'^version = ".*"$', 'version = "{version}"')],
+        Tool.Parsec: [
+            ReplaceRegex(
+                r'^version = ".*" # __PARSEC_VERSION__$',
+                'version = "{version}" # __PARSEC_VERSION__',
+            )
+        ],
     },
 }
 

--- a/newsfragments/8041.bugfix.rst
+++ b/newsfragments/8041.bugfix.rst
@@ -1,0 +1,2 @@
+Fix CLI where possible identical short device ID can be displayed in command ``device list``.
+Now the size of the short ID depends on the actual devices ID and not the device list size.


### PR DESCRIPTION
Previously, we determine the short device id (**sid**) using the number of devices to display.
But this is not optimal if some device ids share the same prefix as we may risk display multiple similar **sid** that reference different devices.

```
088 - TestOrg-fc47f825-1f0d-4304-9395-: First <first@dev1.com> @ dev1
088 - TestOrg-fc47f825-1f0d-4304-9395-: Second <second@dev2.com> @ second
```

To fix that, we need to calculate the smallest **sid** that ensure it's unique for the whole set of devices.

---

To make things more interesting, I've added a benchmark using `criterion` to bench the different versions of the function `get_short_device_id_size` where I got from `40ms` down to `10µs` on my PC.

Closes #8034