### PR TITLE
Remove prebuild app object from the server

### DIFF
--- a/server/parsec/__init__.py
+++ b/server/parsec/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from parsec._version import __version__
-from parsec.asgi import app
+from parsec.asgi import AsgiApp, app_factory
 from parsec.backend import Backend, backend_factory
 from parsec.config import (
     ActiveUsersLimit,
@@ -19,6 +19,7 @@ from parsec.config import (
 
 __all__ = (
     "ActiveUsersLimit",
+    "AsgiApp",
     "Backend",
     "BackendConfig",
     "MockedBlockStoreConfig",
@@ -29,6 +30,6 @@ __all__ = (
     "S3BlockStoreConfig",
     "SmtpEmailConfig",
     "__version__",
-    "app",
+    "app_factory",
     "backend_factory",
 )

--- a/server/parsec/asgi/__init__.py
+++ b/server/parsec/asgi/__init__.py
@@ -25,7 +25,7 @@ templates = Jinja2Templates(
 )
 
 
-def app_factory() -> AsgiApp:
+def app_factory(backend: Backend) -> AsgiApp:
     app = FastAPI(
         title="Parsec Server",
         version=parsec_version,
@@ -35,8 +35,7 @@ def app_factory() -> AsgiApp:
         openapi_url=None,
     )
 
-    # Must be overwritten before the app is started !
-    app.state.backend = None
+    app.state.backend = backend
 
     app.mount("/static", StaticFiles(packages=[("parsec", "static")]))
 
@@ -57,9 +56,6 @@ def app_factory() -> AsgiApp:
     app.include_router(administration_router)
 
     return app
-
-
-app: AsgiApp = app_factory()
 
 
 class Server(uvicorn.Server):

--- a/server/parsec/cli/run.py
+++ b/server/parsec/cli/run.py
@@ -10,8 +10,7 @@ import click
 
 from parsec._parsec import ActiveUsersLimit, ParsecAddr
 from parsec._version import __version__ as server_version
-from parsec.asgi import app as parsec_app
-from parsec.asgi import serve_parsec_asgi_app
+from parsec.asgi import app_factory, serve_parsec_asgi_app
 from parsec.backend import backend_factory
 from parsec.cli.options import (
     _split_with_escaping,
@@ -489,7 +488,7 @@ async def _run_backend(
                 retry_policy.success()
 
                 # Serve backend through TCP
-                parsec_app.state.backend = backend
+                parsec_app = app_factory(backend)
                 await serve_parsec_asgi_app(
                     app=parsec_app,
                     host=host,


### PR DESCRIPTION
This simplifies customization of the `app` (parameter passed to `app_factory` instead of overwriting blind fields on the prebuild `app` object)