### PR TITLE
Fix minor issues with app desktop entry

### DIFF
--- a/.cspell/cspell.config.yml
+++ b/.cspell/cspell.config.yml
@@ -89,6 +89,7 @@ overrides:
       - fr-fr
       - fr-fr-90
     filename:
+      - "**/client/electron/assets/parsec.desktop"
       - "**/client/electron/src/index.ts"
       - "**/client/electron/src/setup.ts"
       - "**/client/src/locales/fr-FR.json"

--- a/client/electron/README.md
+++ b/client/electron/README.md
@@ -1,8 +1,10 @@
 # Electron app for Parsec
 
-## Signing Windows releases
+## Signing a Windows release
 
-The `package-client` workflow produces an artefact called `Windows-X64-electron-app-exe-pre-built`. This artefact contains all the assets, build artefacts and scripts necessary to build a windows release (i.e an NSIS installer). More precisely, the artefact contains the following files and directories:
+The `package-client` workflow produces an artefact called `Windows-X64-electron-app-exe-pre-built`.
+This artefact contains all the assets, build artefacts and scripts necessary to build a windows release (i.e an NSIS installer).
+More precisely, the artefact contains the following files and directories:
 
 - `client/electron/app`
 - `client/electron/build`
@@ -40,3 +42,64 @@ There are two requirements:
 - `SimplySign` has to be installed (you will be prompted for a token during the first signing operation)
 
 Then the installer is available in `dist`, for instance as `dist/Parsec_3.0.0-b.11.dev.19916+299b464_win_x86_64.exe`.
