### PR TITLE
fix(webapp): Configure BASE_URL to `/client`

### DIFF
--- a/.github/workflows/package-client.yml
+++ b/.github/workflows/package-client.yml
@@ -126,6 +126,7 @@ jobs:
         run: npm run web:release
         env:
           PARSEC_APP_SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          BASE_URL: /client
         working-directory: client
 
       - name: Zip webapp content

--- a/client/src/router/types.ts
+++ b/client/src/router/types.ts
@@ -146,6 +146,9 @@ if (import.meta.env.PARSEC_APP_TEST_MODE?.toLowerCase() === 'true') {
   });
 }
 
+if (!import.meta.env.BASE_URL.startsWith('/')) {
+  console.warn(`BASE_URL is not an absolute path, this will cause issue with vue-router (BASE_URL=${import.meta.env.BASE_URL})`);
+}
 const router: Router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes,

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -79,7 +79,7 @@ const config: UserConfigExport = () => ({
   },
   // Since we do not know in advance how the webapp will be hosted we use a relative base href.
   // That way the app can be at the root or in a sub-folder and limit the need to specific build.
-  base: './',
+  base: process.env.BASE_URL || './',
   test: {
     include: ['tests/unit/specs/*.spec.ts'],
     setupFiles: [path.resolve(__dirname, './tests/component/support/setup.ts')],


### PR DESCRIPTION
`vue-router` does not support relative `BASE_URL` so we to use an absolute URL.