### PR TITLE
feat(rust-deps): Update env-logger to 0.11.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,20 +81,19 @@ checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_log-sys"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecc8056bf6ab9892dcd53216c83d1597487d7dacac16c8df6b877d127df9937"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
 
 [[package]]
 name = "android_logger"
-version = "0.13.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c494134f746c14dc653a35a4ea5aca24ac368529da5370ecf41fe0341c35772f"
+checksum = "f6f39be698127218cca460cb624878c9aa4e2b47dba3b277963d2bf00bad263b"
 dependencies = [
  "android_log-sys",
- "env_logger 0.10.2",
+ "env_filter",
  "log",
- "once_cell",
 ]
 
 [[package]]
@@ -1073,16 +1072,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
@@ -2030,7 +2019,7 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 name = "libparsec"
 version = "3.3.3-a.0+dev"
 dependencies = [
- "env_logger 0.11.7",
+ "env_logger",
  "libparsec_client",
  "libparsec_client_connection",
  "libparsec_crypto",
@@ -2238,7 +2227,7 @@ name = "libparsec_platform_mountpoint"
 version = "3.3.3-a.0+dev"
 dependencies = [
  "ctrlc",
- "env_logger 0.11.7",
+ "env_logger",
  "fuser",
  "libc",
  "libparsec_client",
@@ -2367,7 +2356,7 @@ version = "3.3.3-a.0+dev"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
- "env_logger 0.11.7",
+ "env_logger",
  "hex-literal",
  "libparsec_tests_macros",
  "log",
@@ -2994,7 +2983,7 @@ dependencies = [
  "criterion",
  "ctrlc",
  "dialoguer",
- "env_logger 0.11.7",
+ "env_logger",
  "itertools 0.12.1",
  "libparsec",
  "libparsec_client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c494134f746c14dc653a35a4ea5aca24ac368529da5370ecf41fe0341c35772f"
 dependencies = [
  "android_log-sys",
- "env_logger",
+ "env_logger 0.10.2",
  "log",
  "once_cell",
 ]
@@ -1062,16 +1062,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
- "humantime",
- "is-terminal",
  "log",
  "regex",
- "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -1562,12 +1582,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,6 +1905,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "jiff"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,7 +2030,7 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 name = "libparsec"
 version = "3.3.3-a.0+dev"
 dependencies = [
- "env_logger",
+ "env_logger 0.11.7",
  "libparsec_client",
  "libparsec_client_connection",
  "libparsec_crypto",
@@ -2200,7 +2238,7 @@ name = "libparsec_platform_mountpoint"
 version = "3.3.3-a.0+dev"
 dependencies = [
  "ctrlc",
- "env_logger",
+ "env_logger 0.11.7",
  "fuser",
  "libc",
  "libparsec_client",
@@ -2329,7 +2367,7 @@ version = "3.3.3-a.0+dev"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
- "env_logger",
+ "env_logger 0.11.7",
  "hex-literal",
  "libparsec_tests_macros",
  "log",
@@ -2956,7 +2994,7 @@ dependencies = [
  "criterion",
  "ctrlc",
  "dialoguer",
- "env_logger",
+ "env_logger 0.11.7",
  "itertools 0.12.1",
  "libparsec",
  "libparsec_client",
@@ -3168,9 +3206,18 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.6.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -4418,15 +4465,6 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ libparsec_types = { path = "libparsec/crates/types", default-features = false }
 libparsec_zstd = { path = "libparsec/crates/zstd", default-features = false }
 
 # Third parties
-android_logger = { version = "0.13", default-features = false }
+android_logger = { version = "0.15", default-features = false }
 anyhow = { version = "1.0.96", default-features = false }
 argon2 = { version = "0.5.3", default-features = false }
 assert_cmd = { version = "2.0.16", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ digest = { version = "0.10.7", default-features = false }
 dirs = { version = "5.0.1", default-features = false }
 ed25519-dalek = { version = "2.1.1", default-features = false }
 email-address-parser = { version = "2.0.0", default-features = false }
-env_logger = { version = "0.10.2", default-features = false }
+env_logger = { version = "0.11.7", default-features = false }
 event-listener = { version = "5.4.0", default-features = false }
 eventsource-stream = { version = "0.2.3", default-features = false }
 flate2 = { version = "1.1.0", features = ["rust_backend"], default-features = false }


### PR DESCRIPTION
This fix the warning about `humantime` unmaintained