### PR TITLE
[MS] Added support for custom branding

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -43,3 +43,5 @@ npm-debug.log*
 /playwright-report/
 /playwright/.cache/
 .env.development.local
+# Resources for custom branding
+/public/custom

--- a/client/electron/src/communicationChannels.ts
+++ b/client/electron/src/communicationChannels.ts
@@ -26,4 +26,5 @@ export enum WindowToPageChannel {
   IsDevMode = 'parsec-is-dev-mode',
   PrintToConsole = 'parsec-print-to-console',
   LongPathsDisabled = 'parsec-long-paths-disabled',
+  CustomBrandingFolder = 'parsec-custom-branding-folder',
 }

--- a/client/electron/src/index.ts
+++ b/client/electron/src/index.ts
@@ -63,7 +63,7 @@ try {
   fs.mkdirSync(newConfigDir, { recursive: true });
   app.setPath('userData', newConfigDir);
 } catch (e: any) {
-  console.log(`Failed to set config path to '{$newConfigDir}'`);
+  console.log(`Failed to set config path to '${newConfigDir}'`);
 }
 
 // Configure Sentry
@@ -112,6 +112,7 @@ if (!lock) {
     setupContentSecurityPolicy(myCapacitorApp.getCustomURLScheme());
     // Initialize our app, build windows, and load content.
     await myCapacitorApp.init();
+    myCapacitorApp.sendEvent(WindowToPageChannel.CustomBrandingFolder, path.join(app.getPath('userData'), 'custom'));
 
     process.on('SIGINT', () => {
       if (!sigProcessed) {

--- a/client/src/services/resourcesManager.ts
+++ b/client/src/services/resourcesManager.ts
@@ -1,0 +1,156 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { isWeb } from '@/parsec';
+import axios from 'axios';
+
+enum Resources {
+  LogoFull = 'logo.svg',
+  LogoIcon = 'logo_icon.svg',
+  ParsecLogo = 'parsec_logo.svg',
+  TranslationEnUs = 'en_US.json',
+  TranslationFrFr = 'fr_FR.json',
+  HomeSidebar = 'home_sidebar.png',
+}
+
+async function convertSVG(buffer: ArrayBuffer): Promise<string> {
+  return new TextDecoder('utf-8').decode(buffer);
+}
+
+async function convertJSON(buffer: ArrayBuffer): Promise<object> {
+  return JSON.parse(new TextDecoder('utf-8').decode(buffer));
+}
+
+async function convertBinary(buffer: ArrayBuffer): Promise<Uint8Array> {
+  return new Uint8Array(buffer);
+}
+
+type convertFunction = (buffer: ArrayBuffer) => Promise<NonNullable<unknown>>;
+
+const ResourceConverters = new Map<Resources, convertFunction>([
+  [Resources.TranslationEnUs, convertJSON],
+  [Resources.TranslationFrFr, convertJSON],
+  [Resources.LogoFull, convertSVG],
+  [Resources.LogoIcon, convertSVG],
+  [Resources.ParsecLogo, convertSVG],
+  [Resources.HomeSidebar, convertBinary],
+]);
+
+class ResourcesMap {
+  map: Map<Resources, NonNullable<unknown>>;
+
+  constructor() {
+    this.map = new Map<Resources, NonNullable<unknown>>();
+  }
+
+  get(res: Resources): NonNullable<unknown> | undefined {
+    return this.map.get(res);
+  }
+
+  set(res: Resources, content: NonNullable<unknown>): void {
+    this.map.set(res, content);
+  }
+
+  has(res: Resources): boolean {
+    return this.map.has(res);
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+}
+
+interface IResourcesProvider {
+  load(res: Resources): Promise<NonNullable<unknown>>;
+}
+
+class WebResourcesProvider implements IResourcesProvider {
+  path: string;
+
+  constructor(path: string = '/custom') {
+    this.path = path;
+  }
+
+  async load(res: Resources): Promise<NonNullable<unknown>> {
+    const axiosInstance = axios.create({
+      baseURL: this.path,
+      timeout: 1000,
+    });
+
+    const resp = await axiosInstance.get(res, { responseType: 'arraybuffer' });
+    if (resp.status !== 200) {
+      throw new Error(`HTTP status ${resp.status} ${resp.statusText}`);
+    }
+    // Returns index.html if resource does not exist
+    if (resp.headers['content-type'] === 'text/html') {
+      throw new Error('Resource not found');
+    }
+    const convertF = ResourceConverters.get(res);
+    if (!convertF) {
+      throw new Error("Don't know how to convert");
+    }
+    return await convertF(resp.data);
+  }
+}
+
+class FileSystemResourcesProvider implements IResourcesProvider {
+  async load(res: Resources): Promise<NonNullable<unknown>> {
+    const data = await window.electronAPI.readCustomFile(res);
+
+    if (!data) {
+      throw new Error('File not found');
+    }
+    const convertF = ResourceConverters.get(res);
+    if (!convertF) {
+      throw new Error("Don't know how to convert");
+    }
+    return await convertF(data);
+  }
+}
+
+class _ResourcesManager {
+  resources: ResourcesMap;
+  provider: WebResourcesProvider | FileSystemResourcesProvider;
+
+  constructor() {
+    this.resources = new ResourcesMap();
+    this.provider = isWeb() ? new WebResourcesProvider() : new FileSystemResourcesProvider();
+  }
+
+  async loadAll(): Promise<void> {
+    const promises: Array<Promise<NonNullable<unknown>>> = [];
+    for (const res of Object.values(Resources)) {
+      const promise = this.provider.load(res);
+
+      // then/catch to process all queries simultaneously
+      promise
+        .then((resource) => {
+          if (resource !== undefined) {
+            this.resources.set(res, resource);
+          }
+        })
+        .catch((reason) => {
+          window.electronAPI.log('info', `Failed to retrieve custom resource ${res}: ${reason.toString()}`);
+        });
+      promises.push(promise);
+    }
+    // Waiting for everything to be loaded
+    await Promise.allSettled(promises);
+  }
+
+  get(res: Resources, defaultValue: any = undefined): NonNullable<unknown> | undefined {
+    return this.resources.get(res) ?? defaultValue;
+  }
+}
+
+class ResourcesManager {
+  static manager: _ResourcesManager | undefined;
+
+  static instance(): _ResourcesManager {
+    if (!this.manager) {
+      this.manager = new _ResourcesManager();
+    }
+    return this.manager;
+  }
+}
+
+export { Resources, ResourcesManager };

--- a/client/src/views/home/HomePageSidebar.vue
+++ b/client/src/views/home/HomePageSidebar.vue
@@ -1,18 +1,41 @@
 <!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
 
 <template>
-  <div class="sidebar-container">
+  <!-- prettier-ignore -->
+  <div
+    class="sidebar-container"
+    :class="{'sidebar-container--custom': ResourcesManager.instance().get(Resources.ParsecLogo)}"
+  >
     <ms-image
-      :image="LogoRowWhite"
+      :image="(ResourcesManager.instance().get(Resources.LogoFull, LogoRowWhite) as string)"
       class="logo-img"
     />
-    <ion-text class="sidebar-tagline subtitles-lg">{{ $msTranslate('HomePage.sidebar.tagline') }}</ion-text>
+    <div class="sidebar-bottom">
+      <ion-text class="sidebar-tagline subtitles-lg">{{ $msTranslate('HomePage.sidebar.tagline') }}</ion-text>
+      <ms-image
+        class="logo-icon"
+        v-if="ResourcesManager.instance().get(Resources.ParsecLogo)"
+        :image="(ResourcesManager.instance().get(Resources.ParsecLogo) as string)"
+      />
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { MsImage, LogoRowWhite } from 'megashark-lib';
 import { IonText } from '@ionic/vue';
+import { ResourcesManager, Resources } from '@/services/resourcesManager';
+import { onMounted, ref } from 'vue';
+
+const backgroundImage = ref('url("@/assets/images/background/shapes-circles.svg")');
+
+onMounted(() => {
+  const sidebarImage = ResourcesManager.instance().get(Resources.HomeSidebar) as Uint8Array;
+  if (sidebarImage) {
+    const blob = new Blob([sidebarImage], { type: 'image/png' });
+    backgroundImage.value = `url("${window.URL.createObjectURL(blob)}")`;
+  }
+});
 </script>
 
 <style lang="scss" scoped>
@@ -37,10 +60,16 @@ import { IonText } from '@ionic/vue';
     max-height: 70vh;
     top: 0;
     right: 0;
-    background-image: url('@/assets/images/background/shapes-circles.svg');
+    background-image: v-bind(backgroundImage);
     background-size: cover;
     background-repeat: no-repeat;
     background-position: top left;
+  }
+
+  .sidebar-bottom {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
   }
 
   .logo-img {
@@ -52,6 +81,67 @@ import { IonText } from '@ionic/vue';
     text-align: center;
     margin-bottom: 20%;
     margin-inline: 2rem;
+  }
+}
+
+.sidebar-container--custom {
+  background-image: v-bind(backgroundImage);
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: top left;
+  display: flex;
+  justify-content: end;
+  padding-bottom: 5%;
+
+  &::before {
+    content: '';
+    opacity: 0.5;
+    background: var(--parsec-color-light-gradient-background);
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    max-height: 100%;
+    top: 0;
+    right: 0;
+    z-index: 0;
+  }
+
+  &::after {
+    content: '';
+    opacity: 0.5;
+    background: linear-gradient(180deg, rgba(27, 27, 40, 0) 0%, var(--parsec-color-light-secondary-black) 100%);
+    position: absolute;
+    width: 100%;
+    height: 15rem;
+    flex-shrink: 0;
+    bottom: 0;
+    right: 0;
+    z-index: 0;
+  }
+
+  .sidebar-bottom {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .sidebar-tagline {
+    position: relative;
+    z-index: 1;
+    margin-bottom: 0;
+    margin-inline: 0;
+  }
+
+  .logo-img {
+    max-width: 10rem;
+    width: 100%;
+    z-index: 2;
+  }
+
+  .logo-icon {
+    width: 6rem;
+    position: relative;
+    z-index: 2;
   }
 }
 </style>


### PR DESCRIPTION
Closes #10500 

This adds the support for custom branding.
Files can be put inside `public/custom` for web, or `electron/custom` for electron, and they will be used if available. For now, it only uses a few files defined in `resourcesManager.ts`. Texts can be fully replaced with `en_US.json` and `fr_FR.json`.

- [X] Keep changes in the pull request as small as possible
- [X] Ensure the commit history is sanitized
- [X] Give a meaningful title to your PR
- [X] Describe your changes
- [X] Link any related issue in the description

