### PR TITLE
ci(npm): Install dependencies without running audit

### DIFF
--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -59,8 +59,10 @@ jobs:
         shell: bash -o pipefail -ex {0}
         run: |
           # Execute 'npm install' until success,
-          # This is done that way because sometime some CDN respond with 503
-          until npm install --ignore-scripts; do
+          # This is done that way because sometime some CDN respond with 503.
+          # We use `ignore-scripts` to skip the postinstall that install electron dependencies,
+          # and `no-audit` to skip auditing packages in CI (it's faster that way).
+          until npm install --ignore-scripts --no-audit; do
             echo "Failed install, retrying ...";
           done
           # Failed if package-lock.json was modified

--- a/.github/workflows/package-client.yml
+++ b/.github/workflows/package-client.yml
@@ -64,6 +64,8 @@ env:
   node-version: 18.12.0
   wasm-pack-version: 0.12.1
   WINFSP_VERSION: 2.0.23075
+  # When installing npm dependencies, we skip the audit to have faster installation time.
+  NPM_ARGS: --no-audit
 
 permissions:
   contents: read
@@ -110,7 +112,7 @@ jobs:
         run: git apply --allow-empty ${{ runner.temp }}/version.patch/version.patch
 
       - name: Install dependencies
-        run: npm clean-install
+        run: npm clean-install ${{ env.NPM_ARGS }}
         working-directory: client
 
       # Install syft
@@ -352,17 +354,17 @@ jobs:
       - name: Install client dependencies
         # Use `--ignore-scripts` to prevent the postinstall script trying to be smarter than us and
         # install electron dependencies (as it would use `npm install` instead of `npm clean-install`).
-        run: npm clean-install --ignore-scripts
+        run: npm clean-install --ignore-scripts ${{ env.NPM_ARGS }}
         working-directory: client
         timeout-minutes: 10
 
       - name: Install electron dependencies
-        run: npm clean-install
+        run: npm clean-install ${{ env.NPM_ARGS }}
         working-directory: client/electron
         timeout-minutes: 2
 
       - name: Install electron bindings dependencies
-        run: npm clean-install
+        run: npm clean-install ${{ env.NPM_ARGS }}
         working-directory: bindings/electron
         timeout-minutes: 1
 

--- a/client/electron/snap/snapcraft.yaml
+++ b/client/electron/snap/snapcraft.yaml
@@ -75,7 +75,7 @@ parts:
       cargo --version
 
       cd bindings/electron
-      npm clean-install
+      npm clean-install --no-audit
       npm run build:release
 
       cp -va dist/libparsec.node "$CRAFT_PART_INSTALL/libparsec.node"
@@ -99,7 +99,7 @@ parts:
       mkdir -pv megashark-lib && cd megashark-lib
       tar --extract --file ../megashark-lib-src.tar.gz --strip-components=1
 
-      npm clean-install
+      npm clean-install --no-audit
       MEGASHARK_ARCHIVE=$(npm pack | tail -n1)
 
       cp -v $MEGASHARK_ARCHIVE "$CRAFT_STAGE/megashark-lib.tar.gz"
@@ -130,12 +130,12 @@ parts:
 
       # Use `--ignore-scripts` to prevent the postinstall script trying to be smarter than us and
       # install electron dependencies (as it would use `npm install` instead of `npm clean-install`).
-      npm install --ignore-scripts
+      npm install --ignore-scripts --no-audit
       npm run native:build -- --mode $VITE_MODE
       npm exec cap copy @capacitor-community/electron
 
       cd electron
-      npm clean-install
+      npm clean-install --no-audit
 
       # Copy bindings
       rm -rf build # Cleanup build folder


### PR DESCRIPTION
The audit phase only list know vulnerabilities, we do not use that capabilities during CI run/build.
