### PR TITLE
add fastapi CORSMiddleware to allow CORS

### DIFF
--- a/server/parsec/asgi/__init__.py
+++ b/server/parsec/asgi/__init__.py
@@ -7,6 +7,7 @@ from typing import cast
 import anyio
 import uvicorn
 from fastapi import FastAPI, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -41,13 +42,22 @@ tags_metadata = [
 ]
 
 
-def app_factory(backend: Backend, with_client_web_app: Path | None = None) -> AsgiApp:
+def app_factory(
+    backend: Backend,
+    cors_allow_origins: list[str] = [],
+    with_client_web_app: Path | None = None,
+) -> AsgiApp:
     app = FastAPI(
         title="Parsec Server",
         version=parsec_version,
         openapi_tags=tags_metadata,
     )
-
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=cors_allow_origins,
+        allow_methods=["OPTIONS", "GET", "POST", "PATCH"],
+        allow_headers=["api-version", "authorization"],
+    )
     app.state.backend = backend
 
     if with_client_web_app:

--- a/server/parsec/cli/run.py
+++ b/server/parsec/cli/run.py
@@ -326,6 +326,16 @@ For instance: `en_US:https://example.com/tos_en,fr_FR:https://example.com/tos_fr
     ),
 )
 @click.option(
+    "--cors-allow-origins",
+    default=[],
+    show_default=True,
+    multiple=True,
+    type=list[str],
+    envvar="PARSEC_CORS_ALLOW_ORIGINS",
+    show_envvar=True,
+    help="A list of allowed origins for Cross-Origin Resource Sharing (CORS)",
+)
+@click.option(
     "--dev",
     cls=DevOption,
     is_flag=True,
@@ -372,6 +382,7 @@ def run_cmd(
     sentry_dsn: str | None,
     sentry_environment: str,
     with_client_web_app: Path | None,
+    cors_allow_origins: list[str],
     debug: bool,
     dev: bool,
 ) -> None:
@@ -439,6 +450,7 @@ def run_cmd(
                     ssl_keyfile=ssl_keyfile,
                     retry_policy=retry_policy,
                     with_client_web_app=with_client_web_app,
+                    cors_allow_origins=cors_allow_origins,
                     app_config=app_config,
                 )
             )
@@ -483,6 +495,7 @@ async def _run_backend(
     ssl_keyfile: Path | None,
     retry_policy: RetryPolicy,
     with_client_web_app: Path | None,
+    cors_allow_origins: list[str],
     app_config: BackendConfig,
 ) -> None:
     # Log the server version and the backend configuration
@@ -505,6 +518,7 @@ async def _run_backend(
                 parsec_app = app_factory(
                     backend,
                     with_client_web_app=with_client_web_app,
+                    cors_allow_origins=cors_allow_origins,
                 )
 
                 await serve_parsec_asgi_app(


### PR DESCRIPTION
## Describe your changes

When user wants to create an organization on trial for another domain, OPTIONS request have 405 result status code.
This is because CORS is not explicitly enable.

## Checklist

- [x] Keep changes in the pull request as small as possible
- [x] Ensure the commit history is sanitized
- [x] Give a meaningful title to your PR
- [x] Describe your changes
- [x] Link any related issue in the description
- [x] Link any dependent pull request in the description
