### PR TITLE
[MS] Hide wrong toast when logging out while importing

### DIFF
--- a/newsfragments/8584.bugfix.rst
+++ b/newsfragments/8584.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed incorrect toast sometimes displayed when logging out while importing files


### PR DESCRIPTION
When logging out while importing, the import operations are cancelled which triggers a refresh of the file list, but the handle is already invalid due to logging out, which causes a toast to be displayed on the home page.

- [x] Keep changes in the pull request as small as possible
- [x] Ensure the commit history is sanitized
- [x] Give a meaningful title to your PR
- [x] Describe your changes
