### PR TITLE
[MS] Fixed switch org bug

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -28,7 +28,7 @@
                 "file-type": "^19.6.0",
                 "luxon": "^3.4.4",
                 "mammoth": "^1.8.0",
-                "megashark-lib": "git+https://github.com/Scille/megashark-lib.git#dadbcb5a858d0e7cc78b02fb993b39a23ec3fba5",
+                "megashark-lib": "git+https://github.com/Scille/megashark-lib.git#3e8d49c48c492f50830311731a54704f65b86397",
                 "monaco-editor": "^0.52.0",
                 "pdfjs-dist": "^4.8.69",
                 "qrcode-vue3": "^1.6.8",
@@ -7504,8 +7504,8 @@
         },
         "node_modules/megashark-lib": {
             "version": "0.0.1",
-            "resolved": "git+ssh://git@github.com/Scille/megashark-lib.git#dadbcb5a858d0e7cc78b02fb993b39a23ec3fba5",
-            "integrity": "sha512-0ZfM04fC98w0YXy3egCVQexoUgw8Nt2VPrbwv0jQApCpiizQlwIuS5lQ2L2q9JQQegwXknAEoEHaqOYeVA0aMg==",
+            "resolved": "git+ssh://git@github.com/Scille/megashark-lib.git#3e8d49c48c492f50830311731a54704f65b86397",
+            "integrity": "sha512-5AiZ2sR29cwXG2e1pWImyJSoY2trCIYPsTJ2LvE7ZkTGgxPNAuEcLM1ODGe8lu5SAWI+7K4Kho2zdRt/UM2cog==",
             "dependencies": {
                 "@ionic/vue": "^7.0.0",
                 "@stripe/stripe-js": "^4.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -50,7 +50,7 @@
         "axios": "^1.7.4",
         "file-type": "^19.6.0",
         "luxon": "^3.4.4",
-        "megashark-lib": "git+https://github.com/Scille/megashark-lib.git#dadbcb5a858d0e7cc78b02fb993b39a23ec3fba5",
+        "megashark-lib": "git+https://github.com/Scille/megashark-lib.git#3e8d49c48c492f50830311731a54704f65b86397",
         "mammoth": "^1.8.0",
         "monaco-editor": "^0.52.0",
         "pdfjs-dist": "^4.8.69",

--- a/client/src/views/layouts/LoadingLayout.vue
+++ b/client/src/views/layouts/LoadingLayout.vue
@@ -37,13 +37,18 @@ onMounted(async () => {
     async () => {
       const query = getCurrentRouteQuery();
       if (query.loginInfo) {
-        const loginInfo = Base64.toObject(query.loginInfo) as RouteBackup;
-        await navigateTo(loginInfo.data.route, {
-          params: loginInfo.data.params,
-          query: loginInfo.data.query,
-          skipHandle: true,
-          replace: true,
-        });
+        try {
+          const loginInfo = Base64.toObject(query.loginInfo) as RouteBackup;
+          await navigateTo(loginInfo.data.route, {
+            params: loginInfo.data.params,
+            query: loginInfo.data.query,
+            skipHandle: true,
+            replace: true,
+          });
+        } catch (e: any) {
+          window.electronAPI.log('error', `Invalid log in info provided: ${e}`);
+          await navigateTo(Routes.Home, { skipHandle: true, replace: true });
+        }
       } else {
         window.electronAPI.log('error', 'Trying to log in with no log in info provided');
         await navigateTo(Routes.Home, { skipHandle: true, replace: true });

--- a/newsfragments/9287.bugfix.rst
+++ b/newsfragments/9287.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a rare bug that could occur when switching organizations


### PR DESCRIPTION
Closes #9287 

Steps to reproduce are given in #9287 

I would also advice testing with the following patch applied to check the behavior in case the base64 encoding still crashes.

```diff
diff --git a/client/src/router/navigation.ts b/client/src/router/navigation.ts
index b1d9e55d5..36c81a7bc 100644
--- a/client/src/router/navigation.ts
+++ b/client/src/router/navigation.ts
@@ -97,6 +97,7 @@ export async function switchOrganization(handle: ConnectionHandle | null, backup
     }
     const backup = routesBackup[backupIndex];
     try {
+      throw new Error('Error');
       await navigateTo(Routes.Loading, { skipHandle: true, replace: true, query: { loginInfo: Base64.fromObject(backup) } });
     } catch (e: any) {
       // We encounter an error, probably the base64 serialization, we remove the backup and log in to the default page

```

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description