### PR TITLE
feat(server): Valide account authentication token

### DIFF
--- a/libparsec/crates/client_connection/src/authenticated_account_cmds.rs
+++ b/libparsec/crates/client_connection/src/authenticated_account_cmds.rs
@@ -175,12 +175,18 @@ fn prepare_request(
     time_provider: &TimeProvider,
     account: &AccountPassword,
 ) -> RequestBuilder {
-    let mut content_headers = HeaderMap::with_capacity(4);
+    // TODO: user hmac key is sent alongside the request
+    //       until it can be provided by the internal state.
+    let mut content_headers = HeaderMap::with_capacity(4 + 1);
     content_headers.insert(API_VERSION_HEADER_NAME, api_version_header_value);
     content_headers.insert(CONTENT_TYPE, HeaderValue::from_static(PARSEC_CONTENT_TYPE));
     content_headers.insert(
         CONTENT_LENGTH,
         HeaderValue::from_str(&body.len().to_string()).expect("numeric value are valid char"),
+    );
+    content_headers.insert(
+        reqwest::header::HeaderName::from_static("x-hmac-key"),
+        HeaderValue::from_str(&BASE64URL.encode(account.hmac_key.as_ref())).expect("Always valid"),
     );
     let body_sha256 = libparsec_crypto::HashDigest::from_data(&body);
     let authorization_header_value = HeaderValue::from_str(&generate_authorization_header_value(

--- a/server/parsec/components/memory/auth.py
+++ b/server/parsec/components/memory/auth.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from pydantic.networks import EmailStr
+
 from parsec._parsec import DateTime, DeviceID, InvitationToken, OrganizationID
 from parsec.components.auth import (
     AnonymousAccountAuthInfo,
@@ -125,9 +127,8 @@ class MemoryAuthComponent(BaseAuthComponent):
     ) -> AnonymousAccountAuthInfo | AuthAnonymousAccountAuthBadOutcome:
         return AnonymousAccountAuthInfo()
 
-    async def authenticated_account_auth(
-        self,
-        now: DateTime,
+    async def _get_authenticated_account_info(
+        self, email: EmailStr
     ) -> AuthenticatedAccountAuthInfo | AuthAuthenticatedAccountAuthBadOutcome:
-        # TODO check signature
+        # TODO: Retrieve actual info from state
         return AuthenticatedAccountAuthInfo()

--- a/server/tests/common/client.py
+++ b/server/tests/common/client.py
@@ -1,6 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-from base64 import b64decode
+from base64 import b64decode, urlsafe_b64encode
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import AsyncContextManager, AsyncGenerator, AsyncIterator
@@ -100,6 +100,7 @@ class AuthenticatedAccountRpcClient(BaseAuthenticatedAccountRpcClient):
         self.headers = {
             "Content-Type": "application/msgpack",
             "Api-Version": str(ApiVersion.API_LATEST_VERSION),
+            "X-Hmac-Key": urlsafe_b64encode(key.secret),
         }
         self.email = email
         self.key = key


### PR DESCRIPTION
Currently we do not have access to the user hmac key, so we need to send it alongside the request until it can be provided by the internal state.

Close #10171