### PR TITLE
Update macOS runner image to v14 for ci-rust

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -206,7 +206,7 @@ jobs:
       matrix:
         include:
           - name: 🍎 macOS
-            os: macos-13
+            os: macos-14
           - name: 🏁 Windows
             os: windows-2022
     name: "${{ matrix.name }}: 🦀 Rust tests"


### PR DESCRIPTION
Closes #8687
