### PR TITLE
Improve logging in the parsec server

### DIFF
--- a/server/parsec/asgi/administration.py
+++ b/server/parsec/asgi/administration.py
@@ -121,6 +121,9 @@ def log_request[**P, T: BaseModel | Response](
         except Exception as e:
             logger.error(f"{request.method} {request.url.path} exception", exc_info=e)
             raise
+        except BaseException as e:
+            logger.debug(f"{request.method} {request.url.path} base exception", exc_info=e)
+            raise
         if isinstance(result, Response):
             debug_extra = {
                 "status_code": result.status_code,

--- a/server/parsec/asgi/rpc.py
+++ b/server/parsec/asgi/rpc.py
@@ -411,7 +411,7 @@ async def run_request(
     backend: Backend,
     client_ctx: AuthenticatedClientContext | InvitedClientContext | AnonymousClientContext,
     request: object,
-) -> None:
+) -> object:
     client_ctx.logger.debug(
         "RPC request",
         req=LoggedReq(request),
@@ -428,6 +428,9 @@ async def run_request(
         raise
     except Exception as exc:
         logger.error("RPC exception", exc_info=exc)
+        raise
+    except BaseException as exc:
+        logger.debug("RPC base exception", exc_info=exc)
         raise
     client_ctx.logger.info_with_debug_extra(
         "RPC reply",
@@ -828,6 +831,9 @@ class StreamingResponseMiddleware(StreamingResponse):
             raise
         except Exception as exc:
             self.client_ctx.logger.error("SSE session exception", exc_info=exc)
+            raise
+        except BaseException as exc:
+            self.client_ctx.logger.debug("SSE session base exception", exc_info=exc)
             raise
         else:
             self.client_ctx.logger.info("SSE session end")

--- a/server/parsec/backend.py
+++ b/server/parsec/backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Type, TypeAlias
@@ -38,6 +39,7 @@ from parsec.components.shamir import BaseShamirComponent
 from parsec.components.user import BaseUserComponent
 from parsec.components.vlob import BaseVlobComponent
 from parsec.config import BackendConfig
+from parsec.logging import get_logger
 from parsec.webhooks import WebhooksComponent
 
 if TYPE_CHECKING:
@@ -52,9 +54,12 @@ if TYPE_CHECKING:
         TestbedEvent: TypeAlias = Any  # pyright: ignore[reportRedeclaration]
         TestbedTemplateContent: TypeAlias = Any  # pyright: ignore[reportRedeclaration]
 
+logger = get_logger()
+
 
 @asynccontextmanager
 async def backend_factory(config: BackendConfig) -> AsyncGenerator[Backend, None]:
+    logger.info("Backend configuration", **dataclasses.asdict(config))
     if config.db_url == "MOCKED":
         components_factory = mocked_components_factory
     else:

--- a/server/parsec/client_context.py
+++ b/server/parsec/client_context.py
@@ -119,7 +119,7 @@ class AuthenticatedClientContext:
 
     def __post_init__(self):
         self.logger = logger.bind(
-            request=uuid4().hex,
+            request=uuid4().hex[:4],
             api=f"{self.settled_api_version.version}.{self.settled_api_version.revision}",
             auth="authenticated",
             organization=self.organization_id.str,

--- a/server/parsec/client_context.py
+++ b/server/parsec/client_context.py
@@ -118,8 +118,11 @@ class AuthenticatedClientContext:
     logger: ParsecBoundLogger = field(init=False)
 
     def __post_init__(self):
+        # Generate a request ID just for the logs
+        # It doesn't have to be as long as a UUID, 4 hex characters should be enough
+        request_id = (uuid4().hex[:4],)
         self.logger = logger.bind(
-            request=uuid4().hex[:4],
+            request=request_id,
             api=f"{self.settled_api_version.version}.{self.settled_api_version.revision}",
             auth="authenticated",
             organization=self.organization_id.str,

--- a/server/parsec/config.py
+++ b/server/parsec/config.py
@@ -50,6 +50,12 @@ class S3BlockStoreConfig(BaseBlockStoreConfig):
     s3_key: str
     s3_secret: str
 
+    def __str__(self) -> str:
+        # Do not show the secret in the logs
+        return f"{self.__class__.__name__}(s3_endpoint_url={self.s3_endpoint_url}, s3_region={self.s3_region}, s3_bucket={self.s3_bucket}, s3_key={self.s3_key})"
+
+    __repr__ = __str__
+
 
 @dataclass(slots=True)
 class SWIFTBlockStoreConfig(BaseBlockStoreConfig):
@@ -60,6 +66,12 @@ class SWIFTBlockStoreConfig(BaseBlockStoreConfig):
     swift_container: str
     swift_user: str
     swift_password: str
+
+    def __str__(self) -> str:
+        # Do not show the password in the logs
+        return f"{self.__class__.__name__}(swift_authurl={self.swift_authurl}, swift_tenant={self.swift_tenant}, swift_container={self.swift_container}, swift_user={self.swift_user})"
+
+    __repr__ = __str__
 
 
 @dataclass(slots=True)
@@ -85,7 +97,10 @@ class SmtpEmailConfig:
     sender: str
 
     def __str__(self) -> str:
+        # Do not show the password in the logs
         return f"{self.__class__.__name__}(sender={self.sender}, host={self.host}, port={self.port}, use_ssl={self.use_ssl})"
+
+    __repr__ = __str__
 
 
 @dataclass(slots=True)
@@ -94,9 +109,6 @@ class MockedEmailConfig:
 
     sender: str
     tmpdir: str
-
-    def __str__(self) -> str:
-        return f"{self.__class__.__name__}(sender={self.sender}, tmpdir={self.tmpdir})"
 
 
 EmailConfig = SmtpEmailConfig | MockedEmailConfig


### PR DESCRIPTION
More specifically:
- consistently log the different outcomes of RPC requests
- reduce the request id size to 4 characters
- log the different steps and outcomes in the SSE context
- bind the command name the the client context logger
- log base exceptions in debug mode, so cancellation or other base exception can appear

~It also adds debug logs to postgre transactions, although these could be dropped when the server crash investigation is over, up to debate.~ removed.

Also add a `--with-postgresql` option to the testbed server