### PR TITLE
[MS] Added cache for getting workspace name

### DIFF
--- a/client/src/common/cache.ts
+++ b/client/src/common/cache.ts
@@ -1,0 +1,39 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+interface CacheTuple<T> {
+  data: T;
+  created: number;
+}
+
+const DEFAULT_KEEP_ALIVE = 1000 * 60 * 5; // 5min default
+
+export class DataCache<K, V> {
+  data: Map<K, CacheTuple<V>>;
+  keepAlive: number;
+
+  constructor(keepAlive: number = DEFAULT_KEEP_ALIVE) {
+    this.data = new Map<K, CacheTuple<V>>();
+    this.keepAlive = keepAlive;
+  }
+
+  get(key: K): V | undefined {
+    const tuple = this.data.get(key);
+
+    if (!tuple) {
+      return undefined;
+    }
+    if (tuple.created + this.keepAlive < Date.now()) {
+      this.data.delete(key);
+      return undefined;
+    }
+    return tuple.data;
+  }
+
+  set(key: K, value: V): void {
+    this.data.set(key, { data: value, created: Date.now() });
+  }
+
+  has(key: K): boolean {
+    return this.data.has(key);
+  }
+}

--- a/client/src/components/files/FileCopyItem.vue
+++ b/client/src/components/files/FileCopyItem.vue
@@ -31,9 +31,9 @@
         </ion-text>
         <ion-label
           class="element-details__workspace body-sm"
-          v-if="workspaceInfo"
+          v-if="workspaceName"
         >
-          {{ workspaceInfo.currentName }}
+          {{ workspaceName }}
         </ion-label>
         <div
           class="element-details-progress-container"
@@ -106,7 +106,7 @@
 <script setup lang="ts">
 import { shortenFileName } from '@/common/file';
 import { MsImage, MsInformationTooltip, Translatable, Copy } from 'megashark-lib';
