### PR TITLE
[MS] Separate webkitGetAsEntry and files methods in drag&drop files

### DIFF
--- a/client/src/components/files/utils.ts
+++ b/client/src/components/files/utils.ts
@@ -39,12 +39,14 @@ export async function getFilesFromDrop(event: DragEvent, path: FsPath): Promise<
         files.push(event.dataTransfer.files[i]);
       }
     }
-    if (entries.length || files.length) {
-      const imports: FileImportTuple[] = [];
+    const imports: FileImportTuple[] = [];
+    if (entries.length) {
       for (const entry of entries) {
         const result = await unwindEntry(path, entry);
         imports.push(...result);
       }
+      return imports;
+    } else if (files.length) {
       for (const file of files) {
         imports.push({ file: file, path: path });
       }


### PR DESCRIPTION
Closes https://github.com/Scille/parsec-cloud/issues/8918

The issue was that `.webloc` files were accounted for twice in the `DragEvent.dataTransfer`, once in `items` and once in `files`, and both showed up when importing such a file (see videos in the issue).

This PR separates the two lists: either `webkitGetAsEntry` works and the import is based on `items`, or it doesn't (`entry` list is empty) and the import is based on `files`.