### PR TITLE
Fix extra `false` added to the cmd packaging electron

### DIFF
--- a/.github/workflows/package-client.yml
+++ b/.github/workflows/package-client.yml
@@ -331,7 +331,7 @@ jobs:
         # we need to escape the flag another time by adding another `--`.
         run: >-
           npm run electron:release
-          ${{ (matrix.platform == 'linux' || inputs.nightly_build) && '--' }}
+          ${{ (matrix.platform == 'linux' || inputs.nightly_build) && '--' || '' }}
           ${{ matrix.platform == 'linux' && 'appimage' || '' }}
           ${{ inputs.nightly_build && '--nightly' || '' }}
         env:


### PR DESCRIPTION
When we do not package electron on linux nor we are in a nightly build an extra `false` was added to the command line causing failure on windows & macos jobs.

This commit fix that by handling the `false` case with empty string.