### PR TITLE
[MS] Fixed processing file link when opening Parsec

### DIFF
--- a/client/src/views/files/FoldersPage.vue
+++ b/client/src/views/files/FoldersPage.vue
@@ -479,7 +479,8 @@ onMounted(async () => {
   }
   callbackId = await fileOperationManager.registerCallback(onFileOperationState);
   currentPath.value = getDocumentPath();
-  await listFolder();
+  const query = getCurrentRouteQuery();
+  await listFolder({ selectFile: query.selectFile });
 });
 
 onUnmounted(async () => {


### PR DESCRIPTION
Correctly select the item when opening Parsec with a file link.
This bug was "added" after the last release so there's no need for a newsfragment.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
 