### PR TITLE
[MS] Tests warning appearing on Safari

### DIFF
--- a/client/src/parsec/environment.ts
+++ b/client/src/parsec/environment.ts
@@ -52,6 +52,9 @@ export async function detectBrowser(): Promise<Browser | undefined> {
   if (!isWeb()) {
     return;
   }
+  if ((window as any).TESTING_MOCK_BROWSER !== undefined) {
+    return (window as any).TESTING_MOCK_BROWSER as Browser;
+  }
   const result = await detectIncognito();
   return result.browserName as Browser;
 }

--- a/client/tests/e2e/helpers/fixtures.ts
+++ b/client/tests/e2e/helpers/fixtures.ts
@@ -15,6 +15,7 @@ interface SetupOptions {
   withParsecAccount?: boolean;
   withCustomBranding?: boolean;
   displaySize?: DisplaySize;
+  mockBrowser?: 'Chrome' | 'Firefox' | 'Safari' | 'Edge' | 'Brave' | 'Chromium';
 }
 
 const DEV_TOOLS_OFFSET = 400;
@@ -29,6 +30,9 @@ export async function setupNewPage(page: MsPage, opts: SetupOptions = {}): Promi
     }
     if (options.withCustomBranding) {
       (window as any).TESTING_ENABLE_CUSTOM_BRANDING = true;
+    }
+    if (options.mockBrowser) {
+      (window as any).TESTING_MOCK_BROWSER = options.mockBrowser;
     }
     (window as any).showSaveFilePicker = async (): Promise<FileSystemFileHandle> => {
       console.log('Show save file Picker');

--- a/client/tests/e2e/specs/home_page.spec.ts
+++ b/client/tests/e2e/specs/home_page.spec.ts
@@ -216,6 +216,6 @@ msTest('Warn on Safari', async ({ context }) => {
   await setupNewPage(page, { mockBrowser: 'Safari' });
   const modal = page.locator('.incompatible-environment');
   await expect(modal).toBeVisible();
-  await expect(modal.locator('.incompatible-content__title')).toHaveText('Your browser is not compatibly with Parsec yet.');
+  await expect(modal.locator('.incompatible-content__title')).toHaveText('Your browser is not compatible with Parsec yet.');
   await context.close();
 });

--- a/client/tests/e2e/specs/home_page.spec.ts
+++ b/client/tests/e2e/specs/home_page.spec.ts
@@ -1,6 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { DisplaySize, expect, fillIonInput, logout, msTest, sortBy } from '@tests/e2e/helpers';
+import { DisplaySize, expect, fillIonInput, logout, MsPage, msTest, setupNewPage, sortBy } from '@tests/e2e/helpers';
 
 const USER_NAMES = ['Alicey McAliceFace', 'Boby McBobFace', 'Malloryy McMalloryFace'];
 
@@ -207,4 +207,15 @@ msTest('Open feedback', async ({ home }) => {
   const newTab = await newTabPromise;
   await newTab.waitForLoadState();
   await expect(newTab).toHaveURL(new RegExp('https://sign(-dev)?.parsec.cloud/contact'));
+});
+
+msTest('Warn on Safari', async ({ context }) => {
+  const page = (await context.newPage()) as MsPage;
+  // Tried changing the user agent but the detection is too good,
+  // so we need a little extra step.
+  await setupNewPage(page, { mockBrowser: 'Safari' });
+  const modal = page.locator('.incompatible-environment');
+  await expect(modal).toBeVisible();
+  await expect(modal.locator('.incompatible-content__title')).toHaveText('Your browser is not compatibly with Parsec yet.');
+  await context.close();
 });


### PR DESCRIPTION
My initial thought was to test
- Warning on Safari
- Warning on small display
- Warning if indexedDB is not available

Sadly, I cannot add a test for the small display because we disable it when using the testbed to not be too annoying when developping, and I don't want to have specific code in the app just for one specific test.
For indexedDB, I haven't found a way to disable it in Playwright: no permissions, and it's used in the web worker so I can't mock `window.indexedDB` or something like that.

We end up we a simple small test to check that the warning is properly displayed on Safari.