### PR TITLE
Use organization_initial_tos in postgresql create organization method

### DIFF
--- a/server/parsec/asgi/administration.py
+++ b/server/parsec/asgi/administration.py
@@ -11,7 +11,6 @@ from typing import (
     Any,
     Awaitable,
     Callable,
-    Literal,
     cast,
 )
 
@@ -78,14 +77,14 @@ class CreateOrganizationIn(BaseModel):
     # /!\ Missing field and field set to `None` does not mean the same thing:
     # - missing field: ask the server to use its default value for this field
     # - field set to `None`: `None` is a valid value to use for this field
-    user_profile_outsider_allowed: bool | Literal[UnsetType.Unset] = Unset
-    active_users_limit: ActiveUsersLimitField | Literal[UnsetType.Unset] = Unset
-    minimum_archiving_period: int | Literal[UnsetType.Unset] = Unset
-    tos: dict[TosLocale, TosUrl] | Literal[UnsetType.Unset] = Unset
+    user_profile_outsider_allowed: bool | UnsetType = Unset
+    active_users_limit: ActiveUsersLimitField | UnsetType = Unset
+    minimum_archiving_period: int | UnsetType = Unset
+    tos: dict[TosLocale, TosUrl] | UnsetType = Unset
 
     @field_validator("active_users_limit", mode="plain")
     @classmethod
-    def validate_active_users_limit(cls, v: Any) -> ActiveUsersLimit | Literal[UnsetType.Unset]:
+    def validate_active_users_limit(cls, v: Any) -> ActiveUsersLimit | UnsetType:
         match v:
             case ActiveUsersLimit():
                 return v
@@ -240,18 +239,18 @@ class PatchOrganizationOut(BaseModel):
 
 class PatchOrganizationIn(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, strict=True)
-    is_expired: bool | Literal[UnsetType.Unset] = Unset
+    is_expired: bool | UnsetType = Unset
     # /!\ Missing field and field set to `None` does not mean the same thing:
     # - missing field: ask the server to use its default value for this field
     # - field set to `None`: `None` is a valid value to use for this field
-    user_profile_outsider_allowed: bool | Literal[UnsetType.Unset] = Unset
-    active_users_limit: ActiveUsersLimitField | Literal[UnsetType.Unset] = Unset
-    minimum_archiving_period: Literal[UnsetType.Unset] | int = Unset
-    tos: Literal[UnsetType.Unset] | dict[TosLocale, TosUrl] | None = Unset
+    user_profile_outsider_allowed: bool | UnsetType = Unset
+    active_users_limit: ActiveUsersLimitField | UnsetType = Unset
+    minimum_archiving_period: UnsetType | int = Unset
+    tos: UnsetType | dict[TosLocale, TosUrl] | None = Unset
 
     @field_validator("active_users_limit", mode="plain")
     @classmethod
-    def validate_active_users_limit(cls, v: Any) -> ActiveUsersLimit | Literal[UnsetType.Unset]:
+    def validate_active_users_limit(cls, v: Any) -> ActiveUsersLimit | UnsetType:
         match v:
             case ActiveUsersLimit():
                 return v

--- a/server/parsec/components/memory/organization.py
+++ b/server/parsec/components/memory/organization.py
@@ -1,7 +1,7 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 from __future__ import annotations
 
-from typing import Any, Literal, override
+from typing import Any, override
 
 from parsec._parsec import (
     ActiveUsersLimit,
@@ -64,10 +64,10 @@ class MemoryOrganizationComponent(BaseOrganizationComponent):
         self,
         now: DateTime,
         id: OrganizationID,
-        active_users_limit: Literal[UnsetType.Unset] | ActiveUsersLimit = Unset,
-        user_profile_outsider_allowed: Literal[UnsetType.Unset] | bool = Unset,
-        minimum_archiving_period: Literal[UnsetType.Unset] | int = Unset,
-        tos: Literal[UnsetType.Unset] | dict[TosLocale, TosUrl] = Unset,
+        active_users_limit: UnsetType | ActiveUsersLimit = Unset,
+        user_profile_outsider_allowed: UnsetType | bool = Unset,
+        minimum_archiving_period: UnsetType | int = Unset,
+        tos: UnsetType | dict[TosLocale, TosUrl] = Unset,
         force_bootstrap_token: BootstrapToken | None = None,
     ) -> BootstrapToken | OrganizationCreateBadOutcome:
         bootstrap_token = force_bootstrap_token or BootstrapToken.new()
