### PR TITLE
Specify shell in all GitHub Actions workflows when needed

### DIFF
--- a/.github/actions/use-pre-commit/action.yml
+++ b/.github/actions/use-pre-commit/action.yml
@@ -49,13 +49,12 @@ runs:
     - name: Install pre-commit
       id: install-precommit
       if: steps.cache-pre-commit.outputs.cache-hit != 'true'
+      shell: bash -eux {0}
       run: |
-        set -eux
         mkdir -p ${{ inputs.install-dir }}
         curl --proto '=https' --tlsv1.2 -sSL \
           https://github.com/pre-commit/pre-commit/releases/download/v${{ inputs.version }}/pre-commit-${{ inputs.version }}.pyz \
           > ${{ inputs.install-dir }}/pre-commit.pyz
-      shell: bash
 
     - name: Debug installed python package
       run: |
@@ -83,9 +82,8 @@ runs:
 
     - name: Run pre-commit
       if: inputs.install-only != 'true'
+      shell: bash -ex {0}
       run: |
-        # Run pre-commit
-        set -x
         python \
           ${{ inputs.install-dir }}/pre-commit.pyz \
           run \
@@ -98,4 +96,3 @@ runs:
           ${{ inputs.config-file != '' && format('--config {0}', inputs.config-file) || '' }}
           ${{ steps.suggested-run.outputs.args }}
           ${{ inputs.extra-args }}
-      shell: bash

--- a/.github/workflows/_releaser_nightly_build.yml
+++ b/.github/workflows/_releaser_nightly_build.yml
@@ -46,10 +46,12 @@ jobs:
 
       - name: Get commit for nightly tag
         id: commit
+        shell: bash
         run: echo "id=$(git rev-parse HEAD)" | tee -a $GITHUB_OUTPUT
         timeout-minutes: 1
 
       - name: Parse version
         id: version
+        shell: bash
         run: python misc/releaser.py version | tee -a $GITHUB_OUTPUT
         timeout-minutes: 1

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -54,6 +54,7 @@ jobs:
         timeout-minutes: 2
 
       - name: Check if `*.po` were modified
+        shell: bash
         run: |
           if git status --porcelain | grep '**.po'; then
             # PO files were modified, the step fail

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -60,8 +60,8 @@ jobs:
         if: (!inputs.style-only)
         # GitHub Actions apt proxy is super unstable
         # see https://github.com/actions/runner-images/issues/7048
+        shell: bash -eux -o pipefail {0}
         run: |
-          set -eux -o pipefail
           COUNTRY=$(curl ipinfo.io | jq -r .country)
           MIRROR_FILE=$(mktemp)
           curl "http://mirrors.ubuntu.com/$COUNTRY.txt" > $MIRROR_FILE
@@ -76,9 +76,8 @@ jobs:
         if: (!inputs.style-only)
         env:
           POSTGRES_APT_KEY_SHA_512: df557805862cd279f40819834af14e1723b18044df9dc22bea710b6980c98cc8ed39e75ed5c9adaa1932992710f1180f0491dc9437bfd485b4aa2b75776407d4  /usr/share/keyrings/postgresql-keyring.gpg
+        shell: bash -ex -o pipefail {0}
         run: |
-          set -x -o pipefail
-
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc \
             | sudo gpg --dearmor --output /usr/share/keyrings/postgresql-keyring.gpg
 
@@ -154,9 +153,8 @@ jobs:
         timeout-minutes: 5
 
       - name: Install python deps
-        shell: bash
+        shell: bash -ex {0}
         run: |
-          set -ex
           poetry --directory ./server env info
           if ${{ env.SKIP_EXT_BUILD }}; then export POETRY_LIBPARSEC_BUILD_STRATEGY=no_build; fi
           python make.py python-ci-install
@@ -180,8 +178,8 @@ jobs:
           install-only: true
 
       - name: Check python code style
+        shell: bash -eux {0}
         run: |
