### PR TITLE
Add option to enable proxy header

### DIFF
--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -2,25 +2,24 @@
 
 # Hosting Server
 
-- [Hosting Server](#hosting-server)
-  - [Requirements](#requirements)
-  - [Hosting](#hosting)
-  - [Installation](#installation)
-  - [Run](#run)
-  - [Settings](#settings)
-    - [Host](#host)
-    - [Port](#port)
-    - [Database URL](#database-url)
-    - [Database connections](#database-connections)
-    - [Blockstore URL](#blockstore-url)
-    - [Administration token](#administration-token)
-    - [SSL](#ssl)
-    - [Logs](#logs)
-    - [Email](#email)
-    - [Webhooks](#webhooks)
-    - [SSE Keepalive](#sse-keepalive)
-    - [Sentry](#sentry)
-    - [Debug](#debug)
+- [Requirements](#requirements)
+- [Hosting](#hosting)
+- [Installation](#installation)
+- [Run](#run)
+- [Settings](#settings)
+  - [Host](#host)
+  - [Port](#port)
+  - [Database URL](#database-url)
+  - [Database connections](#database-connections)
+  - [Blockstore URL](#blockstore-url)
+  - [Administration token](#administration-token)
+  - [SSL](#ssl)
+  - [Logs](#logs)
+  - [Email](#email)
+  - [Webhooks](#webhooks)
+  - [SSE Keepalive](#sse-keepalive)
+  - [Sentry](#sentry)
+  - [Debug](#debug)
 
 ## Requirements
 
@@ -167,15 +166,6 @@ SSL key file. This setting enables serving Parsec over SSL.
 - Environ: ``PARSEC_SSL_CERTFILE``
 
 SSL certificate file. This setting enables serving Parsec over SSL.
-
-- ``--forward-proto-enforce-https``
-- Environ: ``PARSEC_FORWARD_PROTO_ENFORCE_HTTPS``
-
-Enforce HTTPS by redirecting incoming request that do not comply with the provided header.
-This is useful when running Parsec behind a forward proxy handing the SSL layer.
-You should *only* use this setting if you control your proxy or have some other
-guarantee that it sets/strips this header appropriately.
-Typical value for this setting should be `X-Forwarded-Proto:https`.
 
 ### Logs
 

--- a/docs/hosting/deployment/parsec.env
+++ b/docs/hosting/deployment/parsec.env
@@ -7,9 +7,6 @@ PARSEC_SSL_KEYFILE=/run/secrets/parsec-pem-key
 # The SSL certificate file.
 PARSEC_SSL_CERTFILE=/run/secrets/parsec-pem-crt
 
-# Enforce HTTPS by redirecting HTTP request.
-PARSEC_FORWARD_PROTO_ENFORCE_HTTPS=X-Forwarded-Proto:https
-
 # The granularity of Error log outputs.
 PARSEC_LOG_LEVEL=WARNING
 

--- a/newsfragments/8626.feature.rst
+++ b/newsfragments/8626.feature.rst
@@ -1,0 +1,1 @@
+Add server option ``--proxy-trusted-addresses`` to enable parsing of proxy headers from trusted addresses. By default, the server will trust the proxy headers from localhost.

--- a/server/packaging/server/template-prod.env.list
+++ b/server/packaging/server/template-prod.env.list
@@ -23,8 +23,6 @@ PARSEC_DB_MAX_CONNECTIONS=7
 # PARSEC_SSL_KEYFILE
 # The SSL certificate file.
 # PARSEC_SSL_CERTFILE
-# Enforce HTTPS by redirecting HTTP request.
-PARSEC_FORWARD_PROTO_ENFORCE_HTTPS=true
 
 # The granularity of Error log outputs.
 PARSEC_LOG_LEVEL=WARNING

--- a/server/parsec/cli/testbed.py
+++ b/server/parsec/cli/testbed.py
@@ -240,7 +240,7 @@ async def testbed_backend_factory(
         debug=True,
         db_config=db_config,
         sse_keepalive=30,
-        forward_proto_enforce_https=None,
+        proxy_trusted_addresses=[],
         server_addr=server_addr,
         email_config=MockedEmailConfig("no-reply@parsec.com", tmpdir),
         blockstore_config=blockstore_config,
@@ -343,7 +343,9 @@ def testbed_cmd(
 
                 app.state.testbed = testbed
                 app.state.backend = testbed.backend
-                await serve_parsec_asgi_app(host=host, port=port, app=app)
+                await serve_parsec_asgi_app(
+                    host=host, port=port, app=app, proxy_trusted_addresses=[]
+                )
 
                 click.echo("bye ;-)")
 

--- a/server/parsec/config.py
+++ b/server/parsec/config.py
@@ -177,7 +177,7 @@ class BackendConfig:
     blockstore_config: BaseBlockStoreConfig
 
     email_config: SmtpEmailConfig | MockedEmailConfig
-    forward_proto_enforce_https: tuple[str, str] | None
+    proxy_trusted_addresses: list[str]
     server_addr: ParsecAddr | None
 
     debug: bool

--- a/server/tests/common/backend.py
+++ b/server/tests/common/backend.py
@@ -11,7 +11,12 @@ from parsec.asgi import app as asgi_app
 from parsec.backend import Backend, backend_factory
 from parsec.cli.testbed import TestbedBackend, TestbedTemplate
 from parsec.components.memory.organization import MemoryOrganization, OrganizationID
-from parsec.config import BackendConfig, BaseBlockStoreConfig, BaseDatabaseConfig, MockedEmailConfig
+from parsec.config import (
+    BackendConfig,
+    BaseBlockStoreConfig,
+    BaseDatabaseConfig,
+    MockedEmailConfig,
+)
 from tests.common.postgresql import reset_postgresql_testbed
 
 SERVER_DOMAIN = "parsec.invalid"
@@ -33,7 +38,7 @@ def backend_config(
         debug=True,
         db_config=db_config,
         sse_keepalive=30,
-        forward_proto_enforce_https=None,
+        proxy_trusted_addresses=[],
         server_addr=ParsecAddr(hostname=SERVER_DOMAIN, port=None, use_ssl=True),
         email_config=MockedEmailConfig("no-reply@parsec.com", tmpdir),
         blockstore_config=blockstore_config,


### PR DESCRIPTION
Add a new option that configure the list of trusted address to parse the proxy headers from.
The parsing is handled by `uvicorn` which currently only support `x-forwarded-{for,proto}` headers.

Closes #8626, closes #8427