### PR TITLE
Workspace store deadlock protection

### DIFF
--- a/libparsec/crates/client/src/workspace/store/manifest_access.rs
+++ b/libparsec/crates/client/src/workspace/store/manifest_access.rs
@@ -33,11 +33,11 @@ pub(super) async fn get_manifest(
     entry_id: VlobID,
 ) -> Result<ArcLocalChildManifest, GetManifestError> {
     // Fast path: cache lookup
-    {
-        let cache = store.current_view_cache.lock().expect("Mutex is poisoned");
-        if let Some(manifest) = cache.manifests.get(&entry_id) {
-            return Ok(manifest.clone());
-        }
+    let maybe_found = store
+        .data
+        .with_current_view_cache(|cache| cache.manifests.get(&entry_id).cloned());
+    if let Some(manifest) = maybe_found {
+        return Ok(manifest);
     }
 
     // Entry not in the cache, try to fetch it from the local storage...

--- a/libparsec/crates/platform_async/src/lib.rs
+++ b/libparsec/crates/platform_async/src/lib.rs
@@ -107,7 +107,8 @@ macro_rules! select3_biased {
 // Platform specific stuff
 
 pub use platform::{
-    oneshot, pretend_future_is_send_on_web, sleep, spawn, watch, AbortHandle, JoinHandle,
+    oneshot, pretend_future_is_send_on_web, sleep, spawn, try_task_id, watch, AbortHandle,
+    JoinHandle, TaskID,
 };
 pub use std::time::Duration; // Re-exposed to simplify use of `sleep`
 

--- a/libparsec/crates/platform_async/src/native/mod.rs
+++ b/libparsec/crates/platform_async/src/native/mod.rs
@@ -2,6 +2,8 @@
 
 use futures::FutureExt;
 
+pub use tokio::task::{try_id as try_task_id, Id as TaskID};
+
 pub mod oneshot {
     pub use tokio::sync::oneshot::{
         channel,

--- a/libparsec/crates/platform_async/src/web/mod.rs
+++ b/libparsec/crates/platform_async/src/web/mod.rs
@@ -11,6 +11,13 @@ pub async fn sleep(duration: std::time::Duration) {
     pretend_future_is_send_on_web(not_send_future).await
 }
 
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub struct TaskID;
+
+pub fn try_task_id() -> Option<TaskID> {
+    todo!()
+}
+
 #[derive(Debug)]
 pub struct JoinHandle<T> {
     phantom: std::marker::PhantomData<T>,


### PR DESCRIPTION
- Hide `WorkspaceStore`'s cache & storage (i.e. local db) internals
- Access must be done through callback API to limit the scope the lock is taken
- A runtime deadlock detector is present in debug build \o/