### PR TITLE
ci(build-testbed): Ignore `.md` file change

### DIFF
--- a/.github/workflows/docker-testbed.yml
+++ b/.github/workflows/docker-testbed.yml
@@ -12,6 +12,7 @@ on:
       # Testbed code also depends on `libparsec/**`, but this code change very often
       # and we consider the server tests are good enough on this part.
       - server/packaging/testbed-server/**
+      - "!server/packaging/testbed-server/**.md"
       - .github/workflows/docker-testbed.yml
   push:
     branches:
@@ -20,6 +21,7 @@ on:
       # Testbed code also depends on `libparsec/**`, but this code change very often
       # and we consider the server tests are good enough on this part.
       - server/packaging/testbed-server/**
+      - "!server/packaging/testbed-server/**.md"
       - .github/workflows/docker-testbed.yml
 
 permissions:


### PR DESCRIPTION
The workflow `build-docker-tesbed` is trigger on change on `testbed-server/` folder.

When we update the version of the used testbed accross the repo, we modify a `README.md` file contain in the said folder triggering a new workflow run.

To ignore the `README.md`, we use a negative match pattern

>  The order that you define paths patterns matters:
>
>  - A matching negative pattern (prefixed with !) after a positive match will exclude the path.
>  - A matching positive pattern after a negative match will include the path again.
>
> [`on.<push|pull_request|pull_request_target>.<paths|paths-ignore>`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore)