### PR TITLE
Restore local confinement points in outbound sync

### DIFF
--- a/libparsec/crates/client/src/workspace/transactions/outbound_sync.rs
+++ b/libparsec/crates/client/src/workspace/transactions/outbound_sync.rs
@@ -306,10 +306,14 @@ async fn outbound_sync_folder(
 
     // Do the actual storage update
 
-    let local_from_remote = Arc::new(LocalFolderManifest::from_remote(
-        remote,
-        &ops.config.prevent_sync_pattern,
-    ));
+    let local_from_remote = Arc::new(
+        LocalFolderManifest::from_remote_with_restored_local_confinement_points(
+            remote,
+            &ops.config.prevent_sync_pattern,
+            local.as_ref(),
+            timestamp,
+        ),
+    );
     updater
         .update_manifest(ArcLocalChildManifest::Folder(local_from_remote))
         .await

--- a/libparsec/crates/client/src/workspace/transactions/read_folder.rs
+++ b/libparsec/crates/client/src/workspace/transactions/read_folder.rs
@@ -96,6 +96,7 @@ impl FolderReader {
     /// Return the stat of the folder itself.
     pub fn stat_folder(&self) -> EntryStat {
         EntryStat::Folder {
+            // TODO: Set confinement point
             confinement_point: None,
             id: self.manifest.base.id,
             parent: self.manifest.base.parent,

--- a/libparsec/crates/client/src/workspace/transactions/stat_entry.rs
+++ b/libparsec/crates/client/src/workspace/transactions/stat_entry.rs
@@ -106,6 +106,7 @@ pub(crate) async fn stat_entry_by_id(
 
     let info = match manifest {
         ArcLocalChildManifest::Folder(manifest) => EntryStat::Folder {
+            // TODO: Set confinement point
             confinement_point: None,
             id: manifest.base.id,
             parent: manifest.parent,
@@ -116,6 +117,7 @@ pub(crate) async fn stat_entry_by_id(
             need_sync: manifest.need_sync,
         },
         ArcLocalChildManifest::File(manifest) => EntryStat::File {
+            // TODO: Set confinement point
             confinement_point: None,
             id: manifest.base.id,
             parent: manifest.parent,


### PR DESCRIPTION
Partial fix to #8263

Add TODOs for https://github.com/Scille/parsec-cloud/issues/8276