### PR TITLE
Keep using FORWARDED_ALLOW_IPS if PARSEC_PROXY_TRUSTED_ADDRESSES is not provided

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -214,6 +214,7 @@ gsettings
 gtod
 guce
 guci
+gunicorn
 hashdigest
 hasnt
 hatin'

--- a/docs/hosting/deployment/index.rst
+++ b/docs/hosting/deployment/index.rst
@@ -389,6 +389,8 @@ Running behind a reverse proxy
 
 To run Parsec behind a reverse proxy you will need to add the option ``--proxy-trusted-address`` or set the environment variable ``PARSEC_PROXY_TRUSTED_ADDRESS`` to the address of the reverse proxy (e.g.: ``localhost``).
 
+If this option is not set, the gunicorn/uvicorn `FORWARDED_ALLOW_IPS` environment variable is used, defaulting to trusting only localhost if absent.
+
 .. tip::
 
   You can provide multiple addresses by separating them with a comma.

--- a/server/parsec/asgi/__init__.py
+++ b/server/parsec/asgi/__init__.py
@@ -65,7 +65,7 @@ async def serve_parsec_asgi_app(
     app: AsgiApp,
     host: str,
     port: int,
-    proxy_trusted_addresses: list[str],
+    proxy_trusted_addresses: str | None,
     ssl_certfile: Path | None = None,
     ssl_keyfile: Path | None = None,
     workers: int | None = None,
@@ -98,8 +98,11 @@ async def serve_parsec_asgi_app(
         # When enabled, is restricted to only trusting connecting IPs in forwarded-allow-ips.
         # See: https://www.uvicorn.org/settings/#http
         # Currently uvicorn only supports X-Forwarded-* headers (https://github.com/encode/uvicorn/issues/2237)
-        proxy_headers=(proxy_trusted_addresses != []),
+        # TODO: expose this setting to the user so it can be disabled.
+        proxy_headers=True,
         # Comma separated list of IP Addresses, IP Networks, or literals (e.g. UNIX Socket path) to trust with proxy headers
+        # Use "*" to trust all proxies. If not provided, the gunicorn/uvicorn `FORWARDED_ALLOW_IPS`
+        # environment variable is used, defaulting to trusting only localhost if absent.
         forwarded_allow_ips=proxy_trusted_addresses,
         # Disable lifespan events, we don't need them for the moment
         # and they can cause CancelledError to bubble up in some cases

--- a/server/parsec/cli/run.py
+++ b/server/parsec/cli/run.py
@@ -280,13 +280,13 @@ For instance: `en_US:https://example.com/tos_en,fr_FR:https://example.com/tos_fr
 )
 @click.option(
     "--proxy-trusted-addresses",
-    default=["localhost", "127.0.0.1", "::1"],
     envvar="PARSEC_PROXY_TRUSTED_ADDRESSES",
-    callback=lambda ctx, param, value: [item.strip() for item in str(value).split(",")],
+    type=str,
     show_envvar=True,
     help="""\b
         Comma-separated list of IP Addresses, IP Networks or literals to trust with proxy headers.
-        Set this value to allow the server to use the forwarded headers from those clients.
+        Use "*" to trust all proxies. If not provided, the gunicorn/uvicorn `FORWARDED_ALLOW_IPS`
+        environment variable is used, defaulting to trusting only localhost if absent.
         """,
 )
 @click.option(
@@ -355,7 +355,7 @@ def run_cmd(
     email_use_ssl: bool,
     email_use_tls: bool,
     email_sender: str | None,
-    proxy_trusted_addresses: list[str],
+    proxy_trusted_addresses: str | None,
     ssl_keyfile: Path | None,
     ssl_certfile: Path | None,
     log_level: LogLevel,

--- a/server/parsec/cli/testbed.py
+++ b/server/parsec/cli/testbed.py
@@ -240,7 +240,7 @@ async def testbed_backend_factory(
         debug=True,
         db_config=db_config,
         sse_keepalive=30,
-        proxy_trusted_addresses=[],
+        proxy_trusted_addresses=None,
         server_addr=server_addr,
         email_config=MockedEmailConfig("no-reply@parsec.com", tmpdir),
         blockstore_config=blockstore_config,
@@ -344,7 +344,10 @@ def testbed_cmd(
                 app.state.testbed = testbed
                 app.state.backend = testbed.backend
                 await serve_parsec_asgi_app(
-                    host=host, port=port, app=app, proxy_trusted_addresses=[]
+                    host=host,
+                    port=port,
+                    app=app,
+                    proxy_trusted_addresses=None,
                 )
 
                 click.echo("bye ;-)")

--- a/server/parsec/config.py
+++ b/server/parsec/config.py
@@ -177,7 +177,7 @@ class BackendConfig:
     blockstore_config: BaseBlockStoreConfig
 
     email_config: SmtpEmailConfig | MockedEmailConfig
-    proxy_trusted_addresses: list[str]
+    proxy_trusted_addresses: str | None
     server_addr: ParsecAddr | None
 
     debug: bool

--- a/server/tests/common/backend.py
+++ b/server/tests/common/backend.py
@@ -38,7 +38,7 @@ def backend_config(
         debug=True,
         db_config=db_config,
         sse_keepalive=30,
-        proxy_trusted_addresses=[],
+        proxy_trusted_addresses=None,
         server_addr=ParsecAddr(hostname=SERVER_DOMAIN, port=None, use_ssl=True),
         email_config=MockedEmailConfig("no-reply@parsec.com", tmpdir),
         blockstore_config=blockstore_config,


### PR DESCRIPTION
Typically, scalingo sets `FORWARDED_ALLOW_IPS` for us.

Fix #8699