### PR TITLE
Add route to list organization per users.

### DIFF
--- a/server/parsec/components/memory/user.py
+++ b/server/parsec/components/memory/user.py
@@ -41,7 +41,9 @@ from parsec.components.user import (
     UserGetCertificatesAsUserBadOutcome,
     UserInfo,
     UserListFrozenUsersBadOutcome,
+    UserListOrganizationsBadOutcome,
     UserListUsersBadOutcome,
+    UserOrgInfo,
     UserRevokeUserStoreBadOutcome,
     UserRevokeUserValidateBadOutcome,
     UserUpdateUserStoreBadOutcome,
@@ -844,3 +846,19 @@ class MemoryUserComponent(BaseUserComponent):
             return UserAcceptTosBadOutcome.TOS_MISMATCH
 
         user.tos_accepted_on = now
+
+    @override
+    async def list_organizations(
+        self, user_email: str
+    ) -> list[UserOrgInfo] | UserListOrganizationsBadOutcome:
+        info = []
+        for org_id, org in self._data.organizations.items():
+            for _, user in org.users.items():
+                if user.cooked.human_handle.email == user_email:
+                    info.append(
+                        UserOrgInfo(
+                            org_id=org_id,
+                        ),
+                    )
+
+        return info

--- a/server/parsec/components/postgresql/user.py
+++ b/server/parsec/components/postgresql/user.py
@@ -28,6 +28,7 @@ from parsec.components.postgresql.user_get_user_info import (
     user_get_user_info_from_email,
 )
 from parsec.components.postgresql.user_list_frozen_users import user_list_frozen_users
+from parsec.components.postgresql.user_list_organizations import user_list_organizations
 from parsec.components.postgresql.user_list_users import user_list_users
 from parsec.components.postgresql.user_revoke_user import user_revoke_user
 from parsec.components.postgresql.user_test_dump_current_users import user_test_dump_current_users
@@ -54,7 +55,9 @@ from parsec.components.user import (
     UserGetCertificatesAsUserBadOutcome,
     UserInfo,
     UserListFrozenUsersBadOutcome,
+    UserListOrganizationsBadOutcome,
     UserListUsersBadOutcome,
+    UserOrgInfo,
     UserRevokeUserStoreBadOutcome,
     UserRevokeUserValidateBadOutcome,
     UserUpdateUserStoreBadOutcome,
@@ -357,3 +360,10 @@ class PGUserComponent(BaseUserComponent):
             author,
             tos_updated_on,
         )
+
+    @override
+    @no_transaction
+    async def list_organizations(
+        self, conn: AsyncpgConnection, user_email: str
+    ) -> list[UserOrgInfo] | UserListOrganizationsBadOutcome:
+        return await user_list_organizations(conn, user_email)

--- a/server/parsec/components/postgresql/user_list_organizations.py
+++ b/server/parsec/components/postgresql/user_list_organizations.py
@@ -1,0 +1,43 @@
+# Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+from __future__ import annotations
+
+from parsec._parsec import (
+    OrganizationID,
+)
+from parsec.components.postgresql import AsyncpgConnection
+from parsec.components.postgresql.utils import Q
+from parsec.components.user import (
+    UserListOrganizationsBadOutcome,
+    UserOrgInfo,
+)
+
+_q_get_organizations = Q("""
+SELECT
+    organization,
+FROM human
+WHERE
+    human.email = $user_email
+""")
+
+
+async def user_list_organizations(
+    conn: AsyncpgConnection, user_email: str
+) -> list[UserOrgInfo] | UserListOrganizationsBadOutcome:
+    rows = await conn.fetch(*_q_get_organizations(user_email=user_email))
+    if not rows:
+        return UserListOrganizationsBadOutcome.USER_NOT_FOUND
+
+    orgs = []
+    for row in rows:
+        match row["organization"]:
+            case str() as raw_org_id:
+                org_id = OrganizationID(raw_org_id)
+            case _:
+                assert False, row
+
+        orgs.append(
+            UserOrgInfo(
+                org_id=org_id,
+            )
+        )
+    return orgs

--- a/server/parsec/components/user.py
+++ b/server/parsec/components/user.py
@@ -71,6 +71,12 @@ class UserInfo:
     frozen: bool
 
 
+@dataclass(slots=True)
+class UserOrgInfo:
+    org_id: OrganizationID
+    # TODO profile ? current, initial, history ? organization expired ? user id ? frozen ? revoked ?
+
+
 class UserCreateUserValidateBadOutcome(BadOutcomeEnum):
     INVALID_CERTIFICATE = auto()
     TIMESTAMP_MISMATCH = auto()
@@ -366,6 +372,10 @@ class UserListFrozenUsersBadOutcome(BadOutcomeEnum):
     AUTHOR_REVOKED = auto()
 
 
+class UserListOrganizationsBadOutcome(BadOutcomeEnum):
+    USER_NOT_FOUND = auto()
+
+
 class BaseUserComponent:
     #
     # Public methods
@@ -487,6 +497,11 @@ class BaseUserComponent:
     async def list_frozen_users(
         self, organization_id: OrganizationID, device_id: DeviceID
     ) -> list[UserID] | UserListFrozenUsersBadOutcome:
+        raise NotImplementedError
+
+    async def list_organizations(
+        self, user_email: str
+    ) -> list[UserOrgInfo] | UserListOrganizationsBadOutcome:
         raise NotImplementedError
 
     #


### PR DESCRIPTION
Fix #9710 

TODO 
- [ ] update after #9806 
- [ ] tests

Some other fields could be added to know more about how a user is in an organization:
- human name is trivial
- user_id, if they are revoked, or frozen, their initial and current profile are a join with _user table away

Also note that in memory we must iterate on every user of every organization because of the way the datamodel is build. One may want to keep that index aside to improve performance, but the memory implementation is mostly used to test. 