### PR TITLE
Rename the option `workspace-id` to `workspace` in the CLI command `ls`

### DIFF
--- a/cli/src/commands/ls.rs
+++ b/cli/src/commands/ls.rs
@@ -1,11 +1,8 @@
-use libparsec::{FsPath, VlobID};
+use libparsec::FsPath;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin]
+    #[with = config_dir, device, password_stdin, workspace]
     pub struct Ls {
-        /// Workspace id
-        #[arg(short, long, value_parser = VlobID::from_hex)]
-        workspace_id: VlobID,
         /// Path to list
         path: Option<FsPath>,
     }
@@ -13,7 +10,7 @@ crate::clap_parser_with_shared_opts_builder!(
 
 pub async fn ls(args: Ls) -> anyhow::Result<()> {
     let Ls {
-        workspace_id,
+        workspace,
         path,
         password_stdin,
         device,
@@ -22,13 +19,13 @@ pub async fn ls(args: Ls) -> anyhow::Result<()> {
     let path = path.unwrap_or(FsPath::default());
 
     log::trace!(
-        "ls: {workspace_id}:{path:?}",
-        workspace_id = workspace_id,
+        "ls: {workspace}:{path:?}",
+        workspace = workspace,
         path = path
     );
 
     let client = crate::utils::load_client(&config_dir, device, password_stdin).await?;
-    let workspace = client.start_workspace(workspace_id).await?;
+    let workspace = client.start_workspace(workspace).await?;
     let entries = workspace.stat_folder_children(&path).await?;
 
     for (entry, _stat) in entries {

--- a/cli/tests/integration/ls.rs
+++ b/cli/tests/integration/ls.rs
@@ -43,7 +43,7 @@ async fn ls_files(tmp_path: TmpPath) {
         "ls",
         "--device",
         &alice.device_id.hex(),
-        "--workspace-id",
+        "--workspace",
         &wid.hex()
     )
     .stdout(predicates::str::contains("test.txt\n").and(predicates::str::contains("foo\n")));

--- a/newsfragments/8629.feature.rst
+++ b/newsfragments/8629.feature.rst
@@ -1,0 +1,1 @@
+Rename the option ``workspace-id`` to ``workspace`` in the CLI command ``ls``.


### PR DESCRIPTION
Closes #8629