-          set -eux
           for step in black ruff pyright ${{ !inputs.style-only && 'sqlfluff' || '' }}; do
             python \
               ${{ steps.pre-commit.outputs.install-path }} \

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -108,6 +108,7 @@ jobs:
 
       - name: Categorize workspace crates
         id: crates
+        shell: bash
         run: |
           (
             for type in agnostic platform bindings; do
@@ -168,7 +169,8 @@ jobs:
 
       - name: Retrieve clippy args
         id: clippy-args
-        run: yq -r '"args=" + (.repos | map(.hooks) | flatten | map(select(.id == "clippy")) | first | .args | join(" "))' .pre-commit-config.yaml | tee -a $GITHUB_OUTPUT
+        shell: bash
+        run: yq -r '"args=" + (.repos | map(.hooks) | flatten | map(select(.id == "clippy"))[0] | .args | join(" "))' .pre-commit-config.yaml | tee -a $GITHUB_OUTPUT
         timeout-minutes: 1
 
       - name: Check rust code format
@@ -178,8 +180,8 @@ jobs:
       - name: SQL lint
         # Cannot use `./misc/lint_sql.py` here since it would require us to install the
         # whole Python server project.
+        shell: bash -eux {0}
         run: |
-          set -eux
           pipx install sqlfluff
           sqlfluff lint --disable-progress-bar --config libparsec/crates/platform_storage/src/native/sql/.sqlfluff  libparsec/crates/platform_storage/src/native/sql/
 
@@ -248,9 +250,8 @@ jobs:
 
       - name: Install winfsp
         if: startsWith(matrix.os, 'windows')
-        shell: bash
+        shell: bash -eux {0}
         run: |
-          set -eux
           choco install winfsp -y --version=${{ env.WINFSP_VERSION }}
           curl -L https://github.com/winfsp/winfsp/releases/download/v2.0/winfsp-tests-${{ env.WINFSP_VERSION }}.zip -o D:/a/_temp/winfsp-tests.zip
           unzip D:/a/_temp/winfsp-tests.zip -d D:/a/_temp/
@@ -267,9 +268,8 @@ jobs:
           tool: nextest@0.9.54
 
       - name: Check rust agnostic codebase
-        shell: bash
+        shell: bash -ex {0}
         run: |
-          set -x
           NON_BINDINGS_CRATES=`python3 misc/libparsec_crates_flags.py agnostic platform`
           cargo check ${{ env.CARGO_CI_FLAGS }} $NON_BINDINGS_CRATES --features use-sodiumoxide
         timeout-minutes: 15 # It can be very slow if cache has missed
@@ -283,9 +283,8 @@ jobs:
         timeout-minutes: 10
 
       - name: Test Rust platform codebase with sodium
-        shell: bash
+        shell: bash -ex -o pipefail {0}
         run: |
-          set -x
           PLATFORM_CRATES=`python3 misc/libparsec_crates_flags.py platform`
           if [[ '${{ matrix.os }}' = macos* ]]; then
             # Mountpoint cannot be tested on macOS because it requires macFUSE installation,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,9 @@ jobs:
 
       - name: Determine which workflows need to be run
         id: need-check
+        shell: bash -eux -o pipefail {0}
         run: |
           env | grep NEED_CHECK_
-          set -eux -o pipefail
           for check in $(env | grep -o 'NEED_CHECK_[a-z_]\+' ); do
             env_value=$(eval "echo \${$check}")
             echo "${check#NEED_CHECK_}=$env_value"

--- a/.github/workflows/docker-server.yml
+++ b/.github/workflows/docker-server.yml
@@ -83,6 +83,7 @@ jobs:
 
       - name: Start docker test container
         id: test-container
+        shell: bash
         run: |
           (
             echo -n "id=";

--- a/.github/workflows/docker-testbed.yml
+++ b/.github/workflows/docker-testbed.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Get current version
         id: version
+        shell: bash
         run: python misc/releaser.py version --uniq-dev | tee -a $GITHUB_OUTPUT
         timeout-minutes: 1
 
@@ -89,6 +90,7 @@ jobs:
 
       - name: Start docker test container
         id: test-container
+        shell: bash
         run: |
           (
             echo -n "id=";

--- a/.github/workflows/package-client.yml
+++ b/.github/workflows/package-client.yml
@@ -274,9 +274,8 @@ jobs:
 
       - name: Windows > Install WinFSP
         if: matrix.platform == 'windows'
-        shell: bash
+        shell: bash -eux {0}
         run: |
-          set -eux
           choco install winfsp -y --version=${{ env.WINFSP_VERSION }}
           curl -L https://github.com/winfsp/winfsp/releases/download/v2.0/winfsp-tests-${{ env.WINFSP_VERSION }}.zip -o D:/a/_temp/winfsp-tests.zip
           unzip D:/a/_temp/winfsp-tests.zip -d D:/a/_temp/

--- a/.github/workflows/package-server.yml
+++ b/.github/workflows/package-server.yml
@@ -109,9 +109,8 @@ jobs:
 
       - name: Hack the wheel macos version
         if: startsWith(matrix.os, 'macos-')
-        shell: bash
+        shell: bash -eux -o pipefail {0}
         run: |
-          set -eux
           # Old wheel name
           OLD_WHEEL_NAME=$(basename dist/parsec_cloud-*.whl)
           # Unzip the wheel

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,14 +62,14 @@ jobs:
 
       - name: Get tag version
         id: version
-        run: |
-          set -eux -o pipefail
-          gh release \
-            --repo=${{ github.server_url }}/${{ github.repository }} \
-            download \
-            ${{ env.RELEASE_TAG }} \
-            --pattern=version \
-            --output=- | tee -a $GITHUB_OUTPUT
+        shell: bash -eux -o pipefail {0}
+        run: >-
+          gh release
+          --repo=${{ github.server_url }}/${{ github.repository }}
+          download
+          ${{ env.RELEASE_TAG }}
+          --pattern=version
+          --output=- | tee -a $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ github.token }}
         timeout-minutes: 2
@@ -109,8 +109,8 @@ jobs:
 
       - name: Get releases for snapcraft
         id: snapcraft-channels
-        run: |
-          set -o pipefail
+        shell: bash
+        run: >-
           (
             echo -n "channels=";
             python misc/snapcraft_releases.py ${{ inputs.nightly && '--nightly' || '' }} ${{ steps.version.outputs.full }}
@@ -118,6 +118,7 @@ jobs:
         timeout-minutes: 1
 
       - name: Check that snapcraft credential is not empty
+        shell: bash
         run: test $(printenv SNAPCRAFT_STORE_CREDENTIALS | wc -c | tee /dev/stderr) -gt 10
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_CREDENTIALS }}

--- a/libparsec/crates/platform_device_loader/tests/archive.rs
+++ b/libparsec/crates/platform_device_loader/tests/archive.rs
@@ -24,7 +24,7 @@ async fn archive_ok(tmp_path: TmpPath, env: &TestbedEnv) {
 
     // 3. Check that the device as been archived.
     assert!(!key_file.exists(), "Device file should have been archived");
-    let expected_archive_path = key_file.with_extension(format!("device.archived"));
+    let expected_archive_path = key_file.with_extension("device.archived");
     assert!(
         expected_archive_path.exists(),
         "Device file should have been archived at the expected location ({})",


### PR DESCRIPTION
Summary
-------

- `shell: bash` was added when a run command used pipes (including command that used `set -e -o pipefail`).

   For the documentation: <https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference>

   Setting `shell` to that value will automatically add the `-o pipefail` (alongside `-e`)

- `shell: bash ... {0}` was used for run commands that used `set ...`

Fixes
-----

- Fix `yq` syntax (GA use `yq-go` not `yq` (the python wrapper of `jq`))