### PR TITLE
[MS] Fixed tos modal opening twice in some cases

### DIFF
--- a/client/src/components/sidebar/SidebarWorkspaceItem.vue
+++ b/client/src/components/sidebar/SidebarWorkspaceItem.vue
@@ -45,7 +45,7 @@ onMounted(async () => {
 });
 
 onBeforeUnmount(async () => {
-  itemRef.value.removeEventListener('contextmenu');
+  itemRef.value.$el.removeEventListener('contextmenu');
 });
 </script>
 


### PR DESCRIPTION
AcceptTOSEvent are sent twice. The GUI did account for this in two ways:
1. Events while the accept modal itself is opened are ignored
2. It keeps track of the last TOS accepted (using the date) and if the TOS have not changed at the next event, it discards the event

When testing locally, we always ended up in the first case: modal was already opened anyway, so we would just discard the event. But with a distant server and some latency, we can enter the second case, and sadly, the comparaison between the two dates did not work (=== can't be used between two luxon DateTime it seems).

It can be replicated locally by adding some latency:
`tc qdisc add dev lo root handle 1:0 netem delay 400msec`
and
`tc qdisc del dev lo root` to clear it.

Also fixes an error when trying to clear and event listener, lowers the timeout for opening the TOS Modal if the app was busy down from 1 minute to 10 seconds, fixes the error message not displayed properly, and replaces setInterval with timeout.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
