### PR TITLE
[MS] Custom order multi org

### DIFF
--- a/client/src/components/organizations/OrganizationSwitchClientPopover.vue
+++ b/client/src/components/organizations/OrganizationSwitchClientPopover.vue
@@ -45,15 +45,6 @@
           />
         </div>
       </ion-item>
-      <ion-item
-        class="organization-list__item"
-        v-show="querying"
-      >
-        <ion-skeleton-text
-          class="organization"
-          :animated="true"
-        />
-      </ion-item>
     </ion-list>
     <div
       class="organization-divider"
@@ -88,31 +79,24 @@
 </template>
 
 <script setup lang="ts">
-import { IonAvatar, IonIcon, IonItem, IonLabel, IonList, IonTitle, popoverController, IonSkeletonText } from '@ionic/vue';
+import { IonAvatar, IonIcon, IonItem, IonLabel, IonList, IonTitle, popoverController } from '@ionic/vue';
 import { arrowForward, checkmark, addCircle } from 'ionicons/icons';
 import { onMounted, ref } from 'vue';
-import { BillingSystem, BmsAccessInstance, BmsOrganization, DataType } from '@/services/bms';
+import { BmsOrganization } from '@/services/bms';
 import { MsModalResult } from 'megashark-lib';
 import { DefaultBmsOrganization, isDefaultOrganization } from '@/views/client-area/types';
 
 const props = defineProps<{
   currentOrganization: BmsOrganization;
+  organizations: Array<BmsOrganization>;
 }>();
 
