### PR TITLE
Allow to specify the organization id to use for the test environment

### DIFF
--- a/cli/src/commands/run_testenv.rs
+++ b/cli/src/commands/run_testenv.rs
@@ -24,6 +24,9 @@ pub struct RunTestenv {
     /// Skip initialization
     #[arg(short, long, default_value_t)]
     empty: bool,
+    /// The organization id to use for the test environment.
+    #[arg(default_value_os = "Org")]
+    org_id: libparsec::OrganizationID,
 }
 
 pub async fn run_testenv(run_testenv: RunTestenv) -> anyhow::Result<()> {
@@ -31,6 +34,7 @@ pub async fn run_testenv(run_testenv: RunTestenv) -> anyhow::Result<()> {
         main_process_id,
         source_file,
         empty,
+        org_id,
     } = run_testenv;
 
     let tmp_dir = std::env::temp_dir().join(format!("parsec-testenv-{}", &uuid::Uuid::new_v4()));
@@ -53,7 +57,6 @@ pub async fn run_testenv(run_testenv: RunTestenv) -> anyhow::Result<()> {
 
     if !empty {
         let url = url.expect("Mismatch condition in new_environment when starting a new server");
-        let org_id = "Org".parse().expect("Unreachable");
         let org = initialize_test_organization(ClientConfig::default(), url, org_id).await?;
 
         println!("Alice & Bob devices (password: {YELLOW}{DEFAULT_DEVICE_PASSWORD}{RESET}):");


### PR DESCRIPTION
This is useful when the default org id was already used and we don't want to restart the testbed.
