### PR TITLE
Use all the entries after the confinement point to detect previously confined entries to synchronize

### DIFF
--- a/libparsec/crates/client/src/monitors/workspace_inbound_sync.rs
+++ b/libparsec/crates/client/src/monitors/workspace_inbound_sync.rs
@@ -222,7 +222,12 @@ struct ConfinedEntriesTracker {
 }
 
 impl ConfinedEntriesTracker {
-    fn register_confined_entry(&mut self, confinement_point: VlobID, confined_entry: VlobID) {
+    fn register_confined_entry(
+        &mut self,
+        confinement_point: VlobID,
+        _entry_chain: &[VlobID],
+        confined_entry: VlobID,
+    ) {
         self.confinement_point_to_confined_entries
             .entry(confinement_point)
             .or_default()
@@ -369,10 +374,16 @@ async fn inbound_sync_monitor_loop(realm_id: VlobID, mut io: impl InboundSyncMan
                         confined_entries_tracker.unregister_confined_entry(entry_id);
                         break;
                     }
-                    Ok(InboundSyncOutcome::EntryIsConfined(confinement_point)) => {
+                    Ok(InboundSyncOutcome::EntryIsConfined {
+                        confinement_point,
+                        entry_chain,
+                    }) => {
                         // Add the entry to the list of confined entries
-                        confined_entries_tracker
-                            .register_confined_entry(confinement_point, entry_id);
+                        confined_entries_tracker.register_confined_entry(
+                            confinement_point,
+                            &entry_chain,
+                            entry_id,
+                        );
                         break;
                     }
                     Ok(InboundSyncOutcome::EntryIsBusy) => {

--- a/libparsec/crates/client/src/monitors/workspace_inbound_sync.rs
+++ b/libparsec/crates/client/src/monitors/workspace_inbound_sync.rs
@@ -377,6 +377,10 @@ async fn inbound_sync_monitor_loop(realm_id: VlobID, mut io: impl InboundSyncMan
         for entry_id in to_sync {
             // Need a loop here to retry the operation in case the server is not available
             loop {
+                // Sleep a bit to avoid busy loops
+                // TODO: investigate why this fixes issue #9752
+                #[cfg(test)]
+                libparsec_platform_async::sleep(std::time::Duration::from_millis(1)).await;
                 let outcome = io.workspace_ops_inbound_sync(entry_id).await;
                 log::debug!("Workspace {realm_id}: inbound sync {entry_id}, outcome: {outcome:?}");
                 match outcome {

--- a/libparsec/crates/client/src/workspace/store/resolve_path.rs
+++ b/libparsec/crates/client/src/workspace/store/resolve_path.rs
@@ -891,6 +891,8 @@ pub(crate) enum RetrievePathFromIDEntry {
         #[allow(unused)]
         path: FsPath,
         confinement_point: PathConfinementPoint,
+        // The chain of entry IDs from the root to the provided entry
+        // (both the root and the provided entry are included in the chain).
         entry_chain: Vec<VlobID>,
     },
 }

--- a/libparsec/crates/client/src/workspace/transactions/inbound_sync.rs
+++ b/libparsec/crates/client/src/workspace/transactions/inbound_sync.rs
@@ -198,6 +198,8 @@ pub enum InboundSyncOutcome {
     /// The entry is confined
     EntryIsConfined {
         confinement_point: VlobID,
+        // The chain of entry IDs from the root to the provided entry
+        // (both the root and the provided entry are included in the chain).
         entry_chain: Vec<VlobID>,
     },
 }

--- a/libparsec/crates/client/src/workspace/transactions/inbound_sync.rs
+++ b/libparsec/crates/client/src/workspace/transactions/inbound_sync.rs
@@ -196,7 +196,10 @@ pub enum InboundSyncOutcome {
     /// be overwritten by the ongoing modification. Instead we should just retry later.
     EntryIsBusy,
     /// The entry is confined
-    EntryIsConfined(VlobID),
+    EntryIsConfined {
+        confinement_point: VlobID,
+        entry_chain: Vec<VlobID>,
+    },
 }
 
 /// Download and merge remote changes from the server.
@@ -298,11 +301,15 @@ pub async fn inbound_sync(
             Ok((
                 _,
                 RetrievePathFromIDEntry::Reachable {
-                    confinement_point: PathConfinementPoint::Confined(confinement),
+                    confinement_point: PathConfinementPoint::Confined(confinement_point),
+                    entry_chain,
                     ..
                 },
             )) => {
-                return Ok(InboundSyncOutcome::EntryIsConfined(confinement));
+                return Ok(InboundSyncOutcome::EntryIsConfined {
+                    confinement_point,
+                    entry_chain,
+                });
             }
             Ok((updater, RetrievePathFromIDEntry::Unreachable { manifest })) => {
                 // The entry is unreachable in our path-space.

--- a/libparsec/crates/client/src/workspace/transactions/outbound_sync.rs
+++ b/libparsec/crates/client/src/workspace/transactions/outbound_sync.rs
@@ -71,7 +71,10 @@ pub enum OutboundSyncOutcome {
     /// The entry is unreachable, this is typically because the entry has been deleted.
     EntryIsUnreachable,
     /// The entry is confined
-    EntryIsConfined(VlobID),
+    EntryIsConfined {
+        confinement_point: VlobID,
+        entry_chain: Vec<VlobID>,
+    },
 }
 
 async fn outbound_sync_child(
@@ -95,10 +98,16 @@ async fn outbound_sync_child(
             Ok((
                 _,
                 RetrievePathFromIDEntry::Reachable {
-                    confinement_point: PathConfinementPoint::Confined(confinement),
+                    confinement_point: PathConfinementPoint::Confined(confinement_point),
+                    entry_chain,
                     ..
                 },
-            )) => return Ok(OutboundSyncOutcome::EntryIsConfined(confinement)),
+            )) => {
+                return Ok(OutboundSyncOutcome::EntryIsConfined {
+                    confinement_point,
+                    entry_chain,
+                })
+            }
             Ok((_, RetrievePathFromIDEntry::Unreachable { .. })) => {
                 return Ok(OutboundSyncOutcome::EntryIsUnreachable)
             }

--- a/libparsec/crates/client/src/workspace/transactions/outbound_sync.rs
+++ b/libparsec/crates/client/src/workspace/transactions/outbound_sync.rs
@@ -73,6 +73,8 @@ pub enum OutboundSyncOutcome {
     /// The entry is confined
     EntryIsConfined {
         confinement_point: VlobID,
+        // The chain of entry IDs from the root to the provided entry
+        // (both the root and the provided entry are included in the chain).
         entry_chain: Vec<VlobID>,
     },
 }

--- a/libparsec/crates/client/tests/unit/client/with_monitors.rs
+++ b/libparsec/crates/client/tests/unit/client/with_monitors.rs
@@ -417,6 +417,8 @@ async fn multi_devices_with_confinement(env: &TestbedEnv) {
     assert!(stat.is_empty());
 
     // 5) Alice1 rename the file so it's no longer confined
+    // But wait a bit first, to make sure the sync monitor have time to be in a resting state
+    libparsec_platform_async::sleep(std::time::Duration::from_millis(200)).await;
     alice1_workspace
         .move_entry(
             foo_bar_tmp_path.clone(),
@@ -617,6 +619,8 @@ async fn multi_devices_with_move_out_of_confinement(env: &TestbedEnv) {
     p_assert_matches!(stat, WorkspaceStatEntryError::EntryNotFound);
 
     // 5) Alice1 move the inner directory so it's no longer confined
+    // But wait a bit first, to make sure the sync monitor have time to be in a resting state
+    libparsec_platform_async::sleep(std::time::Duration::from_millis(200)).await;
     alice1_workspace
         .move_entry(
             "/foo.tmp/a/b".parse().unwrap(),

--- a/libparsec/crates/client/tests/unit/client/with_monitors.rs
+++ b/libparsec/crates/client/tests/unit/client/with_monitors.rs
@@ -13,6 +13,8 @@ use crate::{
     WorkspaceStorageCacheSize,
 };
 
+// Those tests are quite heavy and might be flaky, due to hard-polling for events.
+// Do not hesitate to ignore them using `#[ignore]` if they happen to make the CI fail.
 #[parsec_test(testbed = "coolorg", with_server)]
 async fn multi_devices(env: &TestbedEnv) {
     let alice1 = env.local_device("alice@dev1");
@@ -131,6 +133,8 @@ async fn multi_devices(env: &TestbedEnv) {
     alice2_client.stop().await;
 }
 
+// Those tests are quite heavy and might be flaky, due to hard-polling for events.
+// Do not hesitate to ignore them using `#[ignore]` if they happen to make the CI fail.
 #[parsec_test(testbed = "coolorg", with_server)]
 async fn sharing(env: &TestbedEnv) {
     let alice = env.local_device("alice@dev1");
@@ -260,6 +264,8 @@ async fn wait_workspace_in_sync(workspace1: &WorkspaceOps, workspace2: &Workspac
     }
 }
 
+// Those tests are quite heavy and might be flaky, due to hard-polling for events.
+// Do not hesitate to ignore them using `#[ignore]` if they happen to make the CI fail.
 #[parsec_test(testbed = "coolorg", with_server)]
 async fn multi_devices_with_confinement(env: &TestbedEnv) {
     let alice1 = env.local_device("alice@dev1");
@@ -448,6 +454,8 @@ async fn multi_devices_with_confinement(env: &TestbedEnv) {
     }
 }
 
+// Those tests are quite heavy and might be flaky, due to hard-polling for events.
+// Do not hesitate to ignore them using `#[ignore]` if they happen to make the CI fail.
 #[parsec_test(testbed = "coolorg", with_server)]
 async fn multi_devices_with_move_out_of_confinement(env: &TestbedEnv) {
     let alice1 = env.local_device("alice@dev1");

--- a/libparsec/crates/client/tests/unit/workspace/folder_transactions.rs
+++ b/libparsec/crates/client/tests/unit/workspace/folder_transactions.rs
@@ -628,7 +628,7 @@ async fn ops_outbound_sync(ops: &WorkspaceOps) {
                 OutboundSyncOutcome::EntryIsBusy => {
                     panic!("Entry is busy")
                 }
-                OutboundSyncOutcome::EntryIsConfined(_) => {
+                OutboundSyncOutcome::EntryIsConfined { .. } => {
                     confined_entries.insert(entry);
                 }
                 OutboundSyncOutcome::EntryIsUnreachable => {


### PR DESCRIPTION
PR #9741 did not synchronize previously confined entries that are moved outside of their confinement, for instance:

- Consider a confined file: `test.tmp/a/b/file.txt`
- The `b` directory is moved to `/`
- Note that the confinement point `test.tmp` hasn't changed (it sill has one child, `a`)
- Note that the confined entry hasn't changed (only `b` has been reparented)
- That means that nothing will trigger an event to attempt to synchronize `file.txt`

This PR fixes this by using all the entries after the confinement point to detect potential new synchronization.