+
+## Building snap locally
+
+Build configuration is stored in `snap/snapcraft.yaml` file. Currently, it includes a single app (`parsec`).
+
+You can find an overview of the `snapcraft.yaml` schema in
+[Snapcraft Build Configuration](https://snapcraft.io/docs/build-configuration).
+
+The instructions below summarize how to build snap locally using `snapcraft` and `lxd`.
+You may need to adapt it for your specific system (see [Snapcraft Quickstart](https://snapcraft.io/docs/snapcraft-quickstart))
+
+1. Install `snapcraft`
+
+   ```shell
+   sudo snap install --classic snapcraft
+   ```
+
+2. Install `lxd`
+
+   ```shell
+   sudo snap install lxd
+   ```
+
+3. Add your user to the snap `lxd` group
+
+   ```shell
+   sudo usermod -a -G lxd $USER
+   ```
+
+4. Logout and re-open your user session for the new group to become active.
+
+5. Initialize LXD (press ENTER to select default value each time)
+
+   ```shell
+   lxd init
+   ```
+
+6. Create a symbolic link to the snap directory from the repo root directory
+
+   ```shell
+   ln -sv client/electron/snap
+   ```
+
+7. (optional) Clean your repo so the default lxd storage (30Go) does not run out of space
+
+   ```shell
+   fd node_modules --type d --prune --no-ignore --exec-batch rm -rf
+   cargo clean
+   snapcraft clean
+   ```
+
+8. Build the snap
+
+   ```shell
+   snapcraft pack --use-lxd -v
+   ```
+
+   - In case of error, `snapcraft` will print the path to the log file.
+     Make sure to check it for hints about how to fix it.
+
+Your Parsec snap should now be available at the root of the repo.

--- a/client/electron/assets/parsec.desktop
+++ b/client/electron/assets/parsec.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Name=Parsec
+Comment=Secure file sharing in the cloud
+GenericName=File Sharing
+Exec=\${SNAP}/bin/desktop-launch %U
+Icon=\${SNAP}/usr/share/icons/hicolor/512x512/apps/parsec.png
+SingleMainWindow=true
+StartupNotify=false
+StartupWMClass=parsec
+Type=Application
+Terminal=false
+MimeType=x-scheme-handler/parsec3;
+Categories=Office;Network;FileTransfer;Filesystem;Security;
+Keywords=backup;cloud;collaboration;file;share;storage;synchronization;workspace;
+Keywords[fr]=sauvegarde;cloud;collaboration;fichier;partage;stockage;synchronisation;

--- a/client/electron/package.js
+++ b/client/electron/package.js
@@ -111,13 +111,13 @@ const UNSIGNED_ARTIFACT_NAME =
 
 /**
  * @type {import('electron-builder').Configuration}
- * @see https://www.electron.build/configuration/configuration
+ * @see https://www.electron.build/configuration
  */
 const options = {
   /* eslint-disable max-len */
   /*
    * Doc mentions that it's used as a CFBundleIdentifier on MacOS, and as an Application User Model ID on Windows
-   * (https://www.electron.build/configuration/configuration.html#configuration)
+   * (https://www.electron.build/configuration#appid)
    * The doc for CFBundleIdentifier specifies that this should be in reverse-dns format
    *   https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102070
    * The doc for Application User Model ID specifies that it should be in the `CompanyName.ProductName.SubProduct.VersionInformation` format
@@ -187,9 +187,8 @@ const options = {
   },
 
   linux: {
-    synopsis: 'Secure cloud framework',
-    description: 'Parsec is an open-source cloud-based application that allows simple yet cryptographically secure file hosting.',
-    category: 'Office Network FileTransfer FileSystem Security',
+    synopsis: 'Secure file sharing in the cloud',
+    category: 'Office;Network;FileTransfer;Filesystem;Security;',
     desktop: {
       MimeType: `x-scheme-handler/${PARSEC_SCHEME}`,
     },

--- a/client/electron/package.json
+++ b/client/electron/package.json
@@ -1,7 +1,7 @@
 {
     "name": "parsec",
     "version": "3.4.0-a.7+dev",
-    "description": "Parsec.cloud",
+    "description": "Secure file sharing in the cloud",
     "author": {
         "name": "Scille SAS",
         "email": "contact@scille.fr"

--- a/client/electron/snap/snapcraft.yaml
+++ b/client/electron/snap/snapcraft.yaml
@@ -163,7 +163,6 @@ parts:
     build-environment:
       - ICON_PATH: &desktop-icon-path usr/share/icons/hicolor/512x512/apps/parsec.png
       - DESKTOP_PATH: &desktop-path usr/share/applications/parsec.desktop
-      - PARSEC_SCHEME: parsec3
     prime:
       - *desktop-icon-path
       - *desktop-path
@@ -172,17 +171,7 @@ parts:
       cp -v 512x512.png "$CRAFT_PART_INSTALL"/$ICON_PATH
 
       mkdir -p $(dirname "$CRAFT_PART_INSTALL"/$DESKTOP_PATH)
-      cat << EOF > "$CRAFT_PART_INSTALL"/$DESKTOP_PATH
-      [Desktop Entry]
-      Name=Parsec
-      Comment=Secure cloud framework
-      Exec=\${SNAP}/bin/desktop-launch %U
-      Icon=\${SNAP}/$ICON_PATH
-      Terminal=false
-      Type=Application
-      Categories=Office Network FileTransfer FileSystem Security
-      MimeType=x-scheme-handler/$PARSEC_SCHEME;
-      EOF
+      cp -v parsec.desktop "$CRAFT_PART_INSTALL"/$DESKTOP_PATH
 
   # Ideally, the gtk platform (i.e. gnome-platform) should be provided by snapcraft by using extensions.
   # However, it is not available under `classic` confinement.

--- a/client/electron/snap/snapcraft.yaml
+++ b/client/electron/snap/snapcraft.yaml
@@ -1,8 +1,23 @@
 name: parsec
 base: core22
 version: 3.4.0-a.7+dev
-summary: Secure cloud framework
-description: Parsec is an open-source cloud-based application that allows simple yet cryptographically secure file hosting.
+summary: Secure file sharing in the cloud
+license: BUSL-1.1
+description: |
+  Parsec is a cloud-based application for simple, yet cryptographically secure file sharing.
+
+  Key features:
+  - Client-side encryption to ensure your data is only accessed by you and the people you share it with.
+  - Cryptographic signature to identify the author of each change.
+  - Easily and securely invite users to join your organization via link and token code.
+  - Virtual drive on your computer so you can access your data with your preferred software as usual.
+  - Browse data history and recover files from any point in time.
+  - Easy to self-host
+icon: client/electron/assets/512x512.png
+website: https://parsec.cloud
+contact: contact@parsec.cloud
+source-code: https://github.com/Scille/parsec-cloud
+issues: https://github.com/Scille/parsec-cloud/issues
 grade: stable
 confinement: classic
 type: app


### PR DESCRIPTION
Related to #8422

Changes in this PR:

- Added extra info about app in `snapcraft.yaml` and `package.json`.
- Added instructions on how to build snap locally
- Moved desktop entry to a specific file in the `assets` directory. The following keys were changed:
  - Added `SingleMainWindow=true` so that the desktop manager does not include a "New Window" action
  - Added `StartupNotify=false` to be explicit that this is not managed
  - Added `StartupWMClass=parsec` to be explicit about the wmclass
  - Fixed `Categories` to use `;` separator
  - Added `Keywords` to make it easier to find the application
  - Added `GenericName` and improve `Comment`

See: https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html