### PR TITLE
Update `list_workspace_users` to include revoked & unshared

### DIFF
--- a/libparsec/crates/client/src/certif/realm_key_rotation.rs
+++ b/libparsec/crates/client/src/certif/realm_key_rotation.rs
@@ -245,7 +245,7 @@ async fn generate_realm_rotate_key_req(
 
             let per_participant_keys_bundle_access = {
                 let mut per_user_role = store
-                    .get_realm_current_users_roles(UpTo::Current, realm_id)
+                    .get_realm_current_users_roles(UpTo::Current, realm_id, false)
                     .await?;
 
                 let mut per_participant_keys_bundle_access =

--- a/libparsec/crates/client/tests/unit/certif/list_workspace_users.rs
+++ b/libparsec/crates/client/tests/unit/certif/list_workspace_users.rs
@@ -33,8 +33,8 @@ async fn ok(env: &TestbedEnv) {
         res,
         [(
             "alice".parse().unwrap(),
-            UserProfile::Admin,
-            RealmRole::Owner
+            Some(UserProfile::Admin),
+            Some(RealmRole::Owner)
         )]
     );
 }
@@ -75,13 +75,13 @@ async fn multiple(env: &TestbedEnv) {
         [
             (
                 "bob".parse().unwrap(),
-                UserProfile::Standard,
-                RealmRole::Contributor
+                Some(UserProfile::Standard),
+                Some(RealmRole::Contributor)
             ),
             (
                 "alice".parse().unwrap(),
-                UserProfile::Admin,
-                RealmRole::Owner
+                Some(UserProfile::Admin),
+                Some(RealmRole::Owner)
             ),
         ]
     );

--- a/libparsec/crates/client/tests/unit/certif/store.rs
+++ b/libparsec/crates/client/tests/unit/certif/store.rs
@@ -325,7 +325,7 @@ async fn get_realm_current_users_roles(env: &TestbedEnv) {
     let last_user_roles = store
         .for_read(async |store| {
             store
-                .get_realm_current_users_roles(UpTo::Current, realm_id)
+                .get_realm_current_users_roles(UpTo::Current, realm_id, false)
                 .await
         })
         .await

--- a/libparsec/crates/client/tests/unit/client/process_workspaces_needs.rs
+++ b/libparsec/crates/client/tests/unit/client/process_workspaces_needs.rs
@@ -293,6 +293,9 @@ async fn multiple_realms_and_needs(env: &TestbedEnv) {
                 .await
                 .unwrap()
                 .into_iter()
+                .filter(|access_info| {
+                    access_info.current_role.is_some() && access_info.current_profile.is_some()
+                })
                 .map(|e| e.user_id)
                 .collect::<Vec<_>>();
             users.sort();


### PR DESCRIPTION
`WorkspaceUserAccessInfo` now uses an `Option` for `current_role` (`None` if unshared) & `current_profile` (`None` if revoked).

This required to update `get_realm_current_users_roles` to include unshared certificates: the flag `include_unshared` was added so other calls to `get_realm_current_users_roles` are not impacted.

Closes #10615 