### PR TITLE
Fix AppImage packaging for nightly build

### DIFF
--- a/.github/workflows/package-client.yml
+++ b/.github/workflows/package-client.yml
@@ -331,8 +331,9 @@ jobs:
         # we need to escape the flag another time by adding another `--`.
         run: >-
           npm run electron:release
-          ${{ matrix.platform == 'linux' && '-- appimage' || '' }}
-          ${{ inputs.nightly_build && '-- --nightly' || '' }}
+          ${{ (matrix.platform == 'linux' || inputs.nightly_build) && '--' }}
+          ${{ matrix.platform == 'linux' && 'appimage' || '' }}
+          ${{ inputs.nightly_build && '--nightly' || '' }}
         env:
           VITE_SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         working-directory: client/electron


### PR DESCRIPTION
An extra `--` was added when generating the AppImage for nightly build, causing the flag `--nightly` being parsed as a target alongside `appimage`.

To fix that we factorize adding the `--` part if either _We make a nightly build_ or _Package an AppImage_.
