### PR TITLE
Configure `keyring` to use dbus secret service on linux

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -277,6 +277,7 @@ libbz
 libcolordprivate
 libcupsprintersupport
 libdb
+libdbus
 libdefaultgeometryloader
 libdrm
 libegl

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -93,10 +93,10 @@ jobs:
         timeout-minutes: 5
 
       # Install fuse
-      - name: Install fuse
+      - name: Install build dependencies
         shell: bash
         run: |
-          until sudo apt-get -y install fuse3 libfuse3-dev; do
+          until sudo apt-get -y install fuse3 libfuse3-dev libdbus-1-dev; do
             echo "Fail to install APT package retrying ...";
           done
         timeout-minutes: 5

--- a/.github/workflows/package-cli.yml
+++ b/.github/workflows/package-cli.yml
@@ -114,7 +114,7 @@ jobs:
           --target=${{ matrix.target }}
           $(python make.py cli-release-cargo-flags --quiet)
         env:
-          LIBPARSEC_FORCE_VENDORED_OPENSSL: ${{ matrix.target == 'x86_64-unknown-linux-musl' && 'true' || 'false' }}
+          LIBPARSEC_FORCE_VENDORED_LIBS: ${{ matrix.target == 'x86_64-unknown-linux-musl' && 'true' || 'false' }}
         timeout-minutes: 15
 
       - name: Debug target folder

--- a/.github/workflows/package-client.yml
+++ b/.github/workflows/package-client.yml
@@ -305,7 +305,7 @@ jobs:
       - name: Linux > Install system dependencies
         if: matrix.platform == 'linux'
         run: |
