### PR TITLE
Improve server logging

### DIFF
--- a/server/parsec/asgi/__init__.py
+++ b/server/parsec/asgi/__init__.py
@@ -148,10 +148,6 @@ async def serve_parsec_asgi_app(
         # Force a shutdown after 10 seconds, in case of a graceful shutdown failure
         # See the `Server` docstring for more information
         timeout_graceful_shutdown=10,
-        # TODO: configure access log format:
-        # Timestamp is added by the log processor configured in `parsec.logging`,
-        # here we configure peer address + req line + rep status + rep body size + time
-        # (e.g. "GET 88.0.12.52:54160 /foo 1.1 404 823o 12343ms")
     )
     server = Server(config)
 

--- a/server/parsec/asgi/__init__.py
+++ b/server/parsec/asgi/__init__.py
@@ -127,6 +127,8 @@ async def serve_parsec_asgi_app(
         server_header=False,
         headers=[("Server", server_header)],
         log_level="info",
+        # Remove default log config to inherit instead the one we set in `parsec.logging`
+        log_config=None,
         ssl_keyfile=ssl_keyfile,
         ssl_certfile=ssl_certfile,
         workers=workers,

--- a/server/parsec/cli/options.py
+++ b/server/parsec/cli/options.py
@@ -34,7 +34,7 @@ from parsec.config import (
     S3BlockStoreConfig,
     SWIFTBlockStoreConfig,
 )
-from parsec.logging import configure_logging, enable_sentry_logging
+from parsec.logging import LogFormat, configure_logging, enable_sentry_logging
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -59,8 +59,8 @@ def logging_config_options(
         @click.option(
             "--log-format",
             "-f",
-            type=click.Choice(("CONSOLE", "JSON"), case_sensitive=False),
-            default="CONSOLE",
+            type=click.Choice([x.name for x in LogFormat], case_sensitive=False),
+            default=LogFormat.CONSOLE.name,
             show_default=True,
             envvar="PARSEC_LOG_FORMAT",
             show_envvar=True,
@@ -96,12 +96,15 @@ def logging_config_options(
                     yield cast(TextIO, click.open_file(filename=log_file, mode="w"))
 
             parsed_log_level = LogLevel[log_level.upper()]
+            parsed_log_format = LogFormat[log_format.upper()]
             kwargs["log_level"] = parsed_log_level
-            kwargs["log_format"] = log_format
+            kwargs["log_format"] = parsed_log_format
             kwargs["log_file"] = log_file
 
             with open_log_file() as fd:
-                configure_logging(log_level=parsed_log_level, log_format=log_format, log_stream=fd)
+                configure_logging(
+                    log_level=parsed_log_level, log_format=parsed_log_format, log_stream=fd
+                )
 
                 return fn(*args, **kwargs)
 

--- a/server/parsec/logging.py
+++ b/server/parsec/logging.py
@@ -226,7 +226,7 @@ def _structlog_to_sentry_processor(
         sentry_sdk.capture_event(sentry_event)
 
     # Info & Warning log levels
-    if level_number >= logging.INFO:
+    elif level_number >= logging.INFO:
         # Breadcrumbs do not generate an issue. Instead, they are recorded
         # by Sentry until an event/error occurs, then they are added to
         # the issue as contextual information (useful for debugging!).

--- a/server/parsec/logging.py
+++ b/server/parsec/logging.py
@@ -1,10 +1,11 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 from __future__ import annotations
 
+import enum
 import logging
 import sys
 from datetime import datetime, timezone
-from typing import Any, Callable, MutableMapping, TextIO, Union, cast
+from typing import Any, Callable, Literal, MutableMapping, TextIO, Union, cast
 
 import sentry_sdk
 import structlog
@@ -18,8 +19,36 @@ from structlog.types import EventDict, ExcInfo
 from parsec._version import __version__
 from parsec.config import LogLevel
 
+StructlogLevels = Literal["fatal", "critical", "error", "warning", "info", "debug"]
+
+
 # Re-expose structlog's get_logger with the correct typing
 get_logger: Callable[[], ParsecBoundLogger] = structlog.get_logger
+
+
+class LogFormat(enum.Enum):
+    CONSOLE = enum.auto()
+    """
+    Default output: provides the timestamp and a colored output in human readable format.
+
+    e.g. `2024-12-23T10:40:51.719267Z [info     ] Parsec version                 version=3.2.1-a.0+dev`
+    """
+
+    CONSOLE_NO_TIMESTAMP = enum.auto()
+    """
+    Provides a colored output in human-readable format without timestamp informations.
+    This is useful when used with an external log collector that adds a timestamp by itself
+    (typical for 12 factor apps on PAAS like Heroku).
+
+    e.g. `[info     ] Parsec version                 version=3.2.1-a.0+dev``
+    """
+
+    JSON = enum.auto()
+    """
+    Provides a JSON output without color.
+
+    e.g. `{"version": "3.2.1-a.0+dev", "event": "Parsec version", "level": "info", "timestamp": "2024-12-23T13:17:58.739691Z"}`
+    """
 
 
 class ParsecBoundLogger(structlog.typing.FilteringBoundLogger):
@@ -97,13 +126,15 @@ def _make_filtering_bound_logger(min_level: int) -> type[ParsecBoundLogger]:
 # - Sentry integration for on-error telemetry
 #
 # What we need to do:
-# - Configure structlog with a stream handler to spit logs
+# - Configure structlog with a stream handler to spit logs.
 # - Configure stdlib with a separate stream handler to spit logs (redirecting
-#   structlog-to-stdlib or stdlib-to-structlog is very error-prone)
-# - Configure stdlib with a structlog formatter to have consistent output format
+#   structlog-to-stdlib or stdlib-to-structlog is very error-prone).
+# - Configure stdlib with a structlog formatter to have consistent output format.
 # - Configure Sentry as a processor in structlog before any formatting processor
-#   (so Sentry doesn't end up with a single string log blob)
-# - Configure Sentry stdlib integration (so 3rd party logs are also captured)
+#   (so Sentry doesn't end up with a single string log blob).
+# - Configure Sentry stdlib integration (so 3rd party logs are also captured).
+#   Note this integration uses its own handler, so it will be totally isolated
+#   from our own structlog-based stdlib configuration.
 #
 # Note this makes stdlib and structlog strictly decoupled: they both output the
 # same format to the same destination but don't know about each other.
@@ -118,15 +149,6 @@ def _make_filtering_bound_logger(min_level: int) -> type[ParsecBoundLogger]:
 # a "renderer" which is used by structlog to output the log message.
 #
 # See: https://www.structlog.org/en/stable/processors.html
-
-
-def _format_renderer_processor(log_format: str) -> ConsoleRenderer | JSONRenderer:
-    if log_format == "CONSOLE":
-        return structlog.dev.ConsoleRenderer()
-    elif log_format == "JSON":
-        return structlog.processors.JSONRenderer()
-    else:
-        raise ValueError(f"Unknown log format `{log_format}`")
 
 
 def _add_timestamp_processor(
@@ -144,6 +166,31 @@ def _format_timestamp_processor(
     return event
 
 
+def _format_stdlib_positional_args(
+    logger: logging.Logger, method_name: str, event: MutableMapping[str, object]
+) -> MutableMapping[str, object]:
+    positional_args = event.pop("positional_args", ())
+    if not positional_args:
+        return event
+
+    event["event"] = event["_record"].msg % positional_args  # type: ignore
+
+    return event
+
+
+def _format_stdlib_positional_args_with_color(
+    logger: logging.Logger, method_name: str, event: MutableMapping[str, object]
+) -> MutableMapping[str, object]:
+    positional_args = event.pop("positional_args", ())
+    if not positional_args:
+        return event
+
+    record = event["_record"]
+    event["event"] = getattr(record, "color_message", record.msg) % positional_args  # type: ignore
+
+    return event
+
+
 def _structlog_to_sentry_processor(
     logger: logging.Logger, method_name: str, event: EventDict
 ) -> EventDict:
@@ -154,99 +201,102 @@ def _structlog_to_sentry_processor(
 
     See ./docs/development/how-to-log-with-sentry.md
     """
-    # The level number is only used for comparison below,
-    # no need to keep it in the event dict
-    level_number = event.pop("level_number")
-
     # Clone the event and pop information that will be added to the
     # Sentry event. Anything that remains in the data dictionary
     # will also be sent to Sentry but in the 'extra' key.
     data: EventDict = {**event}
-    level = data.pop("level")
+    level: StructlogLevels = data.pop("level")
     message = data.pop("event")
     timestamp = data.pop("timestamp")
 
     # Error & Critical log levels
-    if level_number >= logging.ERROR:
-        # Cook the exception as a (class, exc, traceback) tuple
-        # This is exactly what the structlog.processors.format_exc_info does
-        # (see  _figure_out_exc_info in structlog.processors.py)
-        # If the event_dict contains the key "exc_info":
-        #   1. If the value is a tuple, use it as-is
-        #   2. If the value is an Exception, cook the tuple from the exception
-        #   3. If the value is true but no tuple, obtain exc_info ourselves and cook the tuple
-        #
-        # NOTE: Why not directly using structlog's internal function?
-        #       v = cast(Union[ExcInfo, Exception, None], data.pop("exc_info", None))
-        #       exc_info: ExcInfo | None = _figure_out_exc_info(v)
-        v = cast(Union[ExcInfo, Exception, None], data.pop("exc_info", None))
-        exc_info: ExcInfo | None
-        if isinstance(v, BaseException):
-            exc_info = (v.__class__, v, v.__traceback__)
-        elif isinstance(v, tuple):
-            exc_info = v
-        elif v:
-            match sys.exc_info():
-                case (None, None, None):
-                    exc_info = None
-                case exc_info:
-                    pass
-        else:
-            exc_info = None
-
-        if exc_info:
-            sentry_event, _ = event_from_exception(
-                exc_info=exc_info,
-                client_options=sentry_sdk.get_client().options,
-                mechanism={"type": "structlog", "handled": True},
+    match level:
+        case "info" | "debug" | "warning":
+            # Breadcrumbs do not generate an issue. Instead, they are recorded
+            # by Sentry until an event/error occurs, then they are added to
+            # the issue as contextual information (useful for debugging!).
+            #
+            # All breadcrumb keys are optional.
+            # - 'type' and 'category' are used to render breadcrumb color and icon in sentry.io
+            # - 'timestamp' supports RFC3339
+            # - 'data' is the place to put any additional information you'd like the
+            #   breadcrumb to include.
+            # See https://docs.sentry.io/product/issues/issue-details/breadcrumbs/
+            sentry_sdk.add_breadcrumb(
+                {
+                    "type": "default",
+                    "category": "console",
+                    # Safe to use structlog's level as it is type-compatible with
+                    # sentry_sdk's `LogLevelStr` (see sentry_sdk._types)
+                    "level": level,
+                    "message": message,
+                    "timestamp": timestamp,
+                    "data": data,
+                }
             )
-        else:
-            sentry_event: Event = {}
 
-        # Add basic attributes to Sentry event
-        # See https://develop.sentry.dev/sdk/event-payloads/
+        case "error" | "critical" | "fatal":
+            # Cook the exception as a (class, exc, traceback) tuple
+            # This is exactly what the structlog.processors.format_exc_info does
+            # (see  _figure_out_exc_info in structlog.processors.py)
+            # If the event_dict contains the key "exc_info":
+            #   1. If the value is a tuple, use it as-is
+            #   2. If the value is an Exception, cook the tuple from the exception
+            #   3. If the value is true but no tuple, obtain exc_info ourselves and cook the tuple
+            #
+            # NOTE: Why not directly using structlog's internal function?
+            #       v = cast(Union[ExcInfo, Exception, None], data.pop("exc_info", None))
+            #       exc_info: ExcInfo | None = _figure_out_exc_info(v)
+            v = cast(Union[ExcInfo, Exception, None], data.pop("exc_info", None))
+            exc_info: ExcInfo | None
+            if isinstance(v, BaseException):
+                exc_info = (v.__class__, v, v.__traceback__)
+            elif isinstance(v, tuple):
+                exc_info = v
+            elif v:
+                match sys.exc_info():
+                    case (None, None, None):
+                        exc_info = None
+                    case exc_info:
+                        pass
+            else:
+                exc_info = None
 
-        # Safe to use structlog's level as it is type-compatible with
-        # sentry_sdk's LogLevelStr (see sentry_sdk._types)
-        sentry_event["level"] = level
-        # Unlike stdlib logging, structlog doesn't provide a separate logger name
-        # for each place a logger is created. So we set a fixed logger name here.
-        # Event messages should be unique enough to know where they come from.
-        sentry_event["logger"] = "parsec.structlog"
-        sentry_event["timestamp"] = timestamp
-        # sentry_sdk's stdlib logging integration stores the message under
-        # `logentry` key with a dict containing `message` and `params`.
-        # However it seems rather exotic given everywhere else the simpler
-        # `message` key is used.
-        sentry_event["message"] = message
-        # Everything that remains in the data dictionary is sent as extra data
-        sentry_event["extra"] = data
+            if exc_info:
+                sentry_event, _ = event_from_exception(
+                    exc_info=exc_info,
+                    client_options=sentry_sdk.get_client().options,
+                    mechanism={"type": "structlog", "handled": True},
+                )
+            else:
+                sentry_event: Event = {}
 
-        # Send the event
-        sentry_sdk.capture_event(sentry_event)
+            # Add basic attributes to Sentry event
+            # See https://develop.sentry.dev/sdk/event-payloads/
 
-    # Info & Warning log levels
-    elif level_number >= logging.INFO:
-        # Breadcrumbs do not generate an issue. Instead, they are recorded
-        # by Sentry until an event/error occurs, then they are added to
-        # the issue as contextual information (useful for debugging!).
-        #
-        # All breadcrumb keys are optional.
-        # - 'type' and 'category' are used to render breadcrumb color and icon in sentry.io
-        # - 'timestamp' supports RFC3339
-        # - 'data' is the place to put any additional information you'd like the
-        #   breadcrumb to include.
-        # See https://docs.sentry.io/product/issues/issue-details/breadcrumbs/
-        sentry_sdk.add_breadcrumb(
-            {
-                "type": "default",
-                "category": "console",
-                "level": level,
-                "message": message,
-                "timestamp": timestamp,
-                "data": data,
-            }
-        )
+            # Safe to use structlog's level as it is type-compatible with
+            # sentry_sdk's `LogLevelStr` (see sentry_sdk._types)
+            sentry_event["level"] = level
+            # Unlike stdlib logging, structlog doesn't provide a separate logger name
+            # for each place a logger is created. So we set a fixed logger name here.
+            # Event messages should be unique enough to know where they come from.
+            sentry_event["logger"] = "parsec.structlog"
+            sentry_event["timestamp"] = timestamp
+            # sentry_sdk's stdlib logging integration stores the message under
+            # `logentry` key with a dict containing `message` and `params`.
+            # However it seems rather exotic given everywhere else the simpler
+            # `message` key is used.
+            sentry_event["message"] = message
+            # Everything that remains in the data dictionary is sent as extra data
+            sentry_event["extra"] = data
+
+            # Send the event
+            sentry_sdk.capture_event(sentry_event)
+
+        # Given `level`'s type has been obtained by a cast, we play defensive here
+        # and force this sanity check that pyright would otherwise consider useless.
+        case unknown:  # pyright: ignore[reportUnnecessaryComparison]
+            assert False, unknown
 
     return event
 
@@ -254,60 +304,182 @@ def _structlog_to_sentry_processor(
 # -- Logger set up and initialization
 
 
-def configure_structlog_logger(log_level: LogLevel, log_format: str, log_stream: TextIO) -> None:
+def _configure_structlog_logger(
+    log_level: LogLevel, log_format: LogFormat, log_stream: TextIO
+) -> None:
     # A bit of structlog architecture:
     # - lazy proxy: component obtained through `structlog.get_logger()`, laziness
     #     is needed given it is imported very early on (later it bind operation
     #     will initialize the logger wrapper)
     # - logger wrapper: component responsible for all the cooking (e.g. calling processors)
     # - logger: actual component that will spit out the log to stdout/file etc.
+
+    match log_format:
+        case LogFormat.CONSOLE:
+            processors = [
+                structlog.processors.add_log_level,
+                _add_timestamp_processor,
+                # Set `exc_info=True` if method name is `exception` and `exc_info` not set
+                # when set to True, the format_exc_info processor below will extract
+                # the exception info from sys.exc_info()
+                structlog.dev.set_exc_info,
+                # Given Sentry needs the whole event context as a dictionary,
+                # this processor must be kept just before we start formatting
+                _structlog_to_sentry_processor,
+                # Finally flatten everything into a printable string
+                # (note `exc_info` is taken care of by `ConsoleRenderer`)
+                _format_timestamp_processor,
+                ConsoleRenderer(),
+            ]
+        case LogFormat.CONSOLE_NO_TIMESTAMP:
+            console_renderer = ConsoleRenderer()
+            # Remove the first column which is supposed to format the timestamp
+            timestamp_column, *console_renderer._columns = console_renderer._columns
+            assert timestamp_column.key == "timestamp"  # Sanity check
+
+            processors = [
+                structlog.processors.add_log_level,
+                # Even if timestamp is not displayed, we still need it for Sentry
+                _add_timestamp_processor,
+                # Set `exc_info=True` if method name is `exception` and `exc_info` not set
+                # when set to True, the format_exc_info processor below will extract
+                # the exception info from sys.exc_info()
+                structlog.dev.set_exc_info,
+                # Given Sentry needs the whole event context as a dictionary,
+                # this processor must be kept just before we start formatting
+                _structlog_to_sentry_processor,
+                # Finally flatten everything into a printable string.
+                # Notes:
+                # - `exc_info` is taken care of by `ConsoleRenderer`)
+                # - `timestamp` field is ignored by the renderer
+                console_renderer,
+            ]
+        case LogFormat.JSON:
+            processors = [
+                structlog.processors.add_log_level,
+                _add_timestamp_processor,
+                # Set `exc_info=True` if method name is `exception` and `exc_info` not set
+                # when set to True, the format_exc_info processor below will extract
+                # the exception info from sys.exc_info()
+                structlog.dev.set_exc_info,
+                # Given Sentry needs the whole event context as a dictionary,
+                # this processor must be kept just before we start formatting
+                _structlog_to_sentry_processor,
+                # Finally flatten everything into a printable string
+                _format_timestamp_processor,
+                structlog.processors.format_exc_info,
+                JSONRenderer(),
+            ]
+
     structlog.configure(
-        processors=[
-            structlog.processors.add_log_level,
-            structlog.stdlib.add_log_level_number,
-            _add_timestamp_processor,
-            # Set `exc_info=True` if method name is `exception` and `exc_info` not set
-            # when set to True, the format_exc_info processor below will extract
-            # the exception info from sys.exc_info()
-            structlog.dev.set_exc_info,
-            # Given Sentry needs the whole event context as a dictionary,
-            # this processor must be kept just before we start formatting
-            _structlog_to_sentry_processor,
-            # Finally flatten everything into a printable string
-            _format_timestamp_processor,
-            structlog.processors.format_exc_info,
-            _format_renderer_processor(log_format),
-        ],
+        processors=processors,
         wrapper_class=_make_filtering_bound_logger(log_level.value),
         logger_factory=structlog.PrintLoggerFactory(file=log_stream),
         cache_logger_on_first_use=True,
     )
 
 
-def configure_stdlib_logger(
-    logger: logging.Logger, log_level: LogLevel, log_format: str, log_stream: TextIO
+def _configure_stdlib_logger(
+    logger: logging.Logger, log_level: LogLevel, log_format: LogFormat, log_stream: TextIO
 ) -> None:
-    # Use structlog to format stdlib logging records.
-    # Note this is only cosmetic: stdlib is still responsible for outputting them.
+    logger.setLevel(log_level.value)
+
+    # Given we want a consistent output between our logs (that uses structlog) and 3rd
+    # party ones (that uses stdlib's logging module), we configure here a handler
+    # that will handle formatting with structlog tools.
+    #
+    # Notes:
+    # - This is only cosmetic: stdlib is still responsible for outputting the logs.
+    # - Structlog integration with stdlib logger is done with a dedicated handler,
+    #   hence this configuration won't affect it.
+
+    match log_format:
+        case LogFormat.CONSOLE:
+            processors = [
+                structlog.processors.add_log_level,
+                _add_timestamp_processor,
+                # Set `exc_info=True` if method name is `exception` and `exc_info` not set
+                # when set to True, the format_exc_info processor below will extract
+                # the exception info from sys.exc_info()
+                structlog.dev.set_exc_info,
+                # Finally flatten everything into a printable string
+                # (note `exc_info` is taken care of by `ConsoleRenderer`)
+                _format_stdlib_positional_args_with_color,
+                _format_timestamp_processor,
+                # Remove ``_record`` and ``_from_structlog`` from *event_dict*.
+                # This must be done last since we don't want them displayed by the renderer,
+                # but `_format_stdlib_positional_args` needs them.
+                structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                ConsoleRenderer(),
+            ]
+        case LogFormat.CONSOLE_NO_TIMESTAMP:
+            console_renderer = ConsoleRenderer()
+            # Remove the first column which is supposed to format the timestamp
+            timestamp_column, *console_renderer._columns = console_renderer._columns
+            assert timestamp_column.key == "timestamp"  # Sanity check
+
+            processors = [
+                structlog.processors.add_log_level,
+                # Set `exc_info=True` if method name is `exception` and `exc_info` not set
+                # when set to True, the format_exc_info processor below will extract
+                # the exception info from sys.exc_info()
+                structlog.dev.set_exc_info,
+                # Finally flatten everything into a printable string.
+                # Notes:
+                # - `exc_info` is taken care of by `ConsoleRenderer`)
+                # - `timestamp` field is ignored by the renderer
+                _format_stdlib_positional_args_with_color,
+                # Remove ``_record`` and ``_from_structlog`` from *event_dict*.
+                # This must be done last since we don't want them displayed by the renderer,
+                # but `_format_stdlib_positional_args` needs them.
+                structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                console_renderer,
+            ]
+        case LogFormat.JSON:
+            processors = [
+                structlog.processors.add_log_level,
+                _add_timestamp_processor,
+                # Set `exc_info=True` if method name is `exception` and `exc_info` not set
+                # when set to True, the format_exc_info processor below will extract
+                # the exception info from sys.exc_info()
+                structlog.dev.set_exc_info,
+                # Finally flatten everything into a printable string
+                _format_stdlib_positional_args,
+                _format_timestamp_processor,
+                structlog.processors.format_exc_info,
+                # Remove ``_record`` and ``_from_structlog`` from *event_dict*.
+                # This must be done last since we don't want them displayed by the renderer,
+                # but `_format_stdlib_positional_args` needs them.
+                structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                JSONRenderer(),
+            ]
+
     formatter = structlog.stdlib.ProcessorFormatter(
-        foreign_pre_chain=[
-            structlog.stdlib.add_log_level,
-            _add_timestamp_processor,
-            _format_timestamp_processor,
-            structlog.processors.format_exc_info,
-        ],
-        processor=_format_renderer_processor(log_format),
+        # By default structlog formats the log message (i.e.`Started server process [%d]` -> `Started server process [255046]`),
+        # however we need to disable this behavior to support Uvicorn's colored output.
+        #
+        # Indeed, Uvicorn's log message sometime contains an additional `color_message` field
+        # that should be used instead of the regular `msg` field during formatting to end
+        # up with a colored message.
+        # So the solution is:
+        # - Set `use_get_message=False` to disable default formatting
+        # - Set `pass_foreign_args=True` to ask structlog to keep the args in a dedicated
+        #   `positional_args` field (since structlogs clears the log's `args` attribute that
+        #   contains them in the first place).
+        # - Add a processor that will do the actual formatting using `msg` or `color_message` field.
+        use_get_message=False,
+        pass_foreign_args=True,
+        processors=processors,
     )
     handler = logging.StreamHandler(log_stream)
     handler.setFormatter(formatter)
 
     logger.addHandler(handler)
-    logger.setLevel(log_level.value)
 
 
-def configure_logging(log_level: LogLevel, log_format: str, log_stream: TextIO) -> None:
-    configure_structlog_logger(log_level, log_format, log_stream)
-    configure_stdlib_logger(
+def configure_logging(log_level: LogLevel, log_format: LogFormat, log_stream: TextIO) -> None:
+    _configure_structlog_logger(log_level, log_format, log_stream)
+    _configure_stdlib_logger(
         logging.getLogger(),  # root stdlib logger
         log_level,
         log_format,


### PR DESCRIPTION
Improve logging configuration in the server

- Don't generate breadcrumb when logs trigger sentry report
- Add `CONSOLE_NO_TIMESTAMP` format (useful in PAAS when the log collecter already provide a timestamp)
- Support colored output from uvicorn logs
- Avoid useless breadcrumb in structlog sentry handler when the log already cause a report
- Remove no longer needed explicit call to exc_info formatter in structlog processors
- Make consistent the log format between stdlib and structlog
