### PR TITLE
chore(lib-client-conn): Remove deps `reqwest-eventsource`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,7 +2125,6 @@ dependencies = [
  "libparsec_types",
  "log",
  "reqwest",
- "reqwest-eventsource",
  "thiserror 2.0.12",
  "tokio",
 ]
@@ -2530,12 +2529,6 @@ checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mini-internal"
@@ -3575,22 +3568,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
-]
-
-[[package]]
-name = "reqwest-eventsource"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
-dependencies = [
- "eventsource-stream",
- "futures-core",
- "futures-timer",
- "mime",
- "nom",
- "pin-project-lite",
- "reqwest",
- "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,6 @@ rand = { version = "0.8.5", default-features = false }
 regex = { version = "1.11.1", default-features = false }
 regex-syntax = { version = "0.8.4", default-features = false }
 reqwest = { version = "0.12.20", default-features = false }
-reqwest-eventsource = { version = "0.6.0", default-features = false }
 rexpect = "0.6.2"
 rmp-serde = { version = "1.3.0", default-features = false }
 rpassword = { version = "7.4.0", default-features = false }

--- a/libparsec/crates/client_connection/Cargo.toml
+++ b/libparsec/crates/client_connection/Cargo.toml
@@ -39,8 +39,6 @@ bytes = { workspace = true, features = ["std"] }
 log = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-# TODO: support SSE for Web
-reqwest-eventsource = { workspace = true }
 # On web TLS is not available it is the responsibility of the browser
 reqwest = { workspace = true, features = ["native-tls"] }
 


### PR DESCRIPTION
The dependency was not used by the crate