### PR TITLE
[MS] Fixed a few things when opening a file with viewers

### DIFF
--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -1750,6 +1750,7 @@
         "details": "Details",
         "openingFile": "Opening file...",
         "fileTooBig": "File is too big to be opened using a viewer.",
+        "genericError": "Failed to open the file.",
         "controls": {
             "zoom": {
                 "in": "Zoom in",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -1750,6 +1750,7 @@
         "details": "Détails",
         "openingFile": "Ouverture du fichier...",
         "fileTooBig": "Le fichier est trop large pour être ouvert avec un visualiseur.",
+        "genericError": "Impossible d'ouvrir le fichier.",
         "controls": {
             "zoom": {
                 "in": "Zoomer",

--- a/client/src/parsec/file.ts
+++ b/client/src/parsec/file.ts
@@ -124,7 +124,7 @@ export async function entryStat(workspaceHandle: WorkspaceHandle, path: FsPath):
   let entry: MockEntry;
 
   if (path !== '/' && fileName.startsWith('File_')) {
-    entry = await generateFile(path, { parentId: `${MOCK_FILE_ID}`, fileName: fileName });
+    entry = await generateFile(await Path.parent(path), { parentId: `${MOCK_FILE_ID}`, fileName: fileName });
   } else {
     entry = await generateFolder(path, { parentId: `${MOCK_FILE_ID}`, fileName: fileName });
   }


### PR DESCRIPTION
Fixes a few things when opening a file with the viewers
1. Display a generic translated error message if the opening fails
2. If the viewer fails, opens the file with the system if possible
3. Use the correct path in the mocks (previously, opening `/A.pdf` would result in the file path for the viewer to be `/A.pdf/A.pdf`. Not super important since it's all mocks, but still.
4. If the viewer fails to open, the current path was set to the path of the document. Opening `/A.pdf` and failing to do so would result in the app trying to list the content of `/A.pdf`, using it as its current path.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
 