@@ -328,11 +328,11 @@ class MemoryOrganizationComponent(BaseOrganizationComponent):
         self,
         now: DateTime,
         id: OrganizationID,
-        is_expired: Literal[UnsetType.Unset] | bool = Unset,
-        active_users_limit: Literal[UnsetType.Unset] | ActiveUsersLimit = Unset,
-        user_profile_outsider_allowed: Literal[UnsetType.Unset] | bool = Unset,
-        minimum_archiving_period: Literal[UnsetType.Unset] | int = Unset,
-        tos: Literal[UnsetType.Unset] | None | dict[TosLocale, TosUrl] = Unset,
+        is_expired: UnsetType | bool = Unset,
+        active_users_limit: UnsetType | ActiveUsersLimit = Unset,
+        user_profile_outsider_allowed: UnsetType | bool = Unset,
+        minimum_archiving_period: UnsetType | int = Unset,
+        tos: UnsetType | None | dict[TosLocale, TosUrl] = Unset,
     ) -> None | OrganizationUpdateBadOutcome:
         try:
             org = self._data.organizations[id]

--- a/server/parsec/components/organization.py
+++ b/server/parsec/components/organization.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import auto
-from typing import Literal
 
 from parsec._parsec import (
     ActiveUsersLimit,
@@ -251,10 +250,10 @@ class BaseOrganizationComponent:
         # `None` is a valid value for some of those params, hence it cannot be used
         # as "param not set" marker and we use a custom `Unset` singleton instead.
         # `None` stands for "no limit"
-        active_users_limit: Literal[UnsetType.Unset] | ActiveUsersLimit = Unset,
-        user_profile_outsider_allowed: Literal[UnsetType.Unset] | bool = Unset,
-        minimum_archiving_period: Literal[UnsetType.Unset] | int = Unset,
-        tos: Literal[UnsetType.Unset] | dict[TosLocale, TosUrl] = Unset,
+        active_users_limit: UnsetType | ActiveUsersLimit = Unset,
+        user_profile_outsider_allowed: UnsetType | bool = Unset,
+        minimum_archiving_period: UnsetType | int = Unset,
+        tos: UnsetType | dict[TosLocale, TosUrl] = Unset,
         force_bootstrap_token: BootstrapToken | None = None,
     ) -> BootstrapToken | OrganizationCreateBadOutcome:
         raise NotImplementedError
@@ -307,12 +306,12 @@ class BaseOrganizationComponent:
         id: OrganizationID,
         # `None` is a valid value for some of those params, hence it cannot be used
         # as "param not set" marker and we use a custom `Unset` singleton instead.
-        is_expired: Literal[UnsetType.Unset] | bool = Unset,
+        is_expired: UnsetType | bool = Unset,
         # `None` stands for "no limit"
-        active_users_limit: Literal[UnsetType.Unset] | ActiveUsersLimit = Unset,
-        user_profile_outsider_allowed: Literal[UnsetType.Unset] | bool = Unset,
-        minimum_archiving_period: Literal[UnsetType.Unset] | int = Unset,
-        tos: Literal[UnsetType.Unset] | None | dict[TosLocale, TosUrl] = Unset,
+        active_users_limit: UnsetType | ActiveUsersLimit = Unset,
+        user_profile_outsider_allowed: UnsetType | bool = Unset,
+        minimum_archiving_period: UnsetType | int = Unset,
+        tos: UnsetType | None | dict[TosLocale, TosUrl] = Unset,
     ) -> None | OrganizationUpdateBadOutcome:
         raise NotImplementedError
 

--- a/server/parsec/components/postgresql/organization.py
+++ b/server/parsec/components/postgresql/organization.py
@@ -141,6 +141,7 @@ class PGOrganizationComponent(BaseOrganizationComponent):
             )
         if minimum_archiving_period is Unset:
             minimum_archiving_period = self._config.organization_initial_minimum_archiving_period
