### PR TITLE
Allow overwriting default config & data directory during CLI command `invite claim`

### DIFF
--- a/cli/src/macro_opts.rs
+++ b/cli/src/macro_opts.rs
@@ -58,6 +58,31 @@ macro_rules! clap_parser_with_shared_opts_builder {
             }
         );
     };
+    // data dir option
+    (
+        #[with = data_dir $(,$modifier:ident)*]
+        $(#[$struct_attr:meta])*
+        $visibility:vis struct $name:ident {
+            $(
+                $(#[$field_attr:meta])*
+                $field_vis:vis $field:ident: $field_type:ty,
+            )*
+        }
+    ) => {
+        $crate::clap_parser_with_shared_opts_builder!(
+            #[with = $($modifier),*]
+            $(#[$struct_attr])*
+            $visibility struct $name {
+                #[doc = "Parsec data directory"]
+                #[arg(short, long, default_value_os_t = libparsec::get_default_data_base_dir(), env = $crate::utils::PARSEC_DATA_DIR)]
+                pub(crate) data_dir: std::path::PathBuf,
+                $(
+                    $(#[$field_attr])*
+                    $field_vis $field: $field_type,
+                )*
+            }
+        );
+    };
     // Device option
     (
         #[with = device $(,$modifier:ident)*]

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -16,6 +16,9 @@ use spinners::{Spinner, Spinners, Stream};
 /// Environment variable to set the Parsec config directory
 /// Should not be confused with [`libparsec::PARSEC_BASE_CONFIG_DIR`]
 pub const PARSEC_CONFIG_DIR: &str = "PARSEC_CONFIG_DIR";
+/// Environment variable to set the Parsec data directory
+/// Should not be confused with [`libparsec::PARSEC_BASE_DATA_DIR`]
+pub const PARSEC_DATA_DIR: &str = "PARSEC_DATA_DIR";
 
 pub const GREEN: &str = "\x1B[92m";
 pub const RED: &str = "\x1B[91m";

--- a/newsfragments/8937.feature.rst
+++ b/newsfragments/8937.feature.rst
@@ -1,0 +1,1 @@
+Allows overwriting default config & data directory during CLI command ``invite claim``


### PR DESCRIPTION
Closes #8937