### PR TITLE
[MS] Updated e2e tests to handle file viewers

### DIFF
--- a/client/src/parsec/file.ts
+++ b/client/src/parsec/file.ts
@@ -3,7 +3,7 @@
 import { needsMocks } from '@/parsec/environment';
 import { wait } from '@/parsec/internals';
 import { MockFiles } from '@/parsec/mock_files';
-import { MockEntry, generateEntries, generateFile, generateFolder } from '@/parsec/mock_generator';
+import { MockEntry, generateEntriesForEachFileType, generateFile, generateFolder } from '@/parsec/mock_generator';
 import { Path } from '@/parsec/path';
 import { getParsecHandle, getWorkspaceHandle } from '@/parsec/routing';
 import {
@@ -182,7 +182,7 @@ export async function statFolderChildren(
   }
 
   await wait(500);
-  const items = (await generateEntries(path)).map((entry) => {
+  const items = (await generateEntriesForEachFileType(path)).map((entry) => {
     (entry as any as EntryStat).baseVersion = entry.version;
     (entry as any as EntryStat).confinementPoint = null;
     (entry as any as EntryStat).isConfined = (): boolean => false;

--- a/client/tests/e2e/helpers/assertions.ts
+++ b/client/tests/e2e/helpers/assertions.ts
@@ -276,6 +276,21 @@ export const expect = baseExpect.extend({
     };
   },
 
+  async toBeViewerPage(page: Page): Promise<AssertReturnType> {
+    try {
+      await expect(page).toHaveURL(/\/\d+\/viewer\??.*$/);
+    } catch (error: any) {
+      return {
+        message: () => `Page is not viewer page (url is '${error.matcherResult.actual}')`,
+        pass: false,
+      };
+    }
+    return {
+      message: () => '',
+      pass: true,
+    };
+  },
+
   async toBeTrulyDisabled(locator: Locator): Promise<AssertReturnType> {
     let errorMessage = '';
     let pass = true;

--- a/client/tests/e2e/specs/document_context_menu.spec.ts
+++ b/client/tests/e2e/specs/document_context_menu.spec.ts
@@ -120,7 +120,7 @@ for (const gridMode of [false, true]) {
     if (gridMode) {
       await toggleViewMode(documents);
     }
-    await documents.locator('.folder-container').click({ button: 'right' });
+    await documents.locator('.folder-container').click({ button: 'right', position: { x: 100, y: 10 } });
     await expect(documents.locator('.folder-global-context-menu')).toBeVisible();
     const popover = documents.locator('.folder-global-context-menu');
     await expect(popover.getByRole('group')).toHaveCount(1);

--- a/client/tests/e2e/specs/documents_list.spec.ts
+++ b/client/tests/e2e/specs/documents_list.spec.ts
@@ -20,50 +20,44 @@ const DIR_MATCHER = /^Dir_[a-z_]+$/;
 const TIME_MATCHER = /^(now|< 1 minute|(\d{1,2}|one) minutes? ago)$/;
 const SIZE_MATCHER = /^[0-9.]+ (K|M|G)?B$/;
 
+const NAME_MATCHER_ARRAY = new Array(2).fill(DIR_MATCHER).concat(new Array(8).fill(FILE_MATCHER));
+const TIME_MATCHER_ARRAY = new Array(10).fill(TIME_MATCHER);
+const SIZE_MATCHER_ARRAY = new Array(2).fill('').concat(new Array(8).fill(SIZE_MATCHER));
+
 msTest('Documents page default state', async ({ documents }) => {
   const actionBar = documents.locator('#folders-ms-action-bar');
   await expect(actionBar.locator('.ms-action-bar-button:visible')).toHaveText(['New folder', 'Import']);
-  await expect(actionBar.locator('.counter')).toHaveText('4 items', { useInnerText: true });
+  await expect(actionBar.locator('.counter')).toHaveText('10 items', { useInnerText: true });
   await expect(actionBar.locator('#select-popover-button')).toHaveText('Name');
   await expect(actionBar.locator('#grid-view')).not.toHaveDisabledAttribute();
   await expect(actionBar.locator('#list-view')).toHaveDisabledAttribute();
   const entries = documents.locator('.folder-container').locator('.file-list-item');
-  await expect(entries).toHaveCount(4);
-  await expect(entries.locator('.file-name').locator('.file-name__label')).toHaveText([
-    DIR_MATCHER,
-    DIR_MATCHER,
-    FILE_MATCHER,
-    FILE_MATCHER,
-  ]);
-  await expect(entries.locator('.file-lastUpdate')).toHaveText(new Array(4).fill(TIME_MATCHER));
-  await expect(entries.locator('.file-size')).toHaveText(['', '', SIZE_MATCHER, SIZE_MATCHER]);
+  await expect(entries).toHaveCount(10);
+  await expect(entries.locator('.file-name').locator('.file-name__label')).toHaveText(NAME_MATCHER_ARRAY);
+  await expect(entries.locator('.file-lastUpdate')).toHaveText(TIME_MATCHER_ARRAY);
+  await expect(entries.locator('.file-size')).toHaveText(SIZE_MATCHER_ARRAY);
 });
 
 msTest('Check documents in grid mode', async ({ documents }) => {
   await toggleViewMode(documents);
   const entries = documents.locator('.folder-container').locator('.file-card-item');
-  await expect(entries).toHaveCount(4);
-  await expect(entries.locator('.card-content__title')).toHaveText([DIR_MATCHER, DIR_MATCHER, FILE_MATCHER, FILE_MATCHER]);
-  await expect(entries.locator('.card-content-last-update')).toHaveText(new Array(4).fill(TIME_MATCHER));
+  await expect(entries).toHaveCount(10);
+  await expect(entries.locator('.card-content__title')).toHaveText(NAME_MATCHER_ARRAY);
+  await expect(entries.locator('.card-content-last-update')).toHaveText(TIME_MATCHER_ARRAY);
 });
 
 msTest('Documents page default state in a read only workspace', async ({ documentsReadOnly }) => {
   const actionBar = documentsReadOnly.locator('#folders-ms-action-bar');
   await expect(actionBar.locator('.ms-action-bar-button:visible')).toHaveCount(0);
-  await expect(actionBar.locator('.counter')).toHaveText('4 items', { useInnerText: true });
+  await expect(actionBar.locator('.counter')).toHaveText('10 items', { useInnerText: true });
   await expect(actionBar.locator('#select-popover-button')).toHaveText('Name');
   await expect(actionBar.locator('#grid-view')).not.toHaveDisabledAttribute();
   await expect(actionBar.locator('#list-view')).toHaveDisabledAttribute();
   const entries = documentsReadOnly.locator('.folder-container').locator('.file-list-item');
-  await expect(entries).toHaveCount(4);
-  await expect(entries.locator('.file-name').locator('.file-name__label')).toHaveText([
-    DIR_MATCHER,
-    DIR_MATCHER,
-    FILE_MATCHER,
-    FILE_MATCHER,
-  ]);
-  await expect(entries.locator('.file-lastUpdate')).toHaveText(new Array(4).fill(TIME_MATCHER));
-  await expect(entries.locator('.file-size')).toHaveText(['', '', SIZE_MATCHER, SIZE_MATCHER]);
+  await expect(entries).toHaveCount(10);
+  await expect(entries.locator('.file-name').locator('.file-name__label')).toHaveText(NAME_MATCHER_ARRAY);
+  await expect(entries.locator('.file-lastUpdate')).toHaveText(TIME_MATCHER_ARRAY);
+  await expect(entries.locator('.file-size')).toHaveText(SIZE_MATCHER_ARRAY);
   // Useless click just to move the mouse
   await documentsReadOnly.locator('.folder-list-header__label').nth(1).click();
   for (const checkbox of await entries.locator('ion-checkbox').all()) {
@@ -150,9 +144,9 @@ msTest('Selection in grid mode', async ({ documents }) => {
   }
   await entries.nth(1).locator('ion-checkbox').click();
   const actionBar = documents.locator('#folders-ms-action-bar');
-  await expect(actionBar.locator('.counter')).toHaveText('3 selected items', { useInnerText: true });
+  await expect(actionBar.locator('.counter')).toHaveText('9 selected items', { useInnerText: true });
   await entries.nth(3).locator('ion-checkbox').click();
-  await expect(actionBar.locator('.counter')).toHaveText('2 selected items', { useInnerText: true });
+  await expect(actionBar.locator('.counter')).toHaveText('8 selected items', { useInnerText: true });
 
   await expect(entries.nth(0).locator('ion-checkbox')).toHaveState('checked');
   await expect(entries.nth(1).locator('ion-checkbox')).toHaveState('unchecked');

--- a/client/tests/e2e/specs/file_details.spec.ts
+++ b/client/tests/e2e/specs/file_details.spec.ts
@@ -22,7 +22,7 @@ for (const testData of TEST_DATA) {
 
     await expect(connected.locator('.topbar-left__breadcrumb')).toContainText('The Copper Coronet');
     const files = connected.locator('.folder-container').getByRole('listitem');
-    await expect(files).toHaveCount(4);
+    await expect(files).toHaveCount(10);
     await expect(files.nth(testData.index).locator('.file-name').locator('.file-name__label')).toHaveText(new RegExp(`^${nameMatcher}$`));
     await expect(files.nth(testData.index).locator('.file-lastUpdate')).toHaveText(/^((?:one|\d{1,2}) minutes? ago|< 1 minute)$/);
     expect(connected.locator('.file-context-menu')).toBeHidden();
@@ -112,7 +112,7 @@ msTest('Show file details in grid mode', async ({ connected }) => {
 
   await connected.locator('#folders-ms-action-bar').locator('#grid-view').click();
   const files = connected.locator('.folders-container-grid').locator('.file-card-item');
-  await expect(files).toHaveCount(4);
+  await expect(files).toHaveCount(10);
   expect(connected.locator('.file-context-menu')).toBeHidden();
   expect(connected.locator('.file-details-modal')).toBeHidden();
   await files.nth(3).hover();

--- a/client/tests/e2e/specs/file_viewers.spec.ts
+++ b/client/tests/e2e/specs/file_viewers.spec.ts
@@ -1,0 +1,15 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { expect, msTest } from '@tests/e2e/helpers';
+
+msTest('Documents page default state', async ({ documents }) => {
+  const entries = documents.locator('.folder-container').locator('.file-list-item');
+
+  await entries.nth(2).dblclick();
+  await expect(documents.locator('.ms-spinner-modal')).toBeVisible();
+  await documents.waitForTimeout(500);
+  await expect(documents.locator('.ms-spinner-modal')).toBeHidden();
+  await expect(documents).toBeViewerPage();
+  await expect(documents).toHavePageTitle('File viewer');
+  await expect(documents.locator('.file-viewer').locator('.file-viewer-topbar').locator('ion-text')).toHaveText(/^File_[a-z0-9_.]+$/);
+});


### PR DESCRIPTION
Generates one file of each type for which we have a viewer.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes