### PR TITLE
Add libparsec logging to file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,6 +1980,7 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 name = "libparsec"
 version = "3.2.5-a.0+dev"
 dependencies = [
+ "env_logger",
  "libparsec_client",
  "libparsec_client_connection",
  "libparsec_crypto",
@@ -2012,7 +2013,6 @@ dependencies = [
 name = "libparsec_bindings_electron"
 version = "3.2.5-a.0+dev"
 dependencies = [
- "env_logger",
  "lazy_static",
  "libparsec",
  "log",

--- a/bindings/electron/Cargo.toml
+++ b/bindings/electron/Cargo.toml
@@ -19,7 +19,6 @@ crate-type = ["cdylib"]
 workspace = true
 
 [dependencies]
-env_logger = { workspace = true, features = ["auto-color", "humantime", "regex"] }
 lazy_static = { workspace = true }
 libparsec = { workspace = true }
 neon = { workspace = true, features = ["napi-8"] }

--- a/bindings/electron/src/lib.rs
+++ b/bindings/electron/src/lib.rs
@@ -31,31 +31,5 @@ fn init_sentry() {
 
 #[neon::main]
 pub fn main(mut cx: ModuleContext) -> NeonResult<()> {
-    let mut builder = env_logger::Builder::from_default_env();
-    // FIXME: This is a workaround to be able to get logs from libparsec
-    // Since electron seems to block stderr writes from libparsec.
-    // But only on unix system, on windows it works fine the logs are display on cmd.
-    #[cfg(target_family = "unix")]
-    let log_file_path = {
-        let now = libparsec::DateTime::now();
-        let log_filename = format!("libparsec-{}.log", now.to_rfc3339());
-        let log_file_path = std::env::temp_dir().join(log_filename);
-        let log_file = std::fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(&log_file_path)
-            .expect("Cannot open log file");
-        builder.target(env_logger::Target::Pipe(Box::new(log_file)));
-        log_file_path
-    };
-
-    if let Err(e) = builder.try_init() {
-        log::error!("Logging already initialized: {e}")
-    } else {
-        #[cfg(target_family = "unix")]
-        log::info!("Writing log to {}", log_file_path.display());
-    };
-
     meths::register_meths(&mut cx)
 }

--- a/libparsec/Cargo.toml
+++ b/libparsec/Cargo.toml
@@ -44,3 +44,5 @@ log = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libparsec_platform_mountpoint = { workspace = true }
 libparsec_platform_ipc = { workspace = true }
+
+env_logger = { workspace = true, features = ["auto-color", "humantime", "regex"] }


### PR DESCRIPTION
Closes #8518

This PR adds:

- setup logging during libparsec initialization
- add `PARSEC_RUST_LOG_FILE` to set log file path (default `{temp_dir}/libparsec-{date}.log`)
- add `PARSEC_RUST_LOG` to set log level (default `info`)
  - note that this is equivalent to `RUST_LOG` (so advanced syntax is supported).

## TODOs

- [ ] Set the default path to `{config_dir}/app/log`