### PR TITLE
[MS] Sets minimal window size for electron

### DIFF
--- a/client/electron/src/setup.ts
+++ b/client/electron/src/setup.ts
@@ -367,6 +367,8 @@ export class ElectronCapacitorApp {
       y: this.mainWindowState.y,
       width: this.mainWindowState.width,
       height: this.mainWindowState.height,
+      minWidth: 1280,
+      minHeight: 720,
       webPreferences: {
         nodeIntegration: true,
         contextIsolation: true,

--- a/newsfragments/9674.bugfix.rst
+++ b/newsfragments/9674.bugfix.rst
@@ -1,0 +1,1 @@
+Added a minimal window size


### PR DESCRIPTION
Closes #9674 

Used 1280x720 as the default as it's a 16/9 resolution (most common ratio and will work with 16/10). It's small enough that the app should fit on most screens that are not 20 years old. 

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
