### PR TITLE
[MS] Set correct button text at the end of trial org creation

### DIFF
--- a/client/src/views/organizations/creation/CreateOrganizationTrial.vue
+++ b/client/src/views/organizations/creation/CreateOrganizationTrial.vue
@@ -14,6 +14,7 @@
     <organization-authentication-page
       v-show="step === Steps.Authentication"
       :class="step === Steps.Authentication ? 'active' : ''"
+      :is-last-step="true"
       @authentication-chosen="onAuthenticationChosen"
       @go-back-requested="onGoBackRequested"
       @close-requested="$emit('closeRequested')"

--- a/client/src/views/organizations/creation/OrganizationAuthenticationPage.vue
+++ b/client/src/views/organizations/creation/OrganizationAuthenticationPage.vue
@@ -40,7 +40,7 @@
           :disabled="!valid"
         >
           <span>
-            {{ $msTranslate('CreateOrganization.button.next') }}
+            {{ isLastStep ? $msTranslate('CreateOrganization.button.create') : $msTranslate('CreateOrganization.button.next') }}
           </span>
           <ion-icon
             slot="start"
@@ -64,6 +64,7 @@ import CreateOrganizationModalHeader from '@/components/organizations/CreateOrga
 
 defineProps<{
   hideBackButton?: boolean;
+  isLastStep?: boolean;
 }>();
 
 defineEmits<{


### PR DESCRIPTION
Since the authentication choice is the last step to the trial organization creation, I replaced the button text from `Next` to `Create organization` to indicate the end of the process.
