### PR TITLE
fix(docs): Fix link to download parsec-cli

### DIFF
--- a/docs/hosting/install_cli.rst
+++ b/docs/hosting/install_cli.rst
@@ -9,7 +9,7 @@ Install Linux CLI
 
 Parsec is also available as a command line interface (CLI) for Linux. It is a standalone binary that is provided in our GitHub releases.
 
-.. _Parsec CLI v3.3.0-rc.7+dev: https://github.com/Scille/parsec-cloud/releases/download/v3.3.0-rc.7+dev/parsec-cli_3.3.0-rc.7+dev_linux_x86_64
+.. _Parsec CLI v3.3.0-rc.7+dev: https://github.com/Scille/parsec-cloud/releases/download/v3.3.0-rc.7+dev/parsec-cli_3.3.0-rc.7+dev_linux-x86_64-musl
 
 1. Download the CLI by following this link:
 
@@ -22,13 +22,13 @@ Parsec is also available as a command line interface (CLI) for Linux. It is a st
 
     .. code-block:: shell
 
-        chmod +x parsec-cli_3.3.0-rc.7+dev_linux_x86_64
+        chmod +x parsec-cli_3.3.0-rc.7+dev_linux-x86_64-musl
 
 3. Verify the installation by running the following command:
 
   .. code-block:: shell
 
-      ./parsec-cli_3.3.0-rc.7+dev_linux_x86_64 --version
+      ./parsec-cli_3.3.0-rc.7+dev_linux-x86_64-musl --version
 
   The CLI should output its version:
 

--- a/misc/version_updater.py
+++ b/misc/version_updater.py
@@ -358,14 +358,16 @@ FILES_WITH_VERSION_INFO: dict[Path, dict[Tool, RawRegexes]] = {
     ROOT_DIR / "docs/hosting/install_cli.rst": {
         Tool.Parsec: [
             ReplaceRegex(
-                r".. _Parsec CLI v.*: https://github.com/Scille/parsec-cloud/releases/download/v.*/parsec-cli_.*_linux_x86_64",
-                ".. _Parsec CLI v{version}: https://github.com/Scille/parsec-cloud/releases/download/v{version}/parsec-cli_{version}_linux_x86_64",
+                r".. _Parsec CLI v.*: https://github.com/Scille/parsec-cloud/releases/download/v.*/parsec-cli_.*_linux-x86_64-musl",
+                ".. _Parsec CLI v{version}: https://github.com/Scille/parsec-cloud/releases/download/v{version}/parsec-cli_{version}_linux-x86_64-musl",
             ),
             ReplaceRegex(
                 r"`Parsec CLI v.*`_",
                 "`Parsec CLI v{version}`_",
             ),
-            ReplaceRegex(r"parsec-cli_.*_linux_x86_64", "parsec-cli_{version}_linux_x86_64"),
+            ReplaceRegex(
+                r"parsec-cli_.*_linux-x86_64-musl", "parsec-cli_{version}_linux-x86_64-musl"
+            ),
             ReplaceRegex(r"parsec-cli .*", "parsec-cli {version}"),
         ]
     },


### PR DESCRIPTION
Also fix the name of the downloaded artifact

Fix #9635