### PR TITLE
Do not run publish workflow on non-nightly release

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -239,8 +239,10 @@ jobs:
 
   publish:
     needs: releaser
+    # Only publish after release if the release is for a nightly build.
+    # We only do that for nightly because we do not create the github release as draft for nightlies to limit the need to human interventions.
     if: >-
-      (github.event_name == 'schedule' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')))
+      (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/tags/nightly'))
       && needs.releaser.result == 'success'
       && always()
     uses: ./.github/workflows/publish.yml


### PR DESCRIPTION
non-nightly releases have their github release created as draft, the publish workflow need the release to be published.