### PR TITLE
Fix unsupported_api_version_from_headers helper

### DIFF
--- a/libparsec/crates/client/src/monitors/connection.rs
+++ b/libparsec/crates/client/src/monitors/connection.rs
@@ -218,7 +218,6 @@ fn handle_sse_error(
         | ConnectionError::BadContent
         | ConnectionError::InvalidResponseStatus(_)
         | ConnectionError::InvalidResponseContent(_)
-        | ConnectionError::MissingApiVersion
         | ConnectionError::MissingSupportedApiVersions
         | ConnectionError::FrozenUser
         | ConnectionError::AuthenticationTokenExpired

--- a/libparsec/crates/client_connection/src/anonymous_cmds.rs
+++ b/libparsec/crates/client_connection/src/anonymous_cmds.rs
@@ -114,7 +114,7 @@ impl AnonymousCmds {
             // No 410: no invitation here
             415 => Err(ConnectionError::BadContent),
             422 => Err(crate::error::unsupported_api_version_from_headers(
-                resp.headers(),
+                *api_version, resp.headers(),
             )),
             460 => Err(ConnectionError::ExpiredOrganization),
             // No 461/462/463: no user here

--- a/libparsec/crates/client_connection/src/authenticated_cmds/mod.rs
+++ b/libparsec/crates/client_connection/src/authenticated_cmds/mod.rs
@@ -168,7 +168,7 @@ impl AuthenticatedCmds {
             // No 410: no invitation here
             415 => Err(ConnectionError::BadContent),
             422 => Err(crate::error::unsupported_api_version_from_headers(
-                resp.headers(),
+                *api_version, resp.headers(),
             )),
             460 => Err(ConnectionError::ExpiredOrganization),
             461 => Err(ConnectionError::RevokedUser),
@@ -257,6 +257,7 @@ impl AuthenticatedCmds {
     where
         T: ProtocolRequest<API_LATEST_MAJOR_VERSION> + Debug + 'static,
     {
+        let api_version = api_version_major_to_full(T::API_MAJOR_VERSION);
         let request_builder = self.sse_request_builder::<T>(last_event_id.as_deref());
 
         #[cfg(feature = "test-with-testbed")]
@@ -277,7 +278,7 @@ impl AuthenticatedCmds {
             415 => return Err(ConnectionError::BadContent),
             // TODO: cannot  access the response headers here...
             422 => return Err(crate::error::unsupported_api_version_from_headers(
-                response.headers(),
+                *api_version, response.headers(),
             )),
             460 => return Err(ConnectionError::ExpiredOrganization),
             461 => return Err(ConnectionError::RevokedUser),

--- a/libparsec/crates/client_connection/src/error.rs
+++ b/libparsec/crates/client_connection/src/error.rs
@@ -47,10 +47,6 @@ pub enum ConnectionError {
     #[error("Failed to deserialize the response: {0}")]
     InvalidResponseContent(ProtocolDecodeError),
 
-    /// We failed to retrieve Api-Version
-    #[error("Api-Version header is missing")]
-    MissingApiVersion,
-
     /// We failed to retrieve Supported-Api-Versions
     #[error("Supported-Api-Versions header is missing")]
     MissingSupportedApiVersions,

--- a/libparsec/crates/client_connection/src/error.rs
+++ b/libparsec/crates/client_connection/src/error.rs
@@ -113,19 +113,9 @@ impl From<ProtocolEncodeError> for ConnectionError {
 }
 
 pub(crate) fn unsupported_api_version_from_headers(
+    api_version: ApiVersion,
     headers: &reqwest::header::HeaderMap,
 ) -> ConnectionError {
-    let api_version = match headers.get("Api-Version") {
-        Some(api_version) => {
-            let api_version = api_version.to_str().unwrap_or_default();
-            match api_version.try_into() {
-                Ok(api_version) => api_version,
-                Err(_) => return ConnectionError::WrongApiVersion(api_version.into()),
-            }
-        }
-        None => return ConnectionError::MissingApiVersion,
-    };
-
     match headers.get("Supported-Api-Versions") {
         Some(supported_api_versions) => ConnectionError::UnsupportedApiVersion {
             api_version,

--- a/libparsec/crates/client_connection/src/invited_cmds.rs
+++ b/libparsec/crates/client_connection/src/invited_cmds.rs
@@ -119,7 +119,7 @@ impl InvitedCmds {
             410 => Err(ConnectionError::InvitationAlreadyUsedOrDeleted),
             415 => Err(ConnectionError::BadContent),
             422 => Err(crate::error::unsupported_api_version_from_headers(
-                resp.headers(),
+                *api_version, resp.headers(),
             )),
             460 => Err(ConnectionError::ExpiredOrganization),
             // No 461/462/463: no user here

--- a/libparsec/crates/client_connection/src/lib.rs
+++ b/libparsec/crates/client_connection/src/lib.rs
@@ -21,7 +21,7 @@ pub use invited_cmds::InvitedCmds;
 pub use testbed::{
     test_register_low_level_send_hook, test_register_low_level_send_hook_default,
     test_register_low_level_send_hook_multicall, test_register_send_hook, Bytes, HeaderMap,
-    HeaderValue, ResponseMock, StatusCode,
+    HeaderName, HeaderValue, ResponseMock, StatusCode,
 };
 // Re-expose
 pub use libparsec_platform_http_proxy::ProxyConfig;

--- a/libparsec/crates/client_connection/src/testbed.rs
+++ b/libparsec/crates/client_connection/src/testbed.rs
@@ -11,7 +11,7 @@ use std::{
 
 pub use bytes::Bytes;
 pub use reqwest::{
-    header::{HeaderMap, HeaderValue},
+    header::{HeaderMap, HeaderName, HeaderValue},
     Error as RequestError, StatusCode,
 };
 use reqwest::{RequestBuilder, Response};

--- a/libparsec/crates/client_connection/tests/unit/invited.rs
+++ b/libparsec/crates/client_connection/tests/unit/invited.rs
@@ -5,10 +5,10 @@
 #![allow(clippy::unwrap_used)]
 
 use crate::{
-    test_register_low_level_send_hook, Bytes, ConnectionError, HeaderMap, HeaderValue, InvitedCmds,
-    ProxyConfig, ResponseMock, StatusCode,
+    test_register_low_level_send_hook, Bytes, ConnectionError, HeaderMap, HeaderName, HeaderValue,
+    InvitedCmds, ProxyConfig, ResponseMock, StatusCode,
 };
-use libparsec_protocol::invited_cmds::latest as invited_cmds;
+use libparsec_protocol::{invited_cmds::latest as invited_cmds, API_LATEST_VERSION};
 use libparsec_tests_fixtures::prelude::*;
 use libparsec_types::prelude::*;
 
@@ -126,7 +126,7 @@ async fn invalid_token(env: &TestbedEnv, mocked: bool) {
 // Must use a macro to generate the parametrized tests here given `test_register_low_level_send_hook`
 // only accept a static closure (i.e. `fn`, not `FnMut`).
 macro_rules! register_rpc_http_hook {
-    ($test_name: ident, $response_status_code: expr, $assert_err_cb: expr) => {
+    ($test_name: ident, $response_status_code: expr, $assert_err_cb: expr $(, $header_key:literal : $header_value:expr)* $(,)?) => {
         #[parsec_test(testbed = "minimal")]
         async fn $test_name(env: &TestbedEnv) {
             let addr = ParsecInvitationAddr::new(
@@ -141,9 +141,18 @@ macro_rules! register_rpc_http_hook {
             test_register_low_level_send_hook(
                 &env.discriminant_dir,
                 move |_request_builder| async {
+                    let header_map = HeaderMap::from_iter(
+                        [
+                            $({
+                                let header_key: HeaderName = $header_key.try_into().unwrap();
+                                let header_value: HeaderValue = $header_value.try_into().unwrap();
+                                (header_key, header_value)
+                            },)*
+                        ]
+                    );
                     Ok(ResponseMock::Mocked((
                         $response_status_code,
-                        HeaderMap::new(),
+                        header_map,
                         "".into(),
                     )))
                 },
@@ -205,8 +214,16 @@ register_rpc_http_hook!(
     rpc_unsupported_api_version_http_codes_422,
     StatusCode::from_u16(422).unwrap(),
     |err| {
-        p_assert_matches!(err, ConnectionError::MissingApiVersion);
+        p_assert_matches!(err, ConnectionError::MissingSupportedApiVersions);
     }
+);
+register_rpc_http_hook!(
+    rpc_unsupported_api_version_http_codes_422_with_supported_api_versions,
+    StatusCode::from_u16(422).unwrap(),
+    |err| {
+        p_assert_matches!(err, ConnectionError::UnsupportedApiVersion { api_version, supported_api_versions } if api_version == *API_LATEST_VERSION && supported_api_versions == vec![(5,1).into(), (6,0).into()]);
+    },
+    "Supported-Api-Versions": "5.1;6.0"
 );
 register_rpc_http_hook!(
     rpc_expired_organization_http_codes_460,


### PR DESCRIPTION
And add client tests for unsupported api version

Part of #9320

I don't think it requires a news fragment.
