### PR TITLE
Add bindings for recovery devices.

### DIFF
--- a/bindings/electron/src/index.d.ts
+++ b/bindings/electron/src/index.d.ts
@@ -665,6 +665,39 @@ export type ClientEvent =
   | ClientEventWorkspacesSelfListChanged
 
 
+// ClientExportRecoveryDeviceError
+export interface ClientExportRecoveryDeviceErrorInternal {
+    tag: "Internal"
+    error: string
+}
+export interface ClientExportRecoveryDeviceErrorInvalidCertificate {
+    tag: "InvalidCertificate"
+    error: string
+}
+export interface ClientExportRecoveryDeviceErrorOffline {
+    tag: "Offline"
+    error: string
+}
+export interface ClientExportRecoveryDeviceErrorStopped {
+    tag: "Stopped"
+    error: string
+}
+export interface ClientExportRecoveryDeviceErrorTimestampOutOfBallpark {
+    tag: "TimestampOutOfBallpark"
+    error: string
+    server_timestamp: number
+    client_timestamp: number
+    ballpark_client_early_offset: number
+    ballpark_client_late_offset: number
+}
+export type ClientExportRecoveryDeviceError =
+  | ClientExportRecoveryDeviceErrorInternal
+  | ClientExportRecoveryDeviceErrorInvalidCertificate
+  | ClientExportRecoveryDeviceErrorOffline
+  | ClientExportRecoveryDeviceErrorStopped
+  | ClientExportRecoveryDeviceErrorTimestampOutOfBallpark
+
+
 // ClientGetTosError
 export interface ClientGetTosErrorInternal {
     tag: "Internal"
@@ -1202,6 +1235,59 @@ export type GreetInProgressError =
   | GreetInProgressErrorTimestampOutOfBallpark
   | GreetInProgressErrorUserAlreadyExists
   | GreetInProgressErrorUserCreateNotAllowed
+
+
+// ImportRecoveryDeviceError
+export interface ImportRecoveryDeviceErrorDecryptionFailed {
+    tag: "DecryptionFailed"
+    error: string
+}
+export interface ImportRecoveryDeviceErrorInternal {
+    tag: "Internal"
+    error: string
+}
+export interface ImportRecoveryDeviceErrorInvalidCertificate {
+    tag: "InvalidCertificate"
+    error: string
+}
+export interface ImportRecoveryDeviceErrorInvalidData {
+    tag: "InvalidData"
+    error: string
+}
+export interface ImportRecoveryDeviceErrorInvalidPassphrase {
+    tag: "InvalidPassphrase"
+    error: string
+}
+export interface ImportRecoveryDeviceErrorInvalidPath {
+    tag: "InvalidPath"
+    error: string
+}
+export interface ImportRecoveryDeviceErrorOffline {
+    tag: "Offline"
+    error: string
+}
+export interface ImportRecoveryDeviceErrorStopped {
+    tag: "Stopped"
+    error: string
+}
+export interface ImportRecoveryDeviceErrorTimestampOutOfBallpark {
+    tag: "TimestampOutOfBallpark"
+    error: string
+    server_timestamp: number
+    client_timestamp: number
+    ballpark_client_early_offset: number
+    ballpark_client_late_offset: number
+}
+export type ImportRecoveryDeviceError =
+  | ImportRecoveryDeviceErrorDecryptionFailed
+  | ImportRecoveryDeviceErrorInternal
+  | ImportRecoveryDeviceErrorInvalidCertificate
+  | ImportRecoveryDeviceErrorInvalidData
+  | ImportRecoveryDeviceErrorInvalidPassphrase
+  | ImportRecoveryDeviceErrorInvalidPath
+  | ImportRecoveryDeviceErrorOffline
+  | ImportRecoveryDeviceErrorStopped
+  | ImportRecoveryDeviceErrorTimestampOutOfBallpark
 
 
 // InviteListItem
@@ -2501,6 +2587,10 @@ export function clientCreateWorkspace(
     client: number,
     name: string
 ): Promise<Result<string, ClientCreateWorkspaceError>>
+export function clientExportRecoveryDevice(
+    client_handle: number,
+    device_label: string
+): Promise<Result<[string, Uint8Array], ClientExportRecoveryDeviceError>>
 export function clientGetTos(
     client: number
 ): Promise<Result<Tos, ClientGetTosError>>
@@ -2633,6 +2723,13 @@ export function greeterUserInitialDoWaitPeer(
     canceller: number,
     handle: number
 ): Promise<Result<UserGreetInProgress1Info, GreetInProgressError>>
+export function importRecoveryDevice(
+    config: ClientConfig,
+    recovery_device: Uint8Array,
+    passphrase: string,
+    device_label: string,
+    save_strategy: DeviceSaveStrategy
+): Promise<Result<AvailableDevice, ImportRecoveryDeviceError>>
 export function isKeyringAvailable(
 ): Promise<boolean>
 export function listAvailableDevices(

--- a/bindings/electron/src/meths.rs
+++ b/bindings/electron/src/meths.rs
@@ -3832,6 +3832,85 @@ fn variant_client_event_rs_to_js<'a>(
     Ok(js_obj)
 }
 
+// ClientExportRecoveryDeviceError
+
+#[allow(dead_code)]
+fn variant_client_export_recovery_device_error_rs_to_js<'a>(
+    cx: &mut impl Context<'a>,
+    rs_obj: libparsec::ClientExportRecoveryDeviceError,
+) -> NeonResult<Handle<'a, JsObject>> {
+    let js_obj = cx.empty_object();
+    let js_display = JsString::try_new(cx, &rs_obj.to_string()).or_throw(cx)?;
+    js_obj.set(cx, "error", js_display)?;
+    match rs_obj {
+        libparsec::ClientExportRecoveryDeviceError::Internal { .. } => {
+            let js_tag =
+                JsString::try_new(cx, "ClientExportRecoveryDeviceErrorInternal").or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::ClientExportRecoveryDeviceError::InvalidCertificate { .. } => {
+            let js_tag = JsString::try_new(cx, "ClientExportRecoveryDeviceErrorInvalidCertificate")
+                .or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::ClientExportRecoveryDeviceError::Offline { .. } => {
+            let js_tag =
+                JsString::try_new(cx, "ClientExportRecoveryDeviceErrorOffline").or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::ClientExportRecoveryDeviceError::Stopped { .. } => {
+            let js_tag =
+                JsString::try_new(cx, "ClientExportRecoveryDeviceErrorStopped").or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::ClientExportRecoveryDeviceError::TimestampOutOfBallpark {
+            server_timestamp,
+            client_timestamp,
+            ballpark_client_early_offset,
+            ballpark_client_late_offset,
+            ..
+        } => {
+            let js_tag =
+                JsString::try_new(cx, "ClientExportRecoveryDeviceErrorTimestampOutOfBallpark")
+                    .or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+            let js_server_timestamp = JsNumber::new(cx, {
+                let custom_to_rs_f64 = |dt: libparsec::DateTime| -> Result<f64, &'static str> {
+                    Ok((dt.as_timestamp_micros() as f64) / 1_000_000f64)
+                };
+                match custom_to_rs_f64(server_timestamp) {
+                    Ok(ok) => ok,
+                    Err(err) => return cx.throw_type_error(err),
+                }
+            });
+            js_obj.set(cx, "serverTimestamp", js_server_timestamp)?;
+            let js_client_timestamp = JsNumber::new(cx, {
+                let custom_to_rs_f64 = |dt: libparsec::DateTime| -> Result<f64, &'static str> {
+                    Ok((dt.as_timestamp_micros() as f64) / 1_000_000f64)
+                };
+                match custom_to_rs_f64(client_timestamp) {
+                    Ok(ok) => ok,
+                    Err(err) => return cx.throw_type_error(err),
+                }
+            });
+            js_obj.set(cx, "clientTimestamp", js_client_timestamp)?;
+            let js_ballpark_client_early_offset = JsNumber::new(cx, ballpark_client_early_offset);
+            js_obj.set(
+                cx,
+                "ballparkClientEarlyOffset",
+                js_ballpark_client_early_offset,
+            )?;
+            let js_ballpark_client_late_offset = JsNumber::new(cx, ballpark_client_late_offset);
+            js_obj.set(
+                cx,
+                "ballparkClientLateOffset",
+                js_ballpark_client_late_offset,
+            )?;
+        }
+    }
+    Ok(js_obj)
+}
+
 // ClientGetTosError
 
 #[allow(dead_code)]
@@ -5157,6 +5236,101 @@ fn variant_greet_in_progress_error_rs_to_js<'a>(
             let js_tag =
                 JsString::try_new(cx, "GreetInProgressErrorUserCreateNotAllowed").or_throw(cx)?;
             js_obj.set(cx, "tag", js_tag)?;
+        }
+    }
+    Ok(js_obj)
+}
+
+// ImportRecoveryDeviceError
+
+#[allow(dead_code)]
+fn variant_import_recovery_device_error_rs_to_js<'a>(
+    cx: &mut impl Context<'a>,
+    rs_obj: libparsec::ImportRecoveryDeviceError,
+) -> NeonResult<Handle<'a, JsObject>> {
+    let js_obj = cx.empty_object();
+    let js_display = JsString::try_new(cx, &rs_obj.to_string()).or_throw(cx)?;
+    js_obj.set(cx, "error", js_display)?;
+    match rs_obj {
+        libparsec::ImportRecoveryDeviceError::DecryptionFailed { .. } => {
+            let js_tag =
+                JsString::try_new(cx, "ImportRecoveryDeviceErrorDecryptionFailed").or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::ImportRecoveryDeviceError::Internal { .. } => {
+            let js_tag = JsString::try_new(cx, "ImportRecoveryDeviceErrorInternal").or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::ImportRecoveryDeviceError::InvalidCertificate { .. } => {
+            let js_tag = JsString::try_new(cx, "ImportRecoveryDeviceErrorInvalidCertificate")
+                .or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::ImportRecoveryDeviceError::InvalidData { .. } => {
+            let js_tag =
+                JsString::try_new(cx, "ImportRecoveryDeviceErrorInvalidData").or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::ImportRecoveryDeviceError::InvalidPassphrase { .. } => {
+            let js_tag =
+                JsString::try_new(cx, "ImportRecoveryDeviceErrorInvalidPassphrase").or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::ImportRecoveryDeviceError::InvalidPath { .. } => {
+            let js_tag =
+                JsString::try_new(cx, "ImportRecoveryDeviceErrorInvalidPath").or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::ImportRecoveryDeviceError::Offline { .. } => {
+            let js_tag = JsString::try_new(cx, "ImportRecoveryDeviceErrorOffline").or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::ImportRecoveryDeviceError::Stopped { .. } => {
+            let js_tag = JsString::try_new(cx, "ImportRecoveryDeviceErrorStopped").or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::ImportRecoveryDeviceError::TimestampOutOfBallpark {
+            server_timestamp,
+            client_timestamp,
+            ballpark_client_early_offset,
+            ballpark_client_late_offset,
+            ..
+        } => {
+            let js_tag = JsString::try_new(cx, "ImportRecoveryDeviceErrorTimestampOutOfBallpark")
+                .or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+            let js_server_timestamp = JsNumber::new(cx, {
+                let custom_to_rs_f64 = |dt: libparsec::DateTime| -> Result<f64, &'static str> {
+                    Ok((dt.as_timestamp_micros() as f64) / 1_000_000f64)
+                };
+                match custom_to_rs_f64(server_timestamp) {
+                    Ok(ok) => ok,
+                    Err(err) => return cx.throw_type_error(err),
+                }
+            });
+            js_obj.set(cx, "serverTimestamp", js_server_timestamp)?;
+            let js_client_timestamp = JsNumber::new(cx, {
+                let custom_to_rs_f64 = |dt: libparsec::DateTime| -> Result<f64, &'static str> {
+                    Ok((dt.as_timestamp_micros() as f64) / 1_000_000f64)
+                };
+                match custom_to_rs_f64(client_timestamp) {
+                    Ok(ok) => ok,
+                    Err(err) => return cx.throw_type_error(err),
+                }
+            });
+            js_obj.set(cx, "clientTimestamp", js_client_timestamp)?;
+            let js_ballpark_client_early_offset = JsNumber::new(cx, ballpark_client_early_offset);
+            js_obj.set(
+                cx,
+                "ballparkClientEarlyOffset",
+                js_ballpark_client_early_offset,
+            )?;
+            let js_ballpark_client_late_offset = JsNumber::new(cx, ballpark_client_late_offset);
+            js_obj.set(
+                cx,
+                "ballparkClientLateOffset",
+                js_ballpark_client_late_offset,
+            )?;
         }
     }
     Ok(js_obj)
@@ -9378,6 +9552,84 @@ fn client_create_workspace(mut cx: FunctionContext) -> JsResult<JsPromise> {
     Ok(promise)
 }
 
+// client_export_recovery_device
+fn client_export_recovery_device(mut cx: FunctionContext) -> JsResult<JsPromise> {
+    crate::init_sentry();
+    let client_handle = {
+        let js_val = cx.argument::<JsNumber>(0)?;
+        {
+            let v = js_val.value(&mut cx);
+            if v < (u32::MIN as f64) || (u32::MAX as f64) < v {
+                cx.throw_type_error("Not an u32 number")?
+            }
+            let v = v as u32;
+            v
+        }
+    };
+    let device_label = {
+        let js_val = cx.argument::<JsString>(1)?;
+        {
+            let custom_from_rs_string = |s: String| -> Result<_, String> {
+                libparsec::DeviceLabel::try_from(s.as_str()).map_err(|e| e.to_string())
+            };
+            match custom_from_rs_string(js_val.value(&mut cx)) {
+                Ok(val) => val,
+                Err(err) => return cx.throw_type_error(err),
+            }
+        }
+    };
+    let channel = cx.channel();
+    let (deferred, promise) = cx.promise();
+
+    // TODO: Promises are not cancellable in Javascript by default, should we add a custom cancel method ?
+    let _handle = crate::TOKIO_RUNTIME
+        .lock()
+        .expect("Mutex is poisoned")
+        .spawn(async move {
+            let ret = libparsec::client_export_recovery_device(client_handle, device_label).await;
+
+            deferred.settle_with(&channel, move |mut cx| {
+                let js_ret = match ret {
+                    Ok(ok) => {
+                        let js_obj = JsObject::new(&mut cx);
+                        let js_tag = JsBoolean::new(&mut cx, true);
+                        js_obj.set(&mut cx, "ok", js_tag)?;
+                        let js_value = {
+                            let (x0, x1) = ok;
+                            let js_array = JsArray::new(&mut cx, 2);
+                            let js_value = JsString::try_new(&mut cx, x0).or_throw(&mut cx)?;
+                            js_array.set(&mut cx, 0, js_value)?;
+                            let js_value = {
+                                let mut js_buff = JsArrayBuffer::new(&mut cx, x1.len())?;
+                                let js_buff_slice = js_buff.as_mut_slice(&mut cx);
+                                for (i, c) in x1.iter().enumerate() {
+                                    js_buff_slice[i] = *c;
+                                }
+                                js_buff
+                            };
+                            js_array.set(&mut cx, 1, js_value)?;
+                            js_array
+                        };
+                        js_obj.set(&mut cx, "value", js_value)?;
+                        js_obj
+                    }
+                    Err(err) => {
+                        let js_obj = cx.empty_object();
+                        let js_tag = JsBoolean::new(&mut cx, false);
+                        js_obj.set(&mut cx, "ok", js_tag)?;
+                        let js_err =
+                            variant_client_export_recovery_device_error_rs_to_js(&mut cx, err)?;
+                        js_obj.set(&mut cx, "error", js_err)?;
+                        js_obj
+                    }
+                };
+                Ok(js_ret)
+            });
+        });
+
+    Ok(promise)
+}
+
 // client_get_tos
 fn client_get_tos(mut cx: FunctionContext) -> JsResult<JsPromise> {
     crate::init_sentry();
@@ -11420,6 +11672,80 @@ fn greeter_user_initial_do_wait_peer(mut cx: FunctionContext) -> JsResult<JsProm
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
                         let js_err = variant_greet_in_progress_error_rs_to_js(&mut cx, err)?;
+                        js_obj.set(&mut cx, "error", js_err)?;
+                        js_obj
+                    }
+                };
+                Ok(js_ret)
+            });
+        });
+
+    Ok(promise)
+}
+
+// import_recovery_device
+fn import_recovery_device(mut cx: FunctionContext) -> JsResult<JsPromise> {
+    crate::init_sentry();
+    let config = {
+        let js_val = cx.argument::<JsObject>(0)?;
+        struct_client_config_js_to_rs(&mut cx, js_val)?
+    };
+    let recovery_device = {
+        let js_val = cx.argument::<JsTypedArray<u8>>(1)?;
+        js_val.as_slice(&mut cx).to_vec()
+    };
+    let passphrase = {
+        let js_val = cx.argument::<JsString>(2)?;
+        js_val.value(&mut cx)
+    };
+    let device_label = {
+        let js_val = cx.argument::<JsString>(3)?;
+        {
+            let custom_from_rs_string = |s: String| -> Result<_, String> {
+                libparsec::DeviceLabel::try_from(s.as_str()).map_err(|e| e.to_string())
+            };
+            match custom_from_rs_string(js_val.value(&mut cx)) {
+                Ok(val) => val,
+                Err(err) => return cx.throw_type_error(err),
+            }
+        }
+    };
+    let save_strategy = {
+        let js_val = cx.argument::<JsObject>(4)?;
+        variant_device_save_strategy_js_to_rs(&mut cx, js_val)?
+    };
+    let channel = cx.channel();
+    let (deferred, promise) = cx.promise();
+
+    // TODO: Promises are not cancellable in Javascript by default, should we add a custom cancel method ?
+    let _handle = crate::TOKIO_RUNTIME
+        .lock()
+        .expect("Mutex is poisoned")
+        .spawn(async move {
+            let ret = libparsec::import_recovery_device(
+                config,
+                &recovery_device,
+                passphrase,
+                device_label,
+                save_strategy,
+            )
+            .await;
+
+            deferred.settle_with(&channel, move |mut cx| {
+                let js_ret = match ret {
+                    Ok(ok) => {
+                        let js_obj = JsObject::new(&mut cx);
+                        let js_tag = JsBoolean::new(&mut cx, true);
+                        js_obj.set(&mut cx, "ok", js_tag)?;
+                        let js_value = struct_available_device_rs_to_js(&mut cx, ok)?;
+                        js_obj.set(&mut cx, "value", js_value)?;
+                        js_obj
+                    }
+                    Err(err) => {
+                        let js_obj = cx.empty_object();
+                        let js_tag = JsBoolean::new(&mut cx, false);
+                        js_obj.set(&mut cx, "ok", js_tag)?;
+                        let js_err = variant_import_recovery_device_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -15322,6 +15648,7 @@ pub fn register_meths(cx: &mut ModuleContext) -> NeonResult<()> {
     cx.export_function("clientCancelInvitation", client_cancel_invitation)?;
     cx.export_function("clientChangeAuthentication", client_change_authentication)?;
     cx.export_function("clientCreateWorkspace", client_create_workspace)?;
+    cx.export_function("clientExportRecoveryDevice", client_export_recovery_device)?;
     cx.export_function("clientGetTos", client_get_tos)?;
     cx.export_function("clientGetUserDevice", client_get_user_device)?;
     cx.export_function("clientInfo", client_info)?;
@@ -15401,6 +15728,7 @@ pub fn register_meths(cx: &mut ModuleContext) -> NeonResult<()> {
         "greeterUserInitialDoWaitPeer",
         greeter_user_initial_do_wait_peer,
     )?;
+    cx.export_function("importRecoveryDevice", import_recovery_device)?;
     cx.export_function("isKeyringAvailable", is_keyring_available)?;
     cx.export_function("listAvailableDevices", list_available_devices)?;
     cx.export_function("mountpointToOsPath", mountpoint_to_os_path)?;

--- a/bindings/generator/api/client.py
+++ b/bindings/generator/api/client.py
@@ -26,7 +26,7 @@ from .common import (
     RealmRole,
     Ref,
 )
-from .invite import DeviceSaveStrategy
+from .invite import DeviceSaveStrategy, AvailableDevice
 from .config import ClientConfig
 from .events import OnClientEventCallback
 
@@ -445,4 +445,73 @@ async def client_share_workspace(
 
 
 def is_keyring_available() -> bool:
+    raise NotImplementedError
+
+
+class ImportRecoveryDeviceError(ErrorVariant):
+    class Internal:
+        pass
+
+    class Stopped:
+        pass
+
+    class Offline:
+        pass
+
+    class InvalidCertificate:
+        pass
+
+    class InvalidPath:
+        pass
+
+    class InvalidData:
+        pass
+
+    class InvalidPassphrase:
+        pass
+
+    class DecryptionFailed:
+        pass
+
+    class TimestampOutOfBallpark:
+        server_timestamp: DateTime
+        client_timestamp: DateTime
+        ballpark_client_early_offset: float
+        ballpark_client_late_offset: float
+
+
+class ClientExportRecoveryDeviceError(ErrorVariant):
+    class Internal:
+        pass
+
+    class Stopped:
+        pass
+
+    class Offline:
+        pass
+
+    class InvalidCertificate:
+        pass
+
+    class TimestampOutOfBallpark:
+        server_timestamp: DateTime
+        client_timestamp: DateTime
+        ballpark_client_early_offset: float
+        ballpark_client_late_offset: float
+
+
+async def import_recovery_device(
+    config: ClientConfig,
+    recovery_device: Ref[bytes],
+    passphrase: str,
+    device_label: DeviceLabel,
+    save_strategy: DeviceSaveStrategy,
+) -> Result[AvailableDevice, ImportRecoveryDeviceError]:
+    raise NotImplementedError
+
+
+async def client_export_recovery_device(
+    client_handle: Handle,
+    device_label: DeviceLabel,
+) -> Result[tuple[str, bytes], ClientExportRecoveryDeviceError]:
     raise NotImplementedError

--- a/bindings/generator/generate.py
+++ b/bindings/generator/generate.py
@@ -506,7 +506,7 @@ def generate_api_specs(api_module: ModuleType) -> ApiSpecs:
         api_items[item_name] = item
 
     # The variant/struct types we define for the api can be recursive and/or
-    # refere other types defined later on.
+    # refer other types defined later on.
     # Hence we do the parsing in two passes:
     # - First we populate `TYPES_DB` by collecting the variant/struct types and storing them as placeholders
     # - Then we do the actual type parsing and replace the placeholders

--- a/bindings/web/src/meths.rs
+++ b/bindings/web/src/meths.rs
@@ -4150,6 +4150,95 @@ fn variant_client_event_rs_to_js(rs_obj: libparsec::ClientEvent) -> Result<JsVal
     Ok(js_obj)
 }
 
+// ClientExportRecoveryDeviceError
+
+#[allow(dead_code)]
+fn variant_client_export_recovery_device_error_rs_to_js(
+    rs_obj: libparsec::ClientExportRecoveryDeviceError,
+) -> Result<JsValue, JsValue> {
+    let js_obj = Object::new().into();
+    let js_display = &rs_obj.to_string();
+    Reflect::set(&js_obj, &"error".into(), &js_display.into())?;
+    match rs_obj {
+        libparsec::ClientExportRecoveryDeviceError::Internal { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ClientExportRecoveryDeviceErrorInternal".into(),
+            )?;
+        }
+        libparsec::ClientExportRecoveryDeviceError::InvalidCertificate { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ClientExportRecoveryDeviceErrorInvalidCertificate".into(),
+            )?;
+        }
+        libparsec::ClientExportRecoveryDeviceError::Offline { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ClientExportRecoveryDeviceErrorOffline".into(),
+            )?;
+        }
+        libparsec::ClientExportRecoveryDeviceError::Stopped { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ClientExportRecoveryDeviceErrorStopped".into(),
+            )?;
+        }
+        libparsec::ClientExportRecoveryDeviceError::TimestampOutOfBallpark {
+            server_timestamp,
+            client_timestamp,
+            ballpark_client_early_offset,
+            ballpark_client_late_offset,
+            ..
+        } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ClientExportRecoveryDeviceErrorTimestampOutOfBallpark".into(),
+            )?;
+            let js_server_timestamp = {
+                let custom_to_rs_f64 = |dt: libparsec::DateTime| -> Result<f64, &'static str> {
+                    Ok((dt.as_timestamp_micros() as f64) / 1_000_000f64)
+                };
+                let v = match custom_to_rs_f64(server_timestamp) {
+                    Ok(ok) => ok,
+                    Err(err) => return Err(JsValue::from(TypeError::new(err.as_ref()))),
+                };
+                JsValue::from(v)
+            };
+            Reflect::set(&js_obj, &"serverTimestamp".into(), &js_server_timestamp)?;
+            let js_client_timestamp = {
+                let custom_to_rs_f64 = |dt: libparsec::DateTime| -> Result<f64, &'static str> {
+                    Ok((dt.as_timestamp_micros() as f64) / 1_000_000f64)
+                };
+                let v = match custom_to_rs_f64(client_timestamp) {
+                    Ok(ok) => ok,
+                    Err(err) => return Err(JsValue::from(TypeError::new(err.as_ref()))),
+                };
+                JsValue::from(v)
+            };
+            Reflect::set(&js_obj, &"clientTimestamp".into(), &js_client_timestamp)?;
+            let js_ballpark_client_early_offset = ballpark_client_early_offset.into();
+            Reflect::set(
+                &js_obj,
+                &"ballparkClientEarlyOffset".into(),
+                &js_ballpark_client_early_offset,
+            )?;
+            let js_ballpark_client_late_offset = ballpark_client_late_offset.into();
+            Reflect::set(
+                &js_obj,
+                &"ballparkClientLateOffset".into(),
+                &js_ballpark_client_late_offset,
+            )?;
+        }
+    }
+    Ok(js_obj)
+}
+
 // ClientGetTosError
 
 #[allow(dead_code)]
