### PR TITLE
[MS] Update file size when sync starts and ends

### DIFF
--- a/client/src/parsec/login.ts
+++ b/client/src/parsec/login.ts
@@ -226,9 +226,12 @@ export async function login(
       case ClientEventTag.WorkspaceOpsOutboundSyncDone:
         eventDistributor.dispatchEvent(Events.EntrySynced, { workspaceId: event.realmId, entryId: event.entryId, way: 'outbound' });
         break;
-      // Ignore those events for now
       case ClientEventTag.WorkspaceOpsOutboundSyncStarted:
+        eventDistributor.dispatchEvent(Events.EntrySyncStarted, { workspaceId: event.realmId, entryId: event.entryId, way: 'outbound' });
+        break;
+      // Ignore those events for now
       case ClientEventTag.WorkspaceOpsOutboundSyncProgress:
+      case ClientEventTag.ServerConfigChanged:
         break;
       default:
         window.electronAPI.log('debug', `Unhandled event ${event.tag}`);

--- a/client/src/services/eventDistributor.ts
+++ b/client/src/services/eventDistributor.ts
@@ -20,6 +20,7 @@ enum Events {
   EntrySynced = 1 << 11,
   TOSAcceptRequired = 1 << 12,
   LogoutRequested = 1 << 13,
+  EntrySyncStarted = 1 << 14,
 }
 
 interface WorkspaceCreatedData {
@@ -36,7 +37,7 @@ interface UpdateAvailabilityData {
   version?: string;
 }
 
-interface EntrySyncedData {
+interface EntrySyncData {
   workspaceId: WorkspaceID;
   entryId: EntryID;
   way: 'inbound' | 'outbound';
@@ -46,7 +47,7 @@ interface IncompatibleServerData {
   reason: string;
 }
 
-type EventData = WorkspaceCreatedData | InvitationUpdatedData | UpdateAvailabilityData | EntrySyncedData | IncompatibleServerData;
+type EventData = WorkspaceCreatedData | InvitationUpdatedData | UpdateAvailabilityData | EntrySyncData | IncompatibleServerData;
 
 interface Callback {
   id: string;
@@ -125,4 +126,4 @@ class EventDistributor {
   }
 }
 
-export { EntrySyncedData, EventData, EventDistributor, Events, InvitationUpdatedData, UpdateAvailabilityData, WorkspaceCreatedData };
+export { EntrySyncData, EventData, EventDistributor, Events, InvitationUpdatedData, UpdateAvailabilityData, WorkspaceCreatedData };

--- a/newsfragments/9388.bugfix.rst
+++ b/newsfragments/9388.bugfix.rst
@@ -1,1 +1,1 @@
-Correctly refreshes the size of a file when copying from the file explorer
+Correctly refreshes the displayed size of a file when copying from the file explorer

--- a/newsfragments/9388.bugfix.rst
+++ b/newsfragments/9388.bugfix.rst
@@ -1,0 +1,1 @@
+Correctly refreshes the size of a file when copying from the file explorer


### PR DESCRIPTION
Closes #9388 

File stat when sync starts and ends. Not ideal, the file size will still not be updated while the copy is progressing, but it will update eventually.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description

