### PR TITLE
Update hosting script to be more robust

### DIFF
--- a/docs/hosting/deployment/gen-admin-token.sh
+++ b/docs/hosting/deployment/gen-admin-token.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 ENV_FILE=parsec-admin-token.env
 if [ ! -f $ENV_FILE ]; then

--- a/docs/hosting/deployment/parsec-server.docker.yaml
+++ b/docs/hosting/deployment/parsec-server.docker.yaml
@@ -6,6 +6,9 @@ services:
       POSTGRES_USER: DB_USER
       POSTGRES_PASSWORD: DB_PASS
       POSTGRES_DB: parsec
+    ports:
+      # Expose PostgreSQL to localhost
+      - 127.0.0.1:5432:5432
     volumes:
       - parsec-db-data:/var/lib/postgresql/data
 
@@ -19,6 +22,8 @@ services:
     ports:
       # Admin console exposed to https://127.0.0.1:9090
       - 127.0.0.1:9090:9090
+      # Expose S3 API to localhost
+      - 127.0.0.1:9000:9000
     volumes:
       - parsec-object-data:/data
       - ./parsec-s3.key:/opts/certs/private.key:ro

--- a/docs/hosting/deployment/setup-tls.sh
+++ b/docs/hosting/deployment/setup-tls.sh
@@ -57,11 +57,13 @@ for service in parsec-{s3,server}; do
         generate_cert_conf $service DNS:$service,DNS:localhost,IP:127.0.0.1
     fi
 
-    if [ ! -f $service.key ]; then
+    # Generate key + csr if missing or if the key is older than the conf
+    if [ ! -f $service.key ] || [ $service.key -ot $service.crt.conf ]; then
         generate_certificate_request $service
     fi
 
-    if [ ! -f $service.crt ]; then
+    # Generate crt if missing or if it's older than the csr or the custom CA
+    if [ ! -f $service.crt ] || [ $service.crt -ot $service.csr ] || [ $service.crt -ot custom-ca.key ]; then
         sign_crt_with_ca custom-ca.{crt,key} $service
     fi
 done


### PR DESCRIPTION
- `setup-tls`: The script now compare the date of the files used to generate the key and certificate to regenerate them if needed.
- `gen-admin-token`: Add `set -euo pipefail` to make the script more robust.