### PR TITLE
Use passive install for winfsp so the user can be prompted for admin rights

### DIFF
--- a/client/electron/assets/installer.nsh
+++ b/client/electron/assets/installer.nsh
@@ -3,8 +3,8 @@
 
 !macro installWinFSP
     File /oname=$PLUGINSDIR\${WINFSP_FILE} ${PROJECT_DIR}\build\${WINFSP_FILE}
-    ; Use /qn to for silent installation
-    ExecWait '"msiexec" /i "$PLUGINSDIR\${WINFSP_FILE}" /qn'
+    ; Use /passive for non-interactive installation, except for elevating the installer
+    ExecWait '"msiexec" /i "$PLUGINSDIR\${WINFSP_FILE}" /passive'
 !macroend
 
 !macro mayInstallWinFSP

--- a/newsfragments/8934.bugfix.rst
+++ b/newsfragments/8934.bugfix.rst
@@ -1,0 +1,1 @@
+Prompt the user for administrator permissions when winfsp is being installed, instead of failing silently if the installer wasn't already running in administrator mode.


### PR DESCRIPTION
Fix #8934

Using `/passive` instead of `/qn` allows for prompting the user for privilege escalation. 
That also means that a progress bar will show up during winfsp installation.

This is what's advertised in electron documentation:
https://www.electron.build/nsis.html#custom-nsis-script
> If you want to include additional resources for use during installation, such as scripts or additional installers, you can place them in the build directory and include them with File. For example, to include and run extramsi.msi during installation, place it in the build directory and use the following:
>  ```
>  !macro customInstall
>    File /oname=$PLUGINSDIR\extramsi.msi "${BUILD_RESOURCES_DIR}\extramsi.msi"
>    ExecWait '"msiexec" /i "$PLUGINSDIR\extramsi.msi" /passive'
>  !macroend
>  ```

Note: clicking "no" during privilege escalation does not cause the install to fail.