### PR TITLE
[MS] Re-factored how url are opened

### DIFF
--- a/client/electron/src/communicationChannels.ts
+++ b/client/electron/src/communicationChannels.ts
@@ -11,7 +11,6 @@ export enum PageToWindowChannel {
   Log = 'parsec-log',
   PageIsInitialized = 'parsec-page-is-initialized',
   OpenConfigDir = 'parsec-open-config-dir',
-  AuthorizeURL = 'parsec-authorized-url',
   CriticalError = 'parsec-critical-error',
   MacfuseNotInstalled = 'parsec-macfuse-not-installed',
   SeeInExplorer = 'parsec-see-in-explorer',

--- a/client/electron/src/index.ts
+++ b/client/electron/src/index.ts
@@ -241,10 +241,6 @@ ipcMain.on(PageToWindowChannel.OpenConfigDir, async () => {
   await shell.openExternal(parsecConfigDir.startsWith('file://') ? parsecConfigDir : `file://${parsecConfigDir}`);
 });
 
-ipcMain.on(PageToWindowChannel.AuthorizeURL, async (_event, url: string) => {
-  myCapacitorApp.addAuthorizedURL(url);
-});
-
 ipcMain.on(PageToWindowChannel.MacfuseNotInstalled, async (_event) => {
   const isFRLocale: boolean = app.getLocale().startsWith('fr');
   const url: string = isFRLocale ? INSTALL_GUIDE_URL_FR : INSTALL_GUIDE_URL_EN;

--- a/client/electron/src/preload.ts
+++ b/client/electron/src/preload.ts
@@ -46,9 +46,6 @@ process.once('loaded', async () => {
     openConfigDir: () => {
       ipcRenderer.send(PageToWindowChannel.OpenConfigDir);
     },
-    authorizeURL: (url: string) => {
-      ipcRenderer.send(PageToWindowChannel.AuthorizeURL, url);
-    },
     seeInExplorer: (path: string) => {
       ipcRenderer.send(PageToWindowChannel.SeeInExplorer, path);
     },

--- a/client/electron/src/setup.ts
+++ b/client/electron/src/setup.ts
@@ -17,21 +17,8 @@ import AppUpdater, { UpdaterState, createAppUpdater } from './updater';
 import { electronIsDev } from './utils';
 import { WinRegistry } from './winRegistry';
 
+const AUTHORIZED_PROTOCOLS = ['http', 'https', 'parsec3'];
 const CHECK_UPDATE_INTERVAL = 1000 * 60 * 60; // 1 hour
-const ALLOWED_URL_LIST = [
-  'https://my.parsec.cloud/',
-  'https://parsec.cloud/',
-  'https://github.com/Scille/',
-  'https://raw.githubusercontent.com/Scille/',
-  'https://spdx.org/licenses/',
-  'https://docs.parsec.cloud/',
-  'https://bms-dev.parsec.cloud/',
-  'https://bms.parsec.cloud',
-  'https://sign.parsec.cloud',
-  'https://sign-dev.parsec.cloud',
-  'https://docs.parsec.cloud',
-  'https://learn.microsoft.com',
-];
 
 // Define components for a watcher to detect when the webapp is changed so we can reload in Dev mode.
 const reloadWatcher = {
@@ -234,12 +221,6 @@ export class ElectronCapacitorApp {
 
     if (this.updater) {
       await this.updater.checkForUpdates();
-    }
-  }
-
-  addAuthorizedURL(url: string): void {
-    if (!ALLOWED_URL_LIST.includes(url)) {
-      ALLOWED_URL_LIST.push(url);
     }
   }
 
@@ -517,7 +498,7 @@ export class ElectronCapacitorApp {
     // Security
     this.MainWindow.webContents.setWindowOpenHandler((details) => {
       function isAuthorizedUrl(url: string): boolean {
-        return ALLOWED_URL_LIST.some((prefix) => url.startsWith(prefix));
+        return AUTHORIZED_PROTOCOLS.some((protocol) => url.startsWith(protocol));
       }
 
       // Open browser on trying to reach an external link, but only if we know about it.
@@ -525,7 +506,7 @@ export class ElectronCapacitorApp {
         if (isAuthorizedUrl(details.url)) {
           shell.openExternal(details.url);
         } else {
-          console.warn(`App tried to open unauthorized URL ${details.url}`);
+          this.log('warn', `App tried to open unauthorized URL ${details.url}`);
         }
       }
       if (!details.url.includes(this.customScheme)) {

--- a/client/src/components/client-area/invoices/InvoicesListItem.vue
+++ b/client/src/components/client-area/invoices/InvoicesListItem.vue
@@ -41,7 +41,7 @@
       </span>
       <a
         class="custom-button custom-button-ghost button-medium"
-        @click="Env.Links.openLink(invoice.getLink())"
+        @click="Env.Links.openUrl(invoice.getLink())"
         download
       >
         <ms-image

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -2014,6 +2014,11 @@
         "mediaNotSupported": "This media is not supported.",
         "retrievingFileContent": "Retrieving the file content...",
         "statsFailed": "Can not get file information.",
+        "openLink": {
+            "title": "Open an external link",
+            "question": "This will open the link outside of the application. Do you want to continue?",
+            "yes": "Open the link"
+        },
         "controls": {
             "zoom": {
                 "in": "Zoom in",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -2013,6 +2013,11 @@
         "mediaNotSupported": "Ce média ne peut pas être joué.",
         "retrievingFileContent": "Récupération du contenu du fichier...",
         "statsFailed": "Impossible de récupérer les informations du fichier.",
+        "openLink": {
+            "title": "Ouvrir un lien externe",
+            "question": "Ce lien sera ouvert en dehors de l'application. Voulez-vous continuer ?",
+            "yes": "Ouvrir le lien"
+        },
         "controls": {
             "zoom": {
                 "in": "Zoomer",

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -535,9 +535,6 @@ function setupMockElectronAPI(injectionProvider: InjectionProvider): void {
     openConfigDir: (): void => {
       console.log('OpenConfigDir: Not available');
     },
-    authorizeURL: (_url: string): void => {
-      console.log('AuthorizeURL: Not available');
-    },
     seeInExplorer: (_path: string): void => {
       console.log('SeeInExplorer: Not available');
     },
@@ -674,7 +671,6 @@ declare global {
       log: (level: LogLevel, message: string) => void;
       pageIsInitialized: () => void;
       openConfigDir: () => void;
-      authorizeURL: (url: string) => void;
       seeInExplorer: (path: string) => void;
       getLogs: () => Promise<Array<string>>;
       initError: (error?: string) => void;

--- a/client/src/services/environment.ts
+++ b/client/src/services/environment.ts
@@ -155,11 +155,6 @@ async function openTOS(tosLink: string): Promise<void> {
   await openUrl(tosLink);
 }
 
-async function openLink(link: string): Promise<void> {
-  window.electronAPI.authorizeURL(link);
-  window.open(link, '_blank');
-}
-
 async function openLogs(): Promise<void> {
   const logs = await window.electronAPI.getLogs();
 
@@ -187,7 +182,7 @@ export const Env = {
     openSourcesLink,
     openDeveloperLink,
     openTOS,
-    openLink,
+    openUrl,
     openLogs,
   },
 };

--- a/client/src/views/client-area/BmsLogin.vue
+++ b/client/src/views/client-area/BmsLogin.vue
@@ -158,7 +158,7 @@
             class="create-account__link button-medium"
             @click="
               $event.stopPropagation();
-              Env.Links.openLink(Env.getSignUrl());
+              Env.Links.openUrl(Env.getSignUrl());
             "
           >
             {{ $msTranslate('clientArea.app.createAccount') }}

--- a/client/src/views/client-area/contracts/ContractsPage.vue
+++ b/client/src/views/client-area/contracts/ContractsPage.vue
@@ -49,7 +49,7 @@
             </ion-text>
             <div class="contract-header-invoice__button">
               <a
-                @click="Env.Links.openLink(contractDetails.link)"
+                @click="Env.Links.openUrl(contractDetails.link)"
                 class="custom-button custom-button-fill button-medium"
                 download
               >

--- a/client/src/views/client-area/dashboard/DashboardPage.vue
+++ b/client/src/views/client-area/dashboard/DashboardPage.vue
@@ -121,7 +121,7 @@
                   </span>
                   <a
                     class="custom-button custom-button-ghost button-medium"
-                    @click="Env.Links.openLink(invoice.getLink())"
+                    @click="Env.Links.openUrl(invoice.getLink())"
                     download
                   >
                     <ms-image

--- a/client/src/views/organizations/TOSModal.vue
+++ b/client/src/views/organizations/TOSModal.vue
@@ -95,9 +95,6 @@ using '${link}'`,
 
 onMounted(async () => {
   link.value = getLinkForLocale();
-  if (link.value) {
-    window.electronAPI.authorizeURL(link.value);
-  }
 });
 
 async function openTOS(): Promise<void> {

--- a/client/src/views/viewers/DocumentViewer.vue
+++ b/client/src/views/viewers/DocumentViewer.vue
@@ -53,7 +53,7 @@ const props = defineProps<{
 
 const loading = ref(true);
 const documentContainer = ref();
-const documentContent = ref();
+const documentContent = ref<HTMLDivElement>();
 const pages = ref<HTMLElement[]>([]);
 const zoomControl = ref();
 const zoomLevel = ref(1);
@@ -63,13 +63,13 @@ const error = ref('');
 onMounted(async () => {
   try {
     loading.value = true;
-    await renderAsync(props.contentInfo.data.buffer, documentContent.value, undefined, {
+    await renderAsync(props.contentInfo.data.buffer, documentContent.value!, undefined, {
       ignoreLastRenderedPageBreak: false,
       className: 'docx-page',
     });
 
     // recommended way to get all pages by the library developer
-    pages.value = Array.from(documentContent.value.querySelectorAll('section.docx-page'));
+    pages.value = Array.from(documentContent.value!.querySelectorAll('section.docx-page'));
     loading.value = false;
   } catch (e: any) {
     window.electronAPI.log('error', `Failed to load docx file: ${e}`);

--- a/newsfragments/10466.feature.rst
+++ b/newsfragments/10466.feature.rst
@@ -1,0 +1,1 @@
+Allows opening links in Word Document viewer and ask for confirmation before opening them


### PR DESCRIPTION
When we wanted to open a URL, we has to push the URL inside an array so that electron could check is this URL was authorized or not before opening it. Initially, it was so that only URLs that we know (parsec.cloud, github.com/Scille/parsec-cloud, ...) could be opened.
Since then, some URLs that we can't control have appeared (invoices in customer area, TOS, or links in documents that a user may want to open). This PR removes the whole authorization system, only checking for `http`, `https` and `parsec3` protocol to avoid some potential weird cases with `file://` or `mailto://`.
It's also a bit better at opening links inside a docx (skipping anchors) and ask a question before opening a link in viewers to add a bit of security (at least it's not our fault if the user clicked a dangerous link).

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
