### PR TITLE
Refactor client connection to allow loading a custom CA file for TLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2884,6 +2884,7 @@ dependencies = [
  "clap",
  "env_logger",
  "libparsec",
+ "libparsec_client_connection",
  "log",
  "predicates",
  "reqwest",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,6 +14,7 @@ testenv = []
 
 [dependencies]
 libparsec = { workspace = true }
+libparsec_client_connection = { workspace = true }
 
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["default", "derive", "env"] }
@@ -22,7 +23,7 @@ log = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 rpassword = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["std"] }
 spinners = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 url = { workspace = true, optional = true }

--- a/cli/src/commands/organization/create.rs
+++ b/cli/src/commands/organization/create.rs
@@ -1,7 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use reqwest::Client;
-
 use libparsec::{OrganizationID, ParsecAddr, ParsecOrganizationBootstrapAddr};
 
 use crate::utils::*;
@@ -51,7 +49,8 @@ pub async fn create_organization_req(
 ) -> anyhow::Result<ParsecOrganizationBootstrapAddr> {
     let url = addr.to_http_url(Some("/administration/organizations"));
 
-    let rep = Client::new()
+    let client = libparsec_client_connection::build_client()?;
+    let rep = client
         .post(url)
         .bearer_auth(administration_token)
         .json(&serde_json::json!({

--- a/cli/src/commands/organization/stats.rs
+++ b/cli/src/commands/organization/stats.rs
@@ -1,6 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use reqwest::Client;
 use serde_json::Value;
 
 use libparsec::{OrganizationID, ParsecAddr};
@@ -23,7 +22,8 @@ pub async fn stats_organization_req(
         "/administration/organizations/{organization_id}/stats"
     )));
 
-    let rep = Client::new()
+    let client = libparsec_client_connection::build_client()?;
+    let rep = client
         .get(url)
         .bearer_auth(administration_token)
         .send()

--- a/cli/src/commands/organization/status.rs
+++ b/cli/src/commands/organization/status.rs
@@ -1,6 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use reqwest::Client;
 use serde_json::Value;
 
 use libparsec::{OrganizationID, ParsecAddr};
@@ -23,7 +22,8 @@ pub async fn status_organization_req(
         "/administration/organizations/{organization_id}"
     )));
 
-    let rep = Client::new()
+    let client = libparsec_client_connection::build_client()?;
+    let rep = client
         .get(url)
         .bearer_auth(administration_token)
         .send()

--- a/cli/src/commands/server/stats.rs
+++ b/cli/src/commands/server/stats.rs
@@ -1,6 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use reqwest::{Client, Response};
+use reqwest::Response;
 use serde_json::Value;
 
 use libparsec::{DateTime, ParsecAddr};
@@ -59,7 +59,8 @@ pub async fn stats_server_req(
         }
     )));
 
-    Ok(Client::new()
+    let client = libparsec_client_connection::build_client()?;
+    Ok(client
         .get(url)
         .bearer_auth(administration_token)
         .send()

--- a/libparsec/crates/client_connection/src/anonymous_cmds.rs
+++ b/libparsec/crates/client_connection/src/anonymous_cmds.rs
@@ -38,11 +38,7 @@ impl AnonymousCmds {
         addr: ParsecAnonymousAddr,
         proxy: ProxyConfig,
     ) -> anyhow::Result<Self> {
-        let client = {
-            let builder = reqwest::ClientBuilder::default().user_agent(crate::CLIENT_USER_AGENT);
-            let builder = proxy.configure_http_client(builder);
-            builder.build()?
-        };
+        let client = crate::build_client_with_proxy(proxy)?;
         Ok(Self::from_client(client, config_dir, addr))
     }
 

--- a/libparsec/crates/client_connection/src/authenticated_cmds/mod.rs
+++ b/libparsec/crates/client_connection/src/authenticated_cmds/mod.rs
@@ -47,11 +47,7 @@ impl AuthenticatedCmds {
         device: Arc<LocalDevice>,
         proxy: ProxyConfig,
     ) -> anyhow::Result<Self> {
-        let client = {
-            let builder = reqwest::ClientBuilder::default().user_agent(crate::CLIENT_USER_AGENT);
-            let builder = proxy.configure_http_client(builder);
-            builder.build()?
-        };
+        let client = crate::build_client_with_proxy(proxy)?;
         Ok(Self::from_client(client, config_dir, device))
     }
 

--- a/libparsec/crates/client_connection/src/invited_cmds.rs
+++ b/libparsec/crates/client_connection/src/invited_cmds.rs
@@ -38,11 +38,7 @@ impl InvitedCmds {
         addr: ParsecInvitationAddr,
         proxy: ProxyConfig,
     ) -> anyhow::Result<Self> {
-        let client = {
-            let builder = reqwest::ClientBuilder::default().user_agent(crate::CLIENT_USER_AGENT);
-            let builder = proxy.configure_http_client(builder);
-            builder.build()?
-        };
+        let client = crate::build_client_with_proxy(proxy)?;
         Ok(Self::from_client(client, config_dir, addr))
     }
 


### PR DESCRIPTION
Also refactor CLI to use `libparsec_client_connection::build_client` over directly using `reqwest::Client::new()` (That also mean the CLI now support proxy settings ^^)

Closes #8402