### PR TITLE
Fix start-parsec link in index.html

### DIFF
--- a/server/parsec/templates/index.html
+++ b/server/parsec/templates/index.html
@@ -13,7 +13,7 @@
     <ul class="text-left text-muted">
       <!-- HTML links that open in a new tab or window allow the target page to access the DOM of the
         origin page using window.opener unless link type noopener or noreferrer is specified. -->
-      <li><a href="https://www.parsec.cloud/get-parsec" rel="noopener noreferrer" target="_blank">Install the Parsec
+      <li><a href="https://parsec.cloud/en/start-parsec" rel="noopener noreferrer" target="_blank">Install the Parsec
           client</a></li>
       <li><a href="https://docs.parsec.cloud" rel="noopener noreferrer" target="_blank">Have a look at the
           documentation</a></li>


### PR DESCRIPTION
No issue nor newsfragment required, this page isn't really used in practice.