-          sudo apt-get install -y fuse3 libfuse3-dev
+          sudo apt-get install -y fuse3 libfuse3-dev libdbus-1-dev
         timeout-minutes: 2
 
       - name: Setup rust cache for debugging

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,6 +818,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
+name = "dbus"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "winapi",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42a16374481d92aed73ae45b1f120207d8e71d24fb89f357fadbd8f946fd84b"
+dependencies = [
+ "dbus",
+ "futures-util",
+ "num",
+ "once_cell",
+ "openssl",
+ "rand",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,8 +1867,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f8fe839464d4e4b37d756d7e910063696af79a7e877282cb1825e4ec5f10833"
 dependencies = [
  "byteorder",
+ "dbus-secret-service",
  "linux-keyutils",
  "log",
+ "openssl",
  "security-framework 2.9.2",
  "security-framework 3.0.1",
  "windows-sys 0.59.0",
@@ -1863,6 +1890,16 @@ name = "libc"
 version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -2566,6 +2603,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3135b08af27d103b0a51f2ae0f8632117b7b185ccf931445affa8df530576a41"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2580,6 +2641,15 @@ dependencies = [
  "rand",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2604,6 +2674,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]

--- a/Cross.toml
+++ b/Cross.toml
@@ -7,13 +7,13 @@
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu@sha256:cf091033b6c4b0416a03d181080ad45c418248a262867a623306748a2c02a3c2" # pin ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main
 pre-build = [
     "dpkg --add-architecture $CROSS_DEB_ARCH",
-    "apt-get update && apt-get --assume-yes install libfuse3-dev libssl-dev libunwind-dev liblzma-dev",
+    "apt-get update && apt-get --assume-yes install libfuse3-dev libdbus-1-dev libssl-dev libunwind-dev liblzma-dev",
 ]
 
 [target.x86_64-unknown-linux-musl]
 image = "alpine:3.16"
 pre-build = [
-    "apk add --no-cache fuse3-dev fuse3-static openssl-dev musl-dev build-base perl rustup gcompat",
+    "apk add --no-cache fuse3-dev fuse3-static openssl-dev dbus-dev musl-dev build-base perl rustup gcompat",
     # Install our own rustup toolchain since we prefer to not rely on the host provided one
     "rustup-init -y --default-toolchain stable --profile minimal",
     # Make sure the build user will be able to access the toolchain binaries
@@ -22,6 +22,7 @@ pre-build = [
 
 [target.x86_64-unknown-linux-musl.env]
 passthrough = [
+    "PKG_CONFIG_ALL_STATIC",
     # Modify the PATH to prefer the rust toolchain of the container over the host one.
     "PATH=/root/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,6 +16,7 @@ harness = false
 [features]
 use-sodiumoxide = ["libparsec_crypto/use-sodiumoxide"]
 vendored-openssl = ["libparsec_crypto/vendored-openssl"]
+vendored-keyring = ["libparsec/vendored-keyring"]
 testenv = []
 
 [dependencies]

--- a/client/electron/snap/snapcraft.yaml
+++ b/client/electron/snap/snapcraft.yaml
@@ -39,10 +39,12 @@ parts:
       - python3
       - libssl-dev
       - libfuse3-dev
+      - libdbus-1-dev
       - pkg-config
       - patchelf
     stage-packages:
       # libssl3 is provided by core22
+      # libdbus-1 is provided by core22
       - fuse3
     build-snaps:
       - node/18/stable

--- a/libparsec/Cargo.toml
+++ b/libparsec/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 # Remember kid: RustCrypto is used if `use-sodiumoxide` is not set !
 use-sodiumoxide = ["libparsec_crypto/use-sodiumoxide"]
 vendored-openssl = ["libparsec_crypto/vendored-openssl"]
+vendored-keyring = ["libparsec_platform_device_loader/vendored-keyring"]
 test-utils = [
     "dep:libparsec_testbed",
     "libparsec_platform_device_loader/test-with-testbed",

--- a/libparsec/crates/platform_device_loader/Cargo.toml
+++ b/libparsec/crates/platform_device_loader/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [features]
 test-with-testbed = ["libparsec_testbed"]
+vendored-keyring = ["keyring/vendored"]
 
 [dependencies]
 libparsec_types = { workspace = true }
@@ -25,7 +26,11 @@ log = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dirs = { workspace = true }
-keyring = { workspace = true, features = ["linux-native", "apple-native", "windows-native"] }
+keyring = { workspace = true, features = [
+    "linux-native-sync-persistent",
+    "apple-native",
+    "windows-native",
+] }
 uuid = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 

--- a/make.py
+++ b/make.py
@@ -38,20 +38,29 @@ CUTENESS = [
 # distributed on pypi requires vendoring to comply with manylinux)
 # This is only needed for Linux as other OSs don't provide OpenSSL (and
 # hence it obviously must be vendored anytime we need it).
-MAYBE_FORCE_VENDORED_OPENSSL = ""
+maybe_force_vendored_libs_cargo_flags = maybe_force_vendored_openssl_cargo_flags = ""
 if sys.platform == "linux":
-    if os.environ.get("LIBPARSEC_FORCE_VENDORED_OPENSSL", "false").lower() == "true":
-        MAYBE_FORCE_VENDORED_OPENSSL = "--features vendored-openssl"
+    LIBPARSEC_FORCE_VENDORED_LIBS = os.environ.get("LIBPARSEC_FORCE_VENDORED_LIBS", "false").lower()
+    if (
+        os.environ.get("LIBPARSEC_FORCE_VENDORED_OPENSSL", LIBPARSEC_FORCE_VENDORED_LIBS).lower()
+        == "true"
+    ):
+        maybe_force_vendored_libs_cargo_flags = maybe_force_vendored_openssl_cargo_flags = (
+            "--features vendored-openssl"
+        )
+    if (
+        os.environ.get("LIBPARSEC_FORCE_VENDORED_KEYRING", LIBPARSEC_FORCE_VENDORED_LIBS).lower()
+        == "true"
+    ):
+        maybe_force_vendored_libs_cargo_flags += " --features vendored-keyring"
 
 PYTHON_RELEASE_CARGO_FLAGS = (
-    f"--profile=release --features use-sodiumoxide {MAYBE_FORCE_VENDORED_OPENSSL}"
+    f"--profile=release --features use-sodiumoxide {maybe_force_vendored_openssl_cargo_flags}"
 )
 PYTHON_DEV_CARGO_FLAGS = "--profile=dev-python --features test-utils"
 PYTHON_CI_CARGO_FLAGS = "--profile=ci-python --features test-utils"
 
-ELECTRON_RELEASE_CARGO_FLAGS = (
-    f"--profile=release --features libparsec/use-sodiumoxide {MAYBE_FORCE_VENDORED_OPENSSL}"
-)
+ELECTRON_RELEASE_CARGO_FLAGS = f"--profile=release --features libparsec/use-sodiumoxide {maybe_force_vendored_libs_cargo_flags}"
 ELECTRON_DEV_CARGO_FLAGS = "--profile=dev --features test-utils"
 ELECTRON_CI_CARGO_FLAGS = "--profile=ci-rust --features test-utils"
 
@@ -68,7 +77,7 @@ WEB_RELEASE_CARGO_FLAGS = "--release"  # Note: on web we use RustCrypto for rele
 WEB_DEV_CARGO_FLAGS = "--dev -- --features test-utils"
 WEB_CI_CARGO_FLAGS = f"{WEB_DEV_CARGO_FLAGS} --profile=ci-rust"
 
-CLI_RELEASE_CARGO_FLAGS = f"--profile=release {MAYBE_FORCE_VENDORED_OPENSSL}"
+CLI_RELEASE_CARGO_FLAGS = f"--profile=release {maybe_force_vendored_libs_cargo_flags}"
 
 # TL;DR: ONLY USE THE REAL ZSTD IN PRODUCTION !!!
 #


### PR DESCRIPTION
The migration from v2 to v3 forget to set the feature `linux-native-sync-persistent` for the `keyring` crate. This feature is required if we want the keyring to use the configured secret service on linux.
