### PR TITLE
Fix invite dance tests flakiness introduced in #8066

### DIFF
--- a/cli/tests/integration/invite_device.rs
+++ b/cli/tests/integration/invite_device.rs
@@ -58,7 +58,7 @@ async fn invite_device_dance(tmp_path: TmpPath) {
 
     let token = invitation_addr.token();
 
-    let p_greeter = std::process::Command::cargo_bin("parsec_cli")
+    let mut p_greeter = std::process::Command::cargo_bin("parsec_cli")
         .unwrap()
         .args([
             "greet-invitation",
@@ -74,7 +74,7 @@ async fn invite_device_dance(tmp_path: TmpPath) {
         .spawn()
         .unwrap();
 
-    let p_claimer = std::process::Command::cargo_bin("parsec_cli")
+    let mut p_claimer = std::process::Command::cargo_bin("parsec_cli")
         .unwrap()
         .args([
             "claim-invitation",
@@ -88,10 +88,10 @@ async fn invite_device_dance(tmp_path: TmpPath) {
         .spawn()
         .unwrap();
 
-    let mut stdout_greeter = BufReader::new(p_greeter.stdout.unwrap());
-    let mut stdout_claimer = BufReader::new(p_claimer.stdout.unwrap());
-    let mut stdin_greeter = p_greeter.stdin.unwrap();
-    let mut stdin_claimer = p_claimer.stdin.unwrap();
+    let mut stdout_greeter = BufReader::new(p_greeter.stdout.take().unwrap());
+    let mut stdout_claimer = BufReader::new(p_claimer.stdout.take().unwrap());
+    let mut stdin_greeter = p_greeter.stdin.take().unwrap();
+    let mut stdin_claimer = p_claimer.stdin.take().unwrap();
     let mut buf = String::new();
 
     stdin_greeter
@@ -123,4 +123,6 @@ async fn invite_device_dance(tmp_path: TmpPath) {
         .write_all(format!("{DEFAULT_DEVICE_PASSWORD}\n").as_bytes())
         .unwrap();
     wait_for(&mut stdout_claimer, &mut buf, "Saved");
+    assert!(p_greeter.wait().unwrap().success());
+    assert!(p_claimer.wait().unwrap().success());
 }

--- a/cli/tests/integration/invite_user.rs
+++ b/cli/tests/integration/invite_user.rs
@@ -63,7 +63,7 @@ async fn invite_user_dance(tmp_path: TmpPath) {
 
     let token = invitation_addr.token();
 
-    let p_greeter = std::process::Command::cargo_bin("parsec_cli")
+    let mut p_greeter = std::process::Command::cargo_bin("parsec_cli")
         .unwrap()
         .args([
             "greet-invitation",
@@ -79,7 +79,7 @@ async fn invite_user_dance(tmp_path: TmpPath) {
         .spawn()
         .unwrap();
 
-    let p_claimer = std::process::Command::cargo_bin("parsec_cli")
+    let mut p_claimer = std::process::Command::cargo_bin("parsec_cli")
         .unwrap()
         .args([
             "claim-invitation",
@@ -93,10 +93,10 @@ async fn invite_user_dance(tmp_path: TmpPath) {
         .spawn()
         .unwrap();
 
-    let mut stdout_greeter = BufReader::new(p_greeter.stdout.unwrap());
-    let mut stdout_claimer = BufReader::new(p_claimer.stdout.unwrap());
-    let mut stdin_greeter = p_greeter.stdin.unwrap();
-    let mut stdin_claimer = p_claimer.stdin.unwrap();
+    let mut stdout_greeter = BufReader::new(p_greeter.stdout.take().unwrap());
+    let mut stdout_claimer = BufReader::new(p_claimer.stdout.take().unwrap());
+    let mut stdin_greeter = p_greeter.stdin.take().unwrap();
+    let mut stdin_claimer = p_claimer.stdin.take().unwrap();
     let mut buf = String::new();
 
     stdin_greeter
@@ -135,4 +135,6 @@ async fn invite_user_dance(tmp_path: TmpPath) {
         .write_all(format!("{DEFAULT_DEVICE_PASSWORD}\n").as_bytes())
         .unwrap();
     wait_for(&mut stdout_claimer, &mut buf, "Saved");
+    assert!(p_greeter.wait().unwrap().success());
+    assert!(p_claimer.wait().unwrap().success());
 }


### PR DESCRIPTION

Fix the flaky `invite_user_dance` and `invite_device_dance` tests (flakiness introduced in #8066)

This is done by having the claimer not polling the last step of the greeting attempt.

As explained in this comment:
```
        // Only perform the acknowledge step once
        // This is for two reasons:
        // 1. We don't need to wait for the greeter to actually receive it
        // 2. The invitation might get marked as completed by the greeter
        //    once it has received our acknowledgement. That means that there
        //    are no guarantees that will be able to get the 8th greeter step
        //    if we poll for it.
```