### PR TITLE
Restore cspell-action option removed by mistake

### DIFF
--- a/.github/workflows/cspell.yml
+++ b/.github/workflows/cspell.yml
@@ -82,6 +82,7 @@ jobs:
           # Only check for changed files on a PR
           # But check on all files on the main branch & the merge queue
           incremental_files_only: ${{ github.ref != 'refs/heads/master' && contains(github.ref, 'gh-readonly-queue') != 'true' }}
+          check_dot_files: true
 
       - name: Show result
         run: printenv RESULT | jq -r .


### PR DESCRIPTION
Removed by mistake in https://github.com/Scille/parsec-cloud/pull/10091/files#diff-b5bea6479fd108441c7fc433db75bdd293b651be540c17849a44ed9d98d1c742