@@ -5675,6 +5764,123 @@ fn variant_greet_in_progress_error_rs_to_js(
                 &js_obj,
                 &"tag".into(),
                 &"GreetInProgressErrorUserCreateNotAllowed".into(),
+            )?;
+        }
+    }
+    Ok(js_obj)
+}
+
+// ImportRecoveryDeviceError
+
+#[allow(dead_code)]
+fn variant_import_recovery_device_error_rs_to_js(
+    rs_obj: libparsec::ImportRecoveryDeviceError,
+) -> Result<JsValue, JsValue> {
+    let js_obj = Object::new().into();
+    let js_display = &rs_obj.to_string();
+    Reflect::set(&js_obj, &"error".into(), &js_display.into())?;
+    match rs_obj {
+        libparsec::ImportRecoveryDeviceError::DecryptionFailed { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ImportRecoveryDeviceErrorDecryptionFailed".into(),
+            )?;
+        }
+        libparsec::ImportRecoveryDeviceError::Internal { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ImportRecoveryDeviceErrorInternal".into(),
+            )?;
+        }
+        libparsec::ImportRecoveryDeviceError::InvalidCertificate { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ImportRecoveryDeviceErrorInvalidCertificate".into(),
+            )?;
+        }
+        libparsec::ImportRecoveryDeviceError::InvalidData { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ImportRecoveryDeviceErrorInvalidData".into(),
+            )?;
+        }
+        libparsec::ImportRecoveryDeviceError::InvalidPassphrase { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ImportRecoveryDeviceErrorInvalidPassphrase".into(),
+            )?;
+        }
+        libparsec::ImportRecoveryDeviceError::InvalidPath { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ImportRecoveryDeviceErrorInvalidPath".into(),
+            )?;
+        }
+        libparsec::ImportRecoveryDeviceError::Offline { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ImportRecoveryDeviceErrorOffline".into(),
+            )?;
+        }
+        libparsec::ImportRecoveryDeviceError::Stopped { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ImportRecoveryDeviceErrorStopped".into(),
+            )?;
+        }
+        libparsec::ImportRecoveryDeviceError::TimestampOutOfBallpark {
+            server_timestamp,
+            client_timestamp,
+            ballpark_client_early_offset,
+            ballpark_client_late_offset,
+            ..
+        } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ImportRecoveryDeviceErrorTimestampOutOfBallpark".into(),
+            )?;
+            let js_server_timestamp = {
+                let custom_to_rs_f64 = |dt: libparsec::DateTime| -> Result<f64, &'static str> {
+                    Ok((dt.as_timestamp_micros() as f64) / 1_000_000f64)
+                };
+                let v = match custom_to_rs_f64(server_timestamp) {
+                    Ok(ok) => ok,
+                    Err(err) => return Err(JsValue::from(TypeError::new(err.as_ref()))),
+                };
+                JsValue::from(v)
+            };
+            Reflect::set(&js_obj, &"serverTimestamp".into(), &js_server_timestamp)?;
+            let js_client_timestamp = {
+                let custom_to_rs_f64 = |dt: libparsec::DateTime| -> Result<f64, &'static str> {
+                    Ok((dt.as_timestamp_micros() as f64) / 1_000_000f64)
+                };
+                let v = match custom_to_rs_f64(client_timestamp) {
+                    Ok(ok) => ok,
+                    Err(err) => return Err(JsValue::from(TypeError::new(err.as_ref()))),
+                };
+                JsValue::from(v)
+            };
+            Reflect::set(&js_obj, &"clientTimestamp".into(), &js_client_timestamp)?;
+            let js_ballpark_client_early_offset = ballpark_client_early_offset.into();
+            Reflect::set(
+                &js_obj,
+                &"ballparkClientEarlyOffset".into(),
+                &js_ballpark_client_early_offset,
+            )?;
+            let js_ballpark_client_late_offset = ballpark_client_late_offset.into();
+            Reflect::set(
+                &js_obj,
+                &"ballparkClientLateOffset".into(),
+                &js_ballpark_client_late_offset,
             )?;
         }
     }
