### PR TITLE
Split events related to connection errors

### DIFF
--- a/bindings/electron/src/index.d.ts
+++ b/bindings/electron/src/index.d.ts
@@ -739,8 +739,15 @@ export type ClientDeleteShamirRecoveryError =
 
 
 // ClientEvent
+export interface ClientEventClientErrorResponse {
+    tag: "ClientErrorResponse"
+    error_type: string
+}
 export interface ClientEventExpiredOrganization {
     tag: "ExpiredOrganization"
+}
+export interface ClientEventFrozenSelfUser {
+    tag: "FrozenSelfUser"
 }
 export interface ClientEventGreetingAttemptCancelled {
     tag: "GreetingAttemptCancelled"
@@ -759,7 +766,11 @@ export interface ClientEventGreetingAttemptReady {
 }
 export interface ClientEventIncompatibleServer {
     tag: "IncompatibleServer"
-    detail: string
+    api_version: string
+    supported_api_version: Array<string>
+}
+export interface ClientEventInvitationAlreadyUsedOrDeleted {
+    tag: "InvitationAlreadyUsedOrDeleted"
 }
 export interface ClientEventInvitationChanged {
     tag: "InvitationChanged"
@@ -775,6 +786,9 @@ export interface ClientEventOffline {
 export interface ClientEventOnline {
     tag: "Online"
 }
+export interface ClientEventOrganizationNotFound {
+    tag: "OrganizationNotFound"
+}
 export interface ClientEventPing {
     tag: "Ping"
     ping: string
@@ -784,6 +798,14 @@ export interface ClientEventRevokedSelfUser {
 }
 export interface ClientEventServerConfigChanged {
     tag: "ServerConfigChanged"
+}
+export interface ClientEventServerInvalidResponseContent {
+    tag: "ServerInvalidResponseContent"
+    protocol_decode_error: string
+}
+export interface ClientEventServerInvalidResponseStatus {
+    tag: "ServerInvalidResponseStatus"
+    status_code: string
 }
 export interface ClientEventTooMuchDriftWithServerClock {
     tag: "TooMuchDriftWithServerClock"
@@ -832,18 +854,24 @@ export interface ClientEventWorkspacesSelfListChanged {
     tag: "WorkspacesSelfListChanged"
 }
 export type ClientEvent =
+  | ClientEventClientErrorResponse
   | ClientEventExpiredOrganization
+  | ClientEventFrozenSelfUser
   | ClientEventGreetingAttemptCancelled
   | ClientEventGreetingAttemptJoined
   | ClientEventGreetingAttemptReady
   | ClientEventIncompatibleServer
+  | ClientEventInvitationAlreadyUsedOrDeleted
   | ClientEventInvitationChanged
   | ClientEventMustAcceptTos
   | ClientEventOffline
   | ClientEventOnline
+  | ClientEventOrganizationNotFound
   | ClientEventPing
   | ClientEventRevokedSelfUser
   | ClientEventServerConfigChanged
+  | ClientEventServerInvalidResponseContent
+  | ClientEventServerInvalidResponseStatus
   | ClientEventTooMuchDriftWithServerClock
   | ClientEventWorkspaceLocallyCreated
   | ClientEventWorkspaceOpsInboundSyncDone

--- a/bindings/generator/api/common.py
+++ b/bindings/generator/api/common.py
@@ -159,6 +159,13 @@ class Handle(U32BasedType):
     pass
 
 
+class ApiVersion(StrBasedType):
+    custom_from_rs_string = "|s: String| -> Result<_, String> { libparsec::ApiVersion::try_from(s.as_str()).map_err(|e| e.to_string()) }"
+    custom_to_rs_string = (
+        "|x: libparsec::ApiVersion| -> Result<String, &'static str> { Ok(x.to_string()) }"
+    )
+
+
 class OrganizationID(StrBasedType):
     custom_from_rs_string = "|s: String| -> Result<_, String> { libparsec::OrganizationID::try_from(s.as_str()).map_err(|e| e.to_string()) }"
 

--- a/bindings/generator/api/events.py
+++ b/bindings/generator/api/events.py
@@ -3,6 +3,7 @@
 from typing import Callable
 
 from .common import (
+    ApiVersion,
     DateTime,
     Handle,
     IndexInt,
@@ -86,14 +87,33 @@ class ClientEvent(Variant):
     class ExpiredOrganization:
         pass
 
+    class OrganizationNotFound:
+        pass
+
+    class InvitationAlreadyUsedOrDeleted:
+        pass
+
     class RevokedSelfUser:
+        pass
+
+    class FrozenSelfUser:
         pass
 
     class MustAcceptTos:
         pass
 
     class IncompatibleServer:
-        detail: str
+        api_version: ApiVersion
+        supported_api_version: list[ApiVersion]
+
+    class ClientErrorResponse:
+        error_type: str
+
+    class ServerInvalidResponseStatus:
+        status_code: str
+
+    class ServerInvalidResponseContent:
+        protocol_decode_error: str
 
     # class InvalidKeysBundle:
     #     detail: str

--- a/client/src/parsec/login.ts
+++ b/client/src/parsec/login.ts
@@ -177,7 +177,11 @@ export async function login(
         break;
       case ClientEventTag.IncompatibleServer:
         window.electronAPI.log('warn', `IncompatibleServerEvent: ${JSON.stringify(event)}`);
-        distributor.dispatchEvent(Events.IncompatibleServer, { reason: event.detail }, { delay: 5000 });
+        distributor.dispatchEvent(
+          Events.IncompatibleServer,
+          { version: event.apiVersion, supportedVersions: event.supportedApiVersion },
+          { delay: 5000 },
+        );
         break;
       case ClientEventTag.RevokedSelfUser:
         eventDistributor.dispatchEvent(Events.ClientRevoked);

--- a/client/src/parsec/types.ts
+++ b/client/src/parsec/types.ts
@@ -77,6 +77,7 @@ export {
 export type {
   AnyClaimRetrievedInfoDevice,
   AnyClaimRetrievedInfoUser,
+  ApiVersion,
   ArchiveDeviceError,
   AvailableDevice,
   BootstrapOrganizationError,

--- a/client/src/plugins/libparsec/definitions.ts
+++ b/client/src/plugins/libparsec/definitions.ts
@@ -83,6 +83,7 @@ export enum UserProfile {
     Outsider = 'UserProfileOutsider',
     Standard = 'UserProfileStandard',
 }
+export type ApiVersion = string
 export type DeviceID = string
 export type DeviceLabel = string
 export type EntryName = string
@@ -798,18 +799,24 @@ export type ClientDeleteShamirRecoveryError =
 
 // ClientEvent
 export enum ClientEventTag {
+    ClientErrorResponse = 'ClientEventClientErrorResponse',
     ExpiredOrganization = 'ClientEventExpiredOrganization',
+    FrozenSelfUser = 'ClientEventFrozenSelfUser',
     GreetingAttemptCancelled = 'ClientEventGreetingAttemptCancelled',
     GreetingAttemptJoined = 'ClientEventGreetingAttemptJoined',
     GreetingAttemptReady = 'ClientEventGreetingAttemptReady',
     IncompatibleServer = 'ClientEventIncompatibleServer',
+    InvitationAlreadyUsedOrDeleted = 'ClientEventInvitationAlreadyUsedOrDeleted',
     InvitationChanged = 'ClientEventInvitationChanged',
     MustAcceptTos = 'ClientEventMustAcceptTos',
     Offline = 'ClientEventOffline',
     Online = 'ClientEventOnline',
+    OrganizationNotFound = 'ClientEventOrganizationNotFound',
     Ping = 'ClientEventPing',
     RevokedSelfUser = 'ClientEventRevokedSelfUser',
     ServerConfigChanged = 'ClientEventServerConfigChanged',
+    ServerInvalidResponseContent = 'ClientEventServerInvalidResponseContent',
+    ServerInvalidResponseStatus = 'ClientEventServerInvalidResponseStatus',
     TooMuchDriftWithServerClock = 'ClientEventTooMuchDriftWithServerClock',
     WorkspaceLocallyCreated = 'ClientEventWorkspaceLocallyCreated',
     WorkspaceOpsInboundSyncDone = 'ClientEventWorkspaceOpsInboundSyncDone',
@@ -821,8 +828,15 @@ export enum ClientEventTag {
     WorkspacesSelfListChanged = 'ClientEventWorkspacesSelfListChanged',
 }
 
+export interface ClientEventClientErrorResponse {
+    tag: ClientEventTag.ClientErrorResponse
+    errorType: string
+}
 export interface ClientEventExpiredOrganization {
     tag: ClientEventTag.ExpiredOrganization
+}
+export interface ClientEventFrozenSelfUser {
+    tag: ClientEventTag.FrozenSelfUser
 }
 export interface ClientEventGreetingAttemptCancelled {
     tag: ClientEventTag.GreetingAttemptCancelled
@@ -841,7 +855,11 @@ export interface ClientEventGreetingAttemptReady {
 }
 export interface ClientEventIncompatibleServer {
     tag: ClientEventTag.IncompatibleServer
-    detail: string
+    apiVersion: ApiVersion
+    supportedApiVersion: Array<ApiVersion>
+}
+export interface ClientEventInvitationAlreadyUsedOrDeleted {
+    tag: ClientEventTag.InvitationAlreadyUsedOrDeleted
 }
 export interface ClientEventInvitationChanged {
     tag: ClientEventTag.InvitationChanged
@@ -857,6 +875,9 @@ export interface ClientEventOffline {
 export interface ClientEventOnline {
     tag: ClientEventTag.Online
 }
+export interface ClientEventOrganizationNotFound {
+    tag: ClientEventTag.OrganizationNotFound
+}
 export interface ClientEventPing {
     tag: ClientEventTag.Ping
     ping: string
@@ -866,6 +887,14 @@ export interface ClientEventRevokedSelfUser {
 }
 export interface ClientEventServerConfigChanged {
     tag: ClientEventTag.ServerConfigChanged
+}
+export interface ClientEventServerInvalidResponseContent {
+    tag: ClientEventTag.ServerInvalidResponseContent
+    protocolDecodeError: string
+}
+export interface ClientEventServerInvalidResponseStatus {
+    tag: ClientEventTag.ServerInvalidResponseStatus
+    statusCode: string
 }
 export interface ClientEventTooMuchDriftWithServerClock {
     tag: ClientEventTag.TooMuchDriftWithServerClock
@@ -914,18 +943,24 @@ export interface ClientEventWorkspacesSelfListChanged {
     tag: ClientEventTag.WorkspacesSelfListChanged
 }
 export type ClientEvent =
+  | ClientEventClientErrorResponse
   | ClientEventExpiredOrganization
+  | ClientEventFrozenSelfUser
   | ClientEventGreetingAttemptCancelled
   | ClientEventGreetingAttemptJoined
   | ClientEventGreetingAttemptReady
   | ClientEventIncompatibleServer
+  | ClientEventInvitationAlreadyUsedOrDeleted
   | ClientEventInvitationChanged
   | ClientEventMustAcceptTos
   | ClientEventOffline
   | ClientEventOnline
+  | ClientEventOrganizationNotFound
   | ClientEventPing
   | ClientEventRevokedSelfUser
   | ClientEventServerConfigChanged
+  | ClientEventServerInvalidResponseContent
+  | ClientEventServerInvalidResponseStatus
   | ClientEventTooMuchDriftWithServerClock
   | ClientEventWorkspaceLocallyCreated
   | ClientEventWorkspaceOpsInboundSyncDone

--- a/client/src/services/eventDistributor.ts
+++ b/client/src/services/eventDistributor.ts
@@ -1,6 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { EntryID, InvitationStatus, InvitationToken, WorkspaceID } from '@/parsec';
+import { ApiVersion, EntryID, InvitationStatus, InvitationToken, WorkspaceID } from '@/parsec';
 import { GreetingAttemptID } from '@/plugins/libparsec';
 import { v4 as uuid4 } from 'uuid';
 
@@ -63,7 +63,8 @@ interface EntrySyncData {
 }
 
 interface IncompatibleServerData {
-  reason: string;
+  version: ApiVersion;
+  supportedVersions: Array<ApiVersion>;
 }
 
 type EventData =

--- a/libparsec/crates/client_connection/README.md
+++ b/libparsec/crates/client_connection/README.md
@@ -1,0 +1,13 @@
+# Libparsec Client Connection
+
+This crate provides support for client connection to the server, from transport
+to application (HTTP/RPC) layer.
+
+Client requests are based on [`reqwest`] HTTP Client including proxy
+configuration and certificate management.
+
+Specifics regarding RPC commands, such as handling headers and status codes,
+are implemented by command family. In particular, SSE support is included for
+the `authenticated_cmds` family.
+
+[`reqwest`]: https://docs.rs/reqwest/latest/reqwest/

--- a/libparsec/crates/client_connection/src/lib.rs
+++ b/libparsec/crates/client_connection/src/lib.rs
@@ -1,4 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+#![doc = include_str!("../README.md")]
 
 mod anonymous_cmds;
 mod authenticated_cmds;

--- a/libparsec/crates/client_connection/tests/unit/anonymous.rs
+++ b/libparsec/crates/client_connection/tests/unit/anonymous.rs
@@ -142,7 +142,7 @@ register_rpc_http_hook!(
     rpc_unsupported_api_version_http_codes_422,
     StatusCode::from_u16(422).unwrap(),
     |err| {
-        p_assert_matches!(err, ConnectionError::MissingSupportedApiVersions);
+        p_assert_matches!(err, ConnectionError::MissingSupportedApiVersions { api_version } if api_version == *API_LATEST_VERSION );
     }
 );
 register_rpc_http_hook!(

--- a/libparsec/crates/client_connection/tests/unit/authenticated.rs
+++ b/libparsec/crates/client_connection/tests/unit/authenticated.rs
@@ -841,7 +841,7 @@ register_rpc_http_hook!(
     rpc_unsupported_api_version_http_codes_422,
     StatusCode::from_u16(422).unwrap(),
     |err| {
-        p_assert_matches!(err, ConnectionError::MissingSupportedApiVersions);
+        p_assert_matches!(err, ConnectionError::MissingSupportedApiVersions { api_version } if api_version == *API_LATEST_VERSION );
     }
 );
 register_rpc_http_hook!(
@@ -995,7 +995,7 @@ register_sse_http_hook!(
     sse_unsupported_api_version_http_codes_422,
     StatusCode::from_u16(422).unwrap(),
     |err| {
-        p_assert_matches!(err, ConnectionError::MissingSupportedApiVersions);
+        p_assert_matches!(err, ConnectionError::MissingSupportedApiVersions { api_version } if api_version == *API_LATEST_VERSION );
     }
 );
 register_rpc_http_hook!(

--- a/libparsec/crates/client_connection/tests/unit/invited.rs
+++ b/libparsec/crates/client_connection/tests/unit/invited.rs
@@ -214,7 +214,7 @@ register_rpc_http_hook!(
     rpc_unsupported_api_version_http_codes_422,
     StatusCode::from_u16(422).unwrap(),
     |err| {
-        p_assert_matches!(err, ConnectionError::MissingSupportedApiVersions);
+        p_assert_matches!(err, ConnectionError::MissingSupportedApiVersions { api_version } if api_version == *API_LATEST_VERSION );
     }
 );
 register_rpc_http_hook!(


### PR DESCRIPTION
This PR splits `EventIncompatibleServer` into more specific events depending on the concrete `ConnectionError`.

- Added: 
  - `EventOrganizationNotFound`
  - `EventInvitationAlreadyUsedOrDeleted`
  - `EventFrozenSelfUser`
  - `EventClientErrorResponse(error_type)`
  - `EventServerInvalidResponseStatus(status_code)`
  - `EventServerInvalidResponseContent(decode_error)`
- Changed:
  - `EventIncompatibleServer(api_version, supported_api_versions)` now includes version info instead of a `detail` string.
- Removed (see #10092):
  - `ConnectionError::WrongApiVersion`
  - `ConnectionError::InvalidSSEEventID`

Other changes in this PR:

- Added `README.md` for the `client_connection` crate
- Improve `ConnectionError` messages and comments
- Re-generated bindings

Closes #9996 
Closes #10092