### PR TITLE
Rename the option `user-id` to `user` in the CLI command `workspace share`

### DIFF
--- a/cli/src/commands/workspace/share.rs
+++ b/cli/src/commands/workspace/share.rs
@@ -7,9 +7,9 @@ use crate::utils::*;
 crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, device, workspace, password_stdin]
     pub struct Args {
-        /// Recipient id
+        /// The user ID to share the workspace with
         #[arg(short, long, value_parser = UserID::from_hex)]
-        user_id: UserID,
+        user: UserID,
         /// Role (owner/manager/contributor/reader)
         #[arg(short, long)]
         role: RealmRole,
@@ -19,14 +19,14 @@ crate::clap_parser_with_shared_opts_builder!(
 pub async fn main(args: Args) -> anyhow::Result<()> {
     let Args {
         workspace: wid,
-        user_id,
+        user,
         role,
         device,
         config_dir,
         password_stdin,
     } = args;
     log::trace!(
-        "Sharing workspace {wid} to {user_id} with role {role} (confdir={}, device={})",
+        "Sharing workspace {wid} to {user} with role {role} (confdir={}, device={})",
         config_dir.display(),
         device.as_deref().unwrap_or("N/A")
     );
@@ -34,7 +34,7 @@ pub async fn main(args: Args) -> anyhow::Result<()> {
     let client = load_client(&config_dir, device, password_stdin).await?;
     let mut handle = start_spinner("Sharing workspace".into());
 
-    client.share_workspace(wid, user_id, Some(role)).await?;
+    client.share_workspace(wid, user, Some(role)).await?;
 
     handle.stop_with_message("Workspace has been shared".into());
 

--- a/cli/tests/integration/workspace/share.rs
+++ b/cli/tests/integration/workspace/share.rs
@@ -42,7 +42,7 @@ async fn share_workspace(tmp_path: TmpPath) {
         &alice.device_id.hex(),
         "--workspace",
         &wid.hex(),
-        "--user-id",
+        "--user",
         &bob.user_id.hex(),
         "--role",
         "contributor"

--- a/newsfragments/8628.feature.rst
+++ b/newsfragments/8628.feature.rst
@@ -1,0 +1,1 @@
+Rename the option ``user-id`` to ``user`` in the CLI command ``workspace share``.


### PR DESCRIPTION
Closes #8628