### PR TITLE
Add command to display history for current release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,9 +180,7 @@ jobs:
             )
           && steps.newsfragment-have-changed.outputs.newsfragments == 'true'
         run: |
-          whereis git
-          git fetch origin ${{ github.base_ref }}
-          python .github/scripts/check_newsfragments.py --base=${{ github.base_ref }}
+          python .github/scripts/check_newsfragments.py
         timeout-minutes: 5
 
       - name: Patch pre-commit for line-ending

--- a/misc/releaser.py
+++ b/misc/releaser.py
@@ -936,6 +936,15 @@ def acknowledge_main(args: argparse.Namespace) -> None:
     )
 
 
+def history_main(args: argparse.Namespace) -> None:
+    version: Version = get_version_from_code()
+    release_date: datetime = datetime.now(tz=timezone.utc)
+    newsfragments = collect_newsfragments()
+    newsfragment_rst: defaultdict[str, list[str]] = convert_newsfragments_to_rst(newsfragments)
+
+    print(gen_rst_release_entry(version, release_date, newsfragment_rst))
+
+
 def cli(description: str) -> argparse.Namespace:
     def new_parser(
         name: str,
@@ -1037,6 +1046,12 @@ def cli(description: str) -> argparse.Namespace:
         type=str,
         default=None,
         help="The base ref to use when creating the acknowledge branch",
+    )
+    acknowledge = new_parser(
+        "history",
+        history_main,
+        "Display history for current version",
+        subparsers,
     )
 
     return parser.parse_args()

--- a/newsfragments/README.rst
+++ b/newsfragments/README.rst
@@ -1,33 +1,29 @@
-This directory collects "newsfragments": short files that each contain
-a snippet of ReST-formatted text that will be added to the next
-release notes. This should be a description of aspects of the change
-(if any) that are relevant to users. (This contrasts with your commit
-message and PR description, which are a description of the change as
-relevant to people working on the code itself.)
+About news fragment
+===================
 
-Each file should be named like ``<ISSUE>.<TYPE>.rst``, where
-``<ISSUE>`` is an issue numbers, and ``<TYPE>`` is one of:
+This directory collects "news fragments": short files containing a snippet of
+ReST-formatted text that will be added to the next release notes.
 
-* ``feature``
-* ``bugfix``
-* ``doc``
-* ``removal``
-* ``api``
-* ``misc``
-* ``empty``
+News fragments should contain a description of a change that is relevant to the
+user. This differs from a commit message or PR description, which are a intended
+for developers.
+
+The filename should be ``<ISSUE>.<TYPE>.rst``, where ``<ISSUE>`` is an issue
+number, and ``<TYPE>`` is one of:
+
+  * ``feature``
+  * ``bugfix``
+  * ``doc``
+  * ``removal``
+  * ``api``
+  * ``misc``
+  * ``empty``
 
 So for example: ``123.feature.rst``, ``456.bugfix.rst``
 
-If your PR fixes an issue, use that number here. If there is no issue,
-then after you submit the PR and get the PR number you can add a
-newsfragment using that instead.
+If your PR fixes an issue, use that number here. If there is no issue, then
+submit the PR first, and then use that number to add a news fragment to the PR.
 
-If you want to include a newsfragment, for example to pass the CI, but
-don't want it to be included in the next release, you can use the
-empty type.
+To check how the release nots will look like for the current version, run::
 
-Note that the ``towncrier`` tool will automatically
-reflow your text, so don't try to do any fancy formatting. You can
-install ``towncrier`` and then run ``towncrier --draft`` if you want
-to get a preview of how your change will look in the final release
-notes.
+  python misc/releaser.py history


### PR DESCRIPTION
Also simplify news fragment check in the CI (https://github.com/Scille/parsec-cloud/pull/8467/commits/48898831914c81f6fb65606f44c266614acbae43): with the previous checks it was impossible to update the README file or update an existing news fragment.