### PR TITLE
Rename the option `workspace_id` to `workspace` in the CLI command `workspace import`

### DIFF
--- a/cli/src/commands/workspace/import.rs
+++ b/cli/src/commands/workspace/import.rs
@@ -1,16 +1,13 @@
 use std::{path::PathBuf, vec};
 
-use libparsec::{anyhow::Context, FsPath, OpenOptions, VlobID};
+use libparsec::{anyhow::Context, FsPath, OpenOptions};
 use tokio::io::AsyncReadExt;
 
 use crate::utils::load_client;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin]
+    #[with = config_dir, device, password_stdin, workspace]
     pub struct Args {
-        /// Workspace id
-        #[arg(short, long, value_parser = VlobID::from_hex)]
-        workspace_id: VlobID,
         /// Local file to copy
         src: PathBuf,
         /// Workspace destination path
@@ -22,20 +19,20 @@ pub async fn main(args: Args) -> anyhow::Result<()> {
     let Args {
         src,
         dest,
-        workspace_id,
+        workspace,
         password_stdin,
         device,
         config_dir,
     } = args;
 
     log::trace!(
-        "workspace_import: {src} -> {workspace_id}:{dst}",
+        "workspace_import: {src} -> {workspace}:{dst}",
         src = src.display(),
         dst = dest
     );
 
     let client = load_client(&config_dir, device, password_stdin).await?;
-    let workspace = client.start_workspace(workspace_id).await?;
+    let workspace = client.start_workspace(workspace).await?;
     let fd = workspace
         .open_file(
             dest,

--- a/cli/tests/integration/workspace/import.rs
+++ b/cli/tests/integration/workspace/import.rs
@@ -41,7 +41,7 @@ async fn workspace_import_file(tmp_path: TmpPath) {
         "import",
         "--device",
         &alice.device_id.hex(),
-        "--workspace-id",
+        "--workspace",
         &wid.hex(),
         &file.to_string_lossy(),
         "/test.txt"

--- a/newsfragments/8622.feature.rst
+++ b/newsfragments/8622.feature.rst
@@ -1,0 +1,1 @@
+Rename the option ``workspace-id`` to ``workspace`` in the CLI command ``workspace import``.


### PR DESCRIPTION
Closes #8622
