### PR TITLE
Add `data_dir` option to command using a client

### DIFF
--- a/cli/src/commands/device/export_recovery_device.rs
+++ b/cli/src/commands/device/export_recovery_device.rs
@@ -1,16 +1,14 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use std::path::PathBuf;
-
 use libparsec::{DateTime, DeviceLabel};
 
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin]
+    #[with = client_opts]
     pub struct Args {
         /// Path where to save recovery device data
-        output: PathBuf,
+        output: std::path::PathBuf,
     }
 );
 

--- a/cli/src/commands/invite/cancel.rs
+++ b/cli/src/commands/invite/cancel.rs
@@ -6,7 +6,7 @@ use libparsec::InvitationToken;
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin]
+    #[with = client_opts]
     pub struct Args {
         /// Invitation token
         #[arg(short, long, value_parser = InvitationToken::from_hex)]

--- a/cli/src/commands/invite/device.rs
+++ b/cli/src/commands/invite/device.rs
@@ -6,7 +6,7 @@ use libparsec::{InvitationType, ParsecInvitationAddr};
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin]
+    #[with = client_opts]
     pub struct Args {}
 );
 

--- a/cli/src/commands/invite/greet.rs
+++ b/cli/src/commands/invite/greet.rs
@@ -16,7 +16,7 @@ use libparsec_client::Client;
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin]
+    #[with = client_opts]
     pub struct Args {
         /// Invitation token
         #[arg(value_parser = InvitationToken::from_hex)]

--- a/cli/src/commands/invite/list.rs
+++ b/cli/src/commands/invite/list.rs
@@ -5,7 +5,7 @@ use libparsec::{authenticated_cmds::latest::invite_list::InviteListItem, Invitat
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin]
+    #[with = client_opts]
     pub struct Args {}
 );
 

--- a/cli/src/commands/invite/shared_recovery.rs
+++ b/cli/src/commands/invite/shared_recovery.rs
@@ -5,7 +5,7 @@ use libparsec::{InvitationEmailSentStatus, InvitationType, ParsecInvitationAddr}
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin]
+    #[with = client_opts]
     pub struct Args {
         /// Claimer email (i.e.: The invitee)
         #[arg(long)]

--- a/cli/src/commands/invite/user.rs
+++ b/cli/src/commands/invite/user.rs
@@ -6,7 +6,7 @@ use libparsec::{InvitationType, ParsecInvitationAddr};
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin]
+    #[with = client_opts]
     pub struct Args {
         /// Claimer email (i.e.: The invitee)
         #[arg(short, long)]

--- a/cli/src/commands/ls.rs
+++ b/cli/src/commands/ls.rs
@@ -3,7 +3,7 @@ use libparsec::FsPath;
 use crate::utils::StartedClient;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin, workspace]
+    #[with = client_opts, workspace]
     pub struct Args {
         /// Path to list
         #[arg(default_value_t)]

--- a/cli/src/commands/rm.rs
+++ b/cli/src/commands/rm.rs
@@ -3,7 +3,7 @@ use libparsec::FsPath;
 use crate::utils::StartedClient;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin, workspace]
+    #[with = client_opts, workspace]
     pub struct Args {
         /// Path to remove
         path: FsPath,

--- a/cli/src/commands/shared_recovery/create.rs
+++ b/cli/src/commands/shared_recovery/create.rs
@@ -8,7 +8,7 @@ use crate::utils::{start_spinner, StartedClient, GREEN_CHECKMARK};
 // TODO: should provide the recipients and their share count as a single parameter
 //       e.g. `--recipients=foo@example.com=2,bar@example.com=3`
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin]
+    #[with = client_opts]
     pub struct Args {
         /// Share recipients, if missing organization's admins will be used instead
         /// Author must not be included as recipient.

--- a/cli/src/commands/shared_recovery/delete.rs
+++ b/cli/src/commands/shared_recovery/delete.rs
@@ -1,7 +1,7 @@
 use crate::{build_main_with_client, utils::*};
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin]
+    #[with = client_opts]
     pub struct Args {
     }
 );