-import { StartedWorkspaceInfo, getWorkspaceInfo } from '@/parsec';
+import { getWorkspaceName } from '@/parsec';
 import {
   CopyData,
   CopyFailedError,
@@ -117,7 +117,7 @@ import {
 } from '@/services/fileOperationManager';
 import { IonIcon, IonItem, IonLabel, IonProgressBar, IonText } from '@ionic/vue';
 import { closeCircle, checkmarkCircle } from 'ionicons/icons';
-import { Ref, onMounted, ref } from 'vue';
+import { onMounted, ref } from 'vue';
 
 const props = defineProps<{
   operationData: CopyData;
@@ -125,17 +125,14 @@ const props = defineProps<{
   stateData?: StateData;
 }>();
 
-const workspaceInfo: Ref<StartedWorkspaceInfo | null> = ref(null);
+const workspaceName = ref('');
 
 defineExpose({
   props,
 });
 
 onMounted(async () => {
-  const result = await getWorkspaceInfo(props.operationData.workspaceHandle);
-  if (result.ok) {
-    workspaceInfo.value = result.value;
-  }
+  workspaceName.value = await getWorkspaceName(props.operationData.workspaceHandle);
 });
 
 function getProgress(): number {

--- a/client/src/components/files/FileMoveItem.vue
+++ b/client/src/components/files/FileMoveItem.vue
@@ -31,9 +31,9 @@
         </ion-text>
         <ion-label
           class="element-details__workspace body-sm"
-          v-if="workspaceInfo"
+          v-if="workspaceName"
         >
-          {{ workspaceInfo.currentName }}
+          {{ workspaceName }}
         </ion-label>
         <div
           class="element-details-progress-container"
@@ -113,7 +113,7 @@
 <script setup lang="ts">
 import { shortenFileName } from '@/common/file';
 import { MsImage, MsInformationTooltip, Move } from 'megashark-lib';
-import { StartedWorkspaceInfo, getWorkspaceInfo, Path, EntryName } from '@/parsec';
+import { Path, EntryName, getWorkspaceName } from '@/parsec';
 import { MoveData, FileOperationState, StateData, OperationProgressStateData } from '@/services/fileOperationManager';
 import { IonIcon, IonItem, IonLabel, IonProgressBar, IonText, IonButton } from '@ionic/vue';
 import { checkmarkCircle, closeCircle } from 'ionicons/icons';
@@ -125,7 +125,7 @@ const props = defineProps<{
   state: FileOperationState;
 }>();
 
-const workspaceInfo: Ref<StartedWorkspaceInfo | null> = ref(null);
+const workspaceName = ref('');
 const entryName: Ref<EntryName> = ref('');
 
 defineExpose({
@@ -133,10 +133,7 @@ defineExpose({
 });
 
 onMounted(async () => {
-  const result = await getWorkspaceInfo(props.operationData.workspaceHandle);
-  if (result.ok) {
-    workspaceInfo.value = result.value;
-  }
+  workspaceName.value = await getWorkspaceName(props.operationData.workspaceHandle);
   entryName.value = (await Path.filename(props.operationData.dstPath)) ?? '';
 });
 

--- a/client/src/components/files/FileUploadItem.vue
+++ b/client/src/components/files/FileUploadItem.vue
@@ -31,9 +31,9 @@
           <span class="default-state element-details-info__size">{{ $msTranslate(formatFileSize(fileCache.size)) }}</span>
           <span
             class="default-state element-details-info__workspace"
-            v-if="workspaceInfo"
+            v-if="workspaceName"
           >
-            &bull; {{ workspaceInfo.currentName }}
+            &bull; {{ workspaceName }}
           </span>
           <span
             class="hover-state"
@@ -128,11 +128,11 @@
 <script setup lang="ts">
 import { formatFileSize, getFileIcon, shortenFileName } from '@/common/file';
 import { MsImage, MsInformationTooltip } from 'megashark-lib';
-import { StartedWorkspaceInfo, getWorkspaceInfo } from '@/parsec';
+import { getWorkspaceName } from '@/parsec';
 import { ImportData, FileOperationState, StateData, OperationProgressStateData } from '@/services/fileOperationManager';
 import { IonButton, IonIcon, IonItem, IonLabel, IonProgressBar, IonText } from '@ionic/vue';
 import { arrowForward, checkmarkCircle, closeCircle } from 'ionicons/icons';
-import { Ref, onMounted, ref } from 'vue';
+import { onMounted, ref } from 'vue';
 
 const props = defineProps<{
   operationData: ImportData;
@@ -144,17 +144,14 @@ const props = defineProps<{
 // will never change, so we cache them.
 const fileCache = structuredClone(props.operationData.file);
 
-const workspaceInfo: Ref<StartedWorkspaceInfo | null> = ref(null);
+const workspaceName = ref('');
 
 defineExpose({
   props,
 });
 
 onMounted(async () => {
-  const result = await getWorkspaceInfo(props.operationData.workspaceHandle);
-  if (result.ok) {
-    workspaceInfo.value = result.value;
-  }
+  workspaceName.value = await getWorkspaceName(props.operationData.workspaceHandle);
 });
 
 function getProgress(): number {

--- a/client/src/components/notifications/MultipleUsersJoinWorkspaceNotification.vue
+++ b/client/src/components/notifications/MultipleUsersJoinWorkspaceNotification.vue
@@ -18,7 +18,7 @@
             <strong> {{ notificationData.roles.length }} {{ $msTranslate('notification.users') }} </strong>
           </template>
           <template #workspace>
-            <strong>{{ workspaceInfo ? workspaceInfo.currentName : '' }}</strong>
+            <strong>{{ workspaceName }}</strong>
           </template>
         </i18n-t>
       </ion-text>
@@ -39,24 +39,21 @@
 import { formatTimeSince } from 'megashark-lib';
 import MultipleUsersJoinPopover from '@/components/notifications/MultipleUsersJoinPopover.vue';
 import NotificationItem from '@/components/notifications/NotificationItem.vue';
-import { getWorkspaceInfo, StartedWorkspaceInfo } from '@/parsec';
+import { getWorkspaceName } from '@/parsec';
 import { MultipleUsersJoinWorkspaceData } from '@/services/informationManager';
 import { Notification } from '@/services/notificationManager';
 import { IonIcon, IonText, popoverController } from '@ionic/vue';
 import { people } from 'ionicons/icons';
-import { onMounted, ref, Ref } from 'vue';
+import { onMounted, ref } from 'vue';
 
-const workspaceInfo: Ref<StartedWorkspaceInfo | null> = ref(null);
+const workspaceName = ref('');
 
 const props = defineProps<{
   notification: Notification;
 }>();
 
 onMounted(async () => {
-  const result = await getWorkspaceInfo(notificationData.workspaceHandle);
-  if (result.ok) {
-    workspaceInfo.value = result.value;
-  }
+  workspaceName.value = await getWorkspaceName(notificationData.workspaceHandle);
 });
 
 const notificationData = props.notification.getData<MultipleUsersJoinWorkspaceData>();

--- a/client/src/components/notifications/UserJoinWorkspaceNotification.vue
+++ b/client/src/components/notifications/UserJoinWorkspaceNotification.vue
@@ -16,7 +16,7 @@
             <strong>{{ userInfo ? userInfo.humanHandle.label : '' }}</strong>
           </template>
           <template #workspace>
-            <strong>{{ workspaceInfo ? workspaceInfo.currentName : '' }}</strong>
+            <strong>{{ workspaceName }}</strong>
           </template>
         </i18n-t>
       </ion-text>
@@ -31,26 +31,23 @@
 import { formatTimeSince } from 'megashark-lib';
 import NotificationItem from '@/components/notifications/NotificationItem.vue';
 import UserAvatarName from '@/components/users/UserAvatarName.vue';
-import { StartedWorkspaceInfo, UserInfo, getUserInfo, getWorkspaceInfo } from '@/parsec';
+import { UserInfo, getUserInfo, getWorkspaceName } from '@/parsec';
 import { UserJoinWorkspaceData } from '@/services/informationManager';
 import { Notification } from '@/services/notificationManager';
 import { IonText } from '@ionic/vue';
 import { Ref, onMounted, ref } from 'vue';
 
 const userInfo: Ref<UserInfo | null> = ref(null);
-const workspaceInfo: Ref<StartedWorkspaceInfo | null> = ref(null);
+const workspaceName = ref('');
 
 const props = defineProps<{
   notification: Notification;
 }>();
 
 onMounted(async () => {
-  const resultWorkspace = await getWorkspaceInfo(notificationData.workspaceHandle);
   const resultUser = await getUserInfo(notificationData.userId);
 
-  if (resultWorkspace.ok) {
-    workspaceInfo.value = resultWorkspace.value;
-  }
+  workspaceName.value = await getWorkspaceName(notificationData.workspaceHandle);
 
   if (resultUser.ok) {
     userInfo.value = resultUser.value;

--- a/client/src/parsec/workspace.ts
+++ b/client/src/parsec/workspace.ts
@@ -1,5 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
+import { DataCache } from '@/common/cache';
 import { needsMocks } from '@/parsec/environment';
 import { getClientInfo } from '@/parsec/login';
 import { getParsecHandle } from '@/parsec/routing';
@@ -197,6 +198,22 @@ export async function getWorkspaceInfo(workspaceHandle: WorkspaceHandle): Promis
         return { ok: false, error: { tag: WorkspaceInfoErrorTag.Internal, error: 'internal' } };
     }
   }
+}
+
+const WORKSPACE_NAMES_CACHE = new DataCache<WorkspaceHandle, string>();
+
+export async function getWorkspaceName(workspaceHandle: WorkspaceHandle): Promise<string> {
+  const name = WORKSPACE_NAMES_CACHE.get(workspaceHandle);
+
+  if (name) {
+    return name;
+  }
+  const result = await getWorkspaceInfo(workspaceHandle);
+  if (!result.ok) {
+    return '';
+  }
+  WORKSPACE_NAMES_CACHE.set(workspaceHandle, result.value.currentName);
+  return result.value.currentName;
 }
 
 export async function createWorkspace(name: WorkspaceName): Promise<Result<WorkspaceID, ClientCreateWorkspaceError>> {

--- a/client/src/views/header/HeaderPage.vue
+++ b/client/src/views/header/HeaderPage.vue
@@ -112,7 +112,7 @@
 import HeaderBackButton from '@/components/header/HeaderBackButton.vue';
 import HeaderBreadcrumbs, { RouterPathNode } from '@/components/header/HeaderBreadcrumbs.vue';
 import InvitationsButton from '@/components/header/InvitationsButton.vue';
-import { ClientInfo, Path, StartedWorkspaceInfo, UserProfile, getClientInfo, getWorkspaceInfo, isMobile } from '@/parsec';
+import { ClientInfo, Path, UserProfile, getClientInfo, isMobile, getWorkspaceName } from '@/parsec';
 import {
   Routes,
   currentRouteIs,
@@ -151,7 +151,7 @@ import { Ref, inject, onMounted, onUnmounted, ref } from 'vue';
 
 const hotkeyManager: HotkeyManager = inject(HotkeyManagerKey)!;
 let hotkeys: HotkeyGroup | null = null;
-const workspaceInfo: Ref<StartedWorkspaceInfo | null> = ref(null);
+const workspaceName = ref('');
 const { isVisible: isSidebarMenuVisible, reset: resetSidebarMenu } = useSidebarMenu();
 const userInfo: Ref<ClientInfo | null> = ref(null);
 const fullPath: Ref<RouterPathNode[]> = ref([]);
@@ -192,12 +192,7 @@ async function updateRoute(): Promise<void> {
   } else if (currentRouteIs(Routes.Documents)) {
     const workspaceHandle = getWorkspaceHandle();
     if (workspaceHandle) {
-      const result = await getWorkspaceInfo(workspaceHandle);
-      if (result.ok) {
-        workspaceInfo.value = result.value;
-      } else {
-        console.warn('Could not get workspace info', result.error);
-      }
+      workspaceName.value = await getWorkspaceName(workspaceHandle);
     }
 
     const finalPath: RouterPathNode[] = [];
@@ -212,7 +207,7 @@ async function updateRoute(): Promise<void> {
     const workspacePath = await Path.parse(getDocumentPath());
     finalPath.push({
       id: 1,
-      display: workspaceInfo.value ? workspaceInfo.value.currentName : '',
+      display: workspaceName.value,
       name: Routes.Documents,
       query: { documentPath: '/' },
       params: getCurrentRouteParams(),

--- a/client/tests/unit/specs/testCache.spec.ts
+++ b/client/tests/unit/specs/testCache.spec.ts
@@ -1,0 +1,53 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { DataCache } from '@/common/cache';
+import { DateTime } from 'luxon';
+import { it, vi } from 'vitest';
+
+describe('Data cache', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('Check data cache', () => {
+    // Birth of a very important and exceptional person
+    vi.setSystemTime(DateTime.utc(1988, 4, 7, 12, 0, 0).toJSDate());
+
+    const cache = new DataCache<number, string>(1000 * 60 * 2); // 2min
+
+    cache.set(1, 'First');
+    cache.set(2, 'Second');
+
+    expect(cache.get(1)).to.equal('First');
+    expect(cache.get(2)).to.equal('Second');
+    expect(cache.get(3)).to.be.undefined;
+    expect(cache.has(1)).to.be.true;
+    expect(cache.has(3)).to.be.false;
+
+    // Forward 1min
+    vi.setSystemTime(DateTime.utc(1988, 4, 7, 12, 1, 0).toJSDate());
+    expect(cache.get(1)).to.equal('First');
+    expect(cache.get(2)).to.equal('Second');
+    expect(cache.get(3)).to.be.undefined;
+    expect(cache.has(1)).to.be.true;
+    expect(cache.has(3)).to.be.false;
+
+    // Forward 5min
+    vi.setSystemTime(DateTime.utc(1988, 4, 7, 12, 5, 0).toJSDate());
+    expect(cache.get(1)).to.be.undefined;
+    expect(cache.get(2)).to.be.undefined;
+    expect(cache.get(3)).to.be.undefined;
+    expect(cache.has(1)).to.be.false;
+    expect(cache.has(3)).to.be.false;
+
+    cache.set(1, 'First');
+    cache.set(3, 'Third');
+    expect(cache.get(1)).to.equal('First');
+    expect(cache.get(2)).to.be.undefined;
+    expect(cache.get(3)).to.equal('Third');
+  });
+});


### PR DESCRIPTION
When displaying imports, a query will be done for workspace info for every file imported. This caches up the workspace name so we can avoid querying the bindings. The cache is invalidated after 5min, so workspace name changes will still be visible.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes

