### PR TITLE
Correct Outsider&realm interactions in libparsec&server

### DIFF
--- a/libparsec/crates/client/src/certif/realm_create.rs
+++ b/libparsec/crates/client/src/certif/realm_create.rs
@@ -16,6 +16,8 @@ pub enum CertifEnsureRealmCreatedError {
     Offline,
     #[error("Component has stopped")]
     Stopped,
+    #[error("Author not allowed")]
+    AuthorNotAllowed,
     // Note `InvalidManifest` here, this is because we self-repair in case of invalid
     // user manifest (given otherwise the client would be stuck for good !)
     #[error("Our clock ({client_timestamp}) and the server's one ({server_timestamp}) are too far apart")]
@@ -120,6 +122,8 @@ async fn create_realm_idempotent(
                 );
                 continue;
             }
+            // A concurrent operation must has modified our profile to OUTSIDER
+            Rep::AuthorNotAllowed => Err(CertifEnsureRealmCreatedError::AuthorNotAllowed),
             Rep::TimestampOutOfBallpark {
                 server_timestamp,
                 ballpark_client_early_offset,

--- a/libparsec/crates/client/src/certif/workspace_bootstrap.rs
+++ b/libparsec/crates/client/src/certif/workspace_bootstrap.rs
@@ -114,6 +114,9 @@ pub(super) async fn bootstrap_workspace(
                 CertifEnsureRealmCreatedError::Stopped => {
                     return Err(CertifBootstrapWorkspaceError::Stopped)
                 }
+                CertifEnsureRealmCreatedError::AuthorNotAllowed => {
+                    return Err(CertifBootstrapWorkspaceError::AuthorNotAllowed)
+                }
                 CertifEnsureRealmCreatedError::TimestampOutOfBallpark {
                     server_timestamp,
                     client_timestamp,

--- a/libparsec/crates/client/src/client/mod.rs
+++ b/libparsec/crates/client/src/client/mod.rs
@@ -46,8 +46,8 @@ use crate::{
     event_bus::EventBus,
     monitors::{
         start_certif_poll_monitor, start_connection_monitor, start_server_config_monitor,
-        start_user_sync_monitor, start_workspaces_bootstrap_monitor,
-        start_workspaces_process_needs_monitor, start_workspaces_refresh_list_monitor, Monitor,
+        start_workspaces_bootstrap_monitor, start_workspaces_process_needs_monitor,
+        start_workspaces_refresh_list_monitor, Monitor,
     },
     user::UserOps,
 };
@@ -177,8 +177,20 @@ impl Client {
                 start_workspaces_refresh_list_monitor(client.event_bus.clone(), client.clone())
                     .await;
 
-            let user_sync_monitor =
-                start_user_sync_monitor(client.user_ops.clone(), client.event_bus.clone()).await;
+            // TODO: rework user manifest sync once needed
+            //
+            // User manifest currently doesn't need to be synced (i.e. we only
+            // use local user manifest, and rebuild it from scratch on every new
+            // client).
+            //
+            // The current user manifest sync system relies on realm to store the
+            // data, which is no longer allowed for users with OUTSIDER profile.
+            //
+            // Hence enabling the user sync monitor should have no effect, but it's
+            // safer to disable it entirely.
+
+            // let user_sync_monitor =
+            //     start_user_sync_monitor(client.user_ops.clone(), client.event_bus.clone()).await;
 
             let certif_poll_monitor = start_certif_poll_monitor(
                 client.certificates_ops.clone(),
@@ -198,7 +210,7 @@ impl Client {
             monitors.push(workspaces_bootstrap_monitor);
             monitors.push(workspaces_process_needs_monitor);
             monitors.push(workspaces_refresh_list_monitor);
-            monitors.push(user_sync_monitor);
+            // monitors.push(user_sync_monitor);
             monitors.push(certif_poll_monitor);
             monitors.push(server_config_monitor);
             monitors.push(connection_monitor);

--- a/libparsec/crates/client/src/monitors/mod.rs
+++ b/libparsec/crates/client/src/monitors/mod.rs
@@ -15,6 +15,10 @@ pub(crate) use base::*;
 pub(crate) use certif_poll::*;
 pub(crate) use connection::*;
 pub(crate) use server_config::*;
+// Local user manifest currently doesn't need to be synchronized, hence the
+// user sync monitor is never used (especially since it current implementation
+// is now incompatible with OUTSIDER users now that they can created realm).
+#[allow(unused)]
 pub(crate) use user_sync::*;
 pub(crate) use workspace_inbound_sync::*;
 pub(crate) use workspace_outbound_sync::*;

--- a/libparsec/crates/client/src/user/sync.rs
+++ b/libparsec/crates/client/src/user/sync.rs
@@ -20,6 +20,8 @@ pub enum UserSyncError {
     Offline,
     #[error("Component has stopped")]
     Stopped,
+    #[error("Author not allowed")]
+    AuthorNotAllowed,
     #[error("Sequester service `{service_id}` rejected the data: `{}`", .reason.as_ref().map(|x| x.as_ref()).unwrap_or_else(|| "<no reason>"))]
     RejectedBySequesterService {
         service_id: SequesterServiceID,
@@ -237,6 +239,7 @@ async fn outbound_sync_inner(ops: &UserOps) -> Result<OutboundSyncOutcome, UserS
             .map_err(|err| match err {
                 CertifEnsureRealmCreatedError::Stopped => UserSyncError::Stopped,
                 CertifEnsureRealmCreatedError::Offline => UserSyncError::Offline,
+                CertifEnsureRealmCreatedError::AuthorNotAllowed => UserSyncError::AuthorNotAllowed,
                 CertifEnsureRealmCreatedError::TimestampOutOfBallpark {
                     server_timestamp,
                     client_timestamp,

--- a/libparsec/crates/protocol/schema/authenticated_cmds/realm_create.json5
+++ b/libparsec/crates/protocol/schema/authenticated_cmds/realm_create.json5
@@ -26,6 +26,10 @@
                 ]
             },
             {
+                // Author is OUTSIDER which cannot be OWNER of a realm
+                "status": "author_not_allowed"
+            },
+            {
                 "status": "invalid_certificate"
             },
             {

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v5/realm_create.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v5/realm_create.rs
@@ -174,3 +174,23 @@ pub fn rep_require_greater_timestamp() {
 
     p_assert_eq!(data2, expected);
 }
+
+pub fn rep_author_not_allowed() {
+    // Generated from Parsec 3.0.0-rc.1+dev
+    // Content:
+    //   status: 'author_not_allowed'
+    let raw: &[u8] = hex!("81a6737461747573b2617574686f725f6e6f745f616c6c6f776564").as_ref();
+
+    let expected = authenticated_cmds::realm_create::Rep::AuthorNotAllowed;
+
+    let data = authenticated_cmds::realm_create::Rep::load(raw).unwrap();
+
+    p_assert_eq!(data, expected);
+
+    // Also test serialization round trip
+    let raw2 = data.dump().unwrap();
+
+    let data2 = authenticated_cmds::realm_create::Rep::load(&raw2).unwrap();
+
+    p_assert_eq!(data2, expected);
+}

--- a/server/parsec/_parsec_pyi/protocol/authenticated_cmds/v5/realm_create.pyi
+++ b/server/parsec/_parsec_pyi/protocol/authenticated_cmds/v5/realm_create.pyi
@@ -34,6 +34,11 @@ class RepRealmAlreadyExists(Rep):
     @property
     def last_realm_certificate_timestamp(self) -> DateTime: ...
 
+class RepAuthorNotAllowed(Rep):
+    def __init__(
+        self,
+    ) -> None: ...
+
 class RepInvalidCertificate(Rep):
     def __init__(
         self,

--- a/server/parsec/components/memory/realm.py
+++ b/server/parsec/components/memory/realm.py
@@ -113,6 +113,9 @@ class MemoryRealmComponent(BaseRealmComponent):
             if author_user.is_revoked:
                 return RealmCreateStoreBadOutcome.AUTHOR_REVOKED
 
+            if author_user.current_profile == UserProfile.OUTSIDER:
+                return RealmCreateStoreBadOutcome.AUTHOR_NOT_ALLOWED
+
             assert author_verify_key == author_device.cooked.verify_key
             match realm_create_validate(
                 now=now,

--- a/server/parsec/components/postgresql/realm_create.py
+++ b/server/parsec/components/postgresql/realm_create.py
@@ -7,6 +7,7 @@ from parsec._parsec import (
     OrganizationID,
     RealmRole,
     RealmRoleCertificate,
+    UserProfile,
     VerifyKey,
 )
 from parsec.ballpark import RequireGreaterTimestamp, TimestampOutOfBallpark
@@ -145,6 +146,9 @@ async def realm_create(
             return RealmCreateStoreBadOutcome.AUTHOR_NOT_FOUND
         case AuthAndLockCommonOnlyBadOutcome.AUTHOR_REVOKED:
             return RealmCreateStoreBadOutcome.AUTHOR_REVOKED
+
+    if db_common.user_current_profile == UserProfile.OUTSIDER:
+        return RealmCreateStoreBadOutcome.AUTHOR_NOT_ALLOWED
 
     match realm_create_validate(
         now=now,

--- a/server/parsec/components/realm.py
+++ b/server/parsec/components/realm.py
@@ -262,6 +262,7 @@ class RealmCreateStoreBadOutcome(BadOutcomeEnum):
     ORGANIZATION_EXPIRED = auto()
     AUTHOR_NOT_FOUND = auto()
     AUTHOR_REVOKED = auto()
+    AUTHOR_NOT_ALLOWED = auto()
 
 
 class RealmShareStoreBadOutcome(BadOutcomeEnum):
@@ -634,6 +635,8 @@ class BaseRealmComponent:
                 return authenticated_cmds.latest.realm_create.RepRealmAlreadyExists(
                     last_realm_certificate_timestamp=error.certificate_timestamp
                 )
+            case RealmCreateStoreBadOutcome.AUTHOR_NOT_ALLOWED:
+                return authenticated_cmds.latest.realm_create.RepAuthorNotAllowed()
             case RealmCreateStoreBadOutcome.ORGANIZATION_NOT_FOUND:
                 client_ctx.organization_not_found_abort()
             case RealmCreateStoreBadOutcome.ORGANIZATION_EXPIRED:

--- a/server/tests/api_v5/authenticated/test_user_revoke.py
+++ b/server/tests/api_v5/authenticated/test_user_revoke.py
@@ -25,7 +25,7 @@ from tests.common import (
     bob_becomes_admin_and_changes_alice,
     generate_realm_role_certificate,
 )
-from tests.common.data import wksp1_alice_gives_role
+from tests.common.data import alice_gives_profile, wksp1_alice_gives_role
 
 
 @pytest.mark.parametrize(
@@ -51,6 +51,9 @@ async def test_authenticated_user_revoke_ok(
             pass
 
         case "revoked_is_part_of_one_realm_with_vlobs":
+            await alice_gives_profile(
+                coolorg, backend, coolorg.mallory.user_id, UserProfile.STANDARD
+            )
             realm_id = VlobID.new()
             certif = generate_realm_role_certificate(
                 coolorg,
@@ -82,6 +85,9 @@ async def test_authenticated_user_revoke_ok(
             assert outcome is None
 
         case "revoked_is_part_of_one_realm_without_vlobs":
+            await alice_gives_profile(
+                coolorg, backend, coolorg.mallory.user_id, UserProfile.STANDARD
+            )
             realm_id = VlobID.new()
             certif = generate_realm_role_certificate(
                 coolorg,
@@ -100,6 +106,9 @@ async def test_authenticated_user_revoke_ok(
             assert isinstance(outcome, RealmRoleCertificate)
 
         case "revoked_is_part_of_multiple_realms_with_vlobs":
+            await alice_gives_profile(
+                coolorg, backend, coolorg.mallory.user_id, UserProfile.STANDARD
+            )
             for _ in range(3):
                 realm_id = VlobID.new()
                 certif = generate_realm_role_certificate(
@@ -132,6 +141,9 @@ async def test_authenticated_user_revoke_ok(
                 assert outcome is None
 
         case "revoked_is_part_of_multiple_realms_without_vlobs":
+            await alice_gives_profile(
+                coolorg, backend, coolorg.mallory.user_id, UserProfile.STANDARD
+            )
             for _ in range(3):
                 realm_id = VlobID.new()
                 certif = generate_realm_role_certificate(


### PR DESCRIPTION
close #8226 

New rules are:
- An OUTSIDER cannot create a realm.
- When sharing with an OUTSIDER, the roles MANAGER and OWNER cannot be given.
- A user becoming OUTSIDER retains his existing role in each realm he is part of.
