### PR TITLE
feat(webapp): Define `base_href` to `./`

### DIFF
--- a/.github/workflows/package-client.yml
+++ b/.github/workflows/package-client.yml
@@ -126,6 +126,9 @@ jobs:
         run: npm run web:release
         env:
           PARSEC_APP_SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          # Configure the base href of the WebApp,
+          # we use a relative path since we want to provide a bundle that does not enforce a way to distribute the app.
+          PARSEC_APP_BASEHREF: ./
         working-directory: client
 
       - name: Zip webapp content

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -13,12 +13,12 @@ import wasmPack from './scripts/vite_plugin_wasm_pack';
 const plugins: PluginOption[] = [vue(), topLevelAwait()];
 let platform: string;
 
-// Vite only expose in `import.meta.env` the environ variables with a `PARSEC_APP_` prefix,
+// Vite only expose in `import.meta.env` the environment variables with a `PARSEC_APP_` prefix,
 // but to make it a bit easier, we're also letting the user provide TESTBED_SERVER
 if (process.env.PARSEC_APP_TESTBED_SERVER || process.env.TESTBED_SERVER) {
-  // Why this if guard ? Guess what kiddo !
+  // Why this if guard? Guess what kiddo!
   // Setting `process.env.PARSEC_APP_TESTBED_SERVER = undefined` got chewed up
-  // in the web page into "undefined" string...
+  // in the webpage into "undefined" string...
   process.env.PARSEC_APP_TESTBED_SERVER = process.env.PARSEC_APP_TESTBED_SERVER || process.env.TESTBED_SERVER;
 }
 if (process.env.PARSEC_APP_TEST_MODE || process.env.APP_TEST_MODE) {
@@ -37,7 +37,7 @@ if (process.env.PLATFORM !== undefined) {
     throw new Error('Invalid value for PLATFORM environ variable, accepted values: `web`/`native`');
   }
 } else {
-  // Ain't nobody got time to set environ variable !
+  // Ain't nobody got time to set environment variable !
   console.log('PLATFORM environ variable not set, defaulting to `web`');
   platform = 'web';
 }


### PR DESCRIPTION
`vite` support relative base
(<https://vite.dev/guide/build#relative-base>).

This is fill our gap where we do not know in advance the how the app will be hosted.