-const querying = ref(true);
-const organizations = ref<Array<BmsOrganization>>([]);
-const billingSystem = ref(BmsAccessInstance.get().getPersonalInformation().billingSystem);
+const organizations = ref<Array<BmsOrganization>>(Array.from(props.organizations));
 
 onMounted(async () => {
-  querying.value = true;
-  const result = await BmsAccessInstance.get().listOrganizations();
-  if (!result.isError && result.data && result.data.type === DataType.ListOrganizations) {
-    organizations.value = result.data.organizations;
-    if (billingSystem.value === BillingSystem.Stripe && result.data.organizations.length > 1) {
-      organizations.value.push(DefaultBmsOrganization);
-    }
+  if (props.organizations.length > 1) {
+    organizations.value.push(DefaultBmsOrganization);
   }
-  querying.value = false;
 });
 
 async function openCreateOrganizationModal(): Promise<void> {

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -1783,6 +1783,7 @@
             "from": "From",
             "to": "To",
             "amount": "Amount",
+            "multipleOrganizations": "You have multiple organizations. Please select one from the top-left button or select it below in order to check the contract.",
             "selectAnOrganization": "Please select an organization.",
             "errors": {
                 "noOrganizations": "Failed to list organizations",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -1782,6 +1782,7 @@
             "from": "Depuis",
             "to": "Jusqu'au",
             "amount": "Montant",
+            "multipleOrganizations": "Vous possédez plusieurs organisations. Veuillez en choisir une en utilisant le bouton dans le coin supérieur gauche ou sélectionnez-là ci-dessous pour voir le contrat.",
             "selectAnOrganization": "Veuillez sélectionner une organisation",
             "errors": {
                 "noOrganizations": "Impossible de lister vos organisations",

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -140,6 +140,7 @@ async function setupApp(): Promise<void> {
     window.isDesktop = (): boolean => isDesktop;
     window.isDev = (): boolean => false;
     window.isLinux = (): boolean => isLinux;
+    window.isTesting = (): boolean => 'TESTING' in window && (window.TESTING as boolean);
 
     if (testbedDiscriminantPath) {
       window.usesTestbed = (): boolean => true;
@@ -348,18 +349,21 @@ function setupMockElectronAPI(injectionProvider: InjectionProvider): void {
     },
     getUpdateAvailability: (): void => {
       // Wait for a bit so it seems more natural
-      setTimeout(async () => {
-        injectionProvider.distributeEventToAll(Events.UpdateAvailability, { updateAvailable: true, version: '13.37' });
-        injectionProvider.notifyAll(
-          new Information({
-            message: '',
-            level: InformationLevel.Info,
-            unique: true,
-            data: { type: InformationDataType.NewVersionAvailable, newVersion: '13.37' },
-          }),
-          PresentationMode.Notification,
-        );
-      }, 5000);
+      setTimeout(
+        async () => {
+          injectionProvider.distributeEventToAll(Events.UpdateAvailability, { updateAvailable: true, version: '13.37' });
+          injectionProvider.notifyAll(
+            new Information({
+              message: '',
+              level: InformationLevel.Info,
+              unique: true,
+              data: { type: InformationDataType.NewVersionAvailable, newVersion: '13.37' },
+            }),
+            PresentationMode.Notification,
+          );
+        },
+        window.isTesting() ? 0 : 5000,
+      );
       console.log('GetUpdateAvailability: MOCKED');
     },
     updateApp: (): void => {
@@ -499,6 +503,7 @@ declare global {
     isDesktop: () => boolean;
     isLinux: () => boolean;
     isDev: () => boolean;
+    isTesting: () => boolean;
     usesTestbed: () => boolean;
     electronAPI: {
       sendConfig: (config: Config) => void;

--- a/client/src/services/bms/access.ts
+++ b/client/src/services/bms/access.ts
@@ -355,16 +355,18 @@ class BmsAccess {
     return await this.api.getCustomOrderRequests(this.tokens.access);
   }
 
-  // TODO: Update to add multi-organization support
-  async getCustomOrderInvoices(organization: BmsOrganization): Promise<BmsResponse> {
+  async getCustomOrderInvoices(...organizations: Array<BmsOrganization>): Promise<BmsResponse> {
     assertLoggedIn(this.tokens);
     assertLoggedIn(this.customerInformation);
     await this.ensureFreshToken();
-    return await this.api.getCustomOrderInvoices(this.tokens.access, {
-      userId: this.customerInformation.id,
-      clientId: this.customerInformation.clientId,
-      organization: organization,
-    });
+    return await this.api.getCustomOrderInvoices(
+      this.tokens.access,
+      {
+        userId: this.customerInformation.id,
+        clientId: this.customerInformation.clientId,
+      },
+      ...organizations,
+    );
   }
 
   async clearStoredAccess(): Promise<void> {

--- a/client/src/services/bms/mockApi.ts
+++ b/client/src/services/bms/mockApi.ts
@@ -50,7 +50,7 @@ function createMockFunction(functionName: string, mockSuccess?: MockFunction, mo
         console.info(`Mocking BMS calls to ${functionName}, set up to fail`);
         return async (...args: any[]): Promise<BmsResponse> => {
           await wait(REQUEST_WAIT_TIME);
-          return await mockError(args);
+          return await mockError(...args);
         };
       }
     } else {
@@ -60,7 +60,7 @@ function createMockFunction(functionName: string, mockSuccess?: MockFunction, mo
         console.info(`Mocking BMS calls to ${functionName}, set up to succeed`);
         return async (...args: any[]): Promise<BmsResponse> => {
           await wait(REQUEST_WAIT_TIME);
-          return await mockSuccess(args);
+          return await mockSuccess(...args);
         };
       }
     }
@@ -85,7 +85,10 @@ function getMockParameters(functionName: string): MockParameters {
   return DefaultMockParameters;
 }
 
-function createCustomOrderInvoices(count: number = 1): CustomOrderDetailsResultData | CustomOrderInvoicesResultData {
+function createCustomOrderInvoices(
+  count: number = 1,
+  organizations: Array<BmsOrganization> = [],
+): CustomOrderDetailsResultData | CustomOrderInvoicesResultData {
   const invoices: Array<SellsyInvoice> = [];
 
   for (let i = 1; i < count + 1; i++) {
@@ -121,7 +124,7 @@ function createCustomOrderInvoices(count: number = 1): CustomOrderDetailsResultD
         quantityOrdered: 1 + (i % 2),
         amountWithTaxes: 22.0 + (i % 2) * 5,
       },
-      organizationId: 'CustomOrderOrg',
+      organizationId: organizations.length > 0 ? organizations[i % organizations.length].parsecId : 'CustomOrderOrg',
     };
     invoices.push(new SellsyInvoice(customOrderInvoice));
   }
@@ -294,11 +297,11 @@ export const MockedBmsApi = {
   ),
   getCustomOrderInvoices: createMockFunction(
     'getCustomOrderInvoices',
-    async (_token: AuthenticationToken, _query: CustomOrderQueryData) => {
+    async (_token: AuthenticationToken, _query: CustomOrderQueryData, ...organizations: Array<BmsOrganization>) => {
       return {
         status: 200,
         isError: false,
-        data: createCustomOrderInvoices(12),
+        data: createCustomOrderInvoices(12, organizations),
       };
     },
   ),

--- a/client/src/views/client-area/ClientAreaPage.vue
+++ b/client/src/views/client-area/ClientAreaPage.vue
@@ -19,7 +19,8 @@
           <client-area-sidebar
             v-if="currentOrganization"
             :current-page="currentPage"
-            :organization="currentOrganization"
+            :current-organization="currentOrganization"
+            :organizations="organizations"
             @page-selected="switchPage"
             @organization-selected="onOrganizationSelected"
             :key="refresh"
@@ -76,7 +77,8 @@
               />
               <statistics-page
                 v-if="currentPage === ClientAreaPages.Statistics"
-                :organization="currentOrganization"
+                :current-organization="currentOrganization"
+                :organizations="organizations"
                 @organization-selected="onOrganizationSelected"
               />
               <invoices-page
@@ -96,11 +98,14 @@
               <!-- CustomOrder -->
               <custom-order-statistics-page
                 v-if="currentPage === ClientAreaPages.CustomOrderStatistics"
-                :organization="currentOrganization"
+                :current-organization="currentOrganization"
+                :organizations="organizations"
+                @organization-selected="onOrganizationSelected"
               />
               <contracts-page
                 v-if="currentPage === ClientAreaPages.Contracts"
-                :organization="currentOrganization"
+                :current-organization="currentOrganization"
+                :organizations="organizations"
                 @organization-selected="onOrganizationSelected"
               />
               <orders-page
@@ -115,7 +120,8 @@
               />
               <custom-order-invoices-page
                 v-if="currentPage === ClientAreaPages.CustomOrderInvoices"
-                :organization="currentOrganization"
+                :current-organization="currentOrganization"
+                :organizations="organizations"
               />
               <custom-order-processing-page v-if="currentPage === ClientAreaPages.CustomOrderProcessing" />
             </div>
@@ -198,7 +204,7 @@ onMounted(async () => {
           currentOrganization.value = org;
         }
       } else {
-        if ((organizations.value.length > 0 && billingSystem !== BillingSystem.Stripe) || organizations.value.length === 1) {
+        if (organizations.value.length === 1) {
           currentOrganization.value = organizations.value[0];
         } else {
           currentOrganization.value = DefaultBmsOrganization;

--- a/client/src/views/client-area/payment-methods/PaymentMethodsPage.vue
+++ b/client/src/views/client-area/payment-methods/PaymentMethodsPage.vue
@@ -208,7 +208,7 @@ const savedCards = computed(() => cards.value.filter((card) => !card.isDefault))
 
 onMounted(async () => {
   if (BmsAccessInstance.get().isLoggedIn()) {
-    personalInformation.value = await BmsAccessInstance.get().getPersonalInformation();
+    personalInformation.value = BmsAccessInstance.get().getPersonalInformation();
   }
   await queryBillingDetails();
 });

--- a/client/tests/e2e/helpers/bms.ts
+++ b/client/tests/e2e/helpers/bms.ts
@@ -100,6 +100,8 @@ function createCustomOrderInvoices(count: number = 1, overload: MockCustomOrderD
   const STATUSES = ['paid', 'draft', 'open', 'uncollectible', 'void'];
 
   for (let i = 1; i < count + 1; i++) {
+    const licenseStart = overload.licenseStart ? overload.licenseStart : DateTime.now().minus({ months: count + 1 - i });
+    const licenseEnd = overload.licenseEnd ? overload.licenseEnd : DateTime.now().minus({ months: count - i });
     invoices.push({
       id: `custom_order_id${i}`,
       created: overload.created ? overload.created.toISO() : DateTime.now().minus({ months: count + 1 - i }),
@@ -135,19 +137,11 @@ function createCustomOrderInvoices(count: number = 1, overload: MockCustomOrderD
         custom_fields: [
           {
             code: 'parsec-saas-custom-order-start-date',
-            value: overload.licenseStart
-              ? overload.licenseStart.toISO()
-              : DateTime.now()
-                  .minus({ months: count + 1 - i })
-                  .toISO(),
+            value: licenseStart.toISO(),
           },
           {
             code: 'parsec-saas-custom-order-end-date',
-            value: overload.licenseStart
-              ? overload.licenseStart.toISO()
-              : DateTime.now()
-                  .minus({ months: count - i })
-                  .toISO(),
+            value: licenseEnd.toISO(),
           },
           {
             code: 'parsec-saas-custom-order-admin-license-count',

--- a/client/tests/e2e/helpers/fixtures.ts
+++ b/client/tests/e2e/helpers/fixtures.ts
@@ -12,6 +12,7 @@ const debugTest = base.extend({
     browser: [
       async ({ playwright, browserName }, use): Promise<any> => {
         const args = [];
+        // cspell:disable-next-line
         if (browserName.toLowerCase().includes('chrom')) {
           args.push('--auto-open-devtools-for-tabs');
         }

--- a/client/tests/e2e/helpers/utils.ts
+++ b/client/tests/e2e/helpers/utils.ts
@@ -189,3 +189,18 @@ export async function sliderClick(page: Page, slider: Locator, progressPercent: 
     await page.mouse.click(box.x + (box.width * progressPercent) / 100, box.y);
   }
 }
+
+export async function clientAreaSwitchOrganization(page: Page, organization: string | 'all'): Promise<void> {
+  const selector = page.locator('.sidebar-header').locator('.organization-card-header');
+  await selector.click();
+  const popover = page.locator('#organization-switch-popover');
+  await expect(popover).toBeVisible();
+  const items = popover.locator('.organization-list__item').locator('.organization-name');
+  for (const item of await items.all()) {
+    const text = await item.textContent();
+    if (text === organization || (text === 'All organizations' && organization === 'all')) {
+      await item.click();
+    }
+  }
+  await expect(popover).toBeHidden();
+}

--- a/client/tests/e2e/specs/app_update.spec.ts
+++ b/client/tests/e2e/specs/app_update.spec.ts
@@ -29,7 +29,6 @@ msTest('Opens app update modal with notification', async ({ connected }) => {
   const header = connected.locator('#connected-header');
   const notifButton = header.locator('#trigger-notifications-button');
   const notifCenter = connected.locator('.notification-center-popover');
-  await connected.waitForTimeout(600);
   await expect(notifButton).toHaveTheClass('unread');
   await expect(notifCenter).toBeHidden();
   await notifButton.click();

--- a/client/tests/e2e/specs/client_area_custom_order.spec.ts
+++ b/client/tests/e2e/specs/client_area_custom_order.spec.ts
@@ -10,7 +10,6 @@ msTest('Test initial status', async ({ clientAreaCustomOrder }) => {
     { button: 'Contract', title: 'Contract', url: 'contracts' },
     { button: 'Statistics', title: 'Statistics', url: 'custom-order-statistics' },
     { button: 'Orders', title: 'Orders', url: 'orders' },
-    { button: 'Billing details', title: 'Billing details', url: 'custom-order-billing-details' },
     { button: 'Invoices', title: 'Invoices', url: 'custom-order-invoices' },
   ];
 

--- a/client/tests/e2e/specs/client_area_custom_order_contract.spec.ts
+++ b/client/tests/e2e/specs/client_area_custom_order_contract.spec.ts
@@ -1,11 +1,13 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { expect, msTest } from '@tests/e2e/helpers';
+import { clientAreaSwitchOrganization, expect, msTest } from '@tests/e2e/helpers';
 import { DateTime } from 'luxon';
 
 msTest('Test initial status', async ({ clientAreaCustomOrder }) => {
   const title = clientAreaCustomOrder.locator('.header-content').locator('.header-title');
   await expect(title).toHaveText('Contract');
+
+  await clientAreaSwitchOrganization(clientAreaCustomOrder, 'BlackMesa');
 
   const container = clientAreaCustomOrder.locator('.client-contract-page');
 
@@ -22,8 +24,8 @@ msTest('Test initial status', async ({ clientAreaCustomOrder }) => {
   await expect(container.locator('.contract-header-title__text')).toHaveText('Contract n°FACT001');
 
   const contract = container.locator('.contract-main');
-  await expect(contract.locator('.item-content-date__date').nth(0)).toHaveText('Apr 7, 1988');
-  await expect(contract.locator('.item-content-date__date').nth(1)).toHaveText(DateTime.now().plus({ year: 1 }).toFormat('LLL d, yyyy'));
+  await expect(contract.locator('.item-content-date__date').nth(0)).toHaveText(DateTime.now().minus({ months: 1 }).toFormat('LLL d, yyyy'));
+  await expect(contract.locator('.item-content-date__date').nth(1)).toHaveText(DateTime.now().toFormat('LLL d, yyyy'));
 
   await expect(contract.locator('.data-number').nth(0)).toHaveText('32');
   await expect(contract.locator('.data-number').nth(1)).toHaveText('50');

--- a/client/tests/e2e/specs/client_area_custom_order_invoices.spec.ts
+++ b/client/tests/e2e/specs/client_area_custom_order_invoices.spec.ts
@@ -1,0 +1,25 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { clientAreaSwitchOrganization, DEFAULT_ORGANIZATION_INFORMATION, expect, msTest } from '@tests/e2e/helpers';
+
+msTest('Test all orgs', async ({ clientAreaCustomOrder }) => {
+  const title = clientAreaCustomOrder.locator('.header-content').locator('.header-title');
+
+  await clientAreaCustomOrder.locator('.menu-client').locator('.menu-client-list').getByRole('listitem').nth(3).click();
+  await expect(title).toHaveText('Invoices');
+  const content = clientAreaCustomOrder.locator('.client-page-invoices');
+  const invoices = content.locator('.invoices-year-content-list-item');
+  await expect(invoices).toHaveCount(24);
+});
+
+msTest('Test only one org', async ({ clientAreaCustomOrder }) => {
+  const title = clientAreaCustomOrder.locator('.header-content').locator('.header-title');
+
+  await clientAreaSwitchOrganization(clientAreaCustomOrder, DEFAULT_ORGANIZATION_INFORMATION.name);
+
+  await clientAreaCustomOrder.locator('.menu-client').locator('.menu-client-list').getByRole('listitem').nth(3).click();
+  await expect(title).toHaveText('Invoices');
+  const content = clientAreaCustomOrder.locator('.client-page-invoices');
+  const invoices = content.locator('.invoices-year-content-list-item');
+  await expect(invoices).toHaveCount(12);
+});

--- a/client/tests/e2e/specs/client_area_custom_order_statistics.spec.ts
+++ b/client/tests/e2e/specs/client_area_custom_order_statistics.spec.ts
@@ -1,9 +1,11 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { expect, msTest } from '@tests/e2e/helpers';
+import { clientAreaSwitchOrganization, expect, msTest } from '@tests/e2e/helpers';
 
 msTest('Test initial status', async ({ clientAreaCustomOrder }) => {
   const title = clientAreaCustomOrder.locator('.header-content').locator('.header-title');
+
+  await clientAreaSwitchOrganization(clientAreaCustomOrder, 'BlackMesa');
 
   await clientAreaCustomOrder.locator('.menu-client').locator('.menu-client-list').getByRole('listitem').nth(1).click();
   await expect(title).toHaveText('Statistics');


### PR DESCRIPTION
Closes #9859 

Includes a few things: automatically opens the devtools if launching Playwright in debug mode, adds mock in Playwright for invoices, refactored the customer area to avoid multiple requests to listOrganizations, handle custom order with multiple orgs, updated the listCustomOrderInvoices API, added simple tests for custom order invoices.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description
