### PR TITLE
[MS] Fixed incompatible server modal not being displayed properly

### DIFF
--- a/client/src/parsec/login.ts
+++ b/client/src/parsec/login.ts
@@ -190,7 +190,7 @@ export async function login(
         if (connInfo) {
           connInfo.shouldAcceptTos = true;
         }
-        distributor.dispatchEvent(Events.TOSAcceptRequired, undefined, 2000);
+        distributor.dispatchEvent(Events.TOSAcceptRequired, undefined, { delay: 2000 });
         break;
       case ClientEventTag.InvitationChanged:
         distributor.dispatchEvent(Events.InvitationUpdated, {
@@ -200,7 +200,7 @@ export async function login(
         break;
       case ClientEventTag.IncompatibleServer:
         window.electronAPI.log('warn', `IncompatibleServerEvent: ${JSON.stringify(event)}`);
-        distributor.dispatchEvent(Events.IncompatibleServer, { reason: event.detail });
+        distributor.dispatchEvent(Events.IncompatibleServer, { reason: event.detail }, { delay: 5000 });
         break;
       case ClientEventTag.RevokedSelfUser:
         eventDistributor.dispatchEvent(Events.ClientRevoked);
@@ -218,7 +218,7 @@ export async function login(
         eventDistributor.dispatchEvent(Events.WorkspaceUpdated);
         break;
       case ClientEventTag.WorkspaceWatchedEntryChanged:
-        eventDistributor.dispatchEvent(Events.EntryUpdated, undefined, 1000);
+        eventDistributor.dispatchEvent(Events.EntryUpdated, undefined, { aggregateTime: 1000 });
         break;
       case ClientEventTag.WorkspaceOpsInboundSyncDone:
         eventDistributor.dispatchEvent(Events.EntrySynced, { workspaceId: event.realmId, entryId: event.entryId, way: 'inbound' });

--- a/client/src/services/eventDistributor.ts
+++ b/client/src/services/eventDistributor.ts
@@ -63,7 +63,11 @@ class EventDistributor {
     this.timeouts = new Map<number, Events>();
   }
 
-  async dispatchEvent(event: Events, data?: EventData, aggregateTime?: number): Promise<void> {
+  async dispatchEvent(
+    event: Events,
+    data?: EventData,
+    options: { aggregateTime?: number; delay?: number } = { aggregateTime: undefined, delay: undefined },
+  ): Promise<void> {
     async function sendToAll(callbacks: Array<Callback>, event: Events, data?: EventData): Promise<void> {
       for (const cb of callbacks) {
         if (event & cb.events) {
@@ -72,10 +76,14 @@ class EventDistributor {
       }
     }
 
+    if (options.aggregateTime !== undefined && options.delay !== undefined) {
+      console.warn('Cannot have both aggregateTime and delay set, ignoring this event.');
+      return;
+    }
     // In some cases, events can occur very close to each other, leading to some heavy operations.
     // We can aggregate those cases in order to distribute only one event if multiple occur in a short
     // time lapse.
-    if (aggregateTime !== undefined) {
+    if (options.aggregateTime !== undefined) {
       if (data) {
         // Can't have data with an aggregateTime, we wouldn't know what data to use
         console.warn('Cannot have an aggregate time with data, ignoring this event.');
@@ -90,9 +98,17 @@ class EventDistributor {
       // Create a new timeout
       const interval = window.setTimeout(async () => {
         await sendToAll(this.callbacks, event, undefined);
-      }, aggregateTime);
+      }, options.aggregateTime);
       // Add it to the list
       this.timeouts.set(event, interval);
+    } else if (options.delay !== undefined) {
+      window.setTimeout(
+        async (d?: EventData) => {
+          await sendToAll(this.callbacks, event, d);
+        },
+        options.delay,
+        data,
+      );
     } else {
       await sendToAll(this.callbacks, event, data);
     }


### PR DESCRIPTION
Linked to #9320 

Testable with the testbed in electron, just update in `parsec-cloud/server/parsec/asgi/rpc.py` line `103`:
`SUPPORTED_API_VERSIONS = (ApiVersion(5, 0),)`
and start the testbed.

The event was emitted before we were fully logged in, so the modal would not show. It's a bit clearer with the delay, and it also helps making the notification more visible.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
