### PR TITLE
Backport fix yield in inbound outbound monitors

### DIFF
--- a/libparsec/crates/client/src/monitors/workspace_inbound_sync.rs
+++ b/libparsec/crates/client/src/monitors/workspace_inbound_sync.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use libparsec_platform_async::{channel, pretend_future_is_send_on_web};
+use libparsec_platform_async::{channel, pretend_future_is_send_on_web, yield_now};
 use libparsec_types::prelude::*;
 
 use super::Monitor;
@@ -286,7 +286,19 @@ async fn inbound_sync_monitor_loop(realm_id: VlobID, mut io: impl InboundSyncMan
                     Ok(InboundSyncOutcome::NoChange | InboundSyncOutcome::Updated) => break,
                     Ok(InboundSyncOutcome::EntryIsBusy) => {
                         // Re-enqueue to retry later
+
+                        // We are playing a dangerous game here: `flume::Receiver::recv_async`
+                        // doesn't yield to the executor if it contains an item, and we send
+                        // the event from the very same coroutine that will receive it.
+                        // This means we can end up in a busy-loop if another coroutine locks
+                        // the entry and our executor is mono-threaded !
+                        //
+                        // The solution to avoid this is simple: we just explicitly yield
+                        // before re-enqueueing.
+                        yield_now().await;
+
                         io.retry_later_busy_entry(entry_id).await;
+
                         break;
                     }
                     Err(err) => match err {

--- a/libparsec/crates/platform_async/src/lib.rs
+++ b/libparsec/crates/platform_async/src/lib.rs
@@ -129,7 +129,7 @@ macro_rules! select3_biased {
 
 pub use platform::{
     pretend_future_is_send_on_web, pretend_stream_is_send_on_web, sleep, spawn, try_task_id,
-    AbortHandle, Instant, JoinHandle, TaskID,
+    yield_now, AbortHandle, Instant, JoinHandle, TaskID,
 };
 pub use std::time::Duration; // Re-exposed to simplify use of `sleep`
 

--- a/libparsec/crates/platform_async/src/native/mod.rs
+++ b/libparsec/crates/platform_async/src/native/mod.rs
@@ -22,6 +22,11 @@ pub fn sleep(duration: std::time::Duration) -> impl crate::future::Future<Output
     tokio::time::sleep(duration)
 }
 
+#[inline(always)]
+pub fn yield_now() -> impl crate::future::Future<Output = ()> {
+    tokio::task::yield_now()
+}
+
 #[derive(Debug)]
 pub struct JoinHandle<T>(tokio::task::JoinHandle<T>);
 

--- a/libparsec/crates/platform_async/src/web/mod.rs
+++ b/libparsec/crates/platform_async/src/web/mod.rs
@@ -16,3 +16,8 @@ pub async fn sleep(duration: std::time::Duration) {
     let not_send_future = gloo_timers::future::sleep(duration);
     pretend_future_is_send_on_web(not_send_future).await
 }
+
+#[inline(always)]
+pub async fn yield_now() {
+    sleep(std::time::Duration::from_secs(0)).await
+}

--- a/libparsec/crates/platform_async/tests/unit/mod.rs
+++ b/libparsec/crates/platform_async/tests/unit/mod.rs
@@ -4,6 +4,7 @@ mod oneshot;
 mod select;
 mod task;
 mod watch;
+mod yield_now;
 
 #[cfg(target_arch = "wasm32")]
 libparsec_tests_lite::platform::wasm_bindgen_test_configure!(run_in_browser);

--- a/libparsec/crates/platform_async/tests/unit/yield_now.rs
+++ b/libparsec/crates/platform_async/tests/unit/yield_now.rs
@@ -1,0 +1,28 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use crate::{event::Event, spawn, yield_now};
+use libparsec_tests_lite::prelude::*;
+
+#[parsec_test]
+pub async fn aborted_by_handle() {
+    let should_stop_busy_task = Event::new();
+    let on_should_stop_busy_task = should_stop_busy_task.listen();
+    let handle = spawn(async move {
+        // Busy loop that will never finish if yield_now is not working
+        // (i.e. under a monothreaded async runtime such as on web or on native
+        // for tests, the other coroutine won't get a chance to run to abort this
+        // mad coroutine).
+        let mut count = 0usize;
+        loop {
+            yield_now().await;
+            count += 1;
+            if count == 100 {
+                should_stop_busy_task.notify(u32::MAX);
+            }
+        }
+    });
+
+    on_should_stop_busy_task.await;
+    handle.abort();
+    handle.await.unwrap_err();
+}


### PR DESCRIPTION
backport of https://github.com/Scille/parsec-cloud/pull/9762 on `release/3.3`