### PR TITLE
[MS] Updated sidebar menu icons, save recent file menu state

### DIFF
--- a/client/src/components/sidebar/SidebarMenuList.vue
+++ b/client/src/components/sidebar/SidebarMenuList.vue
@@ -6,7 +6,7 @@
       lines="none"
       class="list-sidebar-header title-h5"
       :class="isContentVisible ? 'open' : 'close'"
-      @click="setContentVisible(!isContentVisible)"
+      @click="emits('update:isContentVisible', !isContentVisible)"
     >
       <div class="list-sidebar-header-title">
         <ion-icon
@@ -35,31 +35,17 @@
 <script setup lang="ts">
 import { IonList, IonHeader, IonIcon, IonText } from '@ionic/vue';
 import { Translatable } from 'megashark-lib';
-import { ref } from 'vue';
 import { chevronDown, chevronForward } from 'ionicons/icons';
-
-const isContentVisible = ref(true);
 
 defineProps<{
   title: Translatable;
   icon?: string;
+  isContentVisible: boolean;
 }>();
-
-defineExpose({
-  isContentVisible,
-  setContentVisible,
-});
 
 const emits = defineEmits<{
-  (event: 'visibilityChanged', visibility: boolean): void;
+  (event: 'update:isContentVisible', visibility: boolean): void;
 }>();
-
-function setContentVisible(visible: boolean, blockEvent = false): void {
-  isContentVisible.value = visible;
-  if (!blockEvent) {
-    emits('visibilityChanged', isContentVisible.value);
-  }
-}
 </script>
 
 <style scoped lang="scss">
