### PR TITLE
Configure pytest's asyncio_default_fixture_loop_scope option

### DIFF
--- a/server/setup.cfg
+++ b/server/setup.cfg
@@ -23,6 +23,7 @@ exclude_lines =
 [tool:pytest]
 # Remove the need for explicit `@pytest.mark.asyncio` decorators
 asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
 # Filter warnings
 filterwarnings =
     # Ignore general deprecation warnings outside of parsec


### PR DESCRIPTION
Fix warning:
```
/home/emmanuel/.cache/pypoetry/virtualenvs/parsec-cloud-fUS9rJbY-py3.12/lib/python3.12/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"
```