### PR TITLE
fix(client): Allow using relative base url by using baseURI

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -118,7 +118,7 @@ async function setupApp(): Promise<void> {
     throw Error('Cannot retrieve #app');
   }
 
-  // nextStage() finally mounts the app using the configPath provided
+  // `nextStage()` finally mounts the app using the configPath provided.
   // Note this function cause a deadlock on `router.isReady` if it is awaited
   // from within `setupApp`, so instead it should be called in fire-and-forget
   // and only awaited when it is called from third party code (i.e. when

--- a/client/src/router/types.ts
+++ b/client/src/router/types.ts
@@ -146,8 +146,12 @@ if (import.meta.env.PARSEC_APP_TEST_MODE?.toLowerCase() === 'true') {
   });
 }
 
+const BASE_URI = new URL(document.baseURI);
+// We use `BASE_URI.pathname` over `import.meta.env.BASE_URL` because `vue-router` need an absolute path
+// and we defined `BASE_URL` as relative to simplify hosting configurations.
+const BASE_URL = BASE_URI.pathname;
 const router: Router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  history: createWebHistory(BASE_URL),
   routes,
 });
 


### PR DESCRIPTION
`vue-router` does not support relative `BASE_URL` and need an absolute value.
We configured the project to use a relative `BASE_URL` to simplify hosting and to not have specific builds.

The solution was to use `document.baseURI`