### PR TITLE
Sync workspace on start

### DIFF
--- a/bindings/electron/src/index.d.ts
+++ b/bindings/electron/src/index.d.ts
@@ -938,6 +938,10 @@ export type ClientStartInvitationGreetError =
 
 
 // ClientStartWorkspaceError
+export interface ClientStartWorkspaceErrorCannotRefreshWorkspace {
+    tag: "CannotRefreshWorkspace"
+    error: string
+}
 export interface ClientStartWorkspaceErrorInternal {
     tag: "Internal"
     error: string
@@ -947,6 +951,7 @@ export interface ClientStartWorkspaceErrorWorkspaceNotFound {
     error: string
 }
 export type ClientStartWorkspaceError =
+  | ClientStartWorkspaceErrorCannotRefreshWorkspace
   | ClientStartWorkspaceErrorInternal
   | ClientStartWorkspaceErrorWorkspaceNotFound
 

--- a/bindings/electron/src/meths.rs
+++ b/bindings/electron/src/meths.rs
@@ -3960,6 +3960,11 @@ fn variant_client_start_workspace_error_rs_to_js<'a>(
     let js_display = JsString::try_new(cx, &rs_obj.to_string()).or_throw(cx)?;
     js_obj.set(cx, "error", js_display)?;
     match rs_obj {
+        libparsec::ClientStartWorkspaceError::CannotRefreshWorkspace { .. } => {
+            let js_tag = JsString::try_new(cx, "ClientStartWorkspaceErrorCannotRefreshWorkspace")
+                .or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
         libparsec::ClientStartWorkspaceError::Internal { .. } => {
             let js_tag = JsString::try_new(cx, "ClientStartWorkspaceErrorInternal").or_throw(cx)?;
             js_obj.set(cx, "tag", js_tag)?;

--- a/bindings/generator/api/workspace.py
+++ b/bindings/generator/api/workspace.py
@@ -30,6 +30,9 @@ class ClientStartWorkspaceError(ErrorVariant):
     class WorkspaceNotFound:
         pass
 
+    class CannotRefreshWorkspace:
+        pass
+
     class Internal:
         pass
 

--- a/bindings/web/src/meths.rs
+++ b/bindings/web/src/meths.rs
@@ -4383,6 +4383,13 @@ fn variant_client_start_workspace_error_rs_to_js(
     let js_display = &rs_obj.to_string();
     Reflect::set(&js_obj, &"error".into(), &js_display.into())?;
     match rs_obj {
+        libparsec::ClientStartWorkspaceError::CannotRefreshWorkspace { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ClientStartWorkspaceErrorCannotRefreshWorkspace".into(),
+            )?;
+        }
         libparsec::ClientStartWorkspaceError::Internal { .. } => {
             Reflect::set(
                 &js_obj,

--- a/client/src/plugins/libparsec/definitions.ts
+++ b/client/src/plugins/libparsec/definitions.ts
@@ -1091,10 +1091,15 @@ export type ClientStartInvitationGreetError =
 
 // ClientStartWorkspaceError
 export enum ClientStartWorkspaceErrorTag {
+    CannotRefreshWorkspace = 'ClientStartWorkspaceErrorCannotRefreshWorkspace',
     Internal = 'ClientStartWorkspaceErrorInternal',
     WorkspaceNotFound = 'ClientStartWorkspaceErrorWorkspaceNotFound',
 }
 
+export interface ClientStartWorkspaceErrorCannotRefreshWorkspace {
+    tag: ClientStartWorkspaceErrorTag.CannotRefreshWorkspace
+    error: string
+}
 export interface ClientStartWorkspaceErrorInternal {
     tag: ClientStartWorkspaceErrorTag.Internal
     error: string
@@ -1104,6 +1109,7 @@ export interface ClientStartWorkspaceErrorWorkspaceNotFound {
     error: string
 }
 export type ClientStartWorkspaceError =
+  | ClientStartWorkspaceErrorCannotRefreshWorkspace
   | ClientStartWorkspaceErrorInternal
   | ClientStartWorkspaceErrorWorkspaceNotFound
 


### PR DESCRIPTION
Currently the client do not have a way to sync the workspace, so we do it on start This approach is not optimum but fix #8178