### PR TITLE
chore(lib-types): Remove dep `flate2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,7 +220,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide 0.7.2",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -1151,16 +1145,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "flate2"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
-dependencies = [
- "crc32fast",
- "miniz_oxide 0.8.5",
 ]
 
 [[package]]
@@ -2400,7 +2384,6 @@ dependencies = [
  "chrono",
  "data-encoding",
  "email-address-parser",
- "flate2",
  "fnmatch-regex",
  "glob",
  "hex",
@@ -2582,15 +2565,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
-dependencies = [
- "adler2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,6 @@ env_logger = { version = "0.11.8", default-features = false }
 error_set = { version = "0.8.5", default-features = false }
 event-listener = { version = "5.4.0", default-features = false }
 eventsource-stream = { version = "0.2.3", default-features = false }
-flate2 = { version = "1.1.2", features = ["rust_backend"], default-features = false }
 flume = { version = "0.11.1", default-features = false }
 fnmatch-regex = { version = "0.2.1", default-features = false }
 fuser = { version = "0.15.1", default-features = false }

--- a/libparsec/crates/types/Cargo.toml
+++ b/libparsec/crates/types/Cargo.toml
@@ -45,7 +45,6 @@ rand = { workspace = true, features = ["std", "std_rng"] }
 thiserror = { workspace = true, features = ["std"] }
 email-address-parser = { workspace = true }
 anyhow = { workspace = true, features = ["std", "backtrace"] }
-flate2 = { workspace = true }
 fnmatch-regex = { workspace = true }
 hex-literal = { workspace = true, optional = true }
 rstest = { workspace = true, optional = true }


### PR DESCRIPTION
That dependency is not used in the crate nor it's dependencies