### PR TITLE
ci(web): Use docker image to run playwright tests

### DIFF
--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -214,17 +214,23 @@ jobs:
       - name: Check testbed server is running
         run: curl http://localhost:6777
 
-      - name: Install Playwright dependencies
-        run: npx playwright install --with-deps chrome
-        working-directory: client
-        timeout-minutes: 5
+      - name: Get current uid:gid
+        id: user
+        run: echo "id=$(id -u):$(id -g)" | tee -a $GITHUB_OUTPUT
+        timeout-minutes: 1
 
       - name: E2E tests
-        run: npm run test:e2e:headless -- --shard=${{ matrix.shard_index }}/${{ matrix.shard_total }}
+        uses: docker://playwright/chrome:playwright-1.51.0
+        with:
+          # To use `playwright-chrome` docker image, we need 2 things, settings the entrypoint to `sh` and configure the user inside the container because it use a different uid:gid than CI.
+          #
+          # But Github action only allows to set `entrypoint` and `command` option for `docker run`.
+          # Fortunately, Github does not sanitize the input of `entrypoint` so we can inject `--user` option by doing some shell quote escape shenanigan.
+          entrypoint: sh" --user "${{ steps.user.outputs.id }}
+          args: -c "cd client; npm run test:e2e:headless -- --shard=${{ matrix.shard_index }}/${{ matrix.shard_total }}"
         env:
-          TESTBED_SERVER: parsec3://localhost:6777?no_ssl=true
-          PARSEC_APP_TRIAL_SERVERS: localhost:6777?no_ssl=true
-        working-directory: client
+          TESTBED_SERVER: parsec3://parsec-testbed-server:6777?no_ssl=true
+          PARSEC_APP_TRIAL_SERVERS: parsec-testbed-server:6777?no_ssl=true
         timeout-minutes: 20
 
       - name: Upload blob report to GitHub Actions Artifacts

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -9,6 +9,8 @@ import dotenv from 'dotenv';
  */
 dotenv.config({ path: '.env.playwright' });
 
+const IN_CI = !!process.env.CI;
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -17,13 +19,13 @@ export default defineConfig({
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
+  forbidOnly: IN_CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: IN_CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 5 : undefined,
+  workers: IN_CI ? 5 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? 'blob' : 'list',
+  reporter: IN_CI ? 'blob' : 'list',
   webServer: {
     command: 'npm run dev -- --port 8080',
     url: 'http://localhost:8080',
@@ -43,7 +45,11 @@ export default defineConfig({
   projects: [
     {
       name: 'Google Chrome',
-      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+      use: {
+        ...devices['Desktop Chrome'],
+        // We use chrome over chromium because we need some media codec during e2e test for the file viewer feature.
+        channel: 'chrome',
+      },
     },
 
     // {


### PR DESCRIPTION
More stable CI duration since we just download the container with the required dependendies already installed.

Closes #9063