### PR TITLE
refactor(device-loader): Use `StorageManager` over `LocalStorage` on web

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -162,6 +162,10 @@ jobs:
       - name: Test platform-device-loader on wasm
         if: inputs.run-wasm-tests
         run: wasm-pack test --headless --firefox libparsec/crates/platform_device_loader
+        env:
+          # RUST_LOG: wasm_bindgen_test_runner
+          # Default timeout is 20, increase it for slow runner
+          WASM_BINDGEN_TEST_TIMEOUT: 40
         timeout-minutes: 10
 
       - name: Build CLI binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1921,9 +1921,8 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
+version = "0.3.77"
+source = "git+https://github.com/FirelightFlagboy/wasm-bindgen.git?rev=9402ae3bd1eea6d4a8c0d6b62dd62efa4c536d6e#9402ae3bd1eea6d4a8c0d6b62dd62efa4c536d6e"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2169,6 +2168,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "uuid",
+ "wasm-bindgen-futures",
  "web-sys",
  "zeroize",
 ]
@@ -4846,24 +4846,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.97"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
+version = "0.2.100"
+source = "git+https://github.com/FirelightFlagboy/wasm-bindgen.git?rev=9402ae3bd1eea6d4a8c0d6b62dd62efa4c536d6e#9402ae3bd1eea6d4a8c0d6b62dd62efa4c536d6e"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.97"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
+version = "0.2.100"
+source = "git+https://github.com/FirelightFlagboy/wasm-bindgen.git?rev=9402ae3bd1eea6d4a8c0d6b62dd62efa4c536d6e#9402ae3bd1eea6d4a8c0d6b62dd62efa4c536d6e"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -4872,11 +4870,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.47"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if 1.0.0",
+ "futures-core",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -4885,9 +4884,8 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.97"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
+version = "0.2.100"
+source = "git+https://github.com/FirelightFlagboy/wasm-bindgen.git?rev=9402ae3bd1eea6d4a8c0d6b62dd62efa4c536d6e#9402ae3bd1eea6d4a8c0d6b62dd62efa4c536d6e"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4895,9 +4893,8 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.97"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
+version = "0.2.100"
+source = "git+https://github.com/FirelightFlagboy/wasm-bindgen.git?rev=9402ae3bd1eea6d4a8c0d6b62dd62efa4c536d6e#9402ae3bd1eea6d4a8c0d6b62dd62efa4c536d6e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4908,20 +4905,20 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.97"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
+version = "0.2.100"
+source = "git+https://github.com/FirelightFlagboy/wasm-bindgen.git?rev=9402ae3bd1eea6d4a8c0d6b62dd62efa4c536d6e#9402ae3bd1eea6d4a8c0d6b62dd62efa4c536d6e"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.47"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d919bb60ebcecb9160afee6c71b43a58a4f0517a2de0054cd050d02cec08201"
+checksum = "66c8d5e33ca3b6d9fa3b4676d774c5778031d27a578c2b007f905acf816152c3"
 dependencies = [
  "js-sys",
  "minicov",
- "once_cell",
- "scoped-tls",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
@@ -4929,9 +4926,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.47"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222ebde6ea87fbfa6bdd2e9f1fd8a91d60aee5db68792632176c4e16a74fc7d8"
+checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4953,9 +4950,8 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
+version = "0.3.77"
+source = "git+https://github.com/FirelightFlagboy/wasm-bindgen.git?rev=9402ae3bd1eea6d4a8c0d6b62dd62efa4c536d6e#9402ae3bd1eea6d4a8c0d6b62dd62efa4c536d6e"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,7 +206,7 @@ uuid = { version = "1.16.0", default-features = false }
 wasm-bindgen = { version = "0.2.97", default-features = false }
 wasm-bindgen-futures = { version = "0.4.47", default-features = false }
 wasm-bindgen-test = { version = "0.3.47", default-features = false, features = ["std"] }
-web-sys = { version = "0.3.72", default-features = false }
+web-sys = { version = "0.3.77", default-features = false }
 web-time = { version = "1.1.0", default-features = false }
 widestring = { version = "1.2.0", default-features = false }
 windows-sys = { version = "0.59.0", default-features = false }
@@ -215,6 +215,14 @@ winfsp_wrs_build = { version = "0.4.0", default-features = false }
 x25519-dalek = { version = "2.0.1", default-features = false }
 zeroize = { version = "1.8.1", default-features = false }
 zstd = { version = "0.13.3", default-features = false }
+
+[patch.crates-io]
+# Patch web-sys for `Blob.bytes`
+# FIXME: Remove me once https://github.com/rustwasm/wasm-bindgen/pull/4506 is merged and released
+web-sys = { git = "https://github.com/FirelightFlagboy/wasm-bindgen.git", rev = "9402ae3bd1eea6d4a8c0d6b62dd62efa4c536d6e" }
+wasm-bindgen = { git = "https://github.com/FirelightFlagboy/wasm-bindgen.git", rev = "9402ae3bd1eea6d4a8c0d6b62dd62efa4c536d6e" }
+js-sys = { git = "https://github.com/FirelightFlagboy/wasm-bindgen.git", rev = "9402ae3bd1eea6d4a8c0d6b62dd62efa4c536d6e" }
+# End patch web-sys for `Blob.bytes`
 
 [workspace.dependencies.criterion]
 default-features = false

--- a/deny.toml
+++ b/deny.toml
@@ -276,7 +276,7 @@ required-git-spec = "rev"
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
-allow-git = []
+allow-git = ["https://github.com/FirelightFlagboy/wasm-bindgen.git"]
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for

--- a/libparsec/crates/platform_device_loader/Cargo.toml
+++ b/libparsec/crates/platform_device_loader/Cargo.toml
@@ -39,7 +39,24 @@ uuid = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = { workspace = true, features = ["Window", "Storage"] }
+wasm-bindgen-futures = { workspace = true, features = ["futures-core-03-stream"] }
+web-sys = { workspace = true, features = [
+    "DomException",
+    "FileSystemDirectoryHandle",
+    "FileSystemGetDirectoryOptions",
+    "FileSystemGetFileOptions",
+    "FileSystemWritableFileStream",
+    "File",
+    "Blob",
+    "FileSystemHandle",
+    "FileSystemFileHandle",
+    "FileSystemHandleKind",
+    "Navigator",
+    "StorageManager",
+    "Window",
+    "WorkerGlobalScope",
+    "WorkerNavigator",
+] }
 serde_json = { workspace = true, features = ["std"] }
 data-encoding = { workspace = true }
 error_set = { workspace = true }

--- a/libparsec/crates/platform_device_loader/src/native/mod.rs
+++ b/libparsec/crates/platform_device_loader/src/native/mod.rs
@@ -12,8 +12,8 @@ use uuid::Uuid;
 use libparsec_types::prelude::*;
 
 use crate::{
-    ArchiveDeviceError, ListAvailableDeviceError, LoadDeviceError, RemoveDeviceError,
-    SaveDeviceError, UpdateDeviceError, DEVICE_FILE_EXT,
+    get_device_archive_path, ArchiveDeviceError, ListAvailableDeviceError, LoadDeviceError,
+    RemoveDeviceError, SaveDeviceError, UpdateDeviceError, DEVICE_FILE_EXT,
 };
 
 const KEYRING_SERVICE: &str = "parsec";
@@ -343,18 +343,9 @@ pub async fn update_device(
     Ok((available_device, old_server_addr))
 }
 
-pub const ARCHIVE_DEVICE_EXT: &str = "archived";
-
 /// Archive a device identified by its path.
 pub async fn archive_device(device_path: &Path) -> Result<(), ArchiveDeviceError> {
-    let archive_device_path = if let Some(current_file_extension) = device_path.extension() {
-        // Add ARCHIVE_DEVICE_EXT to the current file extension resulting in extension `.{current}.{ARCHIVE_DEVICE_EXT}`.
-        let mut ext = current_file_extension.to_owned();
-        ext.extend([".".as_ref(), ARCHIVE_DEVICE_EXT.as_ref()]);
-        device_path.with_extension(ext)
-    } else {
-        device_path.with_extension(ARCHIVE_DEVICE_EXT)
-    };
+    let archive_device_path = get_device_archive_path(device_path);
 
     log::debug!(
         "Archiving device {} to {}",

--- a/libparsec/crates/platform_device_loader/src/web/wrapper.rs
+++ b/libparsec/crates/platform_device_loader/src/web/wrapper.rs
@@ -1,0 +1,434 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use std::{
+    ffi::OsStr,
+    ops::Deref,
+    path::{Path, PathBuf},
+};
+
+use libparsec_platform_async::{
+    future::{self, FutureExt},
+    stream::{Stream, StreamExt},
+};
+use wasm_bindgen_futures::{stream::JsStream, JsFuture};
+use web_sys::{js_sys, wasm_bindgen::JsCast, DomException};
+
+use super::error::{
+    CastError, GetDirectoryHandleError, GetFileHandleError, GetRootDirectoryError, ReadToEndError,
+    RemoveEntryError, WriteAllError,
+};
+
+#[derive(Clone)]
+pub struct Directory {
+    pub path: PathBuf,
+    pub handle: web_sys::FileSystemDirectoryHandle,
+}
+
+impl Directory {
+    pub async fn get_root() -> Result<Self, GetRootDirectoryError> {
+        let storage_manager: web_sys::StorageManager = if let Some(window) = web_sys::window() {
+            Ok(window.navigator().storage())
+        } else {
+            // `window` is not available, at that point we consider that we are in a shared
+            // worker.
+
+            // `WorkerGlobalScope` is available as a global
+            // https://github.com/rustwasm/wasm-bindgen/issues/1003
+            js_sys::global()
+                .dyn_into::<web_sys::WorkerGlobalScope>()
+                .map(|scope| scope.navigator().storage())
+                .map_err(|e| GetRootDirectoryError::Cast {
+                    ty: stringify!(web_sys::WorkerGlobalScope),
+                    value: e.into(),
+                })
+        }?;
+        JsFuture::from(storage_manager.get_directory())
+            .await
+            .map_err(|e| {
+                e.dyn_into::<web_sys::DomException>()
+                    .map(|e| {
+                        if e.code() == web_sys::DomException::SECURITY_ERR {
+                            GetRootDirectoryError::StorageNotAvailable { exception: e }
+                        } else {
+                            GetRootDirectoryError::DomException { exception: e }
+                        }
+                    })
+                    .unwrap_or_else(|e| GetRootDirectoryError::Cast {
+                        ty: stringify!(web_sys::DomException),
+                        value: e,
+                    })
+            })
+            .and_then(|raw| {
+                raw.dyn_into::<web_sys::FileSystemDirectoryHandle>()
+                    .map_err(|e| GetRootDirectoryError::Cast {
+                        ty: stringify!(web_sys::FileSystemDirectoryHandle),
+                        value: e,
+                    })
+            })
+            .map(|dir| Self::new(dir, "/".as_ref()))
+    }
+
+    fn new(handle: web_sys::FileSystemDirectoryHandle, parent: &Path) -> Self {
+        Self {
+            path: parent.join(handle.name()),
+            handle,
+        }
+    }
+
+    pub async fn get_directory_from_path(
+        &self,
+        path: &Path,
+        option: Option<OpenOptions>,
+    ) -> Result<Self, GetDirectoryHandleError> {
+        log::trace!("Get directory handle {} from path", path.display());
+        debug_assert!(path.has_root());
+        let Some(dirname) = path.file_name().and_then(std::ffi::OsStr::to_str) else {
+            // no filename mean `/`, so we return self.
+            return Ok(self.clone());
+        };
+        let dir = self
+            .get_parent_directory(path.parent(), option.clone())
+            .await?;
+        dir.as_ref()
+            .unwrap_or(self)
+            .get_directory(dirname, option)
+            .await
+    }
+
+    async fn get_parent_directory(
+        &self,
+        parent: Option<&Path>,
+        option: Option<OpenOptions>,
+    ) -> Result<Option<Self>, GetDirectoryHandleError> {
+        if let Some(parent) = parent {
+            let dir = self
+                .get_directory_from_path(parent, option.clone())
+                .boxed_local()
+                .await?;
+            Ok(Some(dir))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub async fn create_dir_all(&self, path: &Path) -> Result<Self, GetDirectoryHandleError> {
+        self.get_directory_from_path(path, Some(OpenOptions::create()))
+            .await
+    }
+
+    pub async fn get_directory(
+        &self,
+        dirname: &str,
+        option: Option<OpenOptions>,
+    ) -> Result<Directory, GetDirectoryHandleError> {
+        log::trace!(
+            "Get directory handle `{dirname}` in {}",
+            self.path.display()
+        );
+        let promise = if let Some(option) = option {
+            self.handle
+                .get_directory_handle_with_options(dirname, &option.into())
+        } else {
+            self.handle.get_directory_handle(dirname)
+        };
+        JsFuture::from(promise)
+            .await
+            .map_err(|e| match e.dyn_into::<web_sys::DomException>() {
+                Ok(exception) => match exception.code() {
+                    web_sys::DomException::NOT_FOUND_ERR => GetDirectoryHandleError::NotFound {
+                        path: self.path.join(dirname),
+                    },
+                    web_sys::DomException::TYPE_MISMATCH_ERR => {
+                        GetDirectoryHandleError::NotADirectory {
+                            path: self.path.join(dirname),
+                        }
+                    }
+                    _ => GetDirectoryHandleError::DomException { exception },
+                },
+                Err(e) => GetDirectoryHandleError::Promise { error: e },
+            })
+            .and_then(|raw| {
+                raw.dyn_into::<web_sys::FileSystemDirectoryHandle>()
+                    .map_err(|e| GetDirectoryHandleError::Cast {
+                        ty: stringify!(web_sys::FileSystemDirectoryHandle),
+                        value: e,
+                    })
+            })
+            .map(|v| Self::new(v, &self.path))
+            .inspect(|_v| log::trace!("Found handle `{dirname}` in {}", self.path.display()))
+    }
+
+    pub async fn get_file_from_path(
+        &self,
+        path: &Path,
+        option: Option<OpenOptions>,
+    ) -> Result<File, GetFileHandleError> {
+        log::trace!("Get file handle from path {}", path.display());
+        debug_assert!(path.has_root());
+        let filename = path
+            .file_name()
+            .and_then(OsStr::to_str)
+            .expect("Missing filename");
+        let dir = self.get_parent_directory(path.parent(), None).await?;
+        dir.as_ref()
+            .unwrap_or(self)
+            .get_file(filename, option)
+            .await
+    }
+
+    pub async fn get_file(
+        &self,
+        filename: &str,
+        option: Option<OpenOptions>,
+    ) -> Result<File, GetFileHandleError> {
+        log::trace!("Get file handle `{filename}` in {}", self.path.display());
+        let promise = if let Some(option) = option {
+            self.handle
+                .get_file_handle_with_options(filename, &option.into())
+        } else {
+            self.handle.get_file_handle(filename)
+        };
+        JsFuture::from(promise)
+            .await
+            .map_err(|e| match e.dyn_into::<web_sys::DomException>() {
+                Ok(exception) => match exception.code() {
+                    web_sys::DomException::NOT_FOUND_ERR => GetFileHandleError::NotFound {
+                        path: self.path.join(filename),
+                    },
+                    web_sys::DomException::TYPE_MISMATCH_ERR => GetFileHandleError::NotAFile {
+                        path: self.path.join(filename),
+                    },
+                    _ => GetFileHandleError::DomException { exception },
+                },
+                Err(e) => GetFileHandleError::Promise { error: e },
+            })
+            .and_then(|raw| {
+                raw.dyn_into::<web_sys::FileSystemFileHandle>()
+                    .map_err(|e| GetFileHandleError::Cast {
+                        ty: stringify!(web_sys::FileSystemFileHandle),
+                        value: e,
+                    })
+            })
+            .map(|v| File::new(v, &self.path))
+            .inspect(|_v| log::trace!("Found handle `{filename}` in {}", self.path.display()))
+    }
+
+    pub fn entries(&self) -> impl Stream<Item = DirEntry> + use<'_> {
+        log::trace!("Listing entries at {}", self.path.display());
+        JsStream::from(self.handle.values()).filter_map(|v| {
+            log::trace!("Entries {v:?}");
+            future::ready(
+                v.ok()
+                    .and_then(|v| {
+                        v.dyn_into::<web_sys::FileSystemFileHandle>()
+                            .map(DirOrFileHandle::File)
+                            .or_else(|v| {
+                                v.dyn_into::<web_sys::FileSystemDirectoryHandle>()
+                                    .map(DirOrFileHandle::Dir)
+                            })
+                            .inspect_err(|e| {
+                                log::warn!("{e:?} is neither a file or directory handle")
+                            })
+                            .ok()
+                    })
+                    .map(|v| DirEntry::new(v, &self.path)),
+            )
+        })
+    }
+
+    pub async fn remove_entry_from_path(&self, path: &Path) -> Result<(), RemoveEntryError> {
+        log::trace!("Remove entry `{}` from path", path.display());
+        debug_assert!(path.has_root());
+        let entryname = path
+            .file_name()
+            .and_then(OsStr::to_str)
+            .expect("Missing entry name");
+        let dir = self.get_parent_directory(path.parent(), None).await?;
+        dir.as_ref().unwrap_or(self).remove_entry(entryname).await
+    }
+
+    pub async fn remove_entry(&self, entryname: &str) -> Result<(), RemoveEntryError> {
+        JsFuture::from(self.handle.remove_entry(entryname))
+            .await
+            .map_err(|e| match e.dyn_into::<web_sys::DomException>() {
+                Ok(exception) => match exception.code() {
+                    web_sys::DomException::NOT_FOUND_ERR => RemoveEntryError::NotFound {
+                        path: entryname.into(),
+                    },
+                    _ => RemoveEntryError::DomException { exception },
+                },
+                Err(e) => RemoveEntryError::Promise { error: e },
+            })
+            .and(Ok(()))
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct OpenOptions {
+    create: bool,
+}
+
+impl OpenOptions {
+    pub const fn create() -> Self {
+        Self { create: true }
+    }
+}
+
+impl From<OpenOptions> for web_sys::FileSystemGetDirectoryOptions {
+    fn from(value: OpenOptions) -> Self {
+        let v = Self::new();
+        v.set_create(value.create);
+        v
+    }
+}
+
+impl From<OpenOptions> for web_sys::FileSystemGetFileOptions {
+    fn from(value: OpenOptions) -> Self {
+        let v = Self::new();
+        v.set_create(value.create);
+        v
+    }
+}
+
+pub struct DirEntry {
+    pub path: PathBuf,
+    pub handle: DirOrFileHandle,
+}
+
+impl DirEntry {
+    fn new(handle: DirOrFileHandle, parent: &Path) -> Self {
+        Self {
+            path: parent.join(handle.name()),
+            handle,
+        }
+    }
+}
+
+impl TryFrom<DirEntry> for File {
+    type Error = CastError;
+
+    fn try_from(value: DirEntry) -> Result<Self, Self::Error> {
+        match value.handle {
+            DirOrFileHandle::File(handle) => Ok(Self {
+                path: value.path,
+                handle,
+            }),
+            DirOrFileHandle::Dir(d) => Err(CastError::Cast {
+                ty: stringify!(web_sys::FileSystemFileHandle),
+                value: d.into(),
+            }),
+        }
+    }
+}
+
+pub enum DirOrFileHandle {
+    Dir(web_sys::FileSystemDirectoryHandle),
+    File(web_sys::FileSystemFileHandle),
+}
+
+impl DirOrFileHandle {
+    pub fn name(&self) -> String {
+        match self {
+            Self::Dir(v) => v.name(),
+            Self::File(v) => v.name(),
+        }
+    }
+}
+
+pub struct File {
+    pub path: PathBuf,
+    pub handle: web_sys::FileSystemFileHandle,
+}
+
+impl File {
+    fn new(handle: web_sys::FileSystemFileHandle, parent: &Path) -> Self {
+        Self {
+            path: parent.join(handle.name()),
+            handle,
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub async fn read_to_end(&self) -> Result<Vec<u8>, ReadToEndError> {
+        let file = JsFuture::from(self.handle.get_file())
+            .await
+            .map_err(|e| match e.dyn_into::<web_sys::DomException>() {
+                Ok(except) if except.code() == web_sys::DomException::NOT_FOUND_ERR => {
+                    ReadToEndError::NotFound {
+                        path: self.path.clone(),
+                    }
+                }
+                Ok(exception) => ReadToEndError::DomException { exception },
+                Err(e) => ReadToEndError::GetFile { error: e },
+            })
+            .and_then(|v| {
+                v.dyn_into::<web_sys::File>()
+                    .map_err(|e| ReadToEndError::Cast {
+                        ty: stringify!(web_sys::File),
+                        value: e,
+                    })
+            })?;
+        let blob = file.deref();
+        let array_buffer = JsFuture::from(blob.array_buffer())
+            .await
+            .map_err(|e| ReadToEndError::Promise { error: e })
+            .inspect_err(|e| log::error!("Failed to get blob array buffer: {e}"))
+            .and_then(|v| {
+                v.dyn_into::<js_sys::ArrayBuffer>()
+                    .map_err(|e| ReadToEndError::Cast {
+                        ty: stringify!(js_sys::ArrayBuffer),
+                        value: e,
+                    })
+            })?;
+        let u8array = js_sys::Uint8Array::new(array_buffer.as_ref());
+        Ok(u8array.to_vec())
+    }
+
+    pub async fn write_all(&self, data: &[u8]) -> Result<(), WriteAllError> {
+        let stream = JsFuture::from(self.handle.create_writable())
+            .await
+            .map_err(|e| match e.dyn_into::<web_sys::DomException>() {
+                Ok(exception) => match exception.code() {
+                    web_sys::DomException::NOT_FOUND_ERR => WriteAllError::NotFound {
+                        path: self.path.clone(),
+                    },
+                    web_sys::DomException::NO_MODIFICATION_ALLOWED_ERR => {
+                        WriteAllError::CannotEdit {
+                            path: self.path.clone(),
+                            exception,
+                        }
+                    }
+                    _ => WriteAllError::DomException { exception },
+                },
+                Err(e) => WriteAllError::CreateWritable { error: e },
+            })
+            .and_then(|v| {
+                v.dyn_into::<web_sys::FileSystemWritableFileStream>()
+                    .map_err(|e| WriteAllError::Cast {
+                        ty: stringify!(web_sys::FileSystemWritableFileStream),
+                        value: e,
+                    })
+            })?;
+        stream
+            .write_with_u8_array(data)
+            .map(wasm_bindgen_futures::JsFuture::from)
+            .map_err(|e| match e.dyn_into::<DomException>() {
+                Ok(exception) => match exception.code() {
+                    web_sys::DomException::QUOTA_EXCEEDED_ERR => {
+                        WriteAllError::NoSpaceLeft { exception }
+                    }
+                    _ => WriteAllError::DomException { exception },
+                },
+                Err(e) => WriteAllError::Write { error: e },
+            })?
+            .await
+            .map_err(|e| WriteAllError::Write { error: e })?;
+        wasm_bindgen_futures::JsFuture::from(stream.close())
+            .await
+            .map_err(|e| WriteAllError::Close { error: e })
+            .and(Ok(()))
+    }
+}

--- a/libparsec/crates/platform_device_loader/tests/units/archive.rs
+++ b/libparsec/crates/platform_device_loader/tests/units/archive.rs
@@ -23,5 +23,5 @@ async fn archive_ok(tmp_path: TmpPath, env: &TestbedEnv) {
     archive_device(&key_file).await.unwrap();
 
     // 3. Check that the device as been archived.
-    assert!(key_is_archived(&key_file));
+    assert!(key_is_archived(&key_file).await);
 }

--- a/libparsec/crates/platform_device_loader/tests/units/list.rs
+++ b/libparsec/crates/platform_device_loader/tests/units/list.rs
@@ -34,12 +34,13 @@ async fn ignore_invalid_items(tmp_path: TmpPath) {
     // Also add dummy stuff that should be ignored
 
     // Empty file
-    crate::tests::utils::create_device_file(&devices_dir.join("empty.keys"), b"");
+    crate::tests::utils::create_device_file(&devices_dir.join("empty.keys"), b"").await;
     // Dummy file
-    crate::tests::utils::create_device_file(&devices_dir.join("dummy.keys"), b"dummy");
+    crate::tests::utils::create_device_file(&devices_dir.join("dummy.keys"), b"dummy").await;
     // Folder with dummy file
-    crate::tests::utils::create_device_file(&devices_dir.join("dir/a_file.keys"), b"dummy");
+    crate::tests::utils::create_device_file(&devices_dir.join("dir/a_file.keys"), b"dummy").await;
 
+    log::trace!("Listing available devices");
     let devices = list_available_devices(&tmp_path).await.unwrap();
     p_assert_eq!(devices, []);
 }
@@ -263,7 +264,7 @@ async fn list_devices(tmp_path: TmpPath) {
         (&smartcard_path, smartcard_raw),
         (&recovery_path, recovery_raw),
     ] {
-        crate::tests::utils::create_device_file(path, raw);
+        crate::tests::utils::create_device_file(path, raw).await;
     }
 
     // 3. Actual test !

--- a/libparsec/crates/platform_device_loader/tests/units/load.rs
+++ b/libparsec/crates/platform_device_loader/tests/units/load.rs
@@ -50,7 +50,7 @@ async fn bad_path(tmp_path: TmpPath, #[case] kind: BadPathKind) {
 #[parsec_test]
 async fn bad_file_content(tmp_path: TmpPath) {
     let key_file = tmp_path.join("devices/my_device.keys");
-    crate::tests::utils::create_device_file(&key_file, b"dummy");
+    crate::tests::utils::create_device_file(&key_file, b"dummy").await;
 
     let access = DeviceAccessStrategy::Password {
         key_file,
@@ -85,7 +85,7 @@ async fn invalid_salt_size(tmp_path: TmpPath) {
     // Store it in a path compatible with the legacy format
     let key_file =
         tmp_path.join("devices/c17fc4c8bf#corp#alice@laptop/c17fc4c8bf#corp#alice@laptop.keys");
-    crate::tests::utils::create_device_file(&key_file, content);
+    crate::tests::utils::create_device_file(&key_file, content).await;
 
     let access = DeviceAccessStrategy::Password {
         key_file,

--- a/libparsec/crates/platform_device_loader/tests/units/mod.rs
+++ b/libparsec/crates/platform_device_loader/tests/units/mod.rs
@@ -1,7 +1,7 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 #[cfg(target_arch = "wasm32")]
-libparsec_tests_lite::platform::wasm_bindgen_test_configure!(run_in_browser);
+libparsec_tests_lite::platform::wasm_bindgen_test_configure!(run_in_browser run_in_shared_worker);
 
 mod archive;
 mod list;

--- a/libparsec/crates/platform_device_loader/tests/units/remove.rs
+++ b/libparsec/crates/platform_device_loader/tests/units/remove.rs
@@ -24,7 +24,7 @@ async fn remove_ok(tmp_path: TmpPath, env: &TestbedEnv) {
 
     // 3. Check that the device as been removed.
     assert!(
-        !key_present_in_system(&key_file),
+        !key_present_in_system(&key_file).await,
         "Device file should have been removed"
     );
 }

--- a/libparsec/crates/platform_device_loader/tests/units/save_list.rs
+++ b/libparsec/crates/platform_device_loader/tests/units/save_list.rs
@@ -74,7 +74,7 @@ async fn save_list(#[case] kind: DeviceFileType, tmp_path: TmpPath) {
         unknown => panic!("Unknown kind: {unknown:?}"),
     };
 
-    assert!(!key_present_in_system(&key_file));
+    assert!(!key_present_in_system(&key_file).await);
 
     device
         .time_provider
@@ -83,7 +83,7 @@ async fn save_list(#[case] kind: DeviceFileType, tmp_path: TmpPath) {
     device.time_provider.unmock_time();
 
     p_assert_eq!(available_device, expected_available_device);
-    assert!(key_present_in_system(&key_file));
+    assert!(key_present_in_system(&key_file).await);
 
     let devices = list_available_devices(&tmp_path).await.unwrap();
 

--- a/libparsec/crates/platform_device_loader/tests/units/save_load.rs
+++ b/libparsec/crates/platform_device_loader/tests/units/save_load.rs
@@ -75,7 +75,7 @@ async fn save_load(#[case] kind: DeviceFileType, tmp_path: TmpPath) {
         unknown => panic!("Unknown kind: {unknown:?}"),
     };
 
-    assert!(!key_present_in_system(&key_file));
+    assert!(!key_present_in_system(&key_file).await);
 
     device
         .time_provider
@@ -84,7 +84,7 @@ async fn save_load(#[case] kind: DeviceFileType, tmp_path: TmpPath) {
     device.time_provider.unmock_time();
 
     p_assert_eq!(available_device, expected_available_device);
-    assert!(key_present_in_system(&key_file));
+    assert!(key_present_in_system(&key_file).await);
 
     let res = load_device(Path::new(""), &access).await.unwrap();
 

--- a/libparsec/crates/platform_device_loader/tests/units/update_device_change_authentication.rs
+++ b/libparsec/crates/platform_device_loader/tests/units/update_device_change_authentication.rs
@@ -37,14 +37,14 @@ async fn same_key_file(tmp_path: TmpPath) {
     );
 
     // Sanity check
-    assert!(!key_present_in_system(&key_file));
+    assert!(!key_present_in_system(&key_file).await);
 
     TimeProvider::root_provider().mock_time_frozen("2000-01-01T00:00:00Z".parse().unwrap());
     let available1 = save_device(Path::new(""), &access, &device).await.unwrap();
     TimeProvider::root_provider().unmock_time();
 
     // Sanity check
-    assert!(key_present_in_system(&key_file));
+    assert!(key_present_in_system(&key_file).await);
     p_assert_eq!(
         available1.created_on,
         "2000-01-01T00:00:00Z".parse().unwrap()
@@ -65,7 +65,7 @@ async fn same_key_file(tmp_path: TmpPath) {
     TimeProvider::root_provider().unmock_time();
 
     // Sanity check
-    assert!(key_present_in_system(&key_file));
+    assert!(key_present_in_system(&key_file).await);
     let expected_available2 = {
         let mut expected = available1.clone();
         expected.protected_on = "2000-01-02T00:00:00Z".parse().unwrap();
@@ -108,12 +108,12 @@ async fn different_key_file(tmp_path: TmpPath) {
     );
 
     // Sanity check
-    assert!(!key_present_in_system(&key_file));
+    assert!(!key_present_in_system(&key_file).await);
 
     save_device(Path::new(""), &access, &device).await.unwrap();
 
     // Sanity check
-    assert!(key_present_in_system(&key_file));
+    assert!(key_present_in_system(&key_file).await);
 
     let new_key_file = tmp_path.join("devices/alice@dev2.keys");
     let new_access = DeviceAccessStrategy::Password {
@@ -126,8 +126,8 @@ async fn different_key_file(tmp_path: TmpPath) {
         .unwrap();
 
     // Sanity check
-    assert!(!key_present_in_system(&key_file));
-    assert!(key_present_in_system(&new_key_file));
+    assert!(!key_present_in_system(&key_file).await);
+    assert!(key_present_in_system(&new_key_file).await);
 
     p_assert_eq!(
         *load_device(Path::new(""), &new_access).await.unwrap(),

--- a/libparsec/crates/platform_device_loader/tests/units/utils.rs
+++ b/libparsec/crates/platform_device_loader/tests/units/utils.rs
@@ -6,59 +6,76 @@ pub use platform::*;
 mod platform {
     use std::path::Path;
 
-    pub fn create_device_file(path: &Path, content: &[u8]) {
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(path, content).unwrap();
+    pub async fn create_device_file(path: &Path, content: &[u8]) {
+        tokio::fs::create_dir_all(path.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(path, content).await.unwrap();
     }
 
-    pub fn key_present_in_system(path: &Path) -> bool {
+    pub async fn key_present_in_system(path: &Path) -> bool {
         path.exists()
     }
 
-    pub fn key_is_archived(path: &Path) -> bool {
+    pub async fn key_is_archived(path: &Path) -> bool {
         let expected_archive_path = path.with_extension("device.archived");
-        !key_present_in_system(path) && key_present_in_system(&expected_archive_path)
+        !key_present_in_system(path).await && key_present_in_system(&expected_archive_path).await
     }
 }
 
 #[cfg(target_arch = "wasm32")]
 mod platform {
-    use std::path::Path;
+    use crate::{
+        get_device_archive_path,
+        platform::{
+            error::GetFileHandleError,
+            wrapper::{Directory, OpenOptions},
+        },
+    };
+    use std::{ffi::OsStr, path::Path};
 
-    fn get_storage() -> web_sys::Storage {
-        web_sys::window()
-            .unwrap()
-            .session_storage()
-            .unwrap()
-            .unwrap()
+    async fn get_storage() -> Directory {
+        Directory::get_root().await.expect("Cannot get storage")
     }
 
-    fn key_from_path(path: &Path) -> &str {
-        path.to_str().expect("Cannot convert path to key")
-    }
-
-    pub fn create_device_file(path: &Path, content: &[u8]) {
-        let key = key_from_path(path);
-        let b64_data = data_encoding::BASE64.encode(content);
-        let storage = get_storage();
-        storage
-            .set_item(key, &b64_data)
+    pub async fn create_device_file(path: &Path, content: &[u8]) {
+        let storage = get_storage().await;
+        let dir = if let Some(parent) = path.parent() {
+            let parent = storage
+                .create_dir_all(parent)
+                .await
+                .expect("Cannot create dir all");
+            Some(parent)
+        } else {
+            None
+        };
+        let filename = path
+            .file_name()
+            .and_then(OsStr::to_str)
+            .expect("Missing filename");
+        let file = dir
+            .as_ref()
+            .unwrap_or(&storage)
+            .get_file(filename, Some(OpenOptions::create()))
+            .await
+            .expect("Cannot get file");
+        file.write_all(content)
+            .await
             .expect("Cannot add device to storage");
     }
 
-    pub fn key_present_in_system(path: &Path) -> bool {
-        let storage = get_storage();
-        let key = key_from_path(path);
-
-        storage
-            .get_item(key)
-            .expect("Cannot get item in storage")
-            .is_some()
+    pub async fn key_present_in_system(path: &Path) -> bool {
+        let storage = get_storage().await;
+        match storage.get_file_from_path(path, None).await {
+            Ok(_) => true,
+            Err(GetFileHandleError::NotFound { .. }) => false,
+            Err(_) => panic!("Cannot get item in storage"),
+        }
     }
 
-    pub fn key_is_archived(path: &Path) -> bool {
-        let key = key_from_path(path);
-        let archived_key = format!("{}.archived", key);
-        !key_present_in_system(path) && key_present_in_system(Path::new(&archived_key))
+    pub async fn key_is_archived(path: &Path) -> bool {
+        let archived_path = get_device_archive_path(path);
+
+        !key_present_in_system(path).await && key_present_in_system(&archived_path).await
     }
 }

--- a/libparsec/crates/tests_fixtures/src/tmp_path.rs
+++ b/libparsec/crates/tests_fixtures/src/tmp_path.rs
@@ -16,7 +16,7 @@ pub struct TmpPath(PathBuf);
 impl TmpPath {
     pub fn create() -> Self {
         let mut path = if cfg!(target_arch = "wasm32") {
-            PathBuf::default()
+            "/".into()
         } else {
             std::env::temp_dir()
         };


### PR DESCRIPTION
Since `libparsec` is run from a shared worker, we no longer have access to `localStorage` via the `window` property.

This commit refactor the web impl to use `StorageManager` over `LocalStorage` that is available in both browser and shared worker.

Another fix would have been to store the device in IndexedDB.
