### PR TITLE
refactor(crypto): Use `OsRng` over `thread_rng`

### DIFF
--- a/libparsec/crates/crypto/src/rustcrypto/key_derivation.rs
+++ b/libparsec/crates/crypto/src/rustcrypto/key_derivation.rs
@@ -9,7 +9,7 @@ use generic_array::{
     },
     ArrayLength, GenericArray,
 };
-use rand::RngCore;
+use rand::{rngs::OsRng, RngCore};
 use serde::Deserialize;
 use serde_bytes::Bytes;
 
@@ -29,7 +29,7 @@ impl KeyDerivation {
 
     pub fn generate() -> Self {
         let mut bytes = [0u8; Self::SIZE];
-        rand::thread_rng().fill_bytes(&mut bytes);
+        OsRng.fill_bytes(&mut bytes);
         Self(bytes.into())
     }
 

--- a/libparsec/crates/crypto/src/rustcrypto/private.rs
+++ b/libparsec/crates/crypto/src/rustcrypto/private.rs
@@ -15,6 +15,7 @@ mod sealed_box {
 
     //re-export keys
     pub use crypto_box::{PublicKey, SecretKey};
+    use rand::rngs::OsRng;
 
     const BOX_NONCE_LENGTH: usize = 24;
     const BOX_OVERHEAD: usize = 16;
@@ -48,7 +49,7 @@ mod sealed_box {
     pub fn seal(data: &[u8], pk: &PublicKey) -> Vec<u8> {
         let mut out = Vec::with_capacity(SEALED_OVERHEAD + data.len());
 
-        let ep_sk = SecretKey::generate(&mut rand::thread_rng());
+        let ep_sk = SecretKey::generate(&mut OsRng);
         let ep_pk = ep_sk.public_key();
         out.extend_from_slice(ep_pk.as_bytes());
 
@@ -93,6 +94,7 @@ mod sealed_box {
 }
 
 use crypto_box::KEY_SIZE;
+use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use serde_bytes::Bytes;
 use x25519_dalek::x25519;
@@ -126,7 +128,7 @@ impl PrivateKey {
     }
 
     pub fn generate() -> Self {
-        Self(crypto_box::SecretKey::generate(&mut rand::thread_rng()))
+        Self(crypto_box::SecretKey::generate(&mut OsRng))
     }
 
     pub fn decrypt_from_self(&self, ciphered: &[u8]) -> Result<Vec<u8>, CryptoError> {

--- a/libparsec/crates/crypto/src/rustcrypto/secret.rs
+++ b/libparsec/crates/crypto/src/rustcrypto/secret.rs
@@ -11,6 +11,7 @@ use generic_array::{
     },
     ArrayLength, GenericArray,
 };
+use rand::rngs::OsRng;
 use serde::Deserialize;
 use serde_bytes::Bytes;
 
@@ -25,7 +26,7 @@ impl SecretKey {
     pub const SIZE: usize = XSalsa20Poly1305::KEY_SIZE;
 
     pub fn generate() -> Self {
-        Self(XSalsa20Poly1305::generate_key(rand::thread_rng()))
+        Self(XSalsa20Poly1305::generate_key(OsRng))
     }
 
     pub fn encrypt(&self, data: &[u8]) -> Vec<u8> {
@@ -33,7 +34,7 @@ impl SecretKey {
         // TODO: zero copy with pre-allocated buffer
         // let mut ciphered = Vec::with_capacity(NONCE_SIZE + TAG_SIZE + data.len());
         let cipher = XSalsa20Poly1305::new(&self.0);
-        let nonce = XSalsa20Poly1305::generate_nonce(&mut rand::thread_rng());
+        let nonce = XSalsa20Poly1305::generate_nonce(OsRng);
         // TODO: handle this error?
         let mut ciphered = cipher.encrypt(&nonce, data).expect("encryption failure !");
         let mut res = vec![];

--- a/libparsec/crates/crypto/src/rustcrypto/sign.rs
+++ b/libparsec/crates/crypto/src/rustcrypto/sign.rs
@@ -1,6 +1,7 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 use ed25519_dalek::{Signature, Signer, Verifier};
+use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use serde_bytes::Bytes;
 
@@ -36,7 +37,7 @@ impl SigningKey {
     }
 
     pub fn generate() -> Self {
-        Self(ed25519_dalek::SigningKey::generate(&mut rand::thread_rng()))
+        Self(ed25519_dalek::SigningKey::generate(&mut OsRng))
     }
 
     /// Sign the message and prefix it with the signature.


### PR DESCRIPTION
To not have to think if `thread_rng` can be used as a CSRNG

Closes #10501