### PR TITLE
[CLI] Make CLI command `organization create` directly take the organization ID instead of using the option `--organization-id`

### DIFF
--- a/cli/src/commands/organization/create.rs
+++ b/cli/src/commands/organization/create.rs
@@ -7,9 +7,8 @@ use crate::utils::*;
 crate::clap_parser_with_shared_opts_builder!(
     #[with = addr, token]
     pub struct Args {
-        /// OrganizationID
-        #[arg(short, long)]
-        organization_id: OrganizationID,
+        /// The organization name that will be created
+        organization: OrganizationID,
     }
 );
 
@@ -67,15 +66,15 @@ pub async fn create_organization_req(
 
 pub async fn main(args: Args) -> anyhow::Result<()> {
     let Args {
-        organization_id,
+        organization,
         token,
         addr,
     } = args;
-    log::trace!("Creating organization \"{organization_id}\" (addr={addr})");
+    log::trace!("Creating organization \"{organization}\" (addr={addr})");
 
     let mut handle = start_spinner("Creating organization".into());
 
-    let organization_addr = create_organization_req(&organization_id, &addr, &token).await?;
+    let organization_addr = create_organization_req(&organization, &addr, &token).await?;
 
     handle.stop_with_message(format!(
         "Organization bootstrap url: {YELLOW}{organization_addr}{RESET}"

--- a/cli/tests/integration/organization/create.rs
+++ b/cli/tests/integration/organization/create.rs
@@ -13,7 +13,6 @@ async fn create_organization(tmp_path: TmpPath) {
     crate::assert_cmd_success!(
         "organization",
         "create",
-        "--organization-id",
         unique_org_id().as_ref(),
         "--addr",
         &std::env::var(TESTBED_SERVER).unwrap(),

--- a/newsfragments/8620.feature.rst
+++ b/newsfragments/8620.feature.rst
@@ -1,0 +1,1 @@
+Make CLI command ``organization create`` directly take the organization ID instead of using the option `--organization-id`


### PR DESCRIPTION
Closes #8620, closes #8619