### PR TITLE
[MS] Adds spinner when loading workspaces and folders

### DIFF
--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -365,6 +365,7 @@
         "createWorkspace": "New workspace",
         "itemCount": "No items | 1 item | {count} items",
         "noWorkspaces": "You do not have access to any workspace yet. Workspaces that you create or have been shared with you will be listed here.",
+        "loading": "Loading your workspaces...",
         "noMatchingWorkspaces": "No workspace match this search filter.",
         "listError": "Failed to list the workspaces.",
         "newWorkspaceError": "Failed to create a new workspace.",
@@ -430,6 +431,7 @@
         "itemCount": "No items | 1 item | {count} items",
         "itemSelectedCount": "No selected items | 1 selected item | {count} selected items",
         "emptyFolder": "This folder is empty.",
+        "loading": "Loading the folder...",
         "listDisplayTitles": {
             "name": "Name",
             "updatedBy": "Updated By",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -365,6 +365,7 @@
         "createWorkspace": "Nouvel espace de travail",
         "itemCount": "Aucun élément | 1 élément | {count} éléments",
         "noWorkspaces": "Vous n'avez pas encore accès à un espace de travail. Les espaces de travail que vous créerez ou qui vous seront partagés s'afficheront ici.",
+        "loading": "Chargement de vos espaces de travail...",
         "noMatchingWorkspaces": "Aucun espace de travail ne correspond à cette recherche.",
         "listError": "Impossible de lister les espaces de travail.",
         "newWorkspaceError": "Impossible de créer le nouvel espace de travail.",
@@ -430,6 +431,7 @@
         "itemCount": "Aucun élément | Un élément | {count} éléments",
         "itemSelectedCount": "Aucun élément sélectionné | 1 élément sélectionné | {count} éléments sélectionnés",
         "emptyFolder": "Ce dossier est vide.",
+        "loading": "Chargement du dossier...",
         "listDisplayTitles": {
             "name": "Nom",
             "updatedBy": "Modifié par",

--- a/client/src/views/workspaces/WorkspacesPage.vue
+++ b/client/src/views/workspaces/WorkspacesPage.vue
@@ -42,7 +42,19 @@
       <!-- workspaces -->
       <div class="workspaces-container scroll">
         <div
-          v-if="filteredWorkspaces.length === 0"
+          v-show="querying"
+          class="body-lg"
+        >
+          <div class="no-workspaces-content">
+            <ms-spinner />
+            <ion-text>
+              {{ $msTranslate('WorkspacesPage.loading') }}
+            </ion-text>
+          </div>
+        </div>
+
+        <div
+          v-if="!querying && filteredWorkspaces.length === 0"
           class="no-workspaces body"
         >
           <div class="no-workspaces-content">
@@ -161,6 +173,7 @@ import {
   MsSorter,
   MsSorterChangeEvent,
   MsSearchInput,
+  MsSpinner,
 } from 'megashark-lib';
 import {
   WORKSPACES_PAGE_DATA_KEY,
@@ -223,6 +236,7 @@ const workspaceList: Ref<Array<WorkspaceInfo>> = ref([]);
 const displayView = ref(DisplayState.Grid);
 const favorites: Ref<WorkspaceID[]> = ref([]);
 const filterWorkspaceName = ref('');
+const querying = ref(true);
 
 const informationManager: InformationManager = inject(InformationManagerKey)!;
 const storageManager: StorageManager = inject(StorageManagerKey)!;
@@ -396,6 +410,7 @@ async function refreshWorkspacesList(): Promise<void> {
   if (!currentRouteIs(Routes.Workspaces)) {
     return;
   }
+  querying.value = true;
   const result = await parsecListWorkspaces();
   if (result.ok) {
     for (const wk of result.value) {
@@ -424,6 +439,7 @@ async function refreshWorkspacesList(): Promise<void> {
       PresentationMode.Toast,
     );
   }
+  querying.value = false;
 }
 
 const filteredWorkspaces = computed(() => {


### PR DESCRIPTION
Closes #8616 

You can test with the web version by adding a `await wait(5000)` at the start of `parsec/file.ts:statFolderChildren()` and `parsec/workspace.ts:listWorkspaces()` (import the function from parsec/internals.ts if needed).

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
 