### PR TITLE
Backport Parsec 3.2: Quick patch to fix deadlock when reparenting a file from the mountpoint on Windows

### DIFF
--- a/libparsec/crates/client/src/workspace/mod.rs
+++ b/libparsec/crates/client/src/workspace/mod.rs
@@ -56,7 +56,8 @@ struct OpenedFileCursor {
 
 #[derive(Debug)]
 struct OpenedFile {
-    updater: FileUpdater,
+    /// If no cursor is opened in write mode, then the updater may be `None`.
+    updater: Option<FileUpdater>,
     manifest: Arc<LocalFileManifest>,
     /// The file can be opened multiple time, each one of them having it own cursor.
     cursors: Vec<OpenedFileCursor>,

--- a/libparsec/crates/client/src/workspace/transactions/fd_close.rs
+++ b/libparsec/crates/client/src/workspace/transactions/fd_close.rs
@@ -86,7 +86,9 @@ pub async fn close_all_fds(ops: &WorkspaceOps) -> Result<(), WorkspaceFdCloseErr
                     // Unwrap the mutex to obtain ownership on the `OpenedFile` object...
                     let opened_file = opened_file_mutex.into_inner();
                     // ...and finally close the updater !
-                    opened_file.updater.close(&ops.store);
+                    if let Some(updater) = opened_file.updater {
+                        updater.close(&ops.store);
+                    }
                     break;
                 }
                 // The Arc is still referenced by others coroutines...
@@ -217,7 +219,9 @@ pub async fn fd_close(ops: &WorkspaceOps, fd: FileDescriptor) -> Result<(), Work
         };
 
         // Finally close the updater !
-        owned_opened_file.updater.close(&ops.store);
+        if let Some(updater) = owned_opened_file.updater {
+            updater.close(&ops.store);
+        }
 
         // Last step is to broadcast an event if the file has been modified.
         // Note we still broadcast the event even if the flush has failed:

--- a/libparsec/crates/client/src/workspace/transactions/fd_flush.rs
+++ b/libparsec/crates/client/src/workspace/transactions/fd_flush.rs
@@ -93,8 +93,12 @@ pub(super) async fn force_reshape_and_flush(
 
     reshape(ops, opened_file).await?;
 
-    opened_file
+    let updater = opened_file
         .updater
+        .as_ref()
+        .expect("File is opened in write mode");
+
+    updater
         .update_file_manifest_and_continue(
             &ops.store,
             opened_file.manifest.clone(),

--- a/libparsec/crates/platform_mountpoint/tests/unit/operations/move_entry.rs
+++ b/libparsec/crates/platform_mountpoint/tests/unit/operations/move_entry.rs
@@ -10,8 +10,6 @@ use libparsec_tests_fixtures::prelude::*;
 
 use super::utils::mount_and_test;
 
-// TODO: move is not supported yet :'(
-#[ignore]
 #[parsec_test(testbed = "minimal_client_ready")]
 async fn ok_file(tmp_path: TmpPath, env: &TestbedEnv) {
     mount_and_test!(
@@ -43,8 +41,6 @@ async fn ok_file(tmp_path: TmpPath, env: &TestbedEnv) {
     );
 }
 
-// TODO: move is not supported yet :'(
-#[ignore]
 #[parsec_test(testbed = "minimal_client_ready")]
 async fn ok_folder(tmp_path: TmpPath, env: &TestbedEnv) {
     mount_and_test!(

--- a/newsfragments/9012.bugfix.rst
+++ b/newsfragments/9012.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a freeze when moving a file from the Windows File Explorer


### PR DESCRIPTION
Backport for Parsec 3.2 of #9199