### PR TITLE
fix --cors-allow-origins server cli option

### DIFF
--- a/server/parsec/cli/run.py
+++ b/server/parsec/cli/run.py
@@ -327,10 +327,9 @@ For instance: `en_US:https://example.com/tos_en,fr_FR:https://example.com/tos_fr
 )
 @click.option(
     "--cors-allow-origins",
-    default=[],
     show_default=True,
     multiple=True,
-    type=list[str],
+    type=str,
     envvar="PARSEC_CORS_ALLOW_ORIGINS",
     show_envvar=True,
     help="A list of allowed origins for Cross-Origin Resource Sharing (CORS)",


### PR DESCRIPTION
Type `list[str]` was not good, type into click is item type not global value type.

- [x] Keep changes in the pull request as small as possible
- [x] Ensure the commit history is sanitized
- [x] Give a meaningful title to your PR
- [x] Describe your changes
- [x] Link any related issue in the description
- [x] Link any dependent pull request in the description
