### PR TITLE
chore(cargo-deny): Ignore RUSTSEC-2025-0026

### DIFF
--- a/.github/filters/ci.yml
+++ b/.github/filters/ci.yml
@@ -10,7 +10,7 @@ rust-dependencies-workspace: &rust-dependencies-workspace
   - Cargo.toml
   - Cargo.lock
 
-rust-cargo-deny:
+rust-cargo-deny: &rust-cargo-deny
   - deny.toml
   - *rust-dependencies-workspace
 
@@ -38,6 +38,7 @@ rust-changes: &rust-changes
   - *rust-python-binding
   - *rust-web-binding
   - *rust-cli
+  - *rust-cargo-deny
 
 # The rust jobs need to watch for:
 # - The change on the rust code.

--- a/deny.toml
+++ b/deny.toml
@@ -105,6 +105,13 @@ reason = """
 `PyString::from_object` is not used in the codebase.
 """
 
+[[advisories.ignore]]
+id = "RUSTSEC-2025-0026"
+reason = """
+registry is no longer maintained but in a ok state.
+We depend on it from `winfsp-wrs-sys` crate an issue as been opened on their side: https://github.com/Scille/winfsp_wrs/issues/36
+"""
+
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
 # Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.

--- a/deny.toml
+++ b/deny.toml
@@ -85,15 +85,6 @@ id = "RUSTSEC-2023-0071"
 reason = "Currently no fix, but it's currently being worked on, see issue: https://github.com/RustCrypto/RSA/issues/19#issuecomment-1822995643"
 
 [[advisories.ignore]]
-id = "RUSTSEC-2024-0363"
-reason = """
-Possible SQL Injection where input manipulate the SQL query by overflowing the buffer len field (4 bytes).
-
-We are not affected since sqlx is used on the client side to store the files' data.
-Before being stored in SQLite, that data is splitted into chunk and encoded, so we are below the overflow limit of 4GB.
-"""
-
-[[advisories.ignore]]
 id = "RUSTSEC-2024-0436"
 reason = """
 paste is no longer maintained but in a correct state.


### PR DESCRIPTION
A new advisory was created for the now `unmaitained` crate `registry` that
manipulate Windows registry.

We depend on that crate from `winfsp-wrs-sys`, so until
Scille/winfsp_wrs#36 is fixed we have to
ignore it.