### PR TITLE
Fix `WorkspaceOps::watch_entry_oneshot` not being triggered when a missing child of the watched folder is finally synchronized

### DIFF
--- a/bindings/electron/src/index.d.ts
+++ b/bindings/electron/src/index.d.ts
@@ -2697,6 +2697,7 @@ export function clientNewDeviceInvitation(
 ): Promise<Result<NewInvitationInfo, ClientNewDeviceInvitationError>>
 export function clientNewShamirRecoveryInvitation(
     client: number,
+    claimer_user_id: string,
     send_email: boolean
 ): Promise<Result<NewInvitationInfo, ClientNewShamirRecoveryInvitationError>>
 export function clientNewUserInvitation(

--- a/bindings/electron/src/index.d.ts
+++ b/bindings/electron/src/index.d.ts
@@ -842,6 +842,30 @@ export type ClientNewDeviceInvitationError =
   | ClientNewDeviceInvitationErrorOffline
 
 
+// ClientNewShamirRecoveryInvitationError
+export interface ClientNewShamirRecoveryInvitationErrorInternal {
+    tag: "Internal"
+    error: string
+}
+export interface ClientNewShamirRecoveryInvitationErrorNotAllowed {
+    tag: "NotAllowed"
+    error: string
+}
+export interface ClientNewShamirRecoveryInvitationErrorOffline {
+    tag: "Offline"
+    error: string
+}
+export interface ClientNewShamirRecoveryInvitationErrorUserNotFound {
+    tag: "UserNotFound"
+    error: string
+}
+export type ClientNewShamirRecoveryInvitationError =
+  | ClientNewShamirRecoveryInvitationErrorInternal
+  | ClientNewShamirRecoveryInvitationErrorNotAllowed
+  | ClientNewShamirRecoveryInvitationErrorOffline
+  | ClientNewShamirRecoveryInvitationErrorUserNotFound
+
+
 // ClientNewUserInvitationError
 export interface ClientNewUserInvitationErrorAlreadyMember {
     tag: "AlreadyMember"
@@ -2493,48 +2517,48 @@ export type WorkspaceStorageCacheSize =
   | WorkspaceStorageCacheSizeDefault
 
 
-// WorkspaceWatchError
-export interface WorkspaceWatchErrorEntryNotFound {
+// WorkspaceWatchEntryOneShotError
+export interface WorkspaceWatchEntryOneShotErrorEntryNotFound {
     tag: "EntryNotFound"
     error: string
 }
-export interface WorkspaceWatchErrorInternal {
+export interface WorkspaceWatchEntryOneShotErrorInternal {
     tag: "Internal"
     error: string
 }
-export interface WorkspaceWatchErrorInvalidCertificate {
+export interface WorkspaceWatchEntryOneShotErrorInvalidCertificate {
     tag: "InvalidCertificate"
     error: string
 }
-export interface WorkspaceWatchErrorInvalidKeysBundle {
+export interface WorkspaceWatchEntryOneShotErrorInvalidKeysBundle {
     tag: "InvalidKeysBundle"
     error: string
 }
-export interface WorkspaceWatchErrorInvalidManifest {
+export interface WorkspaceWatchEntryOneShotErrorInvalidManifest {
     tag: "InvalidManifest"
     error: string
 }
-export interface WorkspaceWatchErrorNoRealmAccess {
+export interface WorkspaceWatchEntryOneShotErrorNoRealmAccess {
     tag: "NoRealmAccess"
     error: string
 }
-export interface WorkspaceWatchErrorOffline {
+export interface WorkspaceWatchEntryOneShotErrorOffline {
     tag: "Offline"
     error: string
 }
-export interface WorkspaceWatchErrorStopped {
+export interface WorkspaceWatchEntryOneShotErrorStopped {
     tag: "Stopped"
     error: string
 }
-export type WorkspaceWatchError =
-  | WorkspaceWatchErrorEntryNotFound
-  | WorkspaceWatchErrorInternal
-  | WorkspaceWatchErrorInvalidCertificate
-  | WorkspaceWatchErrorInvalidKeysBundle
-  | WorkspaceWatchErrorInvalidManifest
-  | WorkspaceWatchErrorNoRealmAccess
-  | WorkspaceWatchErrorOffline
-  | WorkspaceWatchErrorStopped
+export type WorkspaceWatchEntryOneShotError =
+  | WorkspaceWatchEntryOneShotErrorEntryNotFound
+  | WorkspaceWatchEntryOneShotErrorInternal
+  | WorkspaceWatchEntryOneShotErrorInvalidCertificate
+  | WorkspaceWatchEntryOneShotErrorInvalidKeysBundle
+  | WorkspaceWatchEntryOneShotErrorInvalidManifest
+  | WorkspaceWatchEntryOneShotErrorNoRealmAccess
+  | WorkspaceWatchEntryOneShotErrorOffline
+  | WorkspaceWatchEntryOneShotErrorStopped
 
 
 export function archiveDevice(
@@ -2671,6 +2695,10 @@ export function clientNewDeviceInvitation(
     client: number,
     send_email: boolean
 ): Promise<Result<NewInvitationInfo, ClientNewDeviceInvitationError>>
+export function clientNewShamirRecoveryInvitation(
+    client: number,
+    send_email: boolean
+): Promise<Result<NewInvitationInfo, ClientNewShamirRecoveryInvitationError>>
 export function clientNewUserInvitation(
     client: number,
     claimer_email: string,
@@ -3033,4 +3061,4 @@ export function workspaceStop(
 export function workspaceWatchEntryOneshot(
     workspace: number,
     path: string
-): Promise<Result<string, WorkspaceWatchError>>
+): Promise<Result<string, WorkspaceWatchEntryOneShotError>>

--- a/bindings/electron/src/meths.rs
+++ b/bindings/electron/src/meths.rs
@@ -4173,6 +4173,42 @@ fn variant_client_new_device_invitation_error_rs_to_js<'a>(
     Ok(js_obj)
 }
 
+// ClientNewShamirRecoveryInvitationError
+
+#[allow(dead_code)]
+fn variant_client_new_shamir_recovery_invitation_error_rs_to_js<'a>(
+    cx: &mut impl Context<'a>,
+    rs_obj: libparsec::ClientNewShamirRecoveryInvitationError,
+) -> NeonResult<Handle<'a, JsObject>> {
+    let js_obj = cx.empty_object();
+    let js_display = JsString::try_new(cx, &rs_obj.to_string()).or_throw(cx)?;
+    js_obj.set(cx, "error", js_display)?;
+    match rs_obj {
+        libparsec::ClientNewShamirRecoveryInvitationError::Internal { .. } => {
+            let js_tag = JsString::try_new(cx, "ClientNewShamirRecoveryInvitationErrorInternal")
+                .or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::ClientNewShamirRecoveryInvitationError::NotAllowed { .. } => {
+            let js_tag = JsString::try_new(cx, "ClientNewShamirRecoveryInvitationErrorNotAllowed")
+                .or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::ClientNewShamirRecoveryInvitationError::Offline { .. } => {
+            let js_tag = JsString::try_new(cx, "ClientNewShamirRecoveryInvitationErrorOffline")
+                .or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::ClientNewShamirRecoveryInvitationError::UserNotFound { .. } => {
+            let js_tag =
+                JsString::try_new(cx, "ClientNewShamirRecoveryInvitationErrorUserNotFound")
+                    .or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+    }
+    Ok(js_obj)
+}
+
 // ClientNewUserInvitationError
 
 #[allow(dead_code)]
@@ -8290,50 +8326,55 @@ fn variant_workspace_storage_cache_size_rs_to_js<'a>(
     Ok(js_obj)
 }
 
-// WorkspaceWatchError
+// WorkspaceWatchEntryOneShotError
 
 #[allow(dead_code)]
-fn variant_workspace_watch_error_rs_to_js<'a>(
+fn variant_workspace_watch_entry_one_shot_error_rs_to_js<'a>(
     cx: &mut impl Context<'a>,
-    rs_obj: libparsec::WorkspaceWatchError,
+    rs_obj: libparsec::WorkspaceWatchEntryOneShotError,
 ) -> NeonResult<Handle<'a, JsObject>> {
     let js_obj = cx.empty_object();
     let js_display = JsString::try_new(cx, &rs_obj.to_string()).or_throw(cx)?;
     js_obj.set(cx, "error", js_display)?;
     match rs_obj {
-        libparsec::WorkspaceWatchError::EntryNotFound { .. } => {
-            let js_tag = JsString::try_new(cx, "WorkspaceWatchErrorEntryNotFound").or_throw(cx)?;
+        libparsec::WorkspaceWatchEntryOneShotError::EntryNotFound { .. } => {
+            let js_tag = JsString::try_new(cx, "WorkspaceWatchEntryOneShotErrorEntryNotFound")
+                .or_throw(cx)?;
             js_obj.set(cx, "tag", js_tag)?;
         }
-        libparsec::WorkspaceWatchError::Internal { .. } => {
-            let js_tag = JsString::try_new(cx, "WorkspaceWatchErrorInternal").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-        libparsec::WorkspaceWatchError::InvalidCertificate { .. } => {
+        libparsec::WorkspaceWatchEntryOneShotError::Internal { .. } => {
             let js_tag =
-                JsString::try_new(cx, "WorkspaceWatchErrorInvalidCertificate").or_throw(cx)?;
+                JsString::try_new(cx, "WorkspaceWatchEntryOneShotErrorInternal").or_throw(cx)?;
             js_obj.set(cx, "tag", js_tag)?;
         }
-        libparsec::WorkspaceWatchError::InvalidKeysBundle { .. } => {
+        libparsec::WorkspaceWatchEntryOneShotError::InvalidCertificate { .. } => {
+            let js_tag = JsString::try_new(cx, "WorkspaceWatchEntryOneShotErrorInvalidCertificate")
+                .or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::WorkspaceWatchEntryOneShotError::InvalidKeysBundle { .. } => {
+            let js_tag = JsString::try_new(cx, "WorkspaceWatchEntryOneShotErrorInvalidKeysBundle")
+                .or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::WorkspaceWatchEntryOneShotError::InvalidManifest { .. } => {
+            let js_tag = JsString::try_new(cx, "WorkspaceWatchEntryOneShotErrorInvalidManifest")
+                .or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::WorkspaceWatchEntryOneShotError::NoRealmAccess { .. } => {
+            let js_tag = JsString::try_new(cx, "WorkspaceWatchEntryOneShotErrorNoRealmAccess")
+                .or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::WorkspaceWatchEntryOneShotError::Offline { .. } => {
             let js_tag =
-                JsString::try_new(cx, "WorkspaceWatchErrorInvalidKeysBundle").or_throw(cx)?;
+                JsString::try_new(cx, "WorkspaceWatchEntryOneShotErrorOffline").or_throw(cx)?;
             js_obj.set(cx, "tag", js_tag)?;
         }
-        libparsec::WorkspaceWatchError::InvalidManifest { .. } => {
+        libparsec::WorkspaceWatchEntryOneShotError::Stopped { .. } => {
             let js_tag =
-                JsString::try_new(cx, "WorkspaceWatchErrorInvalidManifest").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-        libparsec::WorkspaceWatchError::NoRealmAccess { .. } => {
-            let js_tag = JsString::try_new(cx, "WorkspaceWatchErrorNoRealmAccess").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-        libparsec::WorkspaceWatchError::Offline { .. } => {
-            let js_tag = JsString::try_new(cx, "WorkspaceWatchErrorOffline").or_throw(cx)?;
-            js_obj.set(cx, "tag", js_tag)?;
-        }
-        libparsec::WorkspaceWatchError::Stopped { .. } => {
-            let js_tag = JsString::try_new(cx, "WorkspaceWatchErrorStopped").or_throw(cx)?;
+                JsString::try_new(cx, "WorkspaceWatchEntryOneShotErrorStopped").or_throw(cx)?;
             js_obj.set(cx, "tag", js_tag)?;
         }
     }
@@ -10508,6 +10549,62 @@ fn client_new_device_invitation(mut cx: FunctionContext) -> JsResult<JsPromise> 
                         js_obj.set(&mut cx, "ok", js_tag)?;
                         let js_err =
                             variant_client_new_device_invitation_error_rs_to_js(&mut cx, err)?;
+                        js_obj.set(&mut cx, "error", js_err)?;
+                        js_obj
+                    }
+                };
+                Ok(js_ret)
+            });
+        });
+
+    Ok(promise)
+}
+
+// client_new_shamir_recovery_invitation
+fn client_new_shamir_recovery_invitation(mut cx: FunctionContext) -> JsResult<JsPromise> {
+    crate::init_sentry();
+    let client = {
+        let js_val = cx.argument::<JsNumber>(0)?;
+        {
+            let v = js_val.value(&mut cx);
+            if v < (u32::MIN as f64) || (u32::MAX as f64) < v {
+                cx.throw_type_error("Not an u32 number")?
+            }
+            let v = v as u32;
+            v
+        }
+    };
+    let send_email = {
+        let js_val = cx.argument::<JsBoolean>(1)?;
+        js_val.value(&mut cx)
+    };
+    let channel = cx.channel();
+    let (deferred, promise) = cx.promise();
+
+    // TODO: Promises are not cancellable in Javascript by default, should we add a custom cancel method ?
+    let _handle = crate::TOKIO_RUNTIME
+        .lock()
+        .expect("Mutex is poisoned")
+        .spawn(async move {
+            let ret = libparsec::client_new_shamir_recovery_invitation(client, send_email).await;
+
+            deferred.settle_with(&channel, move |mut cx| {
+                let js_ret = match ret {
+                    Ok(ok) => {
+                        let js_obj = JsObject::new(&mut cx);
+                        let js_tag = JsBoolean::new(&mut cx, true);
+                        js_obj.set(&mut cx, "ok", js_tag)?;
+                        let js_value = struct_new_invitation_info_rs_to_js(&mut cx, ok)?;
+                        js_obj.set(&mut cx, "value", js_value)?;
+                        js_obj
+                    }
+                    Err(err) => {
+                        let js_obj = cx.empty_object();
+                        let js_tag = JsBoolean::new(&mut cx, false);
+                        js_obj.set(&mut cx, "ok", js_tag)?;
+                        let js_err = variant_client_new_shamir_recovery_invitation_error_rs_to_js(
+                            &mut cx, err,
+                        )?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -15915,7 +16012,8 @@ fn workspace_watch_entry_oneshot(mut cx: FunctionContext) -> JsResult<JsPromise>
                         let js_obj = cx.empty_object();
                         let js_tag = JsBoolean::new(&mut cx, false);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_err = variant_workspace_watch_error_rs_to_js(&mut cx, err)?;
+                        let js_err =
+                            variant_workspace_watch_entry_one_shot_error_rs_to_js(&mut cx, err)?;
                         js_obj.set(&mut cx, "error", js_err)?;
                         js_obj
                     }
@@ -16003,6 +16101,10 @@ pub fn register_meths(cx: &mut ModuleContext) -> NeonResult<()> {
     cx.export_function("clientListWorkspaceUsers", client_list_workspace_users)?;
     cx.export_function("clientListWorkspaces", client_list_workspaces)?;
     cx.export_function("clientNewDeviceInvitation", client_new_device_invitation)?;
+    cx.export_function(
+        "clientNewShamirRecoveryInvitation",
+        client_new_shamir_recovery_invitation,
+    )?;
     cx.export_function("clientNewUserInvitation", client_new_user_invitation)?;
     cx.export_function("clientRenameWorkspace", client_rename_workspace)?;
     cx.export_function("clientRevokeUser", client_revoke_user)?;

--- a/bindings/generator/api/invite.py
+++ b/bindings/generator/api/invite.py
@@ -374,6 +374,7 @@ class ClientNewShamirRecoveryInvitationError(ErrorVariant):
 
 async def client_new_shamir_recovery_invitation(
     client: Handle,
+    claimer_user_id: UserID,
     send_email: bool,
 ) -> Result[
     NewInvitationInfo,

--- a/bindings/generator/api/workspace.py
+++ b/bindings/generator/api/workspace.py
@@ -66,7 +66,7 @@ async def workspace_info(workspace: Handle) -> Result[StartedWorkspaceInfo, Work
     raise NotImplementedError
 
 
-class WorkspaceWatchError(ErrorVariant):
+class WorkspaceWatchEntryOneShotError(ErrorVariant):
     class Offline:
         pass
 
@@ -94,7 +94,7 @@ class WorkspaceWatchError(ErrorVariant):
 
 async def workspace_watch_entry_oneshot(
     workspace: Handle, path: FsPath
-) -> Result[VlobID, WorkspaceWatchError]:
+) -> Result[VlobID, WorkspaceWatchEntryOneShotError]:
     raise NotImplementedError
 
 

--- a/bindings/web/src/meths.rs
+++ b/bindings/web/src/meths.rs
@@ -4526,6 +4526,48 @@ fn variant_client_new_device_invitation_error_rs_to_js(
     Ok(js_obj)
 }
 
+// ClientNewShamirRecoveryInvitationError
+
+#[allow(dead_code)]
+fn variant_client_new_shamir_recovery_invitation_error_rs_to_js(
+    rs_obj: libparsec::ClientNewShamirRecoveryInvitationError,
+) -> Result<JsValue, JsValue> {
+    let js_obj = Object::new().into();
+    let js_display = &rs_obj.to_string();
+    Reflect::set(&js_obj, &"error".into(), &js_display.into())?;
+    match rs_obj {
+        libparsec::ClientNewShamirRecoveryInvitationError::Internal { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ClientNewShamirRecoveryInvitationErrorInternal".into(),
+            )?;
+        }
+        libparsec::ClientNewShamirRecoveryInvitationError::NotAllowed { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ClientNewShamirRecoveryInvitationErrorNotAllowed".into(),
+            )?;
+        }
+        libparsec::ClientNewShamirRecoveryInvitationError::Offline { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ClientNewShamirRecoveryInvitationErrorOffline".into(),
+            )?;
+        }
+        libparsec::ClientNewShamirRecoveryInvitationError::UserNotFound { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"ClientNewShamirRecoveryInvitationErrorUserNotFound".into(),
+            )?;
+        }
+    }
+    Ok(js_obj)
+}
+
 // ClientNewUserInvitationError
 
 #[allow(dead_code)]
@@ -9387,63 +9429,71 @@ fn variant_workspace_storage_cache_size_rs_to_js(
     Ok(js_obj)
 }
 
-// WorkspaceWatchError
+// WorkspaceWatchEntryOneShotError
 
 #[allow(dead_code)]
-fn variant_workspace_watch_error_rs_to_js(
-    rs_obj: libparsec::WorkspaceWatchError,
+fn variant_workspace_watch_entry_one_shot_error_rs_to_js(
+    rs_obj: libparsec::WorkspaceWatchEntryOneShotError,
 ) -> Result<JsValue, JsValue> {
     let js_obj = Object::new().into();
     let js_display = &rs_obj.to_string();
     Reflect::set(&js_obj, &"error".into(), &js_display.into())?;
     match rs_obj {
-        libparsec::WorkspaceWatchError::EntryNotFound { .. } => {
+        libparsec::WorkspaceWatchEntryOneShotError::EntryNotFound { .. } => {
             Reflect::set(
                 &js_obj,
                 &"tag".into(),
-                &"WorkspaceWatchErrorEntryNotFound".into(),
+                &"WorkspaceWatchEntryOneShotErrorEntryNotFound".into(),
             )?;
         }
-        libparsec::WorkspaceWatchError::Internal { .. } => {
+        libparsec::WorkspaceWatchEntryOneShotError::Internal { .. } => {
             Reflect::set(
                 &js_obj,
                 &"tag".into(),
-                &"WorkspaceWatchErrorInternal".into(),
+                &"WorkspaceWatchEntryOneShotErrorInternal".into(),
             )?;
         }
-        libparsec::WorkspaceWatchError::InvalidCertificate { .. } => {
+        libparsec::WorkspaceWatchEntryOneShotError::InvalidCertificate { .. } => {
             Reflect::set(
                 &js_obj,
                 &"tag".into(),
-                &"WorkspaceWatchErrorInvalidCertificate".into(),
+                &"WorkspaceWatchEntryOneShotErrorInvalidCertificate".into(),
             )?;
         }
-        libparsec::WorkspaceWatchError::InvalidKeysBundle { .. } => {
+        libparsec::WorkspaceWatchEntryOneShotError::InvalidKeysBundle { .. } => {
             Reflect::set(
                 &js_obj,
                 &"tag".into(),
-                &"WorkspaceWatchErrorInvalidKeysBundle".into(),
+                &"WorkspaceWatchEntryOneShotErrorInvalidKeysBundle".into(),
             )?;
         }
-        libparsec::WorkspaceWatchError::InvalidManifest { .. } => {
+        libparsec::WorkspaceWatchEntryOneShotError::InvalidManifest { .. } => {
             Reflect::set(
                 &js_obj,
                 &"tag".into(),
-                &"WorkspaceWatchErrorInvalidManifest".into(),
+                &"WorkspaceWatchEntryOneShotErrorInvalidManifest".into(),
             )?;
         }
-        libparsec::WorkspaceWatchError::NoRealmAccess { .. } => {
+        libparsec::WorkspaceWatchEntryOneShotError::NoRealmAccess { .. } => {
             Reflect::set(
                 &js_obj,
                 &"tag".into(),
-                &"WorkspaceWatchErrorNoRealmAccess".into(),
+                &"WorkspaceWatchEntryOneShotErrorNoRealmAccess".into(),
             )?;
         }
-        libparsec::WorkspaceWatchError::Offline { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"WorkspaceWatchErrorOffline".into())?;
+        libparsec::WorkspaceWatchEntryOneShotError::Offline { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"WorkspaceWatchEntryOneShotErrorOffline".into(),
+            )?;
         }
-        libparsec::WorkspaceWatchError::Stopped { .. } => {
-            Reflect::set(&js_obj, &"tag".into(), &"WorkspaceWatchErrorStopped".into())?;
+        libparsec::WorkspaceWatchEntryOneShotError::Stopped { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"WorkspaceWatchEntryOneShotErrorStopped".into(),
+            )?;
         }
     }
     Ok(js_obj)
@@ -10575,6 +10625,31 @@ pub fn clientNewDeviceInvitation(client: u32, send_email: bool) -> Promise {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
                 let js_err = variant_client_new_device_invitation_error_rs_to_js(err)?;
+                Reflect::set(&js_obj, &"error".into(), &js_err)?;
+                js_obj
+            }
+        })
+    })
+}
+
+// client_new_shamir_recovery_invitation
+#[allow(non_snake_case)]
+#[wasm_bindgen]
+pub fn clientNewShamirRecoveryInvitation(client: u32, send_email: bool) -> Promise {
+    future_to_promise(async move {
+        let ret = libparsec::client_new_shamir_recovery_invitation(client, send_email).await;
+        Ok(match ret {
+            Ok(value) => {
+                let js_obj = Object::new().into();
+                Reflect::set(&js_obj, &"ok".into(), &true.into())?;
+                let js_value = struct_new_invitation_info_rs_to_js(value)?;
+                Reflect::set(&js_obj, &"value".into(), &js_value)?;
+                js_obj
+            }
+            Err(err) => {
+                let js_obj = Object::new().into();
+                Reflect::set(&js_obj, &"ok".into(), &false.into())?;
+                let js_err = variant_client_new_shamir_recovery_invitation_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }
@@ -13499,7 +13574,7 @@ pub fn workspaceWatchEntryOneshot(workspace: u32, path: String) -> Promise {
             Err(err) => {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_workspace_watch_error_rs_to_js(err)?;
+                let js_err = variant_workspace_watch_entry_one_shot_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }

--- a/bindings/web/src/meths.rs
+++ b/bindings/web/src/meths.rs
@@ -10635,9 +10635,22 @@ pub fn clientNewDeviceInvitation(client: u32, send_email: bool) -> Promise {
 // client_new_shamir_recovery_invitation
 #[allow(non_snake_case)]
 #[wasm_bindgen]
-pub fn clientNewShamirRecoveryInvitation(client: u32, send_email: bool) -> Promise {
+pub fn clientNewShamirRecoveryInvitation(
+    client: u32,
+    claimer_user_id: String,
+    send_email: bool,
+) -> Promise {
     future_to_promise(async move {
-        let ret = libparsec::client_new_shamir_recovery_invitation(client, send_email).await;
+        let claimer_user_id = {
+            let custom_from_rs_string = |s: String| -> Result<libparsec::UserID, _> {
+                libparsec::UserID::from_hex(s.as_str()).map_err(|e| e.to_string())
+            };
+            custom_from_rs_string(claimer_user_id).map_err(|e| TypeError::new(e.as_ref()))
+        }?;
+
+        let ret =
+            libparsec::client_new_shamir_recovery_invitation(client, claimer_user_id, send_email)
+                .await;
         Ok(match ret {
             Ok(value) => {
                 let js_obj = Object::new().into();

--- a/client/src/plugins/libparsec/definitions.ts
+++ b/client/src/plugins/libparsec/definitions.ts
@@ -3212,6 +3212,7 @@ export interface LibParsecPlugin {
     ): Promise<Result<NewInvitationInfo, ClientNewDeviceInvitationError>>
     clientNewShamirRecoveryInvitation(
         client: Handle,
+        claimer_user_id: UserID,
         send_email: boolean
     ): Promise<Result<NewInvitationInfo, ClientNewShamirRecoveryInvitationError>>
     clientNewUserInvitation(

--- a/client/src/plugins/libparsec/definitions.ts
+++ b/client/src/plugins/libparsec/definitions.ts
@@ -965,6 +965,36 @@ export type ClientNewDeviceInvitationError =
   | ClientNewDeviceInvitationErrorInternal
   | ClientNewDeviceInvitationErrorOffline
 
+// ClientNewShamirRecoveryInvitationError
+export enum ClientNewShamirRecoveryInvitationErrorTag {
+    Internal = 'ClientNewShamirRecoveryInvitationErrorInternal',
+    NotAllowed = 'ClientNewShamirRecoveryInvitationErrorNotAllowed',
+    Offline = 'ClientNewShamirRecoveryInvitationErrorOffline',
+    UserNotFound = 'ClientNewShamirRecoveryInvitationErrorUserNotFound',
+}
+
+export interface ClientNewShamirRecoveryInvitationErrorInternal {
+    tag: ClientNewShamirRecoveryInvitationErrorTag.Internal
+    error: string
+}
+export interface ClientNewShamirRecoveryInvitationErrorNotAllowed {
+    tag: ClientNewShamirRecoveryInvitationErrorTag.NotAllowed
+    error: string
+}
+export interface ClientNewShamirRecoveryInvitationErrorOffline {
+    tag: ClientNewShamirRecoveryInvitationErrorTag.Offline
+    error: string
+}
+export interface ClientNewShamirRecoveryInvitationErrorUserNotFound {
+    tag: ClientNewShamirRecoveryInvitationErrorTag.UserNotFound
+    error: string
+}
+export type ClientNewShamirRecoveryInvitationError =
+  | ClientNewShamirRecoveryInvitationErrorInternal
+  | ClientNewShamirRecoveryInvitationErrorNotAllowed
+  | ClientNewShamirRecoveryInvitationErrorOffline
+  | ClientNewShamirRecoveryInvitationErrorUserNotFound
+
 // ClientNewUserInvitationError
 export enum ClientNewUserInvitationErrorTag {
     AlreadyMember = 'ClientNewUserInvitationErrorAlreadyMember',
@@ -2991,59 +3021,59 @@ export type WorkspaceStorageCacheSize =
   | WorkspaceStorageCacheSizeCustom
   | WorkspaceStorageCacheSizeDefault
 
-// WorkspaceWatchError
-export enum WorkspaceWatchErrorTag {
-    EntryNotFound = 'WorkspaceWatchErrorEntryNotFound',
-    Internal = 'WorkspaceWatchErrorInternal',
-    InvalidCertificate = 'WorkspaceWatchErrorInvalidCertificate',
-    InvalidKeysBundle = 'WorkspaceWatchErrorInvalidKeysBundle',
-    InvalidManifest = 'WorkspaceWatchErrorInvalidManifest',
-    NoRealmAccess = 'WorkspaceWatchErrorNoRealmAccess',
-    Offline = 'WorkspaceWatchErrorOffline',
-    Stopped = 'WorkspaceWatchErrorStopped',
+// WorkspaceWatchEntryOneShotError
+export enum WorkspaceWatchEntryOneShotErrorTag {
+    EntryNotFound = 'WorkspaceWatchEntryOneShotErrorEntryNotFound',
+    Internal = 'WorkspaceWatchEntryOneShotErrorInternal',
+    InvalidCertificate = 'WorkspaceWatchEntryOneShotErrorInvalidCertificate',
+    InvalidKeysBundle = 'WorkspaceWatchEntryOneShotErrorInvalidKeysBundle',
+    InvalidManifest = 'WorkspaceWatchEntryOneShotErrorInvalidManifest',
+    NoRealmAccess = 'WorkspaceWatchEntryOneShotErrorNoRealmAccess',
+    Offline = 'WorkspaceWatchEntryOneShotErrorOffline',
+    Stopped = 'WorkspaceWatchEntryOneShotErrorStopped',
 }
 
-export interface WorkspaceWatchErrorEntryNotFound {
-    tag: WorkspaceWatchErrorTag.EntryNotFound
+export interface WorkspaceWatchEntryOneShotErrorEntryNotFound {
+    tag: WorkspaceWatchEntryOneShotErrorTag.EntryNotFound
     error: string
 }
-export interface WorkspaceWatchErrorInternal {
-    tag: WorkspaceWatchErrorTag.Internal
+export interface WorkspaceWatchEntryOneShotErrorInternal {
+    tag: WorkspaceWatchEntryOneShotErrorTag.Internal
     error: string
 }
-export interface WorkspaceWatchErrorInvalidCertificate {
-    tag: WorkspaceWatchErrorTag.InvalidCertificate
+export interface WorkspaceWatchEntryOneShotErrorInvalidCertificate {
+    tag: WorkspaceWatchEntryOneShotErrorTag.InvalidCertificate
     error: string
 }
-export interface WorkspaceWatchErrorInvalidKeysBundle {
-    tag: WorkspaceWatchErrorTag.InvalidKeysBundle
+export interface WorkspaceWatchEntryOneShotErrorInvalidKeysBundle {
+    tag: WorkspaceWatchEntryOneShotErrorTag.InvalidKeysBundle
     error: string
 }
-export interface WorkspaceWatchErrorInvalidManifest {
-    tag: WorkspaceWatchErrorTag.InvalidManifest
+export interface WorkspaceWatchEntryOneShotErrorInvalidManifest {
+    tag: WorkspaceWatchEntryOneShotErrorTag.InvalidManifest
     error: string
 }
-export interface WorkspaceWatchErrorNoRealmAccess {
-    tag: WorkspaceWatchErrorTag.NoRealmAccess
+export interface WorkspaceWatchEntryOneShotErrorNoRealmAccess {
+    tag: WorkspaceWatchEntryOneShotErrorTag.NoRealmAccess
     error: string
 }
-export interface WorkspaceWatchErrorOffline {
-    tag: WorkspaceWatchErrorTag.Offline
+export interface WorkspaceWatchEntryOneShotErrorOffline {
+    tag: WorkspaceWatchEntryOneShotErrorTag.Offline
     error: string
 }
-export interface WorkspaceWatchErrorStopped {
-    tag: WorkspaceWatchErrorTag.Stopped
+export interface WorkspaceWatchEntryOneShotErrorStopped {
+    tag: WorkspaceWatchEntryOneShotErrorTag.Stopped
     error: string
 }
-export type WorkspaceWatchError =
-  | WorkspaceWatchErrorEntryNotFound
-  | WorkspaceWatchErrorInternal
-  | WorkspaceWatchErrorInvalidCertificate
-  | WorkspaceWatchErrorInvalidKeysBundle
-  | WorkspaceWatchErrorInvalidManifest
-  | WorkspaceWatchErrorNoRealmAccess
-  | WorkspaceWatchErrorOffline
-  | WorkspaceWatchErrorStopped
+export type WorkspaceWatchEntryOneShotError =
+  | WorkspaceWatchEntryOneShotErrorEntryNotFound
+  | WorkspaceWatchEntryOneShotErrorInternal
+  | WorkspaceWatchEntryOneShotErrorInvalidCertificate
+  | WorkspaceWatchEntryOneShotErrorInvalidKeysBundle
+  | WorkspaceWatchEntryOneShotErrorInvalidManifest
+  | WorkspaceWatchEntryOneShotErrorNoRealmAccess
+  | WorkspaceWatchEntryOneShotErrorOffline
+  | WorkspaceWatchEntryOneShotErrorStopped
 
 export interface LibParsecPlugin {
     archiveDevice(
@@ -3180,6 +3210,10 @@ export interface LibParsecPlugin {
         client: Handle,
         send_email: boolean
     ): Promise<Result<NewInvitationInfo, ClientNewDeviceInvitationError>>
+    clientNewShamirRecoveryInvitation(
+        client: Handle,
+        send_email: boolean
+    ): Promise<Result<NewInvitationInfo, ClientNewShamirRecoveryInvitationError>>
     clientNewUserInvitation(
         client: Handle,
         claimer_email: string,
@@ -3542,5 +3576,5 @@ export interface LibParsecPlugin {
     workspaceWatchEntryOneshot(
         workspace: Handle,
         path: FsPath
-    ): Promise<Result<VlobID, WorkspaceWatchError>>
+    ): Promise<Result<VlobID, WorkspaceWatchEntryOneShotError>>
 }

--- a/libparsec/crates/client/src/event_bus.rs
+++ b/libparsec/crates/client/src/event_bus.rs
@@ -413,7 +413,7 @@ impl_events!(
     ///
     /// This event is hence used by the workspace sync monitor to be notified an outbound
     /// sync operation is needed.
-    /// This event is also used to implement `WorkspaceOps::workspace_watch_entry_oneshot`.
+    /// This event is also used to implement `WorkspaceOps::watch_entry_oneshot`.
     WorkspaceOpsOutboundSyncNeeded {
         realm_id: VlobID,
         entry_id: VlobID,
@@ -460,13 +460,13 @@ impl_events!(
     /// manifest has been fetched (and it's useless to communicate progress about
     /// this fetch step).
     ///
-    /// This event is used to implement `WorkspaceOps::workspace_watch_entry_oneshot`.
+    /// This event is used to implement `WorkspaceOps::watch_entry_oneshot`.
     WorkspaceOpsInboundSyncDone {
         realm_id: VlobID,
         entry_id: VlobID,
     },
     /// This event is fired by the workspace ops when a manifest that is watched gets
-    /// modified or local or remote (see `WorkspaceOps::workspace_watch_entry_oneshot`).
+    /// modified on local or remote (see `WorkspaceOps::watch_entry_oneshot`).
     WorkspaceWatchedEntryChanged {
         realm_id: VlobID,
         entry_id: VlobID,

--- a/libparsec/crates/client/src/event_bus.rs
+++ b/libparsec/crates/client/src/event_bus.rs
@@ -464,6 +464,7 @@ impl_events!(
     WorkspaceOpsInboundSyncDone {
         realm_id: VlobID,
         entry_id: VlobID,
+        parent_id: VlobID
     },
     /// This event is fired by the workspace ops when a manifest that is watched gets
     /// modified on local or remote (see `WorkspaceOps::watch_entry_oneshot`).

--- a/libparsec/crates/client/src/workspace/transactions/mod.rs
+++ b/libparsec/crates/client/src/workspace/transactions/mod.rs
@@ -16,6 +16,7 @@ mod outbound_sync;
 mod read_folder;
 mod remove_entry;
 mod stat_entry;
+mod watch_entry;
 
 pub use create_file::*;
 pub use create_folder::*;
@@ -33,3 +34,4 @@ pub use outbound_sync::*;
 pub use read_folder::*;
 pub use remove_entry::*;
 pub use stat_entry::*;
+pub use watch_entry::*;

--- a/libparsec/crates/client/src/workspace/transactions/watch_entry.rs
+++ b/libparsec/crates/client/src/workspace/transactions/watch_entry.rs
@@ -1,0 +1,164 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use libparsec_types::prelude::*;
+
+use crate::{
+    workspace::{store::ResolvePathError, WorkspaceOps},
+    EventBusConnectionLifetime, EventWorkspaceOpsInboundSyncDone,
+    EventWorkspaceOpsOutboundSyncNeeded, EventWorkspaceWatchedEntryChanged,
+    InvalidCertificateError, InvalidKeysBundleError, InvalidManifestError,
+};
+
+pub(crate) struct EntryWatcher {
+    pub id: u32,
+    // Never accessed, but we need to keep it alive
+    #[allow(dead_code)]
+    pub lifetimes: (
+        // Event triggered when a local change occurred
+        EventBusConnectionLifetime<EventWorkspaceOpsOutboundSyncNeeded>,
+        // Event triggered when a remote change occurred
+        EventBusConnectionLifetime<EventWorkspaceOpsInboundSyncDone>,
+    ),
+}
+
+impl std::fmt::Debug for EntryWatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EntryWatcher")
+            .field("id", &self.id)
+            .finish()
+    }
+}
+
+#[derive(Default, Debug)]
+pub(crate) struct EntryWatchers {
+    pub last_id: u32,
+    pub watchers: Vec<EntryWatcher>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum WorkspaceWatchEntryOneShotError {
+    #[error("Cannot reach the server")]
+    Offline,
+    #[error("Component has stopped")]
+    Stopped,
+    #[error("Path doesn't exist")]
+    EntryNotFound,
+    #[error("Not allowed to access this realm")]
+    NoRealmAccess,
+    #[error(transparent)]
+    InvalidKeysBundle(#[from] Box<InvalidKeysBundleError>),
+    #[error(transparent)]
+    InvalidCertificate(#[from] Box<InvalidCertificateError>),
+    #[error(transparent)]
+    InvalidManifest(#[from] Box<InvalidManifestError>),
+    #[error(transparent)]
+    Internal(#[from] anyhow::Error),
+}
+
+pub async fn watch_entry_oneshot(
+    ops: &WorkspaceOps,
+    path: &FsPath,
+) -> Result<VlobID, WorkspaceWatchEntryOneShotError> {
+    // 1) Resolve the path to get the entry id
+
+    let entry_id = ops
+        .store
+        .resolve_path(path)
+        .await
+        .map(|(manifest, _)| manifest.id())
+        .map_err(|err| match err {
+            ResolvePathError::Offline => WorkspaceWatchEntryOneShotError::Offline,
+            ResolvePathError::Stopped => WorkspaceWatchEntryOneShotError::Stopped,
+            ResolvePathError::EntryNotFound => WorkspaceWatchEntryOneShotError::EntryNotFound,
+            ResolvePathError::NoRealmAccess => WorkspaceWatchEntryOneShotError::NoRealmAccess,
+            ResolvePathError::InvalidKeysBundle(err) => {
+                WorkspaceWatchEntryOneShotError::InvalidKeysBundle(err)
+            }
+            ResolvePathError::InvalidCertificate(err) => {
+                WorkspaceWatchEntryOneShotError::InvalidCertificate(err)
+            }
+            ResolvePathError::InvalidManifest(err) => {
+                WorkspaceWatchEntryOneShotError::InvalidManifest(err)
+            }
+            ResolvePathError::Internal(err) => err.context("cannot resolve path").into(),
+        })?;
+
+    // 2) Connect the entry watcher to the event bus
+
+    // Note step 1 and 2 are not atomic, hence a modification occurring between the two
+    // steps will not be caught by the watcher. This should be okay though, as step 1
+    // is only used to get the entry ID from the path, so we can just pretend the
+    // modification occured just before step 1 (it would be different if we were
+    // returning the stat obtained from step 1 to the caller).
+
+    {
+        let mut entry_watchers_guard = ops.entry_watchers.lock().expect("Mutex is poisoned");
+        entry_watchers_guard.last_id += 1;
+        let entry_watcher_id = entry_watchers_guard.last_id;
+
+        let on_event_triggered = {
+            let realm_id = ops.realm_id();
+            let entry_watchers = ops.entry_watchers.clone();
+            let event_bus = ops.event_bus.clone();
+
+            move |candidate_realm_id: VlobID, candidate_entry_id: VlobID| {
+                if candidate_realm_id != realm_id || candidate_entry_id != entry_id {
+                    return;
+                }
+
+                // Disconnect the entry watcher since it is a one-shot
+
+                {
+                    let mut entry_watchers_guard =
+                        entry_watchers.lock().expect("Mutex is poisoned");
+                    let index = entry_watchers_guard
+                        .watchers
+                        .iter()
+                        .position(|x| x.id == entry_watcher_id);
+                    match index {
+                        // The watcher is already disconnected, we should not have received the event !
+                        None => return,
+                        Some(index) => {
+                            let watcher = entry_watchers_guard.watchers.swap_remove(index);
+                            // The watcher object contains an event bus connection lifetime
+                            // about the event type we are currently handling.
+                            // Given each event type has its own dedicated lock, dropping
+                            // the lifetime here would created a deadlock !
+                            // So instead we spawn a task to do the drop later.
+                            libparsec_platform_async::spawn(async move {
+                                drop(watcher);
+                            });
+                        }
+                    }
+                }
+
+                // Dispatch the watcher event
+
+                let event = EventWorkspaceWatchedEntryChanged { realm_id, entry_id };
+                // Sending a event from within an event handler :/
+                // This is fine as long as the event currently handled and
+                // the one being send are of a different type (as each event
+                // type has it own dedicated lock).
+                event_bus.send(&event);
+            }
+        };
+
+        let on_local_change_lifetime = ops.event_bus.connect({
+            let on_event_triggered = on_event_triggered.clone();
+            move |e: &EventWorkspaceOpsOutboundSyncNeeded| {
+                on_event_triggered(e.realm_id, e.entry_id)
+            }
+        });
+
+        let on_remote_change_lifetime = ops.event_bus.connect({
+            move |e: &EventWorkspaceOpsInboundSyncDone| on_event_triggered(e.realm_id, e.entry_id)
+        });
+
+        entry_watchers_guard.watchers.push(EntryWatcher {
+            id: entry_watcher_id,
+            lifetimes: (on_local_change_lifetime, on_remote_change_lifetime),
+        });
+    }
+
+    Ok(entry_id)
+}

--- a/libparsec/crates/client/tests/unit/workspace/inbound_sync_file.rs
+++ b/libparsec/crates/client/tests/unit/workspace/inbound_sync_file.rs
@@ -294,7 +294,18 @@ async fn non_placeholder(
     if matches!(&remote_modification, RemoteModification::Nothing) {
         spy.assert_no_events();
     } else {
-        spy.assert_next(|e| p_assert_matches!(e, EventWorkspaceOpsInboundSyncDone { realm_id,entry_id } if *realm_id == wksp1_id && *entry_id == wksp1_bar_txt_id));
+        let expected_parent_id = if matches!(&remote_modification, RemoteModification::ReParented) {
+            wksp1_foo_id
+        } else {
+            wksp1_id
+        };
+        spy.assert_next(|e| {
+            p_assert_matches!(e, EventWorkspaceOpsInboundSyncDone { realm_id, entry_id, parent_id }
+                if *realm_id == wksp1_id
+                && *entry_id == wksp1_bar_txt_id
+                && *parent_id == expected_parent_id
+            )
+        });
     }
 
     let bar_txt_manifest = match wksp1_ops

--- a/libparsec/crates/client/tests/unit/workspace/inbound_sync_folder.rs
+++ b/libparsec/crates/client/tests/unit/workspace/inbound_sync_folder.rs
@@ -297,7 +297,11 @@ async fn non_placeholder(
     if matches!(&remote_modification, RemoteModification::Nothing) {
         spy.assert_no_events();
     } else {
-        spy.assert_next(|e| p_assert_matches!(e, EventWorkspaceOpsInboundSyncDone { realm_id,entry_id } if *realm_id == wksp1_id && *entry_id == wksp1_foo_id));
+        spy.assert_next(|e| {
+            p_assert_matches!(e, EventWorkspaceOpsInboundSyncDone { realm_id, entry_id, parent_id }
+                if *realm_id == wksp1_id && *entry_id == wksp1_foo_id && *parent_id == wksp1_id
+            )
+        });
     }
 
     let foo_manifest = match wksp1_ops.store.get_manifest(wksp1_foo_id).await.unwrap() {

--- a/libparsec/crates/client/tests/unit/workspace/inbound_sync_root.rs
+++ b/libparsec/crates/client/tests/unit/workspace/inbound_sync_root.rs
@@ -231,7 +231,11 @@ async fn non_placeholder(
     if matches!(&remote_modification, RemoteModification::Nothing) {
         spy.assert_no_events();
     } else {
-        spy.assert_next(|e| p_assert_matches!(e, EventWorkspaceOpsInboundSyncDone { realm_id,entry_id } if *realm_id == wksp1_id && *entry_id == wksp1_id));
+        spy.assert_next(|e| {
+            p_assert_matches!(e, EventWorkspaceOpsInboundSyncDone { realm_id, entry_id, parent_id }
+                if *realm_id == wksp1_id && *entry_id == wksp1_id && *parent_id == wksp1_id
+            )
+        });
     }
 
     let workspace_manifest = wksp1_ops.store.get_root_manifest();

--- a/libparsec/crates/client/tests/unit/workspace/mod.rs
+++ b/libparsec/crates/client/tests/unit/workspace/mod.rs
@@ -32,6 +32,7 @@ mod resolve_path;
 mod retrieve_path_from_id;
 mod stat_entry;
 mod utils;
+mod watch_entry;
 
 #[cfg(unix)]
 mod file_transactions_stateful;

--- a/libparsec/crates/client/tests/unit/workspace/watch_entry.rs
+++ b/libparsec/crates/client/tests/unit/workspace/watch_entry.rs
@@ -1,0 +1,318 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use std::sync::Arc;
+
+use libparsec_client_connection::{
+    test_register_sequence_of_send_hooks, test_send_hook_realm_get_keys_bundle,
+    test_send_hook_vlob_read_batch,
+};
+use libparsec_protocol::authenticated_cmds;
+use libparsec_tests_fixtures::prelude::*;
+use libparsec_types::prelude::*;
+
+use super::utils::workspace_ops_factory;
+use crate::{
+    workspace::{EntryStat, MoveEntryMode, OpenOptions, WorkspaceStatEntryError},
+    EventWorkspaceOpsInboundSyncDone, EventWorkspaceOpsOutboundSyncNeeded,
+    EventWorkspaceWatchedEntryChanged,
+};
+
+#[parsec_test(testbed = "minimal_client_ready")]
+async fn ok_local_change(env: &TestbedEnv) {
+    let wksp1_id: VlobID = *env.template.get_stuff("wksp1_id");
+    let wksp1_foo_id: VlobID = *env.template.get_stuff("wksp1_foo_id");
+    let wksp1_bar_txt_id: VlobID = *env.template.get_stuff("wksp1_bar_txt_id");
+
+    let alice = env.local_device("alice@dev1");
+    let ops = workspace_ops_factory(&env.discriminant_dir, &alice, wksp1_id.to_owned()).await;
+
+    let mut spy = ops.event_bus.spy.start_expecting();
+
+    // 1) Watch multiple things at the same time
+
+    p_assert_eq!(
+        ops.watch_entry_oneshot(&"/".parse().unwrap())
+            .await
+            .unwrap(),
+        wksp1_id,
+    );
+    p_assert_eq!(
+        ops.watch_entry_oneshot(&"/foo".parse().unwrap())
+            .await
+            .unwrap(),
+        wksp1_foo_id,
+    );
+    p_assert_eq!(
+        ops.watch_entry_oneshot(&"/bar.txt".parse().unwrap())
+            .await
+            .unwrap(),
+        wksp1_bar_txt_id,
+    );
+
+    spy.assert_no_events();
+
+    // 2) Change in workspace
+
+    ops.create_file("/new.txt".parse().unwrap()).await.unwrap();
+    spy.assert_next(|e: &EventWorkspaceOpsOutboundSyncNeeded| {
+        p_assert_eq!(e.realm_id, wksp1_id);
+    });
+    spy.assert_next(|e: &EventWorkspaceOpsOutboundSyncNeeded| {
+        p_assert_eq!(e.realm_id, wksp1_id);
+        p_assert_eq!(e.entry_id, wksp1_id);
+    });
+    spy.assert_next(|e: &EventWorkspaceWatchedEntryChanged| {
+        p_assert_eq!(e.realm_id, wksp1_id);
+        p_assert_eq!(e.entry_id, wksp1_id);
+    });
+
+    // Subsequent change is ignored
+
+    ops.create_file("/new2.txt".parse().unwrap()).await.unwrap();
+    spy.assert_next(|e: &EventWorkspaceOpsOutboundSyncNeeded| {
+        p_assert_eq!(e.realm_id, wksp1_id);
+    });
+    spy.assert_next(|e: &EventWorkspaceOpsOutboundSyncNeeded| {
+        p_assert_eq!(e.realm_id, wksp1_id);
+        p_assert_eq!(e.entry_id, wksp1_id);
+    });
+    spy.assert_no_events();
+
+    // 3) Change in folder
+
+    ops.move_entry(
+        "/foo/spam".parse().unwrap(),
+        "/foo/spam2".parse().unwrap(),
+        MoveEntryMode::NoReplace,
+    )
+    .await
+    .unwrap();
+    spy.assert_next(|e: &EventWorkspaceOpsOutboundSyncNeeded| {
+        p_assert_eq!(e.realm_id, wksp1_id);
+        p_assert_eq!(e.entry_id, wksp1_foo_id);
+    });
+    spy.assert_next(|e: &EventWorkspaceWatchedEntryChanged| {
+        p_assert_eq!(e.realm_id, wksp1_id);
+        p_assert_eq!(e.entry_id, wksp1_foo_id);
+    });
+
+    // Subsequent change is ignored
+
+    ops.move_entry(
+        "/foo/spam2".parse().unwrap(),
+        "/foo/spam3".parse().unwrap(),
+        MoveEntryMode::NoReplace,
+    )
+    .await
+    .unwrap();
+    spy.assert_next(|e: &EventWorkspaceOpsOutboundSyncNeeded| {
+        p_assert_eq!(e.realm_id, wksp1_id);
+        p_assert_eq!(e.entry_id, wksp1_foo_id);
+    });
+    spy.assert_no_events();
+
+    // 4) Change in file
+
+    let fd = ops
+        .open_file("/bar.txt".parse().unwrap(), OpenOptions::read_write())
+        .await
+        .unwrap();
+    spy.assert_no_events();
+
+    ops.fd_resize(fd, 0, false).await.unwrap();
+    spy.assert_no_events();
+
+    ops.fd_close(fd).await.unwrap();
+    spy.assert_next(|e: &EventWorkspaceOpsOutboundSyncNeeded| {
+        p_assert_eq!(e.realm_id, wksp1_id);
+        p_assert_eq!(e.entry_id, wksp1_bar_txt_id);
+    });
+    spy.assert_next(|e: &EventWorkspaceWatchedEntryChanged| {
+        p_assert_eq!(e.realm_id, wksp1_id);
+        p_assert_eq!(e.entry_id, wksp1_bar_txt_id);
+    });
+
+    // Subsequent change is ignored
+    let fd = ops
+        .open_file("/bar.txt".parse().unwrap(), OpenOptions::read_write())
+        .await
+        .unwrap();
+    ops.fd_write(fd, 0, b"dummy").await.unwrap();
+    ops.fd_close(fd).await.unwrap();
+    spy.assert_next(|e: &EventWorkspaceOpsOutboundSyncNeeded| {
+        p_assert_eq!(e.realm_id, wksp1_id);
+        p_assert_eq!(e.entry_id, wksp1_bar_txt_id);
+    });
+    spy.assert_no_events();
+}
+
+#[parsec_test(testbed = "minimal_client_ready", with_server)]
+async fn ok_remote_change_self(env: &TestbedEnv) {
+    let wksp1_id: VlobID = *env.template.get_stuff("wksp1_id");
+
+    env.customize(|builder| {
+        builder
+            .create_or_update_workspace_manifest_vlob("alice@dev1", wksp1_id)
+            .customize(|e| {
+                let manifest = Arc::make_mut(&mut e.manifest);
+                let bar_txt_id = manifest
+                    .children
+                    .remove(&"bar.txt".parse().unwrap())
+                    .unwrap();
+                manifest
+                    .children
+                    .insert("bar2.txt".parse().unwrap(), bar_txt_id);
+            });
+    })
+    .await;
+
+    let alice = env.local_device("alice@dev1");
+    let ops = workspace_ops_factory(&env.discriminant_dir, &alice, wksp1_id.to_owned()).await;
+
+    let mut spy = ops.event_bus.spy.start_expecting();
+
+    // 1) Start watching
+
+    p_assert_eq!(
+        ops.watch_entry_oneshot(&"/".parse().unwrap())
+            .await
+            .unwrap(),
+        wksp1_id,
+    );
+    spy.assert_no_events();
+
+    // 2) Fetch the remote change
+
+    test_register_sequence_of_send_hooks!(
+        &env.discriminant_dir,
+        test_send_hook_vlob_read_batch!(env, wksp1_id, wksp1_id),
+        test_send_hook_realm_get_keys_bundle!(env, alice.user_id, wksp1_id),
+    );
+
+    ops.inbound_sync(wksp1_id).await.unwrap();
+
+    spy.assert_next(|e: &EventWorkspaceOpsInboundSyncDone| {
+        p_assert_eq!(e.realm_id, wksp1_id);
+        p_assert_eq!(e.entry_id, wksp1_id);
+    });
+    spy.assert_next(|e: &EventWorkspaceWatchedEntryChanged| {
+        p_assert_eq!(e.realm_id, wksp1_id);
+        p_assert_eq!(e.entry_id, wksp1_id);
+    });
+
+    spy.assert_no_events();
+}
+
+#[parsec_test(testbed = "minimal_client_ready")]
+async fn ok_remote_change_newly_created_child(env: &TestbedEnv) {
+    // A folder manifest can contain children with invalid entry ID.
+    // This can be due to two things:
+    // - The entry is invalid (e.g. uploaded by some malicious client, or a user
+    //   was revoked while synchronizing data)
+    // - The entry will eventually become valid.
+    //
+    // This test is focusing on the second case, so the idea is:
+    // - Client contains a root manifest referencing an invalid entry.
+    // - Client starts watch the root folder.
+    // - Client does an inbound sync to fetch the child. At this point the root
+    //   has changed event if its manifest hasn't (since listing the root folder
+    //   produce a different outcome).
+
+    let wksp1_id: VlobID = *env.template.get_stuff("wksp1_id");
+    let new_child_txt_id = VlobID::default();
+
+    env.customize(|builder| {
+        // We add a new entry `new_child.txt` to the root folder...
+        builder
+            .create_or_update_workspace_manifest_vlob("alice@dev1", wksp1_id)
+            .customize(|e| {
+                let manifest = Arc::make_mut(&mut e.manifest);
+                manifest
+                    .children
+                    .insert("new_child.txt".parse().unwrap(), new_child_txt_id);
+            });
+        builder.create_or_update_file_manifest_vlob(
+            "alice@dev1",
+            wksp1_id,
+            Some(new_child_txt_id),
+            wksp1_id,
+        );
+
+        // ...however only the root folder manifest is up to date on the client !
+        builder.workspace_data_storage_fetch_workspace_vlob(
+            "alice@dev1",
+            wksp1_id,
+            libparsec_types::PreventSyncPattern::empty(),
+        );
+    })
+    .await;
+
+    let alice = env.local_device("alice@dev1");
+    let ops = workspace_ops_factory(&env.discriminant_dir, &alice, wksp1_id.to_owned()).await;
+
+    let mut spy = ops.event_bus.spy.start_expecting();
+
+    // 1) Start watching
+
+    p_assert_eq!(
+        ops.watch_entry_oneshot(&"/".parse().unwrap())
+            .await
+            .unwrap(),
+        wksp1_id,
+    );
+    spy.assert_no_events();
+
+    let last_common_certificate_timestamp = env.get_last_common_certificate_timestamp();
+    let last_realm_certificate_timestamp = env.get_last_realm_certificate_timestamp(wksp1_id);
+    test_register_sequence_of_send_hooks!(
+        &env.discriminant_dir,
+        // First time `new_child.txt` is tried to be accessed is during the sanity
+        // check. At that time we pretend the vlob hasn't been uploaded yet.
+        {
+            move |req: authenticated_cmds::latest::vlob_read_batch::Req| {
+                p_assert_eq!(req.realm_id, wksp1_id);
+                p_assert_eq!(req.vlobs, vec![new_child_txt_id]);
+
+                authenticated_cmds::latest::vlob_read_batch::Rep::Ok {
+                    items: vec![],
+                    needed_common_certificate_timestamp: last_common_certificate_timestamp,
+                    needed_realm_certificate_timestamp: last_realm_certificate_timestamp,
+                }
+            }
+        },
+        // Now should be during the actual inbound sync, at this point we
+        // can provide the `new_child.txt`'s vlob.
+        test_send_hook_vlob_read_batch!(env, wksp1_id, new_child_txt_id),
+        test_send_hook_realm_get_keys_bundle!(env, alice.user_id, wksp1_id),
+    );
+
+    // Sanity check: root folder is up to date, child is not present yet
+    p_assert_matches!(
+        ops.stat_entry(&"/".parse().unwrap()).await,
+        Ok(EntryStat::Folder { base_version, need_sync, .. }) if base_version == 2 && !need_sync
+    );
+    p_assert_matches!(
+        ops.stat_entry(&"/new_child.txt".parse().unwrap()).await,
+        Err(WorkspaceStatEntryError::EntryNotFound)
+    );
+
+    // 2) Fetch the remote change
+
+    ops.inbound_sync(new_child_txt_id).await.unwrap();
+
+    spy.assert_next(|e: &EventWorkspaceOpsInboundSyncDone| {
+        p_assert_eq!(e.realm_id, wksp1_id);
+        p_assert_eq!(e.entry_id, new_child_txt_id);
+    });
+    spy.assert_next(|e: &EventWorkspaceWatchedEntryChanged| {
+        p_assert_eq!(e.realm_id, wksp1_id);
+        p_assert_eq!(e.entry_id, wksp1_id);
+    });
+
+    spy.assert_no_events();
+}
+
+// Note there is no `ok_local_change_newly_created_child` test, this is because
+// local changes modify child and parent manifests atomically.
+// Hence it is not possible to have a local modification leading to a folder
+// referencing a non-existing entry.

--- a/libparsec/src/handle.rs
+++ b/libparsec/src/handle.rs
@@ -2,10 +2,6 @@
 
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
-use libparsec_client::{
-    EventBusConnectionLifetime, EventWorkspaceOpsInboundSyncDone,
-    EventWorkspaceOpsOutboundSyncNeeded,
-};
 use libparsec_platform_async::event::Event;
 use libparsec_types::prelude::*;
 
@@ -16,32 +12,6 @@ const INVALID_HANDLE_ERROR_MSG: &str = "Invalid Handle";
 enum RegisteredHandleItem {
     Open(HandleItem),
     Closed,
-}
-
-pub(crate) struct EntryWatcher {
-    pub id: u32,
-    // Never accessed, but we need to keep it alive
-    #[allow(dead_code)]
-    pub lifetimes: (
-        // Event triggered when a local change occurred
-        EventBusConnectionLifetime<EventWorkspaceOpsOutboundSyncNeeded>,
-        // Event triggered when a remote change occurred
-        EventBusConnectionLifetime<EventWorkspaceOpsInboundSyncDone>,
-    ),
-}
-
-impl std::fmt::Debug for EntryWatcher {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("EntryWatcher")
-            .field("id", &self.id)
-            .finish()
-    }
-}
-
-#[derive(Default, Debug)]
-pub(crate) struct EntryWatchers {
-    pub last_id: u32,
-    pub watchers: Vec<EntryWatcher>,
 }
 
 pub(crate) enum HandleItem {
@@ -67,7 +37,6 @@ pub(crate) enum HandleItem {
     Workspace {
         client: Handle,
         workspace_ops: Arc<libparsec_client::WorkspaceOps>,
-        entry_watchers: Arc<Mutex<EntryWatchers>>,
     },
     #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
     StartingMountpoint {

--- a/newsfragments/9102.bugfix.rst
+++ b/newsfragments/9102.bugfix.rst
@@ -1,0 +1,1 @@
+Fix GUI sometime not updating folder view when new file/folder is being remotely added.


### PR DESCRIPTION
close #9102