### PR TITLE
test(server): Remove stubPath in pyright config

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -166,7 +166,6 @@ ignore = [
     "tests/cli/test_sequester.py",
     "../misc/bench.py",
 ]
-stubPath = "parsec/stubs/"
 reportUnusedImport = true
 reportUnusedClass = true
 reportUnusedFunction = true


### PR DESCRIPTION
The path does not exist and thus generate error when using pyright as LSP