--- a/cli/src/commands/shared_recovery/info.rs
+++ b/cli/src/commands/shared_recovery/info.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use crate::{build_main_with_client, utils::*};
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin]
+    #[with = client_opts]
     pub struct Args {
     }
 );

--- a/cli/src/commands/shared_recovery/list.rs
+++ b/cli/src/commands/shared_recovery/list.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use crate::{build_main_with_client, utils::*};
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin]
+    #[with = client_opts]
     pub struct Args {
     }
 );

--- a/cli/src/commands/tos/accept.rs
+++ b/cli/src/commands/tos/accept.rs
@@ -1,7 +1,7 @@
 use crate::{commands::tos::list::display_tos, utils::StartedClient};
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = device, config_dir, password_stdin]
+    #[with = client_opts]
     pub struct Args {
         #[arg(long)]
         yes: bool,

--- a/cli/src/commands/tos/list.rs
+++ b/cli/src/commands/tos/list.rs
@@ -3,7 +3,7 @@ use libparsec_client::Tos;
 use crate::utils::{StartedClient, BULLET_CHAR};
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin]
+    #[with = client_opts]
     pub struct Args {
     }
 );

--- a/cli/src/commands/user/list.rs
+++ b/cli/src/commands/user/list.rs
@@ -3,7 +3,7 @@
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin]
+    #[with = client_opts]
     pub struct Args {
         /// Skip revoked users
         #[arg(short, long, default_value_t)]

--- a/cli/src/commands/user/revoke.rs
+++ b/cli/src/commands/user/revoke.rs
@@ -5,7 +5,7 @@ use anyhow::anyhow;
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin]
+    #[with = client_opts]
     pub struct Args {
         /// Email of the user to revoke
         #[arg(long)]

--- a/cli/src/commands/workspace/create.rs
+++ b/cli/src/commands/workspace/create.rs
@@ -5,7 +5,7 @@ use libparsec::EntryName;
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin]
+    #[with = client_opts]
     pub struct Args {
         /// New workspace name
         name: EntryName,

--- a/cli/src/commands/workspace/import.rs
+++ b/cli/src/commands/workspace/import.rs
@@ -7,7 +7,7 @@ use tokio::io::AsyncReadExt;
 use crate::utils::StartedClient;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin, workspace]
+    #[with = client_opts, workspace]
     pub struct Args {
         /// Local file to copy
         pub(crate) src: PathBuf,
@@ -16,15 +16,15 @@ crate::clap_parser_with_shared_opts_builder!(
     }
 );
 
-crate::build_main_with_client!(
-    main,
-    workspace_import,
+crate::build_main_with_client!(main, workspace_import, |args: &Args| {
     libparsec::ClientConfig {
         with_monitors: true,
+        config_dir: args.config_dir.clone(),
+        data_base_dir: args.data_dir.clone(),
         ..Default::default()
     }
     .into()
-);
+});
 
 pub async fn workspace_import(args: Args, client: &StartedClient) -> anyhow::Result<()> {
     let Args {

--- a/cli/src/commands/workspace/list.rs
+++ b/cli/src/commands/workspace/list.rs
@@ -3,7 +3,7 @@
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin]
+    #[with = client_opts]
     pub struct Args {}
 );
 

--- a/cli/src/commands/workspace/share.rs
+++ b/cli/src/commands/workspace/share.rs
@@ -5,7 +5,7 @@ use libparsec::{RealmRole, UserID};
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, workspace, password_stdin]
+    #[with = client_opts, workspace]
     pub struct Args {
         /// The user ID to share the workspace with
         #[arg(short, long, value_parser = UserID::from_hex)]

--- a/cli/src/commands/workspace/sync.rs
+++ b/cli/src/commands/workspace/sync.rs
@@ -1,7 +1,7 @@
 use crate::utils::{start_spinner, StartedClient};
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device, password_stdin, workspace]
+    #[with = client_opts, workspace]
     pub struct Args {}
 );
 

--- a/cli/src/testenv_utils.rs
+++ b/cli/src/testenv_utils.rs
@@ -469,3 +469,11 @@ pub fn parsec_addr_from_http_url(url: &str) -> ParsecAddr {
     };
     ParsecAddr::from_any(&url).expect("Invalid testbed url")
 }
