### PR TITLE
fix(build): Install rust with toolchain

### DIFF
--- a/client/electron/snap/snapcraft.yaml
+++ b/client/electron/snap/snapcraft.yaml
@@ -65,7 +65,7 @@ parts:
       update-alternatives --install /usr/local/bin/python python $(which python3) 100
 
       # Install rust
-      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh /dev/stdin -y --default-toolchain none
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh /dev/stdin -y --default-toolchain 1.81.0
       source "$HOME/.cargo/env"
 
       # Debug software versions

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -16,7 +16,7 @@
 
 ## Get the sources
 
-Source code is available on [github](https://github.com/Scille/parsec-cloud).
+Source code is available on [GitHub](https://github.com/Scille/parsec-cloud).
 
 ## Shared requirements
 
@@ -36,10 +36,10 @@ To start hacking, follow the basic steps detailed below:
     2. [`Rust v1.81.0`](https://www.rust-lang.org/fr/learn/get-started)
 
        > We use a `rust-toolchain.toml` file, so you can just install `rustup` and `cargo`
-       > The required toolchain will be install automatically.
+       > The required toolchain will be installed automatically.
 
        ```shell
-       curl --proto '=https' --tlsv1.2 -sSL https://sh.rustup.rs | sh -s -- --default-toolchain none # You can replace `none` with `1.81.0`
+       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.81.0
        ```
 
        > You then need to add the installation path to your `PATH` variable (or equivalent).

--- a/misc/version_updater.py
+++ b/misc/version_updater.py
@@ -71,6 +71,10 @@ TESTBED_VERSION = ReplaceRegex(
     r"ghcr.io/scille/parsec-cloud/parsec-testbed-server:[^\s]+",
     "ghcr.io/scille/parsec-cloud/parsec-testbed-server:{version}",
 )
+RUSTUP_INSTALL = ReplaceRegex(
+    r"curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \| sh -s -- -y --default-toolchain [0-9.]+",
+    "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain {version}",
+)
 
 
 @enum.unique
@@ -307,10 +311,7 @@ FILES_WITH_VERSION_INFO: dict[Path, dict[Tool, RawRegexes]] = {
     ROOT_DIR / "docs/development/README.md": {
         Tool.Rust: [
             ReplaceRegex(r"Rust v[0-9.]+", "Rust v{version}"),
-            ReplaceRegex(
-                r"--default-toolchain none # You can replace `none` with `[0-9.]+`",
-                "--default-toolchain none # You can replace `none` with `{version}`",
-            ),
+            RUSTUP_INSTALL,
         ],
         Tool.Python: [
             ReplaceRegex(r"python v[0-9.]+", hide_patch_version("python v{version}")),
@@ -367,7 +368,8 @@ FILES_WITH_VERSION_INFO: dict[Path, dict[Tool, RawRegexes]] = {
                 "`Parsec CLI v{version}`_",
             ),
             ReplaceRegex(
-                r"parsec-cli_.*_linux-x86_64-musl", "parsec-cli_{version}_linux-x86_64-musl"
+                r"parsec-cli_.*_linux-x86_64-musl",
+                "parsec-cli_{version}_linux-x86_64-musl",
             ),
             ReplaceRegex(r"parsec-cli .*", "parsec-cli {version}"),
         ]
@@ -397,6 +399,7 @@ FILES_WITH_VERSION_INFO: dict[Path, dict[Tool, RawRegexes]] = {
         for tool in Tool
     },
     ROOT_DIR / "server/packaging/server/in-docker-build.sh": {
+        Tool.Rust: [RUSTUP_INSTALL],
         Tool.Poetry: [
             ReplaceRegex(
                 r"curl -sSL https://install.python-poetry.org \| python - --version=[0-9.]+",
@@ -406,6 +409,7 @@ FILES_WITH_VERSION_INFO: dict[Path, dict[Tool, RawRegexes]] = {
     },
     ROOT_DIR / "server/packaging/server/server.dockerfile": {Tool.Python: [PYTHON_DOCKER_VERSION]},
     ROOT_DIR / "server/packaging/testbed-server/in-docker-build.sh": {
+        Tool.Rust: [RUSTUP_INSTALL],
         Tool.Python: [PYTHON_SMALL_VERSION],
         Tool.Poetry: [
             ReplaceRegex(

--- a/server/packaging/server/in-docker-build.sh
+++ b/server/packaging/server/in-docker-build.sh
@@ -3,7 +3,7 @@
 set -xe
 
 # Install Rust (actual toolchain is going to be installed by maturin according to `rust-toolchain.toml`)
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.81.0
 export PATH="/root/.cargo/bin:$PATH"
 cargo --version
 

--- a/server/packaging/testbed-server/in-docker-build.sh
+++ b/server/packaging/testbed-server/in-docker-build.sh
@@ -3,7 +3,7 @@
 set -xe
 
 # Install Rust (actual toolchain is going to be installed by maturin according to `rust-toolchain.toml`)
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.81.0
 export PATH="/root/.cargo/bin:$PATH"
 cargo --version
 


### PR DESCRIPTION
Installing rustup without a specific toolchain was failing when using `cargo` directly:

```shell
$ cargo --version
error: toolchain '1.81.0-x86_64-unknown-linux-gnu' is not installed
help: run `rustup toolchain install 1.81.0-x86_64-unknown-linux-gnu` to install it
```

This is likely due to `rustup-1.28` that no longer automatically install the active toolchain.