### PR TITLE
feat(client_connection): Generate HMAC signature for authentication

### DIFF
--- a/docs/rfcs/1013-parsec-account.md
+++ b/docs/rfcs/1013-parsec-account.md
@@ -87,16 +87,19 @@ Some indices are already present above, we will use an HMAC based authentication
 
 The HMAC code will be put in the `Authorization` HTTP header and will have the following format:
 
-```bash
-PARSEC-HMAC-BLAKE2B.${id}.${account_email}.${timestamp}.${signature}
+```jinja
+PARSEC-PASSWORD-HMAC-BLAKE2B.{{ base64(account_email) }}.{{ timestamp }}.{{ signature }}
 ```
+
+> [!IMPORTANT]
+> We use the URL-safe `base64` variant.
 
 The signature is generated like so:
 
 ```math
 \begin{gather}
 body\_sha256 = sha256(body) \\
-content = \text{"PARSEC-HMAC-BLAKE2B"} \Vert email \Vert timestamp \Vert body\_sha256 \\
+content = \text{"PARSEC-PASSWORD-HMAC-BLAKE2B"} \Vert \text{"."} \Vert base64(email) \Vert \text{"."} \Vert timestamp \Vert \text{"."} \Vert body\_sha256 \\
 code = hmac_{black2b}(shared\_secret, content) \\
 signature = base64(code)
 \end{gather}

--- a/libparsec/crates/crypto/src/rustcrypto/secret.rs
+++ b/libparsec/crates/crypto/src/rustcrypto/secret.rs
@@ -74,6 +74,10 @@ impl SecretKey {
         out
     }
 
+    pub fn hmac_full(&self, data: &[u8]) -> Vec<u8> {
+        self.hmac::<U64>(data)
+    }
+
     pub fn sas_code(&self, data: &[u8]) -> Vec<u8> {
         self.hmac::<U5>(data)
     }

--- a/libparsec/crates/crypto/src/sodiumoxide/secret.rs
+++ b/libparsec/crates/crypto/src/sodiumoxide/secret.rs
@@ -101,6 +101,10 @@ impl SecretKey {
         }
     }
 
+    pub fn hmac_full(&self, data: &[u8]) -> Vec<u8> {
+        self.hmac::<U64>(data)
+    }
+
     pub fn sas_code(&self, data: &[u8]) -> Vec<u8> {
         self.hmac::<U5>(data)
     }


### PR DESCRIPTION
Currently the signature is generated with a random key each time until we have access to a stable secret.

It also use an hardcoded email since we do not have an account struct to store the user information.

Related to #10076