### PR TITLE
Fix CLI command `invite user` generating a device invitation link instead of a user invitation link.

### DIFF
--- a/cli/src/commands/invite/user.rs
+++ b/cli/src/commands/invite/user.rs
@@ -47,7 +47,7 @@ pub async fn main(args: Args) -> anyhow::Result<()> {
         InviteNewUserRep::Ok { token, .. } => ParsecInvitationAddr::new(
             device.organization_addr.clone(),
             device.organization_id().clone(),
-            InvitationType::Device,
+            InvitationType::User,
             token,
         )
         .to_url(),

--- a/cli/tests/integration/invitations/user.rs
+++ b/cli/tests/integration/invitations/user.rs
@@ -16,8 +16,14 @@ use crate::{
 #[rstest::rstest]
 #[tokio::test]
 async fn invite_user(tmp_path: TmpPath) {
-    let (_, TestOrganization { alice, .. }, _) = bootstrap_cli_test(&tmp_path).await.unwrap();
+    let (addr, TestOrganization { alice, .. }, org_id) =
+        bootstrap_cli_test(&tmp_path).await.unwrap();
 
+    let mut addr = addr.to_url();
+    addr.path_segments_mut().unwrap().push(org_id.as_ref());
+    addr.query_pairs_mut()
+        .append_pair("a", "claim_user")
+        .append_key_only("p");
     crate::assert_cmd_success!(
         with_password = DEFAULT_DEVICE_PASSWORD,
         "invite",
@@ -27,7 +33,9 @@ async fn invite_user(tmp_path: TmpPath) {
         "--email",
         "a@b.c"
     )
-    .stdout(predicates::str::contains("Invitation URL:"));
+    .stdout(predicates::str::contains(format!(
+        "Invitation URL: {YELLOW}{addr}"
+    )));
 }
 
 #[rstest::rstest]

--- a/newsfragments/9186.bugfix.rst
+++ b/newsfragments/9186.bugfix.rst
@@ -1,0 +1,1 @@
+Fix CLI command ``invite user`` generating a device invitation link instead of a user invitation link.


### PR DESCRIPTION
Closes #9186