### PR TITLE
Make parsec use $HOME/.config as the base configuration directory for the snap package

### DIFF
--- a/client/electron/scripts/snap_migrate_devices_from_snap_user_data.sh
+++ b/client/electron/scripts/snap_migrate_devices_from_snap_user_data.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# This scripts copies device files (.keys) from the legacy device directory (based on $HOME/snap)
+# to the new device directory (based on $HOME/.config)
+
+config_dir=${PARSEC_BASE_CONFIG_DIR:-$HOME/.config}
+device_dir=$config_dir/parsec3/libparsec/devices
+mkdir -pv "$device_dir"
+# Iterate over device directory from all installed parsec snaps
+for old_device_dir in $(find "$HOME"/snap -type f -name '*.keys' 2>/dev/null | grep parsec | xargs dirname | sort | uniq); do
+    sentinel_file=$old_device_dir/.parsec-migrated-devices
+    # Skip directory if it contains the same devices that are stored in the sentinel file
+    if [ -f "$sentinel_file" ] && [[ "cat $sentinel_file" == "$(ls -1 "$old_device_dir"/*.keys)" ]]; then
+        continue
+    fi
+    echo "Copying devices from '$old_device_dir' to '$device_dir'"
+    # Copy devices preserving attributes (--archive)
+    # and ignoring if already exists in destination directory (--update=none)
+    if cp --archive --update=none --verbose "$old_device_dir"/*.keys "$device_dir" ; then
+        # Register copied devices in a sentinel file
+        ls -1 "$old_device_dir" > "$sentinel_file"
+    else
+        echo "Error copying devices from '$old_device_dir'"
+    fi
+done

--- a/client/electron/snap/snapcraft.yaml
+++ b/client/electron/snap/snapcraft.yaml
@@ -29,6 +29,7 @@ apps:
     environment:
       SENTRY_DSN_GUI_ELECTRON: https://f7f91bb7f676a2f1b8451c386f1a8f9a@o155936.ingest.us.sentry.io/4507638897246208
       SENTRY_DSN_GUI_VITE: https://f7f91bb7f676a2f1b8451c386f1a8f9a@o155936.ingest.us.sentry.io/4507638897246208
+      PARSEC_BASE_CONFIG_DIR: $HOME/.config
 
 parts:
   libparsec:
@@ -215,6 +216,7 @@ parts:
     prime:
       - bin/desktop-launch-wrapper
       - bin/desktop-launch
+      - bin/snap_migrate_devices_from_snap_user_data
       - flavor-select
     override-build: |
       cd gtk
@@ -222,10 +224,12 @@ parts:
 
       cat > command.sh << EOF
       #!/bin/bash -e
+      "\$SNAP/bin/snap_migrate_devices_from_snap_user_data"
       exec "\$SNAP/bin/desktop-launch-wrapper" "\$SNAP/app/parsec" "\$@" --no-sandbox
       EOF
 
       mkdir -p "$CRAFT_PART_INSTALL"/bin
-      install -v --mode=755 desktop-launch "$CRAFT_PART_INSTALL"/bin/desktop-launch-wrapper
-      install -v --mode=755 command.sh "$CRAFT_PART_INSTALL"/bin/desktop-launch
-      install -v --mode=644 flavor-select "$CRAFT_PART_INSTALL"/flavor-select
+      install -v --mode=555 desktop-launch "$CRAFT_PART_INSTALL"/bin/desktop-launch-wrapper
+      install -v --mode=555 command.sh "$CRAFT_PART_INSTALL"/bin/desktop-launch
+      install -v --mode=555 ${SNAPCRAFT_PROJECT_DIR}/client/electron/scripts/snap_migrate_devices_from_snap_user_data.sh "$CRAFT_PART_INSTALL"/bin/snap_migrate_devices_from_snap_user_data
+      install -v --mode=444 flavor-select "$CRAFT_PART_INSTALL"/flavor-select

--- a/client/electron/snap/snapcraft.yaml
+++ b/client/electron/snap/snapcraft.yaml
@@ -93,7 +93,7 @@ parts:
 
       MEGASHARK_COMMIT_ID=$(jq -r '.packages."node_modules/megashark-lib".resolved' package-lock.json | cut -d '#' -f 2)
       wget https://github.com/Scille/megashark-lib/archive/${MEGASHARK_COMMIT_ID}.tar.gz -O megashark-lib-src.tar.gz
-      mkdir megashark-lib && cd megashark-lib
+      mkdir -pv megashark-lib && cd megashark-lib
       tar --extract --file ../megashark-lib-src.tar.gz --strip-components=1
 
       npm clean-install

--- a/newsfragments/8464.bugfix.rst
+++ b/newsfragments/8464.bugfix.rst
@@ -1,0 +1,1 @@
+Fix for lost devices when parsec snap is removed: devices are now stored in ``$HOME/.config`` and are independent from snap. Existing devices are migrated.


### PR DESCRIPTION
Also migrate previous devices located in snap user data

Closes #8464