+        optional_tos = self._config.organization_initial_tos if tos is Unset else tos
 
         outcome = await organization_create(
             conn,
@@ -149,7 +150,7 @@ class PGOrganizationComponent(BaseOrganizationComponent):
             active_users_limit,
             user_profile_outsider_allowed,
             minimum_archiving_period,
-            None if tos is Unset else tos,
+            optional_tos,
             bootstrap_token,
         )
         match outcome:

--- a/server/parsec/components/postgresql/organization.py
+++ b/server/parsec/components/postgresql/organization.py
@@ -1,7 +1,7 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 from __future__ import annotations
 
-from typing import Literal, override
+from typing import override
 
 from parsec._parsec import (
     ActiveUsersLimit,
@@ -126,10 +126,10 @@ class PGOrganizationComponent(BaseOrganizationComponent):
         # `None` is a valid value for some of those params, hence it cannot be used
         # as "param not set" marker and we use a custom `Unset` singleton instead.
         # `None` stands for "no limit"
-        active_users_limit: Literal[UnsetType.Unset] | ActiveUsersLimit = Unset,
-        user_profile_outsider_allowed: Literal[UnsetType.Unset] | bool = Unset,
+        active_users_limit: UnsetType | ActiveUsersLimit = Unset,
+        user_profile_outsider_allowed: UnsetType | bool = Unset,
         minimum_archiving_period: UnsetType | int = Unset,
-        tos: Literal[UnsetType.Unset] | dict[TosLocale, TosUrl] = Unset,
+        tos: UnsetType | dict[TosLocale, TosUrl] = Unset,
         force_bootstrap_token: BootstrapToken | None = None,
     ) -> BootstrapToken | OrganizationCreateBadOutcome:
         bootstrap_token = force_bootstrap_token or BootstrapToken.new()
@@ -317,11 +317,11 @@ class PGOrganizationComponent(BaseOrganizationComponent):
         conn: AsyncpgConnection,
         now: DateTime,
         id: OrganizationID,
-        is_expired: Literal[UnsetType.Unset] | bool = Unset,
-        active_users_limit: Literal[UnsetType.Unset] | ActiveUsersLimit = Unset,
-        user_profile_outsider_allowed: Literal[UnsetType.Unset] | bool = Unset,
-        minimum_archiving_period: Literal[UnsetType.Unset] | int = Unset,
-        tos: Literal[UnsetType.Unset] | None | dict[TosLocale, TosUrl] = Unset,
+        is_expired: UnsetType | bool = Unset,
+        active_users_limit: UnsetType | ActiveUsersLimit = Unset,
+        user_profile_outsider_allowed: UnsetType | bool = Unset,
+        minimum_archiving_period: UnsetType | int = Unset,
+        tos: UnsetType | None | dict[TosLocale, TosUrl] = Unset,
     ) -> None | OrganizationUpdateBadOutcome:
         return await organization_update(
             self.event_bus,

--- a/server/parsec/components/postgresql/organization_update.py
+++ b/server/parsec/components/postgresql/organization_update.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import Literal
 
 from parsec._parsec import (
     ActiveUsersLimit,
@@ -62,11 +61,11 @@ async def organization_update(
     conn: AsyncpgConnection,
     now: DateTime,
     id: OrganizationID,
-    is_expired: Literal[UnsetType.Unset] | bool = Unset,
-    active_users_limit: Literal[UnsetType.Unset] | ActiveUsersLimit = Unset,
-    user_profile_outsider_allowed: Literal[UnsetType.Unset] | bool = Unset,
-    minimum_archiving_period: Literal[UnsetType.Unset] | int = Unset,
-    tos: Literal[UnsetType.Unset] | None | dict[TosLocale, TosUrl] = Unset,
+    is_expired: UnsetType | bool = Unset,
+    active_users_limit: UnsetType | ActiveUsersLimit = Unset,
+    user_profile_outsider_allowed: UnsetType | bool = Unset,
+    minimum_archiving_period: UnsetType | int = Unset,
+    tos: UnsetType | None | dict[TosLocale, TosUrl] = Unset,
 ) -> None | OrganizationUpdateBadOutcome:
     with_is_expired = is_expired is not Unset
     with_active_users_limit = active_users_limit is not Unset


### PR DESCRIPTION
This was properly done in the memory implementation but not in the postgresql one.