### PR TITLE
fix(releaser): Using `github.ref` instead of `github.ref_name`

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -195,7 +195,7 @@ jobs:
         shell: bash -e -o pipefail {0}
         run: |
           (
-            echo 'tag_name=${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'nightly' || github.ref }}'
+            echo 'tag_name=${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'nightly' || github.ref_name }}'
             echo 'release_name=${{ env.NIGHTLY_RELEASE == 'true' && 'Nightly release' || format('Release v{0}', needs.version.outputs.full) }}'
             echo 'repo_path=${{ github.server_url }}/${{ github.repository }}'
           ) | tee -a $GITHUB_OUTPUT


### PR DESCRIPTION
We were using `github.ref` instead of `github.ref_name` to set the value of `tag_name` causing invalid download link when generating the release note.

Both variable hold similar values (`refs/tags/v3.x.x` vs `v3.x.x` respectively) but we want the latter.