### PR TITLE
[MS] Avoid displaying mock values when logging out

### DIFF
--- a/client/src/router/checks.ts
+++ b/client/src/router/checks.ts
@@ -55,3 +55,16 @@ export function currentRouteIsOrganizationManagementRoute(): boolean {
 export function currentRouteIsFileRoute(): boolean {
   return currentRouteIsOneOf([Routes.Documents, Routes.Workspaces]);
 }
+
+export function currentRouteIsLoggedRoute(): boolean {
+  return currentRouteIsOneOf([
+    Routes.Workspaces,
+    Routes.Documents,
+    Routes.Users,
+    Routes.Storage,
+    Routes.Organization,
+    Routes.About,
+    Routes.MyProfile,
+    Routes.RecoveryExport,
+  ]);
+}

--- a/client/src/views/header/HeaderPage.vue
+++ b/client/src/views/header/HeaderPage.vue
@@ -125,6 +125,7 @@ import {
   navigateTo,
   routerGoBack,
   watchRoute,
+  currentRouteIsLoggedRoute,
 } from '@/router';
 import { HotkeyGroup, HotkeyManager, HotkeyManagerKey, Modifiers, Platforms } from '@/services/hotkeyManager';
 import { InformationManager, InformationManagerKey } from '@/services/informationManager';
@@ -160,6 +161,9 @@ const informationManager: InformationManager = inject(InformationManagerKey)!;
 const notificationCenterButton = ref();
 
 const routeWatchCancel = watchRoute(async () => {
+  if (!currentRouteIsLoggedRoute()) {
+    return;
+  }
   const result = await getClientInfo();
   if (result.ok) {
     userInfo.value = result.value;

--- a/client/src/views/users/UsersPage.vue
+++ b/client/src/views/users/UsersPage.vue
@@ -134,7 +134,7 @@ import {
   revokeUser as parsecRevokeUser,
   InvitationStatus,
 } from '@/parsec';
-import { Routes, getCurrentRouteQuery, watchRoute } from '@/router';
+import { Routes, getCurrentRouteQuery, watchRoute, currentRouteIsUserRoute } from '@/router';
 import { HotkeyGroup, HotkeyManager, HotkeyManagerKey, Modifiers, Platforms } from '@/services/hotkeyManager';
 import { Information, InformationLevel, InformationManager, InformationManagerKey, PresentationMode } from '@/services/informationManager';
 import { StorageManager, StorageManagerKey } from '@/services/storageManager';
@@ -464,6 +464,9 @@ async function refreshUserList(): Promise<void> {
 }
 
 const routeWatchCancel = watchRoute(async () => {
+  if (!currentRouteIsUserRoute()) {
+    return;
+  }
   const query = getCurrentRouteQuery();
   if (query.openInvite) {
     await inviteUser();

--- a/newsfragments/8652.bugfix.rst
+++ b/newsfragments/8652.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed mocked values being sometimes displayed when logging out


### PR DESCRIPTION
App could sometimes display the mock values when logging out. This is due to unchecked watchers on the global route. For example:
1. the user pages watches the route for changes
2. the user logs out, which changes the route to /home
3. the watcher gets triggered
4. the page tries to load the data but we have no connection handle, so we load the mock values
The fix is just to make sure the current route is the right one (Routes.Users in this example).

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
