### PR TITLE
Lower `EVENT_VLOB_MAX_BLOB_SIZE` 

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -358,6 +358,7 @@ makensis
 manylinux
 mapbox
 mapboxgl
+maxsplit
 mediaservice
 megashark
 memfs

--- a/server/parsec/events.py
+++ b/server/parsec/events.py
@@ -31,8 +31,8 @@ if TYPE_CHECKING:
 # can be passed with the event (on top of that we keep the events in cache for SSE
 # last-event-id, so better avoid too much pressure of the RAM)
 # We keep a large margin with PostgreSQL limit given the event also contains additional
-# fields and must be encoded in base64 (which alone adds ~33% in size).
-EVENT_VLOB_MAX_BLOB_SIZE = 4096
+# fields and the blob is hex encoded.
+EVENT_VLOB_MAX_BLOB_SIZE = 1024
 
 
 OrganizationIDField = Annotated[

--- a/server/tests/administration/test_freeze_user.py
+++ b/server/tests/administration/test_freeze_user.py
@@ -1,5 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
+import asyncio
 from typing import Any
 
 import httpx
@@ -95,7 +96,8 @@ async def test_disconnect_sse(
         with pytest.raises(StopAsyncIteration):
             # Loop given the server might have send us some events before the freeze
             while True:
-                await alice_sse.next_event()
+                async with asyncio.timeout(1):
+                    await alice_sse.next_event()
 
         # ...and we cannot reconnect !
 


### PR DESCRIPTION
... so the payload doesn't exceed 8000 bytes

Also remove the useless b64 conversion in `send/parse_signal`

Fix #8410