### PR TITLE
Use asyncpg pool for the notification connection

### DIFF
--- a/server/parsec/cli/sequester.py
+++ b/server/parsec/cli/sequester.py
@@ -527,7 +527,7 @@ async def _human_accesses(
 ) -> None:
     async with (
         config.pool() as pool,
-        event_bus_factory(db_url=config.db_url) as event_bus,
+        event_bus_factory(pool) as event_bus,
     ):
         user_component = PGUserComponent(pool=pool, event_bus=event_bus)
         realm_component = PGRealmComponent(pool=pool, event_bus=event_bus)

--- a/server/parsec/components/postgresql/factory.py
+++ b/server/parsec/components/postgresql/factory.py
@@ -38,7 +38,7 @@ async def components_factory(
         min_connections=config.db_config.min_connections,
         max_connections=config.db_config.max_connections,
     ) as pool:
-        async with event_bus_factory(db_url=config.db_config.url) as event_bus:
+        async with event_bus_factory(pool) as event_bus:
             async with httpx.AsyncClient(verify=SSL_CONTEXT) as http_client:
                 webhooks = WebhooksComponent(config, http_client)
                 events = PGEventsComponent(pool=pool, config=config, event_bus=event_bus)


### PR DESCRIPTION
This way, the `PARSEC_DB_MIN_CONNECTIONS/PARSEC_DB_MAX_CONNECTIONS` configuration will correctly reflect the number of connections made to the database.