+
+pub fn client_config_without_monitors_running() -> libparsec_client::ClientConfig {
+    libparsec::ClientConfig {
+        with_monitors: false,
+        ..Default::default()
+    }
+    .into()
+}

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -260,24 +260,12 @@ pub async fn load_cmds(
     Ok((cmds, device))
 }
 
-pub async fn load_client(
-    config_dir: &Path,
-    device: Option<String>,
-    password_stdin: bool,
-) -> anyhow::Result<Arc<StartedClient>> {
-    let device = load_and_unlock_device(config_dir, device, password_stdin).await?;
-    let client = start_client(device).await?;
-
-    Ok(client)
-}
-
 pub async fn load_client_with_config(
-    config_dir: &Path,
     device: Option<String>,
     password_stdin: bool,
     config: libparsec_client::ClientConfig,
 ) -> anyhow::Result<Arc<StartedClient>> {
-    let device = load_and_unlock_device(config_dir, device, password_stdin).await?;
+    let device = load_and_unlock_device(&config.config_dir, device, password_stdin).await?;
     let client = start_client_with_config(device, config).await?;
 
     Ok(client)
@@ -295,20 +283,6 @@ impl Deref for StartedClient {
     fn deref(&self) -> &Self::Target {
         &self.client
     }
-}
-
-pub async fn start_client(device: Arc<LocalDevice>) -> anyhow::Result<Arc<StartedClient>> {
-    let config = default_client_config();
-
-    start_client_with_config(device, config).await
-}
-
-pub fn default_client_config() -> libparsec_client::ClientConfig {
-    libparsec::ClientConfig {
-        with_monitors: false,
-        ..Default::default()
-    }
-    .into()
 }
 
 pub async fn start_client_with_config(

--- a/cli/tests/integration/device/import_recovery_device.rs
+++ b/cli/tests/integration/device/import_recovery_device.rs
@@ -2,8 +2,10 @@ use libparsec::{tmp_path, DeviceLabel, TmpPath};
 
 use crate::{
     integration_tests::bootstrap_cli_test,
-    testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
-    utils::start_client,
+    testenv_utils::{
+        client_config_without_monitors_running, TestOrganization, DEFAULT_DEVICE_PASSWORD,
+    },
+    utils::start_client_with_config,
 };
 
 #[rstest::rstest]
@@ -13,7 +15,9 @@ async fn import_recovery_device(tmp_path: TmpPath) {
 
     let input = tmp_path.join("recovery_device");
 
-    let client = start_client(alice).await.unwrap();
+    let client = start_client_with_config(alice, client_config_without_monitors_running())
+        .await
+        .unwrap();
 
     let (passphrase, data) = client
         .export_recovery_device(DeviceLabel::try_from("recovery".to_string().as_str()).unwrap())

--- a/cli/tests/integration/ls.rs
+++ b/cli/tests/integration/ls.rs
@@ -3,8 +3,10 @@ use predicates::prelude::PredicateBooleanExt;
 
 use super::bootstrap_cli_test;
 use crate::{
-    testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
-    utils::start_client,
+    testenv_utils::{
+        client_config_without_monitors_running, TestOrganization, DEFAULT_DEVICE_PASSWORD,
+    },
+    utils::start_client_with_config,
 };
 
 #[rstest::rstest]
@@ -13,7 +15,10 @@ async fn ls_files(tmp_path: TmpPath) {
     let (_, TestOrganization { alice, .. }, _) = bootstrap_cli_test(&tmp_path).await.unwrap();
 
     let wid = {
-        let client = start_client(alice.clone()).await.unwrap();
+        let client =
+            start_client_with_config(alice.clone(), client_config_without_monitors_running())
+                .await
+                .unwrap();
 
         // Create the workspace used to copy the file to
         let wid = client

--- a/cli/tests/integration/rm.rs
+++ b/cli/tests/integration/rm.rs
@@ -2,8 +2,10 @@ use libparsec::{tmp_path, TmpPath};
 
 use super::bootstrap_cli_test;
 use crate::{
-    testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
-    utils::start_client,
+    testenv_utils::{
+        client_config_without_monitors_running, TestOrganization, DEFAULT_DEVICE_PASSWORD,
+    },
+    utils::start_client_with_config,
 };
 
 #[rstest::rstest]
@@ -12,7 +14,10 @@ async fn rm_files(tmp_path: TmpPath) {
     let (_, TestOrganization { alice, .. }, _) = bootstrap_cli_test(&tmp_path).await.unwrap();
 
     let wid = {
-        let client = start_client(alice.clone()).await.unwrap();
+        let client =
+            start_client_with_config(alice.clone(), client_config_without_monitors_running())
+                .await
+                .unwrap();
 
         // Create the workspace used to copy the file to
         let wid = client
@@ -59,7 +64,9 @@ async fn rm_files(tmp_path: TmpPath) {
     )
     .stdout(predicates::str::is_empty());
 
-    let client = start_client(alice.clone()).await.unwrap();
+    let client = start_client_with_config(alice.clone(), client_config_without_monitors_running())
+        .await
+        .unwrap();
     let workspace = client.start_workspace(wid).await.unwrap();
     let entries = workspace.stat_folder_children_by_id(wid).await.unwrap();
     assert_eq!(entries.len(), 0);

--- a/cli/tests/integration/tos/config.rs
+++ b/cli/tests/integration/tos/config.rs
@@ -5,8 +5,10 @@ use libparsec::{tmp_path, ClientGetTosError, TmpPath};
 use crate::{
     commands::tos::config::{config_tos_for_org_req, TosReq},
     integration_tests::bootstrap_cli_test,
-    testenv_utils::{TestOrganization, DEFAULT_ADMINISTRATION_TOKEN},
-    utils::start_client,
+    testenv_utils::{
+        client_config_without_monitors_running, TestOrganization, DEFAULT_ADMINISTRATION_TOKEN,
+    },
+    utils::start_client_with_config,
 };
 
 #[rstest::rstest]
@@ -29,7 +31,9 @@ async fn test_set_tos_from_arg(tmp_path: TmpPath) {
     )
     .stdout(predicates::str::is_empty());
 
-    let client = start_client(alice).await.unwrap();
+    let client = start_client_with_config(alice, client_config_without_monitors_running())
+        .await
+        .unwrap();
 
     let tos = client.get_tos().await.unwrap();
 
@@ -71,7 +75,9 @@ async fn test_set_tos_from_file(tmp_path: TmpPath) {
     )
     .stdout(predicates::str::is_empty());
 
-    let client = start_client(alice).await.unwrap();
+    let client = start_client_with_config(alice, client_config_without_monitors_running())
+        .await
+        .unwrap();
 
     let tos = client.get_tos().await.unwrap();
 
@@ -93,7 +99,9 @@ async fn test_remove_tos(tmp_path: TmpPath) {
     .await
     .unwrap();
 
-    let client = start_client(alice).await.unwrap();
+    let client = start_client_with_config(alice, client_config_without_monitors_running())
+        .await
+        .unwrap();
     let tos = client.get_tos().await.unwrap();
 
     assert!(!tos.per_locale_urls.is_empty());

--- a/cli/tests/integration/workspace/create.rs
+++ b/cli/tests/integration/workspace/create.rs
@@ -2,8 +2,10 @@ use libparsec::{tmp_path, RealmRole, TmpPath};
 
 use crate::{
     integration_tests::bootstrap_cli_test,
-    testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
-    utils::start_client,
+    testenv_utils::{
+        client_config_without_monitors_running, TestOrganization, DEFAULT_DEVICE_PASSWORD,
+    },
+    utils::start_client_with_config,
 };
 
 #[rstest::rstest]
@@ -21,7 +23,9 @@ async fn create_workspace(tmp_path: TmpPath) {
     )
     .stdout(predicates::str::contains("Workspace has been created"));
 
-    let client = start_client(alice).await.unwrap();
+    let client = start_client_with_config(alice, client_config_without_monitors_running())
+        .await
+        .unwrap();
 
     let workspaces = client.list_workspaces().await;
 

--- a/cli/tests/integration/workspace/share.rs
+++ b/cli/tests/integration/workspace/share.rs
@@ -2,8 +2,10 @@ use libparsec::{tmp_path, RealmRole, TmpPath};
 
 use crate::{
     integration_tests::bootstrap_cli_test,
-    testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
-    utils::start_client,
+    testenv_utils::{
+        client_config_without_monitors_running, TestOrganization, DEFAULT_DEVICE_PASSWORD,
+    },
+    utils::start_client_with_config,
 };
 
 #[rstest::rstest]
@@ -13,7 +15,10 @@ async fn share_workspace(tmp_path: TmpPath) {
 
     let wid = {
         log::debug!("Create a workspace for alice");
-        let alice_client = start_client(alice.clone()).await.unwrap();
+        let alice_client =
+            start_client_with_config(alice.clone(), client_config_without_monitors_running())
+                .await
+                .unwrap();
 
         let wid = alice_client
             .create_workspace("new-workspace".parse().unwrap())
@@ -50,7 +55,9 @@ async fn share_workspace(tmp_path: TmpPath) {
     .stdout(predicates::str::contains("Workspace has been shared"));
 
     log::debug!("Check if bob has been added to the workspace as a contributor");
-    let bob_client = start_client(bob).await.unwrap();
+    let bob_client = start_client_with_config(bob, client_config_without_monitors_running())
+        .await
+        .unwrap();
 
     bob_client.poll_server_for_new_certificates().await.unwrap();
     bob_client.refresh_workspaces_list().await.unwrap();

--- a/cli/tests/integration/workspace/sync.rs
+++ b/cli/tests/integration/workspace/sync.rs
@@ -4,8 +4,10 @@ use libparsec::{internal::Client, tmp_path, EntryName, EntryStat, LocalDevice, T
 
 use crate::{
     integration_tests::bootstrap_cli_test,
-    testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
-    utils::{start_client, StartedClient},
+    testenv_utils::{
+        client_config_without_monitors_running, TestOrganization, DEFAULT_DEVICE_PASSWORD,
+    },
+    utils::{start_client_with_config, StartedClient},
 };
 
 struct Setup {
@@ -16,7 +18,9 @@ struct Setup {
 
 async fn setup_workspace(alice: Arc<LocalDevice>, bob: Arc<LocalDevice>) -> Setup {
     log::debug!("Create a workspace for alice");
-    let alice_client = start_client(alice).await.unwrap();
+    let alice_client = start_client_with_config(alice, client_config_without_monitors_running())
+        .await
+        .unwrap();
 
     let wid = alice_client
         .create_workspace("new-workspace".parse().unwrap())
@@ -32,7 +36,9 @@ async fn setup_workspace(alice: Arc<LocalDevice>, bob: Arc<LocalDevice>) -> Setu
         .unwrap();
 
     log::debug!("Ensure bob has access to the workspace");
-    let bob_client = start_client(bob).await.unwrap();
+    let bob_client = start_client_with_config(bob, client_config_without_monitors_running())
+        .await
+        .unwrap();
     bob_client.poll_server_for_new_certificates().await.unwrap();
     bob_client.refresh_workspaces_list().await.unwrap();
     let bob_wksp_list = bob_client.list_workspaces().await;
@@ -166,6 +172,9 @@ async fn workspace_sync_bob_need_to_sync(tmp_path: TmpPath) {
         &workspace_id.hex()
     );
 
-    let bob_client = start_client(bob.clone()).await.unwrap();
+    let bob_client =
+        start_client_with_config(bob.clone(), client_config_without_monitors_running())
+            .await
+            .unwrap();
     assert!(find_foo_file(&bob_client, workspace_id).await.is_some());
 }


### PR DESCRIPTION
This was done by creating a group `client_opts` in `clap_parser_with_shared_opts_builder` macro and generating a `ClientConfig` using the provided value.

## Other changes

- `load_client_with_config` remove `config_dir` arg that is already present in `config` arg.
- Remove the short option name for options defined by `clap_parser_with_shared_opts_builder`.
- Remove `start_client`.