### PR TITLE
Fix log messages not appended in libparsec.log

### DIFF
--- a/libparsec/src/lib.rs
+++ b/libparsec/src/lib.rs
@@ -106,8 +106,7 @@ fn init_logger(config: &ClientConfig) {
     }
     let log_file = std::fs::OpenOptions::new()
         .create(true)
-        .write(true)
-        .truncate(false)
+        .append(true)
         .open(&log_file_path)
         .expect("Cannot open log file");
     // FIXME: This is a workaround to be able to get logs from libparsec


### PR DESCRIPTION
Fix #10011 