### PR TITLE
feat(docker): Set additional labels

### DIFF
--- a/.github/workflows/docker-server.yml
+++ b/.github/workflows/docker-server.yml
@@ -61,6 +61,25 @@ jobs:
         with:
           images:
             ghcr.io/scille/parsec-cloud/parsec-server
+          # Manually set some labels:
+          # - The title to be more specific than just the repo name.
+          # - The license label as it's not correctly detect by the action
+          #   (internally it use the detected license from github but itself does not support our license)
+          # - The documentation URL
+          # - The version labels to the full version.
+          #
+          # We use the spec defined here: https://github.com/opencontainers/image-spec/blob/main/annotations.md
+          labels: |
+            org.opencontainers.image.title=The Parsec-Cloud server
+            org.opencontainers.image.licenses=BUSL-1.1
+            org.opencontainers.image.documentation=https://docs.parsec.cloud/en/stable/hosting/introduction.html
+            org.opencontainers.image.version=${{ steps.version.outputs.full }}
+          # We set the same values as labels for annotations
+          annotations: |
+            manifest:org.opencontainers.image.title=The Parsec-Cloud server
+            manifest:org.opencontainers.image.licenses=BUSL-1.1
+            manifest:org.opencontainers.image.documentation=https://docs.parsec.cloud/en/stable/hosting/introduction.html
+            manifest:org.opencontainers.image.version=${{ steps.version.outputs.full }}
           tags: |
             type=semver,pattern={{ version }}
             type=semver,pattern={{ major }}.{{ minor }}

--- a/.github/workflows/docker-testbed.yml
+++ b/.github/workflows/docker-testbed.yml
@@ -71,6 +71,22 @@ jobs:
         with:
           images:
             ghcr.io/scille/parsec-cloud/parsec-testbed-server
+          # Manually set some labels:
+          # - The title to be more specific than just the repo name.
+          # - The license label as it's not correctly detect by the action
+          #   (internally it use the detected license from github but itself does not support our license)
+          # - The version labels to the full version.
+          #
+          # We use the spec defined here: https://github.com/opencontainers/image-spec/blob/main/annotations.md
+          labels: |
+            org.opencontainers.image.title=The Parsec-Cloud testbed server
+            org.opencontainers.image.licenses=BUSL-1.1
+            org.opencontainers.image.version=${{ steps.version.outputs.full }}
+          # We set the same values as labels for annotations
+          annotations: |
+            manifest:org.opencontainers.image.title=The Parsec-Cloud testbed server
+            manifest:org.opencontainers.image.licenses=BUSL-1.1
+            manifest:org.opencontainers.image.version=${{ steps.version.outputs.full }}
           tags: |
             type=raw,value=${{ steps.version.outputs.docker }}
           flavor: |


### PR DESCRIPTION
The action `docker/metadata-action` set some labels by default. But their was some issue:

- Our license (BUSL-1.1) is not correctly detected by the action

  internally, it use the GitHub API to retreive that info, and GitHub does not detect the BUSL-1.1 licenses.

- The Title was the repo name (`parsec-cloud`), I've changed that to be more descriptive.

- For the server image, I've added the documentation URL.
- Overwrite the version label with the full version (instead of `{MAJOR}.{minor}.{patch}`)

Closes #9826