### PR TITLE
Add dependabot versioning-strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,6 +68,7 @@ updates:
     directories:
       - /server
       - /docs
+    versioning-strategy: increase-if-necessary
     ignore:
       - dependency-name: typing-extensions
       - dependency-name: anyio

--- a/server/poetry.lock
+++ b/server/poetry.lock
@@ -2330,4 +2330,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.12.0"
-content-hash = "69e04ccb12c746541b14375e1d2df361bd86fcb1afd9aad45846cf43892d7b58"
+content-hash = "b6cf3d19b273fed98cd5709fc065a13f72d863dd06141182cf85a26e224b4aa8"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "parsec-cloud"
 version = "3.4.1-a.0+dev"
-description = "Secure cloud framework"
+description = "Secure file sharing in the cloud"
 authors = ["Scille SAS <contact@scille.fr>"]
 license = "BUSL-1.1"
 readme = "../README.rst"
@@ -30,49 +30,49 @@ parsec = "parsec.cli:cli"
 [tool.poetry.dependencies]
 python = "~3.12.0"
 # Base requirements
-anyio = ">=3.7.1,<4.0.0"
+anyio = "^3.7.1"
 click = "^8.0"
-httpx = ">=0.25,<0.29"
-pbr = { version = ">=5.9,<7.0" }
-pydantic = { version = "^2.10.6" }
+httpx = "^0.28.1"
+pbr = "^6.1.1"
+pydantic = "^2.10.6"
 pydantic-core = "^2.27.2"
-sentry-sdk = "2.30.0"
-starlette = ">=0.37.2,<0.47.0"
-structlog = ">=21.5,<26.0"
+sentry-sdk = "^2.30.0"
+starlette = "^0.46.2"
+structlog = "^25.4.0"
 # ASGI server
-fastapi = ">=0.104.1,<0.116.0"
-uvicorn = ">=0.24,<0.35"
-jinja2 = { version = "^3.0" }
+fastapi = "^0.115.13"
+uvicorn = "^0.34.3"
+jinja2 = "^3.0"
 # PostgreSQL
 asyncpg = "^0.29.0"
 # S3
-boto3 = { version = "^1.38" }
-botocore = { version = "^1.38" }
+boto3 = "^1.38"
+botocore = "^1.38"
 # Swift
-python-swiftclient = { version = ">=3.13,<5.0" }
+python-swiftclient = "^4.8.0"
 
 [tool.poetry.group.dev.dependencies]
 asyncpg-stubs = "^0.29.0"
 Babel = "^2.10"
 boto3-stubs = "^1.38"
-cibuildwheel = "3.0.0"
-deptry = ">=0.16.1,<0.24.0"
-editorconfig-checker = "3.2.1"
-httpx-sse = ">=0.3.1,<0.5.0"
-maturin = "1.8.7"
+cibuildwheel = "^3.0.0"
+deptry = "^0.23.0"
+editorconfig-checker = "^3.2.1"
+httpx-sse = "^0.4.0"
+maturin = "^1.8.7"
 patchelf = { version = "^0.17.2.1", markers = "platform_system=='Linux'" }
-poetry-lock-package = ">=0.4.4,<0.6.0"
-psutil = ">=5.9,<8.0"
+poetry-lock-package = "^0.5.2"
+psutil = "^7.0.0"
 pyright = "^1.1.353"
-pytest = ">=7,<9"
-pytest-asyncio = ">=0.21.1,<1.1.0"
-pytest-cov = ">=4,<7"
-pytest-rerunfailures = ">=10.2,<16.0"
+pytest = "^8.4.0"
+pytest-asyncio = "^1.0.0"
+pytest-cov = "^6.2.1"
+pytest-rerunfailures = "^15.1"
 pytest-timeout = "^2.2.0"
 pytest-xdist = "^3.1"
-ruff = "0.12.0"
-setuptools = ">=63.1,<81.0"
-trustme = ">=0.9,<1.3"
+ruff = "^0.12.0"
+setuptools = "^80.9.0"
+trustme = "^1.2.1"
 types-requests = "^2.28"
 sqlfluff = "^3.1.1"
 
@@ -80,7 +80,7 @@ sqlfluff = "^3.1.1"
 optional = true
 
 [tool.poetry.group.testbed-server.dependencies]
-psutil = ">=5.9,<8.0"
+psutil = "^7.0.0"
 
 [tool.poetry.build]
 generate-setup-file = false


### PR DESCRIPTION
The `increase-if-necessary` strategy tells dependabot not to update `pyproject.toml` if version constraint already covers the new version.

This should reduce the number of unnecessary merge conflicts on dependabot PRs since Poetry computes hash over the version constraints in `pyproject.toml` (and writes that hash to `poetry.lock`).

No dependency is actually updated in this PR, only the version constraints in `pyproject.toml` to reflect the current version in `poetry.lock`.