### PR TITLE
test(playwright): Retain trace on failure

### DIFF
--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -34,8 +34,12 @@ export default defineConfig({
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: 'http://localhost:8080',
 
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    /**
+     * Keep trace of failed test
+     * See https://playwright.dev/docs/trace-viewer on how to use trace
+     * And https://playwright.dev/docs/api/class-testoptions#test-options-trace how to configure the option
+     */
+    trace: 'retain-on-failure',
   },
   testIgnore: ['**/organization_switch_popover.spec.ts', '**/export_recovery_device.spec.ts', '**/import_recovery_device.spec.ts'],
   /* Configure projects for major browsers */


### PR DESCRIPTION
Keep the trace instead of enabling them on first retry to allow investigating the test in case the retry work (meaning flaky) while still keeping trace of retries if they also fail.