@@ -9685,6 +9891,45 @@ pub fn clientCreateWorkspace(client: u32, name: String) -> Promise {
     })
 }
 
+// client_export_recovery_device
+#[allow(non_snake_case)]
+#[wasm_bindgen]
+pub fn clientExportRecoveryDevice(client_handle: u32, device_label: String) -> Promise {
+    future_to_promise(async move {
+        let device_label = {
+            let custom_from_rs_string = |s: String| -> Result<_, String> {
+                libparsec::DeviceLabel::try_from(s.as_str()).map_err(|e| e.to_string())
+            };
+            custom_from_rs_string(device_label).map_err(|e| TypeError::new(e.as_ref()))
+        }?;
+        let ret = libparsec::client_export_recovery_device(client_handle, device_label).await;
+        Ok(match ret {
+            Ok(value) => {
+                let js_obj = Object::new().into();
+                Reflect::set(&js_obj, &"ok".into(), &true.into())?;
+                let js_value = {
+                    let (x1, x2) = value;
+                    let js_array = Array::new_with_length(2);
+                    let js_value = x1.into();
+                    js_array.push(&js_value);
+                    let js_value = JsValue::from(Uint8Array::from(x2.as_ref()));
+                    js_array.push(&js_value);
+                    js_array.into()
+                };
+                Reflect::set(&js_obj, &"value".into(), &js_value)?;
+                js_obj
+            }
+            Err(err) => {
+                let js_obj = Object::new().into();
+                Reflect::set(&js_obj, &"ok".into(), &false.into())?;
+                let js_err = variant_client_export_recovery_device_error_rs_to_js(err)?;
+                Reflect::set(&js_obj, &"error".into(), &js_err)?;
+                js_obj
+            }
+        })
+    })
+}
+
 // client_get_tos
 #[allow(non_snake_case)]
 #[wasm_bindgen]
