### PR TITLE
Further fix for keyring/dbus

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -22,6 +22,8 @@ pre-build = [
 
 [target.x86_64-unknown-linux-musl.env]
 passthrough = [
+    # Make the crate pkg-config add `--static` to the `pkg-config` command line
+    # Mainly used to make static build.
     "PKG_CONFIG_ALL_STATIC",
     # Modify the PATH to prefer the rust toolchain of the container over the host one.
     "PATH=/root/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,7 +16,7 @@ harness = false
 [features]
 use-sodiumoxide = ["libparsec_crypto/use-sodiumoxide"]
 vendored-openssl = ["libparsec_crypto/vendored-openssl"]
-vendored-keyring = ["libparsec/vendored-keyring"]
+vendored-dbus = ["libparsec/vendored-dbus"]
 testenv = []
 
 [dependencies]

--- a/libparsec/Cargo.toml
+++ b/libparsec/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 # Remember kid: RustCrypto is used if `use-sodiumoxide` is not set !
 use-sodiumoxide = ["libparsec_crypto/use-sodiumoxide"]
 vendored-openssl = ["libparsec_crypto/vendored-openssl"]
-vendored-keyring = ["libparsec_platform_device_loader/vendored-keyring"]
+vendored-dbus = ["libparsec_platform_device_loader/vendored-dbus"]
 test-utils = [
     "dep:libparsec_testbed",
     "libparsec_platform_device_loader/test-with-testbed",

--- a/libparsec/crates/platform_device_loader/Cargo.toml
+++ b/libparsec/crates/platform_device_loader/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [features]
 test-with-testbed = ["libparsec_testbed"]
-vendored-keyring = ["keyring/vendored"]
+vendored-dbus = ["keyring/vendored"]
 
 [dependencies]
 libparsec_types = { workspace = true }
@@ -27,6 +27,7 @@ log = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dirs = { workspace = true }
 keyring = { workspace = true, features = [
+    # Persistent means we use DBus's secret-services on linux
     "linux-native-sync-persistent",
     "apple-native",
     "windows-native",

--- a/make.py
+++ b/make.py
@@ -38,21 +38,19 @@ CUTENESS = [
 # distributed on pypi requires vendoring to comply with manylinux)
 # This is only needed for Linux as other OSs don't provide OpenSSL (and
 # hence it obviously must be vendored anytime we need it).
-maybe_force_vendored_libs_cargo_flags = maybe_force_vendored_openssl_cargo_flags = ""
+maybe_force_vendored_dbus_cargo_flags = maybe_force_vendored_openssl_cargo_flags = ""
 if sys.platform == "linux":
     LIBPARSEC_FORCE_VENDORED_LIBS = os.environ.get("LIBPARSEC_FORCE_VENDORED_LIBS", "false").lower()
     if (
         os.environ.get("LIBPARSEC_FORCE_VENDORED_OPENSSL", LIBPARSEC_FORCE_VENDORED_LIBS).lower()
         == "true"
     ):
-        maybe_force_vendored_libs_cargo_flags = maybe_force_vendored_openssl_cargo_flags = (
-            "--features vendored-openssl"
-        )
+        maybe_force_vendored_openssl_cargo_flags = "--features vendored-openssl"
     if (
         os.environ.get("LIBPARSEC_FORCE_VENDORED_KEYRING", LIBPARSEC_FORCE_VENDORED_LIBS).lower()
         == "true"
     ):
-        maybe_force_vendored_libs_cargo_flags += " --features vendored-keyring"
+        maybe_force_vendored_dbus_cargo_flags = "--features vendored-dbus"
 
 PYTHON_RELEASE_CARGO_FLAGS = (
     f"--profile=release --features use-sodiumoxide {maybe_force_vendored_openssl_cargo_flags}"
@@ -60,7 +58,7 @@ PYTHON_RELEASE_CARGO_FLAGS = (
 PYTHON_DEV_CARGO_FLAGS = "--profile=dev-python --features test-utils"
 PYTHON_CI_CARGO_FLAGS = "--profile=ci-python --features test-utils"
 
-ELECTRON_RELEASE_CARGO_FLAGS = f"--profile=release --features libparsec/use-sodiumoxide {maybe_force_vendored_libs_cargo_flags}"
+ELECTRON_RELEASE_CARGO_FLAGS = f"--profile=release --features libparsec/use-sodiumoxide {maybe_force_vendored_openssl_cargo_flags} {maybe_force_vendored_dbus_cargo_flags}"
 ELECTRON_DEV_CARGO_FLAGS = "--profile=dev --features test-utils"
 ELECTRON_CI_CARGO_FLAGS = "--profile=ci-rust --features test-utils"
 
@@ -77,7 +75,7 @@ WEB_RELEASE_CARGO_FLAGS = "--release"  # Note: on web we use RustCrypto for rele
 WEB_DEV_CARGO_FLAGS = "--dev -- --features test-utils"
 WEB_CI_CARGO_FLAGS = f"{WEB_DEV_CARGO_FLAGS} --profile=ci-rust"
 
-CLI_RELEASE_CARGO_FLAGS = f"--profile=release {maybe_force_vendored_libs_cargo_flags}"
+CLI_RELEASE_CARGO_FLAGS = f"--profile=release {maybe_force_vendored_dbus_cargo_flags} {maybe_force_vendored_openssl_cargo_flags}"
 
 # TL;DR: ONLY USE THE REAL ZSTD IN PRODUCTION !!!
 #


### PR DESCRIPTION
Following the peer-review with @touilleMan and @vxgmichel.

- Rename `vendored-keyring` to `vendored-dbus`.
- Use dedicated variable in `make.py` to explicitly state the additional features for vendored libs.
- Add comment in `Cross.toml` for `PKG_CONFIG_ALL_STATIC`.
- Add comment about the meaning of `persistent` in the feature name `linux-native-sync-persistent` of the keyring crate.