### PR TITLE
[RFC-1011] Fix useless token field in invite_claimer_start_greeting_attempt

### DIFF
--- a/docs/rfcs/1011-non-blocking-invite-transport.md
+++ b/docs/rfcs/1011-non-blocking-invite-transport.md
@@ -317,10 +317,6 @@ Schema definition:
             "cmd": "invite_claimer_start_greeting_attempt",
             "fields": [
                 {
-                    "name": "token",
-                    "type": "InvitationToken"
-                },
-                {
                     "name": "greeter",
                     "type": "UserID"
                 }

--- a/libparsec/crates/protocol/schema/invited_cmds/invite_claimer_start_greeting_attempt.json5
+++ b/libparsec/crates/protocol/schema/invited_cmds/invite_claimer_start_greeting_attempt.json5
@@ -7,10 +7,6 @@
             "cmd": "invite_claimer_start_greeting_attempt",
             "fields": [
                 {
-                    "name": "token",
-                    "type": "InvitationToken"
-                },
-                {
                     "name": "greeter",
                     "type": "UserID"
                 }

--- a/libparsec/crates/protocol/tests/invited_cmds/v4/invite_claimer_start_greeting_attempt.rs
+++ b/libparsec/crates/protocol/tests/invited_cmds/v4/invite_claimer_start_greeting_attempt.rs
@@ -4,7 +4,6 @@
 use super::invited_cmds;
 use libparsec_tests_lite::{hex, p_assert_eq};
 use libparsec_types::GreetingAttemptID;
-use libparsec_types::InvitationToken;
 use libparsec_types::UserID;
 
 pub fn rep_greeter_not_allowed() {
@@ -72,7 +71,6 @@ pub fn req() {
     .as_ref();
     let req =
         invited_cmds::invite_claimer_start_greeting_attempt::InviteClaimerStartGreetingAttemptReq {
-            token: InvitationToken::from_hex("d864b93ded264aae9ae583fd3d40c45a").unwrap(),
             greeter: UserID::from_hex("109b68ba5cdf428ea0017fc6bcc04d4a").unwrap(),
         };
     println!("***expected: {:?}", req.dump().unwrap());

--- a/server/parsec/_parsec_pyi/protocol/invited_cmds/v4/invite_claimer_start_greeting_attempt.pyi
+++ b/server/parsec/_parsec_pyi/protocol/invited_cmds/v4/invite_claimer_start_greeting_attempt.pyi
@@ -4,15 +4,13 @@
 
 from __future__ import annotations
 
-from parsec._parsec import GreetingAttemptID, InvitationToken, UserID
+from parsec._parsec import GreetingAttemptID, UserID
 
 class Req:
-    def __init__(self, token: InvitationToken, greeter: UserID) -> None: ...
+    def __init__(self, greeter: UserID) -> None: ...
     def dump(self) -> bytes: ...
     @property
     def greeter(self) -> UserID: ...
-    @property
-    def token(self) -> InvitationToken: ...
 
 class Rep:
     @staticmethod

--- a/server/parsec/components/invite.py
+++ b/server/parsec/components/invite.py
@@ -1526,7 +1526,7 @@ class BaseInviteComponent:
             now=DateTime.now(),
             organization_id=client_ctx.organization_id,
             greeter=req.greeter,
-            token=req.token,
+            token=client_ctx.token,
         )
         match outcome:
             # OK case

--- a/server/tests/api_v4/authenticated/test_invite_greeter_cancel_greeting_attempt.py
+++ b/server/tests/api_v4/authenticated/test_invite_greeter_cancel_greeting_attempt.py
@@ -100,7 +100,6 @@ async def test_authenticated_invite_greeter_cancel_greeting_attempt_greeting_att
     coolorg: CoolorgRpcClients,
 ) -> None:
     rep = await coolorg.invited_alice_dev3.invite_claimer_start_greeting_attempt(
-        token=coolorg.invited_alice_dev3.token,
         greeter=coolorg.alice.user_id,
     )
     assert isinstance(rep, invited_cmds.v4.invite_claimer_start_greeting_attempt.RepOk)

--- a/server/tests/api_v4/authenticated/test_invite_greeter_step.py
+++ b/server/tests/api_v4/authenticated/test_invite_greeter_step.py
@@ -37,7 +37,6 @@ async def claimer_wait_peer_public_key(
 ) -> PublicKey:
     # Claimer start greeting attempt
     rep = await coolorg.invited_alice_dev3.invite_claimer_start_greeting_attempt(
-        token=coolorg.invited_alice_dev3.token,
         greeter=coolorg.alice.user_id,
     )
     assert rep == invited_cmds.v4.invite_claimer_start_greeting_attempt.RepOk(
@@ -140,7 +139,6 @@ async def test_authenticated_invite_greeter_step_greeting_attempt_not_joined(
 ) -> None:
     # Claimer start greeting attempt
     rep = await coolorg.invited_alice_dev3.invite_claimer_start_greeting_attempt(
-        token=coolorg.invited_alice_dev3.token,
         greeter=coolorg.alice.user_id,
     )
     assert isinstance(rep, invited_cmds.v4.invite_claimer_start_greeting_attempt.RepOk)

--- a/server/tests/api_v4/invited/test_invite_claimer_cancel_greeting_attempt.py
+++ b/server/tests/api_v4/invited/test_invite_claimer_cancel_greeting_attempt.py
@@ -25,10 +25,7 @@ def _skip_if_postgresql(skip_if_postgresql: None) -> None:  # type: ignore
 
 @pytest.fixture
 async def greeting_attempt(coolorg: CoolorgRpcClients, backend: Backend) -> GreetingAttemptID:
-    invitation_token = coolorg.invited_alice_dev3.token
-
     rep = await coolorg.invited_alice_dev3.invite_claimer_start_greeting_attempt(
-        token=invitation_token,
         greeter=coolorg.alice.user_id,
     )
     assert isinstance(rep, invited_cmds.v4.invite_claimer_start_greeting_attempt.RepOk)
@@ -48,10 +45,7 @@ async def test_invited_invite_claimer_cancel_greeting_attempt_ok(
 async def test_invited_invite_claimer_cancel_greeting_attempt_greeter_not_allowed(
     coolorg: CoolorgRpcClients,
 ) -> None:
-    invitation_token = coolorg.invited_zack.token
-
     rep = await coolorg.invited_zack.invite_claimer_start_greeting_attempt(
-        token=invitation_token,
         greeter=coolorg.alice.user_id,
     )
     assert isinstance(rep, invited_cmds.v4.invite_claimer_start_greeting_attempt.RepOk)

--- a/server/tests/api_v4/invited/test_invite_claimer_start_greeting_attempt.py
+++ b/server/tests/api_v4/invited/test_invite_claimer_start_greeting_attempt.py
@@ -24,10 +24,7 @@ def _skip_if_postgresql(skip_if_postgresql: None) -> None:  # type: ignore
 async def test_invited_invite_claimer_start_greeting_attempt_ok(
     coolorg: CoolorgRpcClients, backend: Backend
 ) -> None:
-    invitation_token = coolorg.invited_alice_dev3.token
-
     rep = await coolorg.invited_alice_dev3.invite_claimer_start_greeting_attempt(
-        token=invitation_token,
         greeter=coolorg.alice.user_id,
     )
     assert isinstance(rep, invited_cmds.v4.invite_claimer_start_greeting_attempt.RepOk)
@@ -37,10 +34,7 @@ async def test_invited_invite_claimer_start_greeting_attempt_ok(
 async def test_invited_invite_claimer_start_greeting_attempt_greeter_not_found(
     coolorg: CoolorgRpcClients,
 ) -> None:
-    invitation_token = coolorg.invited_alice_dev3.token
-
     rep = await coolorg.invited_alice_dev3.invite_claimer_start_greeting_attempt(
-        token=invitation_token,
         greeter=UserID.new(),
     )
 
@@ -51,7 +45,6 @@ async def test_invited_invite_claimer_start_greeting_attempt_greeter_not_allowed
     coolorg: CoolorgRpcClients,
 ) -> None:
     rep = await coolorg.invited_alice_dev3.invite_claimer_start_greeting_attempt(
-        token=coolorg.invited_alice_dev3.token,
         greeter=coolorg.bob.user_id,
     )
 
@@ -83,7 +76,6 @@ async def test_invited_invite_claimer_start_greeting_attempt_greeter_revoked(
 
     # Try to invite
     rep = await coolorg.invited_alice_dev3.invite_claimer_start_greeting_attempt(
-        token=coolorg.invited_alice_dev3.token,
         greeter=coolorg.alice.user_id,
     )
 

--- a/server/tests/api_v4/invited/test_invite_claimer_step.py
+++ b/server/tests/api_v4/invited/test_invite_claimer_step.py
@@ -27,10 +27,7 @@ def _skip_if_postgresql(skip_if_postgresql: None) -> None:  # type: ignore
 
 @pytest.fixture
 async def greeting_attempt(coolorg: CoolorgRpcClients, backend: Backend) -> GreetingAttemptID:
-    invitation_token = coolorg.invited_alice_dev3.token
-
     rep = await coolorg.invited_alice_dev3.invite_claimer_start_greeting_attempt(
-        token=invitation_token,
         greeter=coolorg.alice.user_id,
     )
     assert isinstance(rep, invited_cmds.v4.invite_claimer_start_greeting_attempt.RepOk)
@@ -92,10 +89,7 @@ async def test_invited_invite_claimer_step_ok(
 async def test_invited_invite_claimer_step_greeter_not_allowed(
     coolorg: CoolorgRpcClients, greeting_attempt: GreetingAttemptID
 ) -> None:
-    invitation_token = coolorg.invited_zack.token
-
     rep = await coolorg.invited_zack.invite_claimer_start_greeting_attempt(
-        token=invitation_token,
         greeter=coolorg.alice.user_id,
     )
     assert isinstance(rep, invited_cmds.v4.invite_claimer_start_greeting_attempt.RepOk)

--- a/server/tests/common/rpc.py
+++ b/server/tests/common/rpc.py
@@ -515,11 +515,9 @@ class BaseInvitedRpcClient:
         return invited_cmds.latest.invite_claimer_cancel_greeting_attempt.Rep.load(raw_rep)
 
     async def invite_claimer_start_greeting_attempt(
-        self, token: InvitationToken, greeter: UserID
+        self, greeter: UserID
     ) -> invited_cmds.latest.invite_claimer_start_greeting_attempt.Rep:
-        req = invited_cmds.latest.invite_claimer_start_greeting_attempt.Req(
-            token=token, greeter=greeter
-        )
+        req = invited_cmds.latest.invite_claimer_start_greeting_attempt.Req(greeter=greeter)
         raw_rep = await self._do_request(req.dump())
         return invited_cmds.latest.invite_claimer_start_greeting_attempt.Rep.load(raw_rep)
 

--- a/server/tests/test_greeting_attempt.py
+++ b/server/tests/test_greeting_attempt.py
@@ -302,7 +302,6 @@ async def test_full_greeting_attempt(
 
     # Claimer starts the attempt
     rep = await claimer.invite_claimer_start_greeting_attempt(
-        token=claimer.token,
         greeter=greeter.user_id,
     )
     assert rep == invited_cmds.v4.invite_claimer_start_greeting_attempt.RepOk(


### PR DESCRIPTION
Follow-up https://github.com/Scille/parsec-cloud/pull/7761

Part of #7018