@@ -10710,6 +10955,58 @@ pub fn greeterUserInitialDoWaitPeer(canceller: u32, handle: u32) -> Promise {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
                 let js_err = variant_greet_in_progress_error_rs_to_js(err)?;
+                Reflect::set(&js_obj, &"error".into(), &js_err)?;
+                js_obj
+            }
+        })
+    })
+}
+
+// import_recovery_device
+#[allow(non_snake_case)]
+#[wasm_bindgen]
+pub fn importRecoveryDevice(
+    config: Object,
+    recovery_device: Uint8Array,
+    passphrase: String,
+    device_label: String,
+    save_strategy: Object,
+) -> Promise {
+    future_to_promise(async move {
+        let config = config.into();
+        let config = struct_client_config_js_to_rs(config)?;
+
+        let recovery_device = recovery_device.to_vec();
+
+        let device_label = {
+            let custom_from_rs_string = |s: String| -> Result<_, String> {
+                libparsec::DeviceLabel::try_from(s.as_str()).map_err(|e| e.to_string())
+            };
+            custom_from_rs_string(device_label).map_err(|e| TypeError::new(e.as_ref()))
+        }?;
+        let save_strategy = save_strategy.into();
+        let save_strategy = variant_device_save_strategy_js_to_rs(save_strategy)?;
+
+        let ret = libparsec::import_recovery_device(
+            config,
+            &recovery_device.to_vec(),
+            passphrase,
+            device_label,
+            save_strategy,
+        )
+        .await;
+        Ok(match ret {
+            Ok(value) => {
+                let js_obj = Object::new().into();
+                Reflect::set(&js_obj, &"ok".into(), &true.into())?;
+                let js_value = struct_available_device_rs_to_js(value)?;
+                Reflect::set(&js_obj, &"value".into(), &js_value)?;
+                js_obj
+            }
+            Err(err) => {
+                let js_obj = Object::new().into();
+                Reflect::set(&js_obj, &"ok".into(), &false.into())?;
+                let js_err = variant_import_recovery_device_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }

--- a/cli/src/testenv_utils.rs
+++ b/cli/src/testenv_utils.rs
@@ -179,6 +179,8 @@ async fn register_new_user(
         None,
         None,
         None,
+        None,
+        None,
     ));
     log::trace!(
         "New user: user_id={}, human_handle={}, device_id={}",

--- a/cli/tests/integration/device_option.rs
+++ b/cli/tests/integration/device_option.rs
@@ -204,6 +204,8 @@ async fn create_second_device(
         None,
         None,
         None,
+        None,
+        None,
     ));
 
     let now = author.now();

--- a/client/src/plugins/libparsec/definitions.ts
+++ b/client/src/plugins/libparsec/definitions.ts
@@ -743,6 +743,46 @@ export type ClientEvent =
   | ClientEventWorkspaceWatchedEntryChanged
   | ClientEventWorkspacesSelfListChanged
 
+// ClientExportRecoveryDeviceError
+export enum ClientExportRecoveryDeviceErrorTag {
+    Internal = 'ClientExportRecoveryDeviceErrorInternal',
+    InvalidCertificate = 'ClientExportRecoveryDeviceErrorInvalidCertificate',
+    Offline = 'ClientExportRecoveryDeviceErrorOffline',
+    Stopped = 'ClientExportRecoveryDeviceErrorStopped',
+    TimestampOutOfBallpark = 'ClientExportRecoveryDeviceErrorTimestampOutOfBallpark',
+}
+
+export interface ClientExportRecoveryDeviceErrorInternal {
+    tag: ClientExportRecoveryDeviceErrorTag.Internal
+    error: string
+}
+export interface ClientExportRecoveryDeviceErrorInvalidCertificate {
+    tag: ClientExportRecoveryDeviceErrorTag.InvalidCertificate
+    error: string
+}
+export interface ClientExportRecoveryDeviceErrorOffline {
+    tag: ClientExportRecoveryDeviceErrorTag.Offline
+    error: string
+}
+export interface ClientExportRecoveryDeviceErrorStopped {
+    tag: ClientExportRecoveryDeviceErrorTag.Stopped
+    error: string
+}
+export interface ClientExportRecoveryDeviceErrorTimestampOutOfBallpark {
+    tag: ClientExportRecoveryDeviceErrorTag.TimestampOutOfBallpark
+    error: string
+    serverTimestamp: DateTime
+    clientTimestamp: DateTime
+    ballparkClientEarlyOffset: number
+    ballparkClientLateOffset: number
+}
+export type ClientExportRecoveryDeviceError =
+  | ClientExportRecoveryDeviceErrorInternal
+  | ClientExportRecoveryDeviceErrorInvalidCertificate
+  | ClientExportRecoveryDeviceErrorOffline
+  | ClientExportRecoveryDeviceErrorStopped
+  | ClientExportRecoveryDeviceErrorTimestampOutOfBallpark
+
 // ClientGetTosError
 export enum ClientGetTosErrorTag {
     Internal = 'ClientGetTosErrorInternal',
@@ -1407,6 +1447,70 @@ export type GreetInProgressError =
   | GreetInProgressErrorTimestampOutOfBallpark
   | GreetInProgressErrorUserAlreadyExists
   | GreetInProgressErrorUserCreateNotAllowed
+
+// ImportRecoveryDeviceError
+export enum ImportRecoveryDeviceErrorTag {
+    DecryptionFailed = 'ImportRecoveryDeviceErrorDecryptionFailed',
+    Internal = 'ImportRecoveryDeviceErrorInternal',
+    InvalidCertificate = 'ImportRecoveryDeviceErrorInvalidCertificate',
+    InvalidData = 'ImportRecoveryDeviceErrorInvalidData',
+    InvalidPassphrase = 'ImportRecoveryDeviceErrorInvalidPassphrase',
+    InvalidPath = 'ImportRecoveryDeviceErrorInvalidPath',
+    Offline = 'ImportRecoveryDeviceErrorOffline',
+    Stopped = 'ImportRecoveryDeviceErrorStopped',
+    TimestampOutOfBallpark = 'ImportRecoveryDeviceErrorTimestampOutOfBallpark',
+}
+
+export interface ImportRecoveryDeviceErrorDecryptionFailed {
+    tag: ImportRecoveryDeviceErrorTag.DecryptionFailed
+    error: string
+}
+export interface ImportRecoveryDeviceErrorInternal {
+    tag: ImportRecoveryDeviceErrorTag.Internal
+    error: string
+}
+export interface ImportRecoveryDeviceErrorInvalidCertificate {
+    tag: ImportRecoveryDeviceErrorTag.InvalidCertificate
+    error: string
+}
+export interface ImportRecoveryDeviceErrorInvalidData {
+    tag: ImportRecoveryDeviceErrorTag.InvalidData
+    error: string
+}
+export interface ImportRecoveryDeviceErrorInvalidPassphrase {
+    tag: ImportRecoveryDeviceErrorTag.InvalidPassphrase
+    error: string
+}
+export interface ImportRecoveryDeviceErrorInvalidPath {
+    tag: ImportRecoveryDeviceErrorTag.InvalidPath
+    error: string
+}
+export interface ImportRecoveryDeviceErrorOffline {
+    tag: ImportRecoveryDeviceErrorTag.Offline
+    error: string
+}
+export interface ImportRecoveryDeviceErrorStopped {
+    tag: ImportRecoveryDeviceErrorTag.Stopped
+    error: string
+}
+export interface ImportRecoveryDeviceErrorTimestampOutOfBallpark {
+    tag: ImportRecoveryDeviceErrorTag.TimestampOutOfBallpark
+    error: string
+    serverTimestamp: DateTime
+    clientTimestamp: DateTime
+    ballparkClientEarlyOffset: number
+    ballparkClientLateOffset: number
+}
+export type ImportRecoveryDeviceError =
+  | ImportRecoveryDeviceErrorDecryptionFailed
+  | ImportRecoveryDeviceErrorInternal
+  | ImportRecoveryDeviceErrorInvalidCertificate
+  | ImportRecoveryDeviceErrorInvalidData
+  | ImportRecoveryDeviceErrorInvalidPassphrase
+  | ImportRecoveryDeviceErrorInvalidPath
+  | ImportRecoveryDeviceErrorOffline
+  | ImportRecoveryDeviceErrorStopped
+  | ImportRecoveryDeviceErrorTimestampOutOfBallpark
 
 // InviteListItem
 export enum InviteListItemTag {
@@ -2985,6 +3089,10 @@ export interface LibParsecPlugin {
         client: Handle,
         name: EntryName
     ): Promise<Result<VlobID, ClientCreateWorkspaceError>>
+    clientExportRecoveryDevice(
+        client_handle: Handle,
+        device_label: DeviceLabel
+    ): Promise<Result<[string, Uint8Array], ClientExportRecoveryDeviceError>>
     clientGetTos(
         client: Handle
     ): Promise<Result<Tos, ClientGetTosError>>
@@ -3117,6 +3225,13 @@ export interface LibParsecPlugin {
         canceller: Handle,
         handle: Handle
     ): Promise<Result<UserGreetInProgress1Info, GreetInProgressError>>
+    importRecoveryDevice(
+        config: ClientConfig,
+        recovery_device: Uint8Array,
+        passphrase: string,
+        device_label: DeviceLabel,
+        save_strategy: DeviceSaveStrategy
+    ): Promise<Result<AvailableDevice, ImportRecoveryDeviceError>>
     isKeyringAvailable(
     ): Promise<boolean>
     listAvailableDevices(

--- a/libparsec/crates/client/src/certif/shamir_recovery_setup.rs
+++ b/libparsec/crates/client/src/certif/shamir_recovery_setup.rs
@@ -176,17 +176,10 @@ async fn create_shamir_recovery_device(
 ) -> Result<CreateShamirRecoveryDeviceOutcome, CertifShamirError> {
     let author = &certificate_ops.device;
 
-    let recovery_device = LocalDevice::generate_new_device(
-        certificate_ops.device.organization_addr.clone(),
-        certificate_ops.device.initial_profile,
-        certificate_ops.device.human_handle.clone(),
+    let recovery_device = LocalDevice::from_existing_device_for_user(
+        &author.clone(),
         DeviceLabel::try_from(format!("shamir-recovery-{timestamp}").as_str())
             .expect("Invalid device label"),
-        Some(certificate_ops.device.user_id),
-        None,
-        None,
-        None,
-        None,
     );
 
     let device_cert = DeviceCertificate {

--- a/libparsec/crates/client/src/client/mod.rs
+++ b/libparsec/crates/client/src/client/mod.rs
@@ -2,6 +2,7 @@
 
 #![allow(dead_code)]
 
+mod recovery_device;
 mod shamir_setup_create;
 mod tos;
 mod user_revoke;
@@ -44,7 +45,11 @@ use crate::{
 };
 use libparsec_client_connection::AuthenticatedCmds;
 use libparsec_platform_async::lock::Mutex as AsyncMutex;
+
 use libparsec_types::prelude::*;
+pub use recovery_device::{
+    import_recovery_device, ClientExportRecoveryDeviceError, ImportRecoveryDeviceError,
+};
 
 // Re-exposed for public API
 pub use crate::certif::{
@@ -532,6 +537,13 @@ impl Client {
 
     pub async fn accept_tos(&self, tos_updated_on: DateTime) -> Result<(), ClientAcceptTosError> {
         tos::accept_tos(self, tos_updated_on).await
+    }
+
+    pub async fn client_export_recovery_device(
+        &self,
+        device_label: DeviceLabel,
+    ) -> Result<(SecretKeyPassphrase, Vec<u8>), ClientExportRecoveryDeviceError> {
+        recovery_device::export_recovery_device(self, device_label).await
     }
 }
 

--- a/libparsec/crates/client/src/client/recovery_device.rs
+++ b/libparsec/crates/client/src/client/recovery_device.rs
@@ -1,0 +1,357 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use std::{path::Path, sync::Arc};
+
+use libparsec_client_connection::{AuthenticatedCmds, ConnectionError, ProxyConfig};
+use libparsec_platform_device_loader::{
+    get_default_key_file, save_device, PlatformImportRecoveryDeviceError, SaveDeviceError,
+};
+use libparsec_platform_storage::certificates::PerTopicLastTimestamps;
+use libparsec_protocol::authenticated_cmds::v4::device_create;
+use libparsec_types::{
+    AvailableDevice, DeviceLabel, DeviceSaveStrategy, LocalDevice, SecretKeyPassphrase,
+};
+
+use crate::{
+    greater_timestamp, CertifPollServerError, GreaterTimestampOffset, InvalidCertificateError,
+};
+use libparsec_types::prelude::*;
+
+use super::Client;
+
+pub async fn export_recovery_device(
+    client: &Client,
+    device_label: DeviceLabel,
+) -> Result<(SecretKeyPassphrase, Vec<u8>), ClientExportRecoveryDeviceError> {
+    let (passphrase, data, recovery_device) =
+        libparsec_platform_device_loader::export_recovery_device(&client.device, device_label)
+            .await;
+
+    // save recovery device
+    let latest_known_timestamp =
+        register_new_device(&client.cmds, &recovery_device, &client.device).await?;
+
+    let latest_known_timestamp = PerTopicLastTimestamps::new_for_common(latest_known_timestamp);
+
+    client
+        .certificates_ops
+        .poll_server_for_new_certificates(Some(&latest_known_timestamp))
+        .await
+        .map_err(|e| match e {
+            CertifPollServerError::Stopped => ClientExportRecoveryDeviceError::Stopped,
+            CertifPollServerError::Offline => ClientExportRecoveryDeviceError::Offline,
+            CertifPollServerError::InvalidCertificate(err) => {
+                ClientExportRecoveryDeviceError::InvalidCertificate(err)
+            }
+            CertifPollServerError::Internal(err) => err
+                .context("Cannot poll server for new certificates")
+                .into(),
+        })?;
+    Ok((passphrase, data))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ClientExportRecoveryDeviceError {
+    #[error("Component has stopped")]
+    Stopped,
+    #[error("Cannot reach the server")]
+    Offline,
+    #[error(transparent)]
+    Internal(#[from] anyhow::Error),
+
+    #[error("Our clock ({client_timestamp}) and the server's one ({server_timestamp}) are too far apart")]
+    TimestampOutOfBallpark {
+        server_timestamp: DateTime,
+        client_timestamp: DateTime,
+        ballpark_client_early_offset: f64,
+        ballpark_client_late_offset: f64,
+    },
+    #[error(transparent)]
+    InvalidCertificate(#[from] Box<InvalidCertificateError>),
+}
+
+impl From<RegisterNewDeviceError> for ClientExportRecoveryDeviceError {
+    fn from(value: RegisterNewDeviceError) -> Self {
+        match value {
+            RegisterNewDeviceError::Stopped => ClientExportRecoveryDeviceError::Stopped,
+            RegisterNewDeviceError::Offline => ClientExportRecoveryDeviceError::Offline,
+            RegisterNewDeviceError::Internal(error) => {
+                ClientExportRecoveryDeviceError::Internal(error)
+            }
+            RegisterNewDeviceError::TimestampOutOfBallpark {
+                server_timestamp,
+                client_timestamp,
+                ballpark_client_early_offset,
+                ballpark_client_late_offset,
+            } => ClientExportRecoveryDeviceError::TimestampOutOfBallpark {
+                server_timestamp,
+                client_timestamp,
+                ballpark_client_early_offset,
+                ballpark_client_late_offset,
+            },
+            RegisterNewDeviceError::InvalidCertificate(invalid_certificate_error) => {
+                ClientExportRecoveryDeviceError::InvalidCertificate(invalid_certificate_error)
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ImportRecoveryDeviceError {
+    #[error("Component has stopped")]
+    Stopped,
+    #[error("Cannot reach the server")]
+    Offline,
+    #[error(transparent)]
+    Internal(#[from] anyhow::Error),
+
+    #[error("Our clock ({client_timestamp}) and the server's one ({server_timestamp}) are too far apart")]
+    TimestampOutOfBallpark {
+        server_timestamp: DateTime,
+        client_timestamp: DateTime,
+        ballpark_client_early_offset: f64,
+        ballpark_client_late_offset: f64,
+    },
+    #[error(transparent)]
+    InvalidCertificate(#[from] Box<InvalidCertificateError>),
+    #[error("Cannot deserialize file content")]
+    InvalidData,
+    #[error("Passphrase format is invalid")]
+    InvalidPassphrase,
+    #[error("Failed to decrypt file content")]
+    DecryptionFailed,
+    #[error(transparent)]
+    InvalidPath(anyhow::Error),
+}
+
+impl From<PlatformImportRecoveryDeviceError> for ImportRecoveryDeviceError {
+    fn from(value: PlatformImportRecoveryDeviceError) -> Self {
+        match value {
+            PlatformImportRecoveryDeviceError::InvalidData => {
+                ImportRecoveryDeviceError::InvalidData
+            }
+            PlatformImportRecoveryDeviceError::InvalidPassphrase => {
+                ImportRecoveryDeviceError::InvalidPassphrase
+            }
+            PlatformImportRecoveryDeviceError::DecryptionFailed => {
+                ImportRecoveryDeviceError::DecryptionFailed
+            }
+        }
+    }
+}
+
+impl From<RegisterNewDeviceError> for ImportRecoveryDeviceError {
+    fn from(value: RegisterNewDeviceError) -> Self {
+        match value {
+            RegisterNewDeviceError::Stopped => ImportRecoveryDeviceError::Stopped,
+            RegisterNewDeviceError::Offline => ImportRecoveryDeviceError::Offline,
+            RegisterNewDeviceError::Internal(error) => ImportRecoveryDeviceError::Internal(error),
+            RegisterNewDeviceError::TimestampOutOfBallpark {
+                server_timestamp,
+                client_timestamp,
+                ballpark_client_early_offset,
+                ballpark_client_late_offset,
+            } => ImportRecoveryDeviceError::TimestampOutOfBallpark {
+                server_timestamp,
+                client_timestamp,
+                ballpark_client_early_offset,
+                ballpark_client_late_offset,
+            },
+            RegisterNewDeviceError::InvalidCertificate(invalid_certificate_error) => {
+                ImportRecoveryDeviceError::InvalidCertificate(invalid_certificate_error)
+            }
+        }
+    }
+}
+
+impl From<SaveDeviceError> for ImportRecoveryDeviceError {
+    fn from(value: SaveDeviceError) -> Self {
+        match value {
+            SaveDeviceError::InvalidPath(error) => ImportRecoveryDeviceError::InvalidPath(error),
+            SaveDeviceError::Internal(error) => ImportRecoveryDeviceError::Internal(error),
+        }
+    }
+}
+
+async fn register_new_device(
+    cmds: &AuthenticatedCmds,
+    new_device: &LocalDevice,
+    author: &LocalDevice,
+) -> Result<DateTime, RegisterNewDeviceError> {
+    // Loop is needed to deal with server requiring greater timestamp
+    let mut timestamp = author.now();
+
+    loop {
+        let outcome = internal_register_new_device(cmds, new_device, author, timestamp).await?;
+
+        match outcome {
+            DeviceInternalsOutcome::Done(timestamp) => return Ok(timestamp),
+            DeviceInternalsOutcome::RequireGreaterTimestamp(strictly_greater_than) => {
+                // TODO: handle `strictly_greater_than` out of the client ballpark by
+                // returning an error
+                timestamp = greater_timestamp(
+                    &author.time_provider,
+                    GreaterTimestampOffset::User,
+                    strictly_greater_than,
+                );
+            }
+        }
+    }
+}
+
+pub(crate) struct DeviceCertificatesBytes {
+    pub full: Bytes,
+    pub redacted: Bytes,
+}
+
+/// generates certificates for new device signed by author at now
+pub(crate) fn generate_new_device_certificates(
+    new_device: &LocalDevice,
+    author: &LocalDevice,
+    now: DateTime,
+) -> DeviceCertificatesBytes {
+    let device_cert = DeviceCertificate {
+        author: CertificateSignerOwned::User(author.device_id),
+        timestamp: now,
+        user_id: new_device.user_id,
+        device_id: new_device.device_id,
+        device_label: MaybeRedacted::Real(new_device.device_label.clone()),
+        verify_key: new_device.verify_key(),
+        algorithm: SigningKeyAlgorithm::Ed25519,
+    };
+
+    let device_certificate = device_cert.dump_and_sign(&author.signing_key).into();
+
+    let redacted_device_cert = device_cert.into_redacted();
+
+    let redacted_device_certificate = redacted_device_cert
+        .dump_and_sign(&author.signing_key)
+        .into();
+
+    DeviceCertificatesBytes {
+        full: device_certificate,
+        redacted: redacted_device_certificate,
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum RegisterNewDeviceError {
+    #[error("Component has stopped")]
+    Stopped,
+    #[error("Cannot reach the server")]
+    Offline,
+    #[error(transparent)]
+    Internal(#[from] anyhow::Error),
+    #[error("Our clock ({client_timestamp}) and the server's one ({server_timestamp}) are too far apart")]
+    TimestampOutOfBallpark {
+        server_timestamp: DateTime,
+        client_timestamp: DateTime,
+        ballpark_client_early_offset: f64,
+        ballpark_client_late_offset: f64,
+    },
+    #[error(transparent)]
+    InvalidCertificate(#[from] Box<InvalidCertificateError>),
+}
+
+impl From<ConnectionError> for RegisterNewDeviceError {
+    fn from(value: ConnectionError) -> Self {
+        match value {
+            ConnectionError::NoResponse(_) => Self::Offline,
+            err => Self::Internal(err.into()),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum DeviceInternalsOutcome {
+    Done(DateTime),
+    RequireGreaterTimestamp(DateTime),
+}
+
+async fn internal_register_new_device(
+    cmds: &AuthenticatedCmds,
+    new_device: &LocalDevice,
+    author: &LocalDevice,
+    now: DateTime,
+) -> Result<DeviceInternalsOutcome, RegisterNewDeviceError> {
+    let DeviceCertificatesBytes {
+        full: device_certificate,
+        redacted: redacted_device_certificate,
+    } = generate_new_device_certificates(new_device, author, now);
+    match cmds
+        .send(device_create::Req {
+            device_certificate,
+            redacted_device_certificate,
+        })
+        .await?
+    {
+        device_create::Rep::Ok => Ok(DeviceInternalsOutcome::Done(now)),
+        device_create::Rep::RequireGreaterTimestamp {
+            strictly_greater_than,
+        } =>
+        // The retry is handled by the caller
+        {
+            Ok(DeviceInternalsOutcome::RequireGreaterTimestamp(
+                strictly_greater_than,
+            ))
+        }
+        device_create::Rep::TimestampOutOfBallpark {
+            server_timestamp,
+            client_timestamp,
+            ballpark_client_early_offset,
+            ballpark_client_late_offset,
+            ..
+        } => Err(RegisterNewDeviceError::TimestampOutOfBallpark {
+            server_timestamp,
+            client_timestamp,
+            ballpark_client_early_offset,
+            ballpark_client_late_offset,
+        }),
+        bad_rep @ (device_create::Rep::UnknownStatus { .. }
+        | device_create::Rep::InvalidCertificate
+        | device_create::Rep::DeviceAlreadyExists) => {
+            Err(anyhow::anyhow!("Unexpected server response: {:?}", bad_rep).into())
+        }
+    }
+}
+
+pub async fn import_recovery_device(
+    config_dir: &Path,
+    recovery_device: &[u8],
+    passphrase: String,
+    device_label: DeviceLabel,
+    save_strategy: DeviceSaveStrategy,
+) -> Result<AvailableDevice, ImportRecoveryDeviceError> {
+    // 0) Load the recovery device
+
+    let recovery_device: Arc<_> = libparsec_platform_device_loader::import_recovery_device(
+        recovery_device,
+        passphrase.into(),
+    )
+    .await?
+    .into();
+    let cmds = AuthenticatedCmds::new(config_dir, recovery_device.clone(), ProxyConfig::default())?;
+
+    // We first register the new device to the server, and only then save it on disk.
+    // This is to ensure the device found on disk are always valid, however the drawback
+    // is it can lead to losing the device if something goes wrong between the two steps.
+    //
+    // This is considered acceptable given 1) the error window is small and
+    // 2) if this occurs, the user can always re-import the recovery device.
+
+    let new_device = LocalDevice::from_existing_device_for_user(&recovery_device, device_label);
+
+    // 1) Upload the device on the server
+
+    register_new_device(&cmds, &new_device, &recovery_device).await?;
+
+    // 2) Save the device on disk
+
+    let access = {
+        let key_file = get_default_key_file(config_dir, &new_device.device_id);
+        save_strategy.into_access(key_file)
+    };
+    let new_available_device = save_device(config_dir, &access, &new_device).await?;
+
+    Ok(new_available_device)
+}

--- a/libparsec/crates/client/src/invite/claimer.rs
+++ b/libparsec/crates/client/src/invite/claimer.rs
@@ -863,6 +863,8 @@ impl UserClaimInProgress3Ctx {
             Some(signing_key),
             Some(private_key),
             Some(self.0.time_provider.clone()),
+            None,
+            None,
         ));
 
         self.0.do_acknowledge().await?;

--- a/libparsec/crates/client/src/invite/organization.rs
+++ b/libparsec/crates/client/src/invite/organization.rs
@@ -66,6 +66,8 @@ pub async fn bootstrap_organization(
         None,
         None,
         None,
+        None,
+        None,
     ));
 
     let timestamp = device.now();

--- a/libparsec/crates/client/tests/unit/client/mod.rs
+++ b/libparsec/crates/client/tests/unit/client/mod.rs
@@ -7,6 +7,7 @@ mod list_users;
 mod list_workspace_users;
 mod list_workspaces;
 mod process_workspaces_needs;
+mod recovery;
 mod rename_workspace;
 mod revoke_user;
 mod shamir_setup_create;

--- a/libparsec/crates/client/tests/unit/client/recovery.rs
+++ b/libparsec/crates/client/tests/unit/client/recovery.rs
@@ -1,0 +1,117 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use crate::DeviceInfo;
+
+use libparsec_platform_device_loader::{get_default_key_file, load_device};
+use libparsec_tests_fixtures::prelude::*;
+use libparsec_types::prelude::*;
+
+use super::utils::client_factory;
+
+fn assert_device(info: &DeviceInfo, expected_device: impl TryInto<DeviceID>, env: &TestbedEnv) {
+    let (certif, _) = env.get_device_certificate(expected_device);
+
+    let DeviceInfo {
+        id,
+        device_label,
+        created_on,
+        created_by,
+    } = info;
+    p_assert_eq!(id, &certif.device_id);
+    let expected_device_label = match &certif.device_label {
+        MaybeRedacted::Real(device_label) => device_label,
+        MaybeRedacted::Redacted(_) => unreachable!(),
+    };
+    p_assert_eq!(device_label, expected_device_label);
+    p_assert_eq!(created_on, &certif.timestamp);
+    let expected_created_by = match &certif.author {
+        CertificateSignerOwned::User(author) => Some(author),
+        CertificateSignerOwned::Root => None,
+    };
+    p_assert_eq!(created_by.as_ref(), expected_created_by);
+}
+
+fn devices_belongs_to_same_user(dev1: &LocalDevice, dev2: &LocalDevice) -> bool {
+    dev1.organization_addr == dev2.organization_addr
+        && dev1.user_id == dev2.user_id
+        && dev1.human_handle == dev2.human_handle
+        && dev1.private_key == dev2.private_key
+        && dev1.initial_profile == dev2.initial_profile
+        && dev1.user_realm_id == dev2.user_realm_id
+        && dev1.user_realm_key == dev2.user_realm_key
+}
+
+#[parsec_test(testbed = "coolorg", with_server)]
+async fn ok(env: &TestbedEnv) {
+    // Part 1: create recovery device
+    let alice = env.local_device("alice@dev1");
+    let client = client_factory(&env.discriminant_dir, alice.clone()).await;
+
+    let config = client.config.clone();
+    let config_dir = config.config_dir.clone();
+    let recovery_device_label = DeviceLabel::try_from("recovery").unwrap();
+    let (passphrase, data) = client
+        .client_export_recovery_device(recovery_device_label.clone())
+        .await
+        .unwrap();
+    client.refresh_workspaces_list().await.unwrap();
+
+    // but why do you test workspace count ?
+    // it was the symptom of the keys not being
+    // properly transmitted to the new devices
+    let workspaces = client.list_workspaces().await;
+    p_assert_eq!(workspaces.len(), 1, "{:?}", workspaces);
+
+    let alice_devices = client
+        .list_user_devices("alice".parse().unwrap())
+        .await
+        .unwrap();
+    p_assert_eq!(alice_devices.len(), 3);
+    assert_device(&alice_devices[0], "alice@dev1", env);
+    assert_device(&alice_devices[1], "alice@dev2", env);
+    assert_eq!(alice_devices[2].device_label, recovery_device_label);
+
+    //  we lose access
+    client.stop().await;
+
+    // Part 2: import recovery device to get new device
+    let new_device_label = DeviceLabel::try_from("new_device").unwrap();
+    let save_strategy = DeviceSaveStrategy::Keyring;
+
+    let saved_device = libparsec_client::import_recovery_device(
+        &config_dir,
+        &data,
+        passphrase.to_string(),
+        new_device_label.clone(),
+        save_strategy.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Part 3: connect with new device
+
+    let access = {
+        let key_file = get_default_key_file(&env.discriminant_dir, &saved_device.device_id);
+        save_strategy.into_access(key_file)
+    };
+    let new_device = load_device(&env.discriminant_dir, &access).await.unwrap();
+    let client = client_factory(&env.discriminant_dir, new_device.clone()).await;
+
+    client.poll_server_for_new_certificates().await.unwrap();
+
+    let alice_devices = client.list_user_devices(client.user_id()).await.unwrap();
+    p_assert_eq!(alice_devices.len(), 4);
+
+    assert_device(&alice_devices[0], "alice@dev1", env);
+    assert_device(&alice_devices[1], "alice@dev2", env);
+    assert_eq!(alice_devices[2].device_label, recovery_device_label);
+    assert_eq!(alice_devices[3].device_label, new_device_label);
+
+    assert!(devices_belongs_to_same_user(&alice, &new_device));
+
+    client.refresh_workspaces_list().await.unwrap();
+    client.ensure_workspaces_bootstrapped().await.unwrap();
+
+    let workspaces = client.list_workspaces().await;
+    p_assert_eq!(workspaces.len(), 1, "{:?}", workspaces);
+}

--- a/libparsec/crates/client/tests/unit/workspace/file_transactions_stateful.rs
+++ b/libparsec/crates/client/tests/unit/workspace/file_transactions_stateful.rs
@@ -160,7 +160,7 @@ impl AsyncStateMachineTest for FileTransactionStateMachine {
             None,
             None,
             None,
-            None,
+            None,None,None,
         );
 
         let realm_id = VlobID::default();

--- a/libparsec/crates/client/tests/unit/workspace/file_transactions_stateful.rs
+++ b/libparsec/crates/client/tests/unit/workspace/file_transactions_stateful.rs
@@ -148,11 +148,12 @@ impl AsyncStateMachineTest for FileTransactionStateMachine {
             .await
             .unwrap();
 
+        let url = ParsecOrganizationAddr::from_any(
+            // cspell:disable-next-line
+            "parsec3://test.invalid:6770/Org?no_ssl=true&p=xCD7SjlysFv3d4mTkRu-ZddRjIZPGraSjUnoOHT9s8rmLA"
+        ).unwrap();
         let device = LocalDevice::generate_new_device(
-            ParsecOrganizationAddr::from_any(
-                // cspell:disable-next-line
-                "parsec3://127.0.0.1:6770/Org?no_ssl=true&p=xCD7SjlysFv3d4mTkRu-ZddRjIZPGraSjUnoOHT9s8rmLA"
-            ).unwrap(),
+            url,
             UserProfile::Admin,
             HumanHandle::new("alice@dev1", "alice").unwrap(),
             "alice label".parse().unwrap(),
@@ -160,7 +161,9 @@ impl AsyncStateMachineTest for FileTransactionStateMachine {
             None,
             None,
             None,
-            None,None,None,
+            None,
+            None,
+            None,
         );
 
         let realm_id = VlobID::default();

--- a/libparsec/crates/platform_device_loader/src/testbed.rs
+++ b/libparsec/crates/platform_device_loader/src/testbed.rs
@@ -249,6 +249,10 @@ pub(crate) fn maybe_load_device(
                             DeviceAccessStrategy::Smartcard { key_file: kf },
                             DeviceAccessStrategy::Smartcard { key_file: c_kf },
                         ) if c_kf == kf => Some(Ok(c_device.to_owned())),
+                        (
+                            DeviceAccessStrategy::Keyring { key_file: kf },
+                            DeviceAccessStrategy::Keyring { key_file: c_kf },
+                        ) if c_kf == kf => Some(Ok(c_device.to_owned())),
                         _ => None,
                     });
 

--- a/libparsec/crates/platform_device_loader/tests/change_auth.rs
+++ b/libparsec/crates/platform_device_loader/tests/change_auth.rs
@@ -15,11 +15,13 @@ async fn same_key_file(tmp_path: TmpPath) {
         key_file: key_file.clone(),
         password: "P@ssw0rd.".to_owned().into(),
     };
+    let url = ParsecOrganizationAddr::from_any(
+        // cspell:disable-next-line
+        "parsec3://test.invalid/Org?no_ssl=true&p=xCD7SjlysFv3d4mTkRu-ZddRjIZPGraSjUnoOHT9s8rmLA",
+    )
+    .unwrap();
     let device = LocalDevice::generate_new_device(
-        ParsecOrganizationAddr::from_any(
-            // cspell:disable-next-line
-            "parsec3://127.0.0.1:6770/Org?no_ssl=true&p=xCD7SjlysFv3d4mTkRu-ZddRjIZPGraSjUnoOHT9s8rmLA"
-        ).unwrap(),
+        url,
         UserProfile::Admin,
         HumanHandle::new("alice@dev1", "alice").unwrap(),
         "alice label".parse().unwrap(),
@@ -27,7 +29,9 @@ async fn same_key_file(tmp_path: TmpPath) {
         None,
         None,
         None,
-        None,None,None,
+        None,
+        None,
+        None,
     );
 
     // Sanity check
@@ -82,11 +86,13 @@ async fn different_key_file(tmp_path: TmpPath) {
         key_file: key_file.clone(),
         password: "P@ssw0rd.".to_owned().into(),
     };
+    let url = ParsecOrganizationAddr::from_any(
+        // cspell:disable-next-line
+        "parsec3://test.invalid/Org?no_ssl=true&p=xCD7SjlysFv3d4mTkRu-ZddRjIZPGraSjUnoOHT9s8rmLA",
+    )
+    .unwrap();
     let device = LocalDevice::generate_new_device(
-        ParsecOrganizationAddr::from_any(
-            // cspell:disable-next-line
-            "parsec3://127.0.0.1:6770/Org?no_ssl=true&p=xCD7SjlysFv3d4mTkRu-ZddRjIZPGraSjUnoOHT9s8rmLA"
-        ).unwrap(),
+        url,
         UserProfile::Admin,
         HumanHandle::new("alice@dev1", "alice").unwrap(),
         "alice label".parse().unwrap(),
@@ -94,7 +100,9 @@ async fn different_key_file(tmp_path: TmpPath) {
         None,
         None,
         None,
-        None,None,None,
+        None,
+        None,
+        None,
     );
 
     // Sanity check

--- a/libparsec/crates/platform_device_loader/tests/change_auth.rs
+++ b/libparsec/crates/platform_device_loader/tests/change_auth.rs
@@ -27,7 +27,7 @@ async fn same_key_file(tmp_path: TmpPath) {
         None,
         None,
         None,
-        None,
+        None,None,None,
     );
 
     // Sanity check
@@ -94,7 +94,7 @@ async fn different_key_file(tmp_path: TmpPath) {
         None,
         None,
         None,
-        None,
+        None,None,None,
     );
 
     // Sanity check

--- a/libparsec/crates/platform_device_loader/tests/recovery.rs
+++ b/libparsec/crates/platform_device_loader/tests/recovery.rs
@@ -15,18 +15,23 @@ use zeroize::Zeroizing;
 
 #[parsec_test]
 async fn test_ok_recovery() {
+    let url = ParsecOrganizationAddr::from_any(
+        // cspell:disable-next-line
+        "parsec3://test.invalid/Org?no_ssl=true&p=xCD7SjlysFv3d4mTkRu-ZddRjIZPGraSjUnoOHT9s8rmLA",
+    )
+    .unwrap();
     let local_device = LocalDevice::generate_new_device(
-        ParsecOrganizationAddr::from_any(
-            // cspell:disable-next-line
-            "parsec3://127.0.0.1:6770/Org?no_ssl=true&p=xCD7SjlysFv3d4mTkRu-ZddRjIZPGraSjUnoOHT9s8rmLA"
-        ).unwrap(),
+        url,
         UserProfile::Admin,
         HumanHandle::new("alice@dev1", "alice").unwrap(),
         "alice label".parse().unwrap(),
         None,
         None,
         None,
-        None,None,None,None,
+        None,
+        None,
+        None,
+        None,
     );
     let recovery_device_label = DeviceLabel::default();
     let (secret_passphrase, data, exported_recovery_device) =

--- a/libparsec/crates/platform_device_loader/tests/recovery.rs
+++ b/libparsec/crates/platform_device_loader/tests/recovery.rs
@@ -1,3 +1,66 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-// TODO !
+#![allow(clippy::unwrap_used)]
+
+use libparsec_platform_device_loader::{
+    export_recovery_device, import_recovery_device, PlatformImportRecoveryDeviceError,
+};
+use libparsec_tests_lite::p_assert_matches;
+use libparsec_tests_lite::parsec_test;
+use libparsec_types::HumanHandle;
+use libparsec_types::ParsecOrganizationAddr;
+use libparsec_types::UserProfile;
+use libparsec_types::{DeviceLabel, LocalDevice};
+use zeroize::Zeroizing;
+
+#[parsec_test]
+async fn test_ok_recovery() {
+    let local_device = LocalDevice::generate_new_device(
+        ParsecOrganizationAddr::from_any(
+            // cspell:disable-next-line
+            "parsec3://127.0.0.1:6770/Org?no_ssl=true&p=xCD7SjlysFv3d4mTkRu-ZddRjIZPGraSjUnoOHT9s8rmLA"
+        ).unwrap(),
+        UserProfile::Admin,
+        HumanHandle::new("alice@dev1", "alice").unwrap(),
+        "alice label".parse().unwrap(),
+        None,
+        None,
+        None,
+        None,None,None,None,
+    );
+    let recovery_device_label = DeviceLabel::default();
+    let (secret_passphrase, data, exported_recovery_device) =
+        export_recovery_device(&local_device, recovery_device_label.clone()).await;
+    let imported_recovery_device = import_recovery_device(&data, secret_passphrase.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(exported_recovery_device, imported_recovery_device);
+    assert_eq!(imported_recovery_device.device_label, recovery_device_label);
+
+    // It's convenient to also test the import bad cases here
+
+    // Invalid data
+    p_assert_matches!(
+        import_recovery_device(&b"dummy"[..], secret_passphrase.clone()).await,
+        Err(PlatformImportRecoveryDeviceError::InvalidData)
+    );
+
+    // Invalid passphrase
+
+    p_assert_matches!(
+        import_recovery_device(&data, Zeroizing::new("dummy".to_string())).await,
+        Err(PlatformImportRecoveryDeviceError::InvalidPassphrase)
+    );
+
+    // Decryption failed
+
+    p_assert_matches!(
+        import_recovery_device(
+            &data,
+            libparsec_types::SecretKey::generate_recovery_passphrase().0
+        )
+        .await,
+        Err(PlatformImportRecoveryDeviceError::DecryptionFailed)
+    );
+}

--- a/libparsec/crates/platform_device_loader/tests/save_load.rs
+++ b/libparsec/crates/platform_device_loader/tests/save_load.rs
@@ -13,11 +13,13 @@ use libparsec_types::prelude::*;
 #[parsec_test]
 async fn save_load(#[values("keyring", "password")] kind: &str, tmp_path: TmpPath) {
     let key_file = tmp_path.join("keyring_file");
+    let url = ParsecOrganizationAddr::from_any(
+        // cspell:disable-next-line
+        "parsec3://test.invalid/Org?no_ssl=true&p=xCD7SjlysFv3d4mTkRu-ZddRjIZPGraSjUnoOHT9s8rmLA",
+    )
+    .unwrap();
     let device = LocalDevice::generate_new_device(
-        ParsecOrganizationAddr::from_any(
-            // cspell:disable-next-line
-            "parsec3://127.0.0.1:6770/Org?no_ssl=true&p=xCD7SjlysFv3d4mTkRu-ZddRjIZPGraSjUnoOHT9s8rmLA"
-        ).unwrap(),
+        url,
         UserProfile::Admin,
         HumanHandle::new("alice@dev1", "alice").unwrap(),
         "alice label".parse().unwrap(),
@@ -25,7 +27,9 @@ async fn save_load(#[values("keyring", "password")] kind: &str, tmp_path: TmpPat
         None,
         None,
         None,
-        None,None,None,
+        None,
+        None,
+        None,
     );
 
     let (access, expected_available_device) = match kind {

--- a/libparsec/crates/platform_device_loader/tests/save_load.rs
+++ b/libparsec/crates/platform_device_loader/tests/save_load.rs
@@ -13,7 +13,6 @@ use libparsec_types::prelude::*;
 #[parsec_test]
 async fn save_load(#[values("keyring", "password")] kind: &str, tmp_path: TmpPath) {
     let key_file = tmp_path.join("keyring_file");
-
     let device = LocalDevice::generate_new_device(
         ParsecOrganizationAddr::from_any(
             // cspell:disable-next-line
@@ -26,7 +25,7 @@ async fn save_load(#[values("keyring", "password")] kind: &str, tmp_path: TmpPat
         None,
         None,
         None,
-        None,
+        None,None,None,
     );
 
     let (access, expected_available_device) = match kind {
@@ -38,7 +37,7 @@ async fn save_load(#[values("keyring", "password")] kind: &str, tmp_path: TmpPat
                 key_file_path: key_file.clone(),
                 created_on: "2000-01-01T00:00:00Z".parse().unwrap(),
                 protected_on: "2000-01-01T00:00:00Z".parse().unwrap(),
-                server_url: "http://127.0.0.1:6770/".to_string(),
+                server_url: "http://test.invalid/".to_string(),
                 organization_id: device.organization_id().to_owned(),
                 user_id: device.user_id,
                 device_id: device.device_id,
@@ -57,7 +56,7 @@ async fn save_load(#[values("keyring", "password")] kind: &str, tmp_path: TmpPat
                 key_file_path: key_file.clone(),
                 created_on: "2000-01-01T00:00:00Z".parse().unwrap(),
                 protected_on: "2000-01-01T00:00:00Z".parse().unwrap(),
-                server_url: "http://127.0.0.1:6770/".to_string(),
+                server_url: "http://test.invalid/".to_string(),
                 organization_id: device.organization_id().to_owned(),
                 user_id: device.user_id,
                 device_id: device.device_id,

--- a/libparsec/crates/platform_storage/tests/unit/native/sqlite_db_creation.rs
+++ b/libparsec/crates/platform_storage/tests/unit/native/sqlite_db_creation.rs
@@ -12,7 +12,7 @@ async fn should_create_db_file_and_reusable(tmp_path: TmpPath) {
     let device_id = "alice@dev1".parse().unwrap();
     let device = LocalDevice::generate_new_device(
         // cspell:disable-next-line
-        "parsec3://127.0.0.1:6770/Org?no_ssl=true&p=xCBs8zpdIwovR8EdliVVo2vUOmtumnfsI6Fdndjm0WconA"
+        "parsec3://test.invalid/Org?no_ssl=true&p=xCBs8zpdIwovR8EdliVVo2vUOmtumnfsI6Fdndjm0WconA"
             .parse()
             .unwrap(),
         UserProfile::Admin,

--- a/libparsec/crates/platform_storage/tests/unit/native/sqlite_db_creation.rs
+++ b/libparsec/crates/platform_storage/tests/unit/native/sqlite_db_creation.rs
@@ -23,6 +23,8 @@ async fn should_create_db_file_and_reusable(tmp_path: TmpPath) {
         None,
         None,
         None,
+        None,
+        None,
     );
 
     let sqlite_path = tmp_path

--- a/libparsec/crates/testbed/src/env.rs
+++ b/libparsec/crates/testbed/src/env.rs
@@ -642,7 +642,7 @@ impl TestbedEnv {
                 }
                 _ => None,
             })
-            .unwrap()
+            .unwrap_or_else(|| panic!("unable to find {device_id}"))
     }
 
     pub fn get_revoked_certificate(

--- a/libparsec/crates/types/src/local_device_file.rs
+++ b/libparsec/crates/types/src/local_device_file.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use libparsec_crypto::Password;
 use libparsec_serialization_format::parsec_data;
 
-use crate as libparsec_types;
+use crate::{self as libparsec_types};
 use crate::{
     impl_transparent_data_format_conversion, DateTime, DeviceID, DeviceLabel, HumanHandle,
     OrganizationID, UserID,
@@ -183,9 +183,26 @@ impl DeviceFileType {
     }
 }
 
+#[derive(Debug, Clone)]
+pub enum DeviceSaveStrategy {
+    Keyring,
+    Password { password: Password },
+    Smartcard,
+}
+
+impl DeviceSaveStrategy {
+    pub fn into_access(self, key_file: PathBuf) -> DeviceAccessStrategy {
+        match self {
+            DeviceSaveStrategy::Keyring => DeviceAccessStrategy::Keyring { key_file },
+            DeviceSaveStrategy::Password { password } => {
+                DeviceAccessStrategy::Password { key_file, password }
+            }
+            DeviceSaveStrategy::Smartcard => DeviceAccessStrategy::Smartcard { key_file },
+        }
+    }
+}
+
 /// Represent how to load/save a device file
-/// Note this is only for regular device given recovery device has dedicated
-/// import/export functions.
 #[derive(Debug, Clone, PartialEq)]
 pub enum DeviceAccessStrategy {
     Keyring {

--- a/libparsec/src/client.rs
+++ b/libparsec/src/client.rs
@@ -19,7 +19,7 @@ use crate::{
         borrow_from_handle, filter_close_handles, register_handle_with_init, take_and_close_handle,
         FilterCloseHandle, Handle, HandleItem,
     },
-    ClientConfig, ClientEvent, DeviceSaveStrategy, OnEventCallbackPlugged,
+    ClientConfig, ClientEvent, OnEventCallbackPlugged,
 };
 
 fn borrow_client(client: Handle) -> anyhow::Result<Arc<libparsec_client::Client>> {

--- a/libparsec/src/handle.rs
+++ b/libparsec/src/handle.rs
@@ -9,6 +9,7 @@ use libparsec_client::{
 use libparsec_platform_async::event::Event;
 use libparsec_types::prelude::*;
 
+/// Used to identify [HandleItem]
 pub type Handle = u32;
 const INVALID_HANDLE_ERROR_MSG: &str = "Invalid Handle";
 
@@ -22,9 +23,9 @@ pub(crate) struct EntryWatcher {
     // Never accessed, but we need to keep it alive
     #[allow(dead_code)]
     pub lifetimes: (
-        // Event triggered when a local change occured
+        // Event triggered when a local change occurred
         EventBusConnectionLifetime<EventWorkspaceOpsOutboundSyncNeeded>,
-        // Event triggered when a remote change occured
+        // Event triggered when a remote change occurred
         EventBusConnectionLifetime<EventWorkspaceOpsInboundSyncDone>,
     ),
 }

--- a/libparsec/src/invite.rs
+++ b/libparsec/src/invite.rs
@@ -1,6 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use std::{path::PathBuf, sync::Arc};
+use std::sync::Arc;
 
 pub use libparsec_client::{
     ClientCancelInvitationError, ClientNewDeviceInvitationError, ClientNewUserInvitationError,
@@ -12,25 +12,6 @@ use crate::{
     handle::{borrow_from_handle, register_handle, take_and_close_handle, Handle, HandleItem},
     listen_canceller, ClientConfig, ClientEvent, OnEventCallbackPlugged,
 };
-
-#[derive(Debug, Clone)]
-pub enum DeviceSaveStrategy {
-    Keyring,
-    Password { password: Password },
-    Smartcard,
-}
-
-impl DeviceSaveStrategy {
-    pub fn into_access(self, key_file: PathBuf) -> DeviceAccessStrategy {
-        match self {
-            DeviceSaveStrategy::Keyring => DeviceAccessStrategy::Keyring { key_file },
-            DeviceSaveStrategy::Password { password } => {
-                DeviceAccessStrategy::Password { key_file, password }
-            }
-            DeviceSaveStrategy::Smartcard => DeviceAccessStrategy::Smartcard { key_file },
-        }
-    }
-}
 
 /*
  * Bootstrap organization

--- a/libparsec/src/lib.rs
+++ b/libparsec/src/lib.rs
@@ -12,6 +12,7 @@ mod handle;
 mod invite;
 mod path;
 mod platform;
+mod recovery;
 mod testbed;
 mod validation;
 mod workspace;
@@ -25,6 +26,7 @@ pub use device::{archive_device, list_available_devices, ArchiveDeviceError};
 pub use events::*;
 pub use handle::Handle;
 pub use invite::*;
+pub use libparsec_client::{ClientExportRecoveryDeviceError, ImportRecoveryDeviceError};
 pub use libparsec_client_connection::*;
 pub use libparsec_platform_device_loader::{
     get_default_key_file, is_keyring_available, load_device, load_recovery_device, save_device,
@@ -34,6 +36,7 @@ pub use libparsec_platform_storage as storage;
 pub use libparsec_protocol::*;
 pub use path::*;
 pub use platform::*;
+pub use recovery::*;
 pub use testbed::*;
 pub use validation::*;
 pub use workspace::*;

--- a/libparsec/src/recovery.rs
+++ b/libparsec/src/recovery.rs
@@ -1,0 +1,40 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use libparsec_client::{ClientExportRecoveryDeviceError, ImportRecoveryDeviceError};
+use libparsec_types::DeviceSaveStrategy;
+use libparsec_types::{AvailableDevice, DeviceLabel};
+
+use crate::handle::{borrow_from_handle, HandleItem};
+use crate::ClientConfig;
+use crate::Handle;
+
+pub async fn import_recovery_device(
+    config: ClientConfig,
+    recovery_device: &[u8],
+    passphrase: String,
+    device_label: DeviceLabel,
+    save_strategy: DeviceSaveStrategy,
+) -> Result<AvailableDevice, ImportRecoveryDeviceError> {
+    libparsec_client::import_recovery_device(
+        &config.config_dir,
+        recovery_device,
+        passphrase,
+        device_label,
+        save_strategy,
+    )
+    .await
+}
+
+pub async fn client_export_recovery_device(
+    client_handle: Handle,
+    device_label: DeviceLabel,
+) -> Result<(String, Vec<u8>), ClientExportRecoveryDeviceError> {
+    let client = borrow_from_handle(client_handle, |x| match x {
+        HandleItem::Client { client, .. } => Some(client.clone()),
+        _ => None,
+    })?;
+
+    let (passphrase, data) = client.client_export_recovery_device(device_label).await?;
+
+    Ok((passphrase.to_string(), data))
+}


### PR DESCRIPTION
Fix #7044

- [x] agree on the interface, see below (thanks @Max-7)
- [x] Adapt/Implement low-level functions in libparsec crate `platform_device_loader` [^1]
  - Adapt existing functions to use bytes instead of paths
  - Since this is OS-agnostic, it could go in the common part (not native/web specific implementation)
- [ ] Adapt CLI existing commands to use the new low-level functions see #8805 
- [x] Implement high-level functions in libparsec 
- [x] Add tests to https://github.com/Scille/parsec-cloud/blob/aa583a0c3565e1e2b69c1e342789eafebe4f8fa0/libparsec/crates/platform_device_loader/tests/recovery.rs
  - Create a recovery device, import it, check if workspace is accessible
  - Bad data tests: wrong passphrase, etc.
  - Dump recovery device and use it in tests, to check for regression in future versions (can be done later, create an issue)
- [x] Expose high-level functions in bindings
  - Translate interface to Python for bindings
  - Create specific enum for error cases
  - Generate bindings

```rust
pub async fn import_recovery_device(
    recovery_device: Vec<u8>,
    passphrase: String,
    device_label: DeviceLabel,
    save_strategy: DeviceSaveStrategy,
) -> Result<AvailableDevice, ImportRecoveryDeviceError> {
    todo!()
}

pub async fn export_recovery_device(
    clientHandle: Handle
) -> Result<(String, Vec<u8>), ExportRecoveryDeviceError> {
    todo!()
}
```

[^1]: in the existing we are using paths because it's only used in the CLI see https://github.com/Scille/parsec-cloud/blob/1e819d6f2b2edb96a6ee7c51042cfd06d8f97962/libparsec/crates/platform_device_loader/src/lib.rs#L226-L241
, but that won't work with the GUI \o/