### PR TITLE
Error management on log initialization

### DIFF
--- a/bindings/electron/src/lib.rs
+++ b/bindings/electron/src/lib.rs
@@ -49,10 +49,13 @@ pub fn main(mut cx: ModuleContext) -> NeonResult<()> {
         builder.target(env_logger::Target::Pipe(Box::new(log_file)));
         log_file_path
     };
-    builder.init();
 
-    #[cfg(target_family = "unix")]
-    log::info!("Writing log to {}", log_file_path.display());
+    if let Err(e) = builder.try_init() {
+        log::error!("Logging already initialized: {e}")
+    } else {
+        #[cfg(target_family = "unix")]
+        log::info!("Writing log to {}", log_file_path.display());
+    };
 
     meths::register_meths(&mut cx)
 }


### PR DESCRIPTION
Related to #8194 


I was unable to reproduce this bug, so here is a patch to avoid panicking. 
The error is still logged so if we are able to to monitor logs, we'll may gather more information on this.