@@ -67,9 +53,7 @@ function setContentVisible(visible: boolean, blockEvent = false): void {
   display: flex;
   flex-direction: column;
   flex: 1;
-  gap: 0.5rem;
   margin-bottom: 1rem;
-  padding: 0.5rem;
   border-radius: var(--parsec-radius-8);
 
   &.list-file {
@@ -81,11 +65,14 @@ function setContentVisible(visible: boolean, blockEvent = false): void {
     align-items: center;
     justify-content: space-between;
     transition: border 0.2s ease-in-out;
+    border-radius: var(--parsec-radius-6);
+    padding: 0.25rem 0.5rem;
     opacity: 0.8;
     cursor: pointer;
 
     &:hover {
       opacity: 1;
+      background: var(--parsec-color-light-primary-30-opacity15);
     }
 
     &.open {
@@ -108,18 +95,12 @@ function setContentVisible(visible: boolean, blockEvent = false): void {
         user-select: none;
       }
     }
-
-    &:active {
-      .list-sidebar-toggle-icon {
-        scale: 0.85;
-      }
-    }
   }
 
   &-toggle-icon {
     user-select: none;
     padding: 0.125rem;
-    font-size: 1.25rem;
+    font-size: 1rem;
     border-radius: var(--parsec-radius-6);
     color: var(--parsec-color-light-secondary-inversed-contrast);
   }

--- a/client/src/components/sidebar/SidebarMenuList.vue
+++ b/client/src/components/sidebar/SidebarMenuList.vue
@@ -10,6 +10,7 @@
     >
       <div class="list-sidebar-header-title">
         <ion-icon
+          v-if="icon"
           class="list-sidebar-header-title__icon"
           :icon="icon"
         />
@@ -19,7 +20,7 @@
       </div>
       <ion-icon
         class="list-sidebar-toggle-icon"
-        :icon="isContentVisible ? remove : add"
+        :icon="isContentVisible ? chevronDown : chevronForward"
       />
     </ion-header>
     <div
@@ -35,13 +36,13 @@
 import { IonList, IonHeader, IonIcon, IonText } from '@ionic/vue';
 import { Translatable } from 'megashark-lib';
 import { ref } from 'vue';
-import { add, remove } from 'ionicons/icons';
+import { chevronDown, chevronForward } from 'ionicons/icons';
 
 const isContentVisible = ref(true);
 
 defineProps<{
   title: Translatable;
-  icon: string;
+  icon?: string;
 }>();
 
 defineExpose({

--- a/client/src/components/sidebar/SidebarWorkspaceItem.vue
+++ b/client/src/components/sidebar/SidebarWorkspaceItem.vue
@@ -55,6 +55,7 @@ onBeforeUnmount(async () => {
 .sidebar-item {
   --background: none;
   border-radius: var(--parsec-radius-8);
+  border: solid 1px transparent;
   --min-height: 0;
   --padding-start: 0.75rem;
   --padding-end: 0.75rem;
@@ -93,7 +94,7 @@ onBeforeUnmount(async () => {
   }
 
   &:hover {
-    outline: solid 1px var(--parsec-color-light-primary-30-opacity15);
+    border-color: var(--parsec-color-light-primary-30-opacity15);
     cursor: pointer;
 
     .sidebar-item-workspace__option {

--- a/client/src/views/sidebar-menu/SidebarMenuPage.vue
+++ b/client/src/views/sidebar-menu/SidebarMenuPage.vue
@@ -166,8 +166,8 @@
               title="SideMenu.favorites"
               :icon="star"
               class="favorites"
-              ref="favoritesMenu"
-              @visibility-changed="onFavoritesMenuVisibilityChanged"
+              v-model:is-content-visible="favoritesMenuVisible"
+              @update:is-content-visible="onFavoritesMenuVisibilityChanged"
             >
               <sidebar-workspace-item
                 v-for="workspace in favoritesWorkspaces"
@@ -185,8 +185,8 @@
               title="SideMenu.workspaces"
               :icon="business"
               class="workspaces"
-              ref="workspacesMenu"
-              @visibility-changed="onWorkspacesMenuVisibilityChanged"
+              v-model:is-content-visible="workspacesMenuVisible"
+              @update:is-content-visible="onWorkspacesMenuVisibilityChanged"
             >
               <ion-text
                 class="body list-sidebar__no-workspace"
@@ -208,17 +208,20 @@
 
           <div
             class="list-sidebar-divider"
-            v-if="recentFileManager.getFiles().length > 0"
+            v-if="recentFileManager.getFiles().length > 0 && !currentRouteIsOrganizationManagementRoute()"
           />
 
           <!-- last opened files -->
-          <div class="file-workspaces">
+          <div
+            class="file-workspaces"
+            v-if="!currentRouteIsOrganizationManagementRoute()"
+          >
             <sidebar-menu-list
-              :title="'SideMenu.recentDocuments'"
+              title="SideMenu.recentDocuments"
               :icon="documentIcon"
               v-show="recentFileManager.getFiles().length > 0"
-              ref="recentFilesMenu"
-              @visibility-changed="onRecentFilesMenuVisibilityChanged"
+              v-model:is-content-visible="recentFilesMenuVisible"
+              @update:is-content-visible="onRecentFilesMenuVisibilityChanged"
             >
               <sidebar-recent-file-item
                 v-for="file in recentFileManager.getFiles()"
@@ -253,14 +256,14 @@
               <ion-item
                 lines="none"
                 button
-                class="sidebar-item button-medium users-title"
+                class="sidebar-item-manage button-medium users-title"
                 :class="currentRouteIsUserRoute() ? 'item-selected' : 'item-not-selected'"
                 @click="navigateTo(Routes.Users)"
               >
-                <div class="sidebar-item-manage">
+                <div class="sidebar-item-manage-content">
                   <ion-icon
                     :icon="people"
-                    class="sidebar-item-icon"
+                    class="sidebar-item-manage__icon"
                   />
                   <ion-text class="sidebar-item-manage__label">{{ $msTranslate('SideMenu.users') }}</ion-text>
                 </div>
@@ -270,15 +273,15 @@
               <ion-item
                 lines="none"
                 button
-                class="sidebar-item button-medium storage-title"
+                class="sidebar-item-manage button-medium storage-title"
                 :class="currentRouteIs(Routes.Storage) ? 'item-selected' : 'item-not-selected'"
                 @click="navigateTo(Routes.Storage)"
                 v-show="userInfo && userInfo.currentProfile === UserProfile.Admin && false"
               >
-                <div class="sidebar-item-manage">
+                <div class="sidebar-item-manage-content">
                   <ion-icon
                     :icon="pieChart"
-                    class="sidebar-item-icon"
+                    class="sidebar-item-manage__icon"
                   />
                   <ion-text class="sidebar-item-manage__label">{{ $msTranslate('SideMenu.storage') }}</ion-text>
                 </div>
@@ -288,14 +291,14 @@
               <ion-item
                 button
                 lines="none"
-                class="sidebar-item button-medium organization-title"
+                class="sidebar-item-manage button-medium organization-title"
                 :class="currentRouteIs(Routes.Organization) ? 'item-selected' : 'item-not-selected'"
                 @click="navigateTo(Routes.Organization)"
               >
-                <div class="sidebar-item-manage">
+                <div class="sidebar-item-manage-content">
                   <ion-icon
                     :icon="informationCircle"
-                    class="sidebar-item-icon"
+                    class="sidebar-item-manage__icon"
                   />
                   <ion-text class="sidebar-item-manage__label">{{ $msTranslate('SideMenu.organizationInfo') }}</ion-text>
                 </div>
@@ -400,9 +403,9 @@ const isTrialOrg = ref(false);
 const expirationDuration = ref<Duration | undefined>(undefined);
 const isExpired = ref(false);
 const loggedInDevices = ref<LoggedInDeviceInfo[]>([]);
-const favoritesMenu = ref<typeof SidebarMenuList>();
-const workspacesMenu = ref<typeof SidebarMenuList>();
-const recentFilesMenu = ref<typeof SidebarMenuList>();
+const favoritesMenuVisible = ref(true);
+const workspacesMenuVisible = ref(true);
+const recentFilesMenuVisible = ref(true);
 let timeoutId: number | undefined = undefined;
 
 const MIN_WIDTH = 150;
@@ -475,6 +478,7 @@ onMounted(async () => {
   );
 
   const savedSidebarData = await storageManager.retrieveComponentData<SidebarSavedData>(SIDEBAR_MENU_DATA_KEY, SidebarDefaultData);
+
   if (savedSidebarData.hidden) {
     computedWidth.value = 2;
     storedWidth.value = savedSidebarData.width;
@@ -482,11 +486,9 @@ onMounted(async () => {
     computedWidth.value = savedSidebarData.width;
   }
   sidebarWidthProperty.value = `${computedWidth.value}px`;
-  if (workspacesMenu.value && favoritesMenu.value && recentFilesMenu.value) {
-    workspacesMenu.value.setContentVisible(savedSidebarData.workspacesVisible, true);
-    favoritesMenu.value.setContentVisible(savedSidebarData.favoritesVisible, true);
-    recentFilesMenu.value.setContentVisible(savedSidebarData.recentFilesVisible, true);
-  }
+  workspacesMenuVisible.value = savedSidebarData.workspacesVisible ?? true;
+  favoritesMenuVisible.value = savedSidebarData.favoritesVisible ?? true;
+  recentFilesMenuVisible.value = savedSidebarData.recentFilesVisible ?? true;
 
   const connInfo = getConnectionInfo();
   if (connInfo) {
@@ -685,7 +687,7 @@ async function onRecentFilesMenuVisibilityChanged(visible: boolean): Promise<voi
   user-select: initial;
 
   &::part(container) {
-    padding: 0.5rem;
+    padding-top: 1.5rem;
     display: flex;
     gap: 1.5rem;
   }
@@ -732,7 +734,7 @@ async function onRecentFilesMenuVisibilityChanged(visible: boolean): Promise<voi
     border-radius: var(--parsec-radius-8);
     box-shadow: none;
     align-items: center;
-    margin-top: 0.75rem;
+    margin: 0 0.5rem;
     padding: 0.5rem 1rem;
     gap: 0.5em;
     position: relative;
@@ -793,7 +795,7 @@ async function onRecentFilesMenuVisibilityChanged(visible: boolean): Promise<voi
     user-select: none;
     gap: 0.75rem;
     padding: 1rem 0 1.5rem;
-    margin-inline: 0.75rem;
+    margin-inline: 0.5rem;
 
     &__item {
       display: flex;
@@ -874,14 +876,6 @@ ion-menu {
 }
 
 .list-sidebar {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
-  padding: 0.5rem;
-  border-radius: var(--parsec-radius-8);
-
   &-header {
     display: flex;
     align-items: center;
@@ -918,44 +912,46 @@ ion-menu {
   }
 }
 
-.sidebar-item {
+// eslint-disable-next-line vue-scoped-css/no-unused-selector
+.sidebar-item-manage {
   --background: none;
   border-radius: var(--parsec-radius-8);
+  border: solid 1px transparent;
   --min-height: 0;
   --padding-start: 0.75rem;
   --padding-end: 0.75rem;
   --padding-bottom: 0.5rem;
   --padding-top: 0.5rem;
 
+  &-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+  }
+
   &:active,
   &.item-selected {
     --background: var(--parsec-color-light-primary-30-opacity15);
   }
 
-  &-icon {
+  &__icon {
     color: var(--parsec-color-light-primary-100);
     font-size: 1.25em;
     margin: 0;
     margin-inline-end: 12px;
   }
 
-  .sidebar-item-manage {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+  &__label {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    color: var(--parsec-color-light-secondary-premiere);
     width: 100%;
-
-    &__label {
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      overflow: hidden;
-      color: var(--parsec-color-light-secondary-premiere);
-      width: 100%;
-    }
   }
 
   &:hover {
-    outline: solid 1px var(--parsec-color-light-primary-30-opacity15);
+    border-color: var(--parsec-color-light-primary-30-opacity15);
     cursor: pointer;
   }
 }

--- a/client/src/views/sidebar-menu/utils.ts
+++ b/client/src/views/sidebar-menu/utils.ts
@@ -5,6 +5,7 @@ export interface SidebarSavedData {
   hidden?: boolean;
   workspacesVisible?: boolean;
   favoritesVisible?: boolean;
+  recentFilesVisible?: boolean;
 }
 
 export const SIDEBAR_MENU_DATA_KEY = 'SidebarMenu';
@@ -14,4 +15,5 @@ export const SidebarDefaultData: Required<SidebarSavedData> = {
   hidden: false,
   workspacesVisible: true,
   favoritesVisible: true,
+  recentFilesVisible: true,
 };

--- a/client/tests/e2e/specs/documents_list.spec.ts
+++ b/client/tests/e2e/specs/documents_list.spec.ts
@@ -199,3 +199,26 @@ for (const gridMode of [false, true]) {
     await expect(documents).toBeWorkspacePage();
   });
 }
+
+msTest('Show recently opened files in sidebar', async ({ documents }) => {
+  const sidebarRecentList = documents.locator('.sidebar').locator('.file-workspaces').locator('ion-list');
+  await expect(sidebarRecentList.locator('.list-sidebar-header')).toHaveText('Recent documents');
+  // Two recently opened files by default in dev mode
+  await expect(sidebarRecentList.locator('.sidebar-item')).toHaveText(['File_Fake PDF document.pdf', 'File_Fake image.png']);
+
+  await expect(documents.locator('.information-modal')).toBeHidden();
+  await expect(documents).toHaveHeader(['The Copper Coronet'], true, true);
+  const fileItem = documents.locator('.folder-container').getByRole('listitem').nth(2);
+  const fileName = await fileItem.locator('.file-name').textContent();
+  await fileItem.dblclick();
+  await expect(documents.locator('.ms-spinner-modal')).toBeVisible();
+  await expect(documents.locator('.ms-spinner-modal').locator('.spinner-label__text')).toHaveText('Opening file...');
+  await expect(documents.locator('.ms-spinner-modal')).toBeHidden();
+  await expect(documents).toHavePageTitle('File viewer');
+  // One file added
+  await expect(sidebarRecentList.locator('.sidebar-item')).toHaveText([
+    fileName ?? '',
+    'File_Fake PDF document.pdf',
+    'File_Fake image.png',
+  ]);
+});

--- a/client/tests/e2e/specs/sidebar.spec.ts
+++ b/client/tests/e2e/specs/sidebar.spec.ts
@@ -1,0 +1,26 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { expect, msTest } from '@tests/e2e/helpers';
+
+msTest('Sidebar in organization management', async ({ organizationPage }) => {
+  const sidebar = organizationPage.locator('.sidebar');
+
+  await expect(sidebar.locator('.file-workspaces')).toBeHidden();
+  await expect(sidebar.locator('.favorites')).toBeHidden();
+  await expect(sidebar.locator('.workspaces')).toBeHidden();
+
+  await expect(sidebar.locator('.manage-organization')).toBeVisible();
+  await expect(sidebar.locator('.manage-organization').locator('.list-sidebar-header')).toHaveText('Manage my organization');
+  const items = sidebar.locator('.manage-organization').locator('.list-sidebar-content').getByRole('listitem');
+  await expect(items).toHaveText(['Users', 'Information']);
+});
+
+msTest('Sidebar in workspaces page', async ({ connected }) => {
+  const sidebar = connected.locator('.sidebar');
+
+  await expect(sidebar.locator('.file-workspaces')).toBeVisible();
+  await expect(sidebar.locator('.favorites')).toBeHidden();
+  await expect(sidebar.locator('.workspaces')).toBeVisible();
+
+  await expect(sidebar.locator('.manage-organization')).toBeHidden();
+});


### PR DESCRIPTION
- Updates the sidebar icons for collapse
- Save the recent documents state
- Fixed recent documents being displaying in org management page
- Show some recent documents by default in dev mode to remember that this feature exists
- Added e2e tests for recents documents
- Added e2e tests for sidebar state

I don't know if a newsfragment is required since the only thing the user will see is the change of icon.

Closes #9306 

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
 