### PR TITLE
Fix handling of SSE connections during gracious teardown of the server

### DIFF
--- a/server/parsec/asgi/__init__.py
+++ b/server/parsec/asgi/__init__.py
@@ -94,8 +94,7 @@ class Server(uvicorn.Server):
         if self._should_exit:
             app = cast(AsgiApp, self.config.app)
             backend = cast(Backend, app.state.backend)
-            for client in backend.events._registered_clients.values():
-                client.cancel_scope.cancel()
+            backend.events.stop()
 
 
 async def serve_parsec_asgi_app(

--- a/server/parsec/asgi/rpc.py
+++ b/server/parsec/asgi/rpc.py
@@ -930,6 +930,11 @@ class StreamingResponseMiddleware(StreamingResponse):
                         api_version=self.settled_api_version,
                         **self.headers,
                     )
+                case SseAPiEventsListenBadOutcome.STOPPED:
+                    # Listening to events in not possible since the server is stopping.
+                    # This is because otherwise the ASGI server would wait pointlessly
+                    # for our task to stop until the gracious shutdown timeout is reached.
+                    raise HTTPException(status_code=503)
 
 
 @rpc_router.post("/authenticated/{raw_organization_id}/tos")


### PR DESCRIPTION
you can reproduce the issue with this patch:
```patch
diff --git a/server/parsec/asgi/rpc.py b/server/parsec/asgi/rpc.py
index 9bf016da1..1c9b7c61c 100644
--- a/server/parsec/asgi/rpc.py
+++ b/server/parsec/asgi/rpc.py
@@ -747,6 +747,10 @@ async def authenticated_events_api(raw_organization_id: str, request: Request) -
         device_verify_key=auth_info.device_verify_key,
     )
 
+    print("================ GO FOR ^C !!!!")
+    import asyncio
+    await asyncio.sleep(5)
+    print("================ NOW RETURNING STREAMING RESPONSE")
     return StreamingResponseMiddleware(
         backend,
         client_ctx,
```

steps to reproduce:
1. startsthe testbed server with `python -m parsec testbed`
2. start the GUI with `TESTBED_SERVER='parsec3://127.0.0.1:6770?no_ssl=true' npm run electron:open`
3. in the GUI, login as any user
4. wait for `GO FOR ^C !!!!` to appear in the server logs...
5. ...and do a ^C ! (this should be done before `NOW RETURNING STREAMING RESPONSE` appears in the logs)

Without the current fix, the server hangs for 10s and stop with the error log complaining the gracious shutdown has failed

With the current fix, the server stops as soon as `NOW RETURNING STREAMING RESPONSE` appears in the log (since before that the task is sleeping, and uvicorn's gracious shutdown waits for it to finish)