### PR TITLE
Remove `dirs` deps from `libparsec` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,7 +1958,6 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 name = "libparsec"
 version = "3.2.1-a.0+dev"
 dependencies = [
- "dirs",
  "libparsec_client",
  "libparsec_client_connection",
  "libparsec_crypto",

--- a/libparsec/Cargo.toml
+++ b/libparsec/Cargo.toml
@@ -39,7 +39,6 @@ libparsec_serialization_format = { workspace = true }
 libparsec_testbed = { workspace = true, optional = true }
 libparsec_tests_fixtures = { workspace = true, optional = true }
 
-dirs = { workspace = true }
 log = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]


### PR DESCRIPTION
This dependency was not used and should not be used by this crate directly (to simplify platform specific path/behavior)