### PR TITLE
Fix instructions for server development

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -4,8 +4,7 @@
 
 - [Get the sources](#get-the-sources)
 - [Shared requirements](#shared-requirements)
-- [Hacking the Python server](#hacking-the-python-server)
-  - [Run the Python tests](#run-the-python-tests)
+- [Hacking Parsec Server](#hacking-parsec-server)
 - [Hacking the clients](#hacking-the-clients)
   - [Base requirement](#base-requirement)
   - [Hacking the web client](#hacking-the-web-client)
@@ -121,55 +120,9 @@ To start hacking, follow the basic steps detailed below:
 
        > If you don't have installed `python` with `pyenv`, you need to replace `$(pyenv prefix 3.12.0)/bin/python` with the path where the python you want to use is located.
 
-## Hacking the Python server
+## Hacking Parsec Server
 
-Once you have installed the [basic requirements](#shared-requirements), you can proceed to setup to python virtual env with `poetry`.
-
-The python code is located in the folder `server`, The following steps and instruction will consider that you're in that folder.
-
-   <!-- markdownlint-disable-next-line no-inline-html -->
-1. Initialize a poetry env <a id="init-server-python-env" />
-
-   ```shell
-   python ./make.py python-dev-install
-   ```
-
-   > The Python server is built from the `server` directory.
-
-2. Start a shell with the initialized virtual env
-
-    ```shell
-    poetry shell
-    ```
-
-3. To run parsec do
-
-    ```shell
-    poetry run parsec
-    ```
-
-Happy Hacking 🐍
-
-### Run the Python tests
-
-Run the tests with `pytest`:
-
-```shell
-poetry run pytest tests
-```
-
-In addition, the following options are available:
-
-| Option           | Description                                              |
-| ---------------- | -------------------------------------------------------- |
-| ``--postgresql`` | Use PostgreSQL in the server instead of a mock in memory |
-| ``-n 4``         | Run tests in parallel (here `4` jobs)                    |
-
-Note you can mix&match the flags, e.g.
-
-```shell
-poetry run pytest tests --postgresql -n auto
-```
+Start by installing [shared requirements](#shared-requirements), then refer to [server/README.md](../../server/README.md).
 
 ## Hacking the clients
 
@@ -242,7 +195,6 @@ In addition to the [shared requirements](#shared-requirements), for working with
       ```shell
       npx electron . "<a file link or an invitation link>"
       ```
-
 
 ### Hacking the electron client
 

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,66 @@
+# Parsec Server
+
+## Development
+
+### Quickstart
+
+1. Start by installing the [shared requirements](../docs/development/README.md#shared-requirements).
+
+2. Activate your virtual environment
+
+   ```shell
+   eval $(poetry -P server env activate)
+   ```
+
+3. Install dependencies (from the root directory)
+
+   ```shell
+   python ./make.py python-dev-install
+   ```
+
+4. Run parsec server
+
+   ```shell
+   poetry run parsec
+   ```
+
+Happy Hacking! 🐍
+
+### Running tests
+
+Run the tests with `pytest` (from `server` directory):
+
+```shell
+# run all tests
+$ poetry run pytest tests
+...
+# run tests from a specific directory
+$ poetry run pytest tests/api_v5/
+...
+# run tests from a specific test file
+$ poetry run pytest tests/api_v5/authenticated/test_shamir_recovery_setup.py
+...
+# run specific tests functions with `-k EXPR`, a Python expression where all
+# names are substring-matched against test names
+$ poetry run pytest -k 'not_allowed or not_found' tests
+```
+
+The following options are available (run `poetry run pytest --help` for many more!):
+
+| Option                | Description                                              |
+| --------------------- | -------------------------------------------------------- |
+| ``-n 4``              | Run tests in parallel (here `4` jobs)                    |
+| ``-x``                | Exit instantly on first error or failed test             |
+| ``-v``                | Increase verbosity                                       |
+| ``--log-level=LEVEL`` | Level of messages to catch/display                       |
+| ``--timeout=TIMEOUT`` | Timeout in seconds before dumping the stacks.            |
+
+#### PostgreSQL tests
+
+By default, tests are run with an *in-memory* backend implementation.
+To use *PostgreSQL* backend implementation use the `--postgresql` option.
+
+| Option                     | Description                                              |
+| -------------------------- | -------------------------------------------------------- |
+| `--postgresql`             | Use PostgreSQL in the server instead of a mock in memory |
+| `--run-postgresql-cluster` | Instead of running the tests, only start a PostgreSQL cluster that can be use for other tests (through `PG_URL` env var) to avoid having to create a new cluster each time. |


### PR DESCRIPTION
- Replace deprecated `poetry shell`
- Complete test section with more examples and options
- Move instructions to server/README.md