### PR TITLE
[MS] Fix assign workspace role with empty user list

### DIFF
--- a/client/tests/pw/e2e/users_list.spec.ts
+++ b/client/tests/pw/e2e/users_list.spec.ts
@@ -74,9 +74,9 @@ msTest('User list default state', async ({ usersPage }) => {
   await expect(usersPage.locator('#users-page-user-list').getByRole('listitem')).toHaveCount(USERS.length);
 });
 
-for (const [index, user] of USERS.entries()) {
-  msTest(`Check user list item of ${user.name}`, async ({ usersPage }) => {
-    const usersList = usersPage.locator('#users-page-user-list');
+msTest('Check user list items', async ({ usersPage }) => {
+  const usersList = usersPage.locator('#users-page-user-list');
+  for (const [index, user] of USERS.entries()) {
     const item = usersList.getByRole('listitem').nth(index);
     await expect(item.locator('.user-name').locator('.person-name')).toHaveText(user.name);
     await expect(item.locator('.user-profile')).toHaveText(user.profile);
@@ -85,13 +85,14 @@ for (const [index, user] of USERS.entries()) {
     if (!user.active) {
       await expect(item).toHaveTheClass('revoked');
     }
-  });
-}
+  }
+});
 
-for (const [index, user] of USERS.entries()) {
-  msTest(`Check user grid item of ${user.name}`, async ({ usersPage }) => {
-    await usersPage.locator('#activate-users-ms-action-bar').locator('.ms-grid-list-toggle').locator('#grid-view').click();
-    const usersGrid = usersPage.locator('.users-container-grid');
+msTest('Check user grid items', async ({ usersPage }) => {
+  await usersPage.locator('#activate-users-ms-action-bar').locator('.ms-grid-list-toggle').locator('#grid-view').click();
+  const usersGrid = usersPage.locator('.users-container-grid');
+
+  for (const [index, user] of USERS.entries()) {
     const card = usersGrid.locator('.user-card-item').nth(index);
     await expect(card.locator('.user-card-info').locator('.user-card-info__name').locator('span').nth(0)).toHaveText(user.name);
     await expect(card.locator('.user-card-info').locator('.user-card-info__email')).toHaveText(user.email);
@@ -102,8 +103,8 @@ for (const [index, user] of USERS.entries()) {
       await expect(card.locator('.user-revoked')).toBeVisible();
       await expect(card).toHaveTheClass('revoked');
     }
-  });
-}
+  }
+});
 
 for (const revokedUser of [false, true]) {
   msTest(`Check user context menu for ${revokedUser ? 'revoked' : 'active'} user`, async ({ usersPage }) => {


### PR DESCRIPTION
Closes #8727 

Caused by the fact that we filter out the current user from the list of users matching the query, but we don't check if the list is empty afterwards.

I also fixed the user tests, we used to create one test per user per list|grid instead of having one test for list and grid that checks all the users.

And I also refactored a bit of code to user an enum instead of raw numbers.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
 