### PR TITLE
[MS] Updated spreadsheet viewer

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -118,6 +118,7 @@ cupi
 cygpath
 CYGPATTERN
 Dalek
+datagrid
 Datelike
 datetimes
 DBPASS
@@ -566,6 +567,8 @@ Reqwest
 rerunfailures
 reseted
 retrier
+revogr
+revolist
 rexpect
 Richcmp
 Rlib

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -22,6 +22,7 @@
                 "@ionic/storage": "^4.0.0",
                 "@ionic/vue": "^7.6.4",
                 "@ionic/vue-router": "^7.6.4",
+                "@revolist/vue3-datagrid": "^4.11.21",
                 "@sentry/vue": "^8.33.1",
                 "@types/luxon": "^3.3.4",
                 "axios": "^1.7.4",
@@ -1769,6 +1770,19 @@
             },
             "engines": {
                 "node": ">=16"
+            }
+        },
+        "node_modules/@revolist/revogrid": {
+            "version": "4.11.21",
+            "resolved": "https://registry.npmjs.org/@revolist/revogrid/-/revogrid-4.11.21.tgz",
+            "integrity": "sha512-2nbylt5u8wzUqvVcmqZ/a5sWBAKfQoWpjrRcTTlZbj/XpVBG6vdCnlB2mDD8vouXy0pJh1P94RTzK7n846PdHA=="
+        },
+        "node_modules/@revolist/vue3-datagrid": {
+            "version": "4.11.21",
+            "resolved": "https://registry.npmjs.org/@revolist/vue3-datagrid/-/vue3-datagrid-4.11.21.tgz",
+            "integrity": "sha512-3R45/PSpV1E6reM6J1jQDmgHVRxzEdav6aMg3j77Xalwot42UIN4RzLeGqhAGlrWSIhiIni/lhxTf15SbTtE7w==",
+            "dependencies": {
+                "@revolist/revogrid": "4.11.21"
             }
         },
         "node_modules/@rollup/plugin-virtual": {

--- a/client/package.json
+++ b/client/package.json
@@ -45,6 +45,7 @@
         "@ionic/storage": "^4.0.0",
         "@ionic/vue": "^7.6.4",
         "@ionic/vue-router": "^7.6.4",
+        "@revolist/vue3-datagrid": "^4.11.21",
         "@sentry/vue": "^8.33.1",
         "@types/luxon": "^3.3.4",
         "axios": "^1.7.4",

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -1779,6 +1779,7 @@
         "noFolderPreview": "Cannot preview folders.",
         "genericError": "Failed to open the file.",
         "mediaNotSupported": "This media is not supported.",
+        "retrievingFileContent": "Retrieving the file content...",
         "controls": {
             "zoom": {
                 "in": "Zoom in",
@@ -1791,7 +1792,9 @@
         },
         "spreadsheet": {
             "loadSheetError": "This sheet could not be loaded.",
-            "loadDocumentError": "Could not load this document."
+            "loadDocumentError": "Could not load this document.",
+            "loadingDocument": "Loading the document...",
+            "loadingSheet": "Loading the sheet `{page}`"
         },
         "pdf": {
             "loadDocumentError": "Could not load this PDF document.",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -1779,6 +1779,7 @@
         "noFolderPreview": "Impossible de prévisualiser les dossiers.",
         "genericError": "Impossible d'ouvrir le fichier.",
         "mediaNotSupported": "Ce média ne peut pas être joué.",
+        "retrievingFileContent": "Récupération du contenu du fichier...",
         "controls": {
             "zoom": {
                 "in": "Zoomer",
@@ -1791,7 +1792,9 @@
         },
         "spreadsheet": {
             "loadSheetError": "Impossible de charger cette feuille.",
-            "loadDocumentError": "Impossible de charger ce document."
+            "loadDocumentError": "Impossible de charger ce document.",
+            "loadingDocument": "Chargement du document...",
+            "loadingSheet": "Chargement de la feuille `{page}`"
         },
         "pdf": {
             "loadDocumentError": "Impossible de charger ce document.",

--- a/client/src/theme/global.scss
+++ b/client/src/theme/global.scss
@@ -118,3 +118,25 @@ ion-title {
 .flip-vertical-ion-icon > ion-icon {
   transform: scaleY(-1);
 }
+
+// revo-grid
+revo-grid {
+  .rowHeaders,
+  revogr-header {
+    background-color: var(--parsec-color-light-secondary-premiere) !important;
+
+    .rgRow {
+      box-shadow: none !important;
+      font-weight: bold;
+      font-size: 14px;
+    }
+  }
+
+  .rgCol {
+    background-color: var(--parsec-color-light-secondary-medium) !important;
+  }
+
+  .rgRow {
+    box-shadow: 0 -1px 0 0 var(--parsec-color-light-secondary-disabled) inset !important;
+  }
+}

--- a/client/src/views/viewers/FileViewer.vue
+++ b/client/src/views/viewers/FileViewer.vue
@@ -4,7 +4,11 @@
   <ion-page>
     <ion-content :fullscreen="true">
       <div class="container">
-        <ms-spinner v-show="!loaded" />
+        <ms-spinner
+          class="file-viewer"
+          title="fileViewers.retrievingFileContent"
+          v-show="!loaded"
+        />
         <div
           v-if="loaded && viewerComponent && contentInfo"
           @click.prevent="onClick"
@@ -128,6 +132,7 @@ async function loadFile(): Promise<void> {
   }
   const fileName = await Path.filename(path);
   if (!fileName) {
+    window.electronAPI.log('error', 'Failed to retrieve the file name');
     return;
   }
 
@@ -152,6 +157,7 @@ async function loadFile(): Promise<void> {
     statsResult = await entryStatAt(workspaceHandle, path, atDateTime.value);
   }
   if (!statsResult.ok || !statsResult.value.isFile()) {
+    window.electronAPI.log('error', 'Failed to stat the entry or entry is not a file');
     return;
   }
 

--- a/client/src/views/viewers/workers/spreadsheet_converter.ts
+++ b/client/src/views/viewers/workers/spreadsheet_converter.ts
@@ -1,8 +1,0 @@
-// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
-
-onmessage = function (event): void {
-  import('xlsx').then((XLSX) => {
-    const content = XLSX.utils.sheet_to_html(event.data, { header: '', footer: '' });
-    postMessage(content);
-  });
-};

--- a/client/src/views/viewers/workers/spreadsheet_document_loader.ts
+++ b/client/src/views/viewers/workers/spreadsheet_document_loader.ts
@@ -1,0 +1,18 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+onmessage = function (event): void {
+  import('xlsx').then((XLSX) => {
+    try {
+      const start = Date.now();
+      const workbook = XLSX.read(event.data, { type: 'array' });
+      const end = Date.now();
+      const delay = end - start < 1000 ? 1000 - (end - start) : 0;
+      // Adds a small delay if the loading is very fast to avoid blinking
+      setTimeout(() => {
+        postMessage({ ok: true, value: workbook });
+      }, delay);
+    } catch (e: any) {
+      postMessage({ ok: false, error: e });
+    }
+  });
+};

--- a/client/src/views/viewers/workers/spreadsheet_page_loader.ts
+++ b/client/src/views/viewers/workers/spreadsheet_page_loader.ts
@@ -1,0 +1,14 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+onmessage = function (event): void {
+  import('xlsx').then((XLSX) => {
+    const start = Date.now();
+    const content = XLSX.utils.sheet_to_json(event.data, { header: 'A' });
+    const end = Date.now();
+    const delay = end - start < 1000 ? 1000 - (end - start) : 0;
+    // Adds a small delay if the loading is very fast to avoid blinking
+    setTimeout(() => {
+      postMessage({ page: event.data, content: content });
+    }, delay);
+  });
+};

--- a/client/tests/e2e/specs/file_viewers.spec.ts
+++ b/client/tests/e2e/specs/file_viewers.spec.ts
@@ -60,10 +60,11 @@ msTest('Spreadsheet viewer', async ({ documents }) => {
   const bottomBar = documents.locator('.file-viewer-bottombar');
   await expect(bottomBar.locator('.file-controls-button')).toContainText(['Sheet1', 'Sheet2']);
   const wrapper = documents.locator('.file-viewer-wrapper');
-  await expect(wrapper.locator('.spreadsheet-content').locator('td')).toHaveText(['A', '1', 'B', '2', 'C', '3', 'D', '4']);
+  const spreadsheet = wrapper.locator('.inner-content-table').nth(1).locator('.content-wrapper');
+  await expect(spreadsheet.locator('.rgCell')).toHaveText(['A', '1', 'B', '2', 'C', '3', 'D', '4']);
   // Switch to second sheet
   await bottomBar.locator('.file-controls-button').nth(1).click();
-  await expect(wrapper.locator('.spreadsheet-content').locator('td')).toHaveText(['E', '5', 'F', '6', 'G', '7', 'H', '8']);
+  await expect(spreadsheet.locator('.rgCell')).toHaveText(['E', '5', 'F', '6', 'G', '7', 'H', '8']);
 });
 
 msTest('Image viewer', async ({ documents }) => {


### PR DESCRIPTION
Transforming the grid into HTML and then injecting that table to the DOM is incredibly slow and inefficient (a 2MB XLSX is converted to a 80MB HTML string). This uses RevoGrid (https://rv-grid.com/) instead to display the data parsed from SheetJS. It also adds some spinners and texts, a dedicated worker to load the file, and a better workers management.
I've been able to open a 14MB XLSX with this. A bit slow (~20s) but it works and once loaded, the display is smooth.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes