### PR TITLE
[MS] Use the bindings to get the org creation date

### DIFF
--- a/client/src/common/organization.ts
+++ b/client/src/common/organization.ts
@@ -42,6 +42,5 @@ export function formatExpirationTime(duration: Duration): Translatable {
 export function isTrialOrganizationDevice(device: AvailableDevice): boolean {
   const url = new URL(device.serverUrl);
   const serverType = getServerTypeFromHost(url.hostname, url.port.length > 0 ? parseInt(url.port) : undefined);
-
   return serverType === ServerType.Trial;
 }

--- a/client/src/components/organizations/OrganizationCard.vue
+++ b/client/src/components/organizations/OrganizationCard.vue
@@ -96,14 +96,15 @@ const expirationDuration = ref<Duration>();
 const props = defineProps<{
   device: AvailableDevice;
   lastLoginDevice?: DateTime;
+  orgCreationDate?: DateTime;
   orgNameOnly?: boolean;
   loggedIn?: boolean;
 }>();
 
 onMounted(async () => {
   isTrialOrg.value = isTrialOrganizationDevice(props.device);
-  if (isTrialOrg.value) {
-    expirationDuration.value = getDurationBeforeExpiration(props.device.createdOn);
+  if (isTrialOrg.value && props.orgCreationDate) {
+    expirationDuration.value = getDurationBeforeExpiration(props.orgCreationDate);
   }
 });
 

--- a/client/src/parsec/types.ts
+++ b/client/src/parsec/types.ts
@@ -24,6 +24,7 @@ export {
   ClientCreateWorkspaceErrorTag,
   ClientEventTag,
   ClientExportRecoveryDeviceErrorTag,
+  ClientGetOrganizationBootstrapDateErrorTag,
   ClientGetUserDeviceErrorTag,
   ClientGetUserInfoErrorTag,
   ClientInfoErrorTag,
@@ -118,6 +119,7 @@ export type {
   ClientEventInvitationChanged,
   ClientEventPing,
   ClientExportRecoveryDeviceError,
+  ClientGetOrganizationBootstrapDateError,
   ClientGetTosError,
   ClientGetUserDeviceError,
   ClientGetUserInfoError,
@@ -374,6 +376,7 @@ interface OrganizationInfo {
   hasUserLimit: boolean;
   organizationAddr: ParsecOrganizationAddr;
   organizationId: OrganizationID;
+  creationDate?: DateTime;
 }
 
 enum AccountAccessStrategy {

--- a/client/src/services/storageManager.ts
+++ b/client/src/services/storageManager.ts
@@ -9,7 +9,8 @@ export const StorageManagerKey = 'storageManager';
 export const ThemeManagerKey = 'themeManager';
 
 export interface StoredDeviceData {
-  lastLogin: DateTime;
+  lastLogin?: DateTime;
+  orgCreationDate?: DateTime;
 }
 
 export interface BmsAccessData {
@@ -76,9 +77,11 @@ export class StorageManager {
     const serialized: { [deviceId: string]: object } = {};
 
     Object.keys(data).forEach((deviceId: string, _data) => {
-      if (data[deviceId] && data[deviceId].lastLogin) {
+      if (data[deviceId]) {
+        const deviceData = data[deviceId];
         serialized[deviceId] = {
-          lastLogin: data[deviceId].lastLogin.toISO(),
+          lastLogin: deviceData?.lastLogin ? deviceData.lastLogin.toISO() : undefined,
+          orgCreationDate: deviceData?.orgCreationDate ? deviceData.orgCreationDate.toISO() : undefined,
         };
       }
     });
@@ -94,11 +97,12 @@ export class StorageManager {
       return deviceData;
     }
     Object.keys(data).forEach((deviceId, _data) => {
-      if (data[deviceId] && data[deviceId].lastLogin) {
+      if (data[deviceId]) {
         deviceData[deviceId] = {
           // Need to add setZone because Luxon (and JavaScript's date) ignore
           // the timezone part otherwise
-          lastLogin: DateTime.fromISO(data[deviceId].lastLogin, { setZone: true }),
+          lastLogin: data[deviceId].lastLogin ? DateTime.fromISO(data[deviceId].lastLogin, { setZone: true }) : undefined,
+          orgCreationDate: data[deviceId].orgCreationDate ? DateTime.fromISO(data[deviceId].orgCreationDate, { setZone: true }) : undefined,
         };
       }
     });

--- a/client/src/views/home/OrganizationListPage.vue
+++ b/client/src/views/home/OrganizationListPage.vue
@@ -112,8 +112,9 @@
             class="organization-list-item"
             :device="device"
             :last-login-device="storedDeviceDataDict[device.deviceId]?.lastLogin"
+            :org-creation-date="storedDeviceDataDict[device.deviceId]?.orgCreationDate"
             @click="$emit('organizationSelect', device)"
-            :logged-in="loggedInDevices.find((info) => info.device.deviceId === device.deviceId) !== undefined"
+            :logged-in="loggedInDevices.find((info: LoggedInDeviceInfo) => info.device.deviceId === device.deviceId) !== undefined"
           />
         </div>
       </div>
@@ -303,12 +304,12 @@ const filteredDevices = computed(() => {
         }
       } else if (sortBy.value === SortCriteria.LastLogin) {
         const aLastLogin =
-          a.deviceId in storedDeviceDataDict.value && storedDeviceDataDict.value[a.deviceId].lastLogin !== undefined
-            ? storedDeviceDataDict.value[a.deviceId].lastLogin
+          storedDeviceDataDict.value[a.deviceId]?.lastLogin !== undefined
+            ? (storedDeviceDataDict.value[a.deviceId].lastLogin as DateTime)
             : DateTime.fromMillis(0);
         const bLastLogin =
-          b.deviceId in storedDeviceDataDict.value && storedDeviceDataDict.value[b.deviceId].lastLogin !== undefined
-            ? storedDeviceDataDict.value[b.deviceId].lastLogin
+          storedDeviceDataDict.value[b.deviceId]?.lastLogin !== undefined
+            ? (storedDeviceDataDict.value[b.deviceId].lastLogin as DateTime)
             : DateTime.fromMillis(0);
         let diff = 0;
         if (sortByAsc.value) {

--- a/client/tests/e2e/helpers/externalWebsites.ts
+++ b/client/tests/e2e/helpers/externalWebsites.ts
@@ -1,0 +1,45 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { expect, Locator } from '@playwright/test';
+import { MsContext, MsPage } from '@tests/e2e/helpers/types';
+
+const EXTERNAL_URLS = [
+  'parsec.cloud',
+  'raw.githubusercontent.com',
+  'github.com',
+  'docs.parsec.cloud',
+  'sign-dev.parsec.cloud',
+  'sign.parsec.cloud',
+];
+
+export async function mockExternalWebsites(context: MsContext): Promise<void> {
+  for (const host of EXTERNAL_URLS) {
+    await context.route(`**://${host}/**`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>MOCKED</title>
+</head>
+<body>
+    <div>${route.request().url()}</div>
+</body>
+</html>
+`,
+      });
+    });
+  }
+}
+
+export async function openExternalLink(page: MsPage, clickable: Locator, expectedUrl: RegExp): Promise<void> {
+  const newTabPromise = page.waitForEvent('popup');
+  await clickable.click();
+  const newTab = await newTabPromise;
+  await expect(newTab).toHaveURL(expectedUrl);
+  await expect(newTab).toHaveTitle('MOCKED');
+  await expect(newTab.locator('div')).toHaveText(expectedUrl);
+  await newTab.close();
+}

--- a/client/tests/e2e/helpers/fixtures.ts
+++ b/client/tests/e2e/helpers/fixtures.ts
@@ -4,6 +4,7 @@ import { Locator, TestInfo, test as base } from '@playwright/test';
 import { expect } from '@tests/e2e/helpers/assertions';
 import { MockBms, MockClientAreaOverload, MockRouteOptions } from '@tests/e2e/helpers/bms';
 import { DEFAULT_USER_INFORMATION, generateDefaultOrganizationInformation, generateDefaultUserData } from '@tests/e2e/helpers/data';
+import { mockExternalWebsites } from '@tests/e2e/helpers/externalWebsites';
 import { dropTestbed, initTestBed } from '@tests/e2e/helpers/testbed';
 import { DisplaySize, MsContext, MsPage } from '@tests/e2e/helpers/types';
 import { createWorkspace, fillInputModal, fillIonInput, importDefaultFiles, logout } from '@tests/e2e/helpers/utils';
@@ -214,6 +215,7 @@ export const msTest = debugTest.extend<{
   context: async ({ browser }, use) => {
     const context = (await browser.newContext()) as MsContext;
     await context.grantPermissions(['clipboard-read']);
+    await mockExternalWebsites(context);
     await use(context);
     await context.close();
   },

--- a/client/tests/e2e/helpers/index.ts
+++ b/client/tests/e2e/helpers/index.ts
@@ -3,6 +3,7 @@
 export * from '@tests/e2e/helpers/assertions';
 export * from '@tests/e2e/helpers/bms';
 export * from '@tests/e2e/helpers/data';
+export * from '@tests/e2e/helpers/externalWebsites';
 export * from '@tests/e2e/helpers/fixtures';
 export * from '@tests/e2e/helpers/greet';
 export * from '@tests/e2e/helpers/mediaAssertions';

--- a/client/tests/e2e/specs/about_modal.spec.ts
+++ b/client/tests/e2e/specs/about_modal.spec.ts
@@ -1,15 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { Locator } from '@playwright/test';
-import { expect, MsPage, msTest } from '@tests/e2e/helpers';
-
-async function openLink(page: MsPage, button: Locator, expectedUrl: RegExp): Promise<void> {
-  const newTabPromise = page.waitForEvent('popup');
-  await button.click();
-  const newTab = await newTabPromise;
-  await expect(newTab).toHaveURL(expectedUrl);
-  await newTab.close();
-}
+import { expect, msTest, openExternalLink } from '@tests/e2e/helpers';
 
 msTest('Opens the about dialog', async ({ home }) => {
   await home.locator('#trigger-version-button').click();
@@ -22,10 +13,10 @@ msTest('Opens the about dialog', async ({ home }) => {
   await expect(titles).toHaveText(['Version', 'Developer', 'License', 'Project']);
   await expect(values).toHaveText([/^ v[a-z0-9-.+]+$/, 'Parsec Cloud', 'BUSL-1.1', ' GitHub ']);
 
-  await openLink(home, values.nth(1), /^https:\/\/parsec\.cloud\/en\/?.+$/);
-  await openLink(home, values.nth(2), /^https:\/\/raw\.githubusercontent\.com\/Scille\/parsec-cloud\/.+\/LICENSE.*$/);
-  await openLink(home, values.nth(3), /^https:\/\/github\.com\/Scille\/parsec-cloud$/);
-  await openLink(home, modal.locator('.changelog-btn'), /^https:\/\/docs\.parsec\.cloud\/.+$/);
+  await openExternalLink(home, values.nth(1), /^https:\/\/parsec\.cloud\/en\/?.*$/);
+  await openExternalLink(home, values.nth(2), /^https:\/\/raw\.githubusercontent\.com\/Scille\/parsec-cloud\/.+\/LICENSE.*$/);
+  await openExternalLink(home, values.nth(3), /^https:\/\/github\.com\/Scille\/parsec-cloud$/);
+  await openExternalLink(home, modal.locator('.changelog-btn'), /^https:\/\/docs\.parsec\.cloud\/.+$/);
 
   await modal.locator('.closeBtn').click();
   await expect(modal).toBeHidden();

--- a/client/tests/e2e/specs/create_organization_saas.spec.ts
+++ b/client/tests/e2e/specs/create_organization_saas.spec.ts
@@ -10,6 +10,7 @@ import {
   fillIonInput,
   getTestbedBootstrapAddr,
   msTest,
+  openExternalLink,
   setupNewPage,
 } from '@tests/e2e/helpers';
 import { randomInt } from 'crypto';
@@ -336,15 +337,16 @@ msTest('Go through saas org creation process from bootstrap link', async ({ cont
   await page.release();
 });
 
-msTest('Open account creation', async ({ home }) => {
+msTest('Open customer account creation', async ({ home }) => {
   const modal = await openCreateOrganizationModal(home);
 
   const bmsContainer = modal.locator('.saas-login');
   await expect(bmsContainer.locator('.saas-login-footer').locator('.create-account__link')).toHaveText('Create an account');
-  await bmsContainer.locator('.saas-login-footer').locator('.create-account__link').click();
-  const newTabPromise = home.waitForEvent('popup');
-  const newTab = await newTabPromise;
-  await expect(newTab).toHaveURL('https://sign-dev.parsec.cloud/');
+  await openExternalLink(
+    home,
+    bmsContainer.locator('.saas-login-footer').locator('.create-account__link'),
+    /https:\/\/sign-dev\.parsec\.cloud.*/,
+  );
 });
 
 msTest('Fail to login to BMS', async ({ home }) => {

--- a/client/tests/e2e/specs/my_profile_page.spec.ts
+++ b/client/tests/e2e/specs/my_profile_page.spec.ts
@@ -1,7 +1,7 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 import { Page } from '@playwright/test';
-import { DisplaySize, expect, fillIonInput, logout, msTest, selectDropdown } from '@tests/e2e/helpers';
+import { DisplaySize, expect, fillIonInput, logout, msTest, openExternalLink, selectDropdown } from '@tests/e2e/helpers';
 
 msTest('Check devices list', async ({ myProfilePage }) => {
   await expect(myProfilePage.locator('.menu-list__item').nth(1)).toHaveText('My devices');
@@ -169,20 +169,24 @@ msTest('Check settings section', async ({ myProfilePage }) => {
 
 msTest('Open documentation', async ({ myProfilePage }) => {
   await expect(myProfilePage.locator('.item-container__text').nth(4)).toHaveText('Documentation');
-  await myProfilePage.locator('.item-container__text').nth(4).click();
-  const newTab = await myProfilePage.waitForEvent('popup');
-  await newTab.waitForLoadState();
-  await expect(newTab).toHaveURL(new RegExp('https://docs.parsec.cloud/(en|fr)/[a-z0-9-+.]+'));
+  await openExternalLink(
+    myProfilePage,
+    myProfilePage.locator('.item-container__text').nth(4),
+    new RegExp('https://docs.parsec.cloud/(en|fr)/[a-z0-9-+.]+'),
+  );
   // Re-check, just to for it to wait
   await expect(myProfilePage.locator('.item-container__text').nth(4)).toHaveText('Documentation');
 });
 
 msTest('Open feedback', async ({ myProfilePage }) => {
   await expect(myProfilePage.locator('.item-container__text').nth(5)).toHaveText('Feedback');
-  await myProfilePage.locator('.item-container__text').nth(5).click();
-  const newTab = await myProfilePage.waitForEvent('popup');
-  await newTab.waitForLoadState();
-  await expect(newTab).toHaveURL(new RegExp('https://sign(-dev)?.parsec.cloud/contact'));
+
+  await openExternalLink(
+    myProfilePage,
+    myProfilePage.locator('.item-container__text').nth(5),
+    new RegExp('https://sign(-dev)?.parsec.cloud/contact'),
+  );
+  await expect(myProfilePage.locator('.item-container__text').nth(5)).toHaveText('Feedback');
 });
 
 msTest('Logout from my profile page', async ({ myProfilePage }) => {

--- a/client/tests/e2e/specs/trial_organization.spec.ts
+++ b/client/tests/e2e/specs/trial_organization.spec.ts
@@ -1,0 +1,61 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { answerQuestion, expect, logout, MsPage, msTest, openExternalLink, setupNewPage } from '@tests/e2e/helpers';
+
+msTest('Homepage with trial orgs', async ({ context }) => {
+  const page = (await context.newPage()) as MsPage;
+  // Making sure that the testbed is recognized as the trial server
+  const testbedUrl = new URL(process.env.TESTBED_SERVER ?? '');
+  await setupNewPage(page, { trialServers: testbedUrl.host, saasServers: 'unknown.host' });
+
+  const topBar = page.locator('.topbar');
+  await expect(topBar.locator('.topbar-left-text__title')).toHaveText('Welcome to Parsec');
+  await expect(topBar.locator('.topbar-left-text__subtitle')).toHaveText('Access your organizations');
+
+  await page.release();
+});
+
+msTest('Sidebar with trial orgs', async ({ context }) => {
+  const page = (await context.newPage()) as MsPage;
+  // Making sure that the testbed is recognized as the trial server
+  const testbedUrl = new URL(process.env.TESTBED_SERVER ?? '');
+  await setupNewPage(page, { trialServers: testbedUrl.host, saasServers: 'unknown.host' });
+
+  const topBar = page.locator('.topbar');
+  await expect(topBar.locator('.topbar-left-text__title')).toHaveText('Welcome to Parsec');
+
+  await page.locator('.organization-card').first().click();
+  await expect(page.locator('#password-input')).toBeVisible();
+
+  await expect(page.locator('.login-button')).toHaveDisabledAttribute();
+
+  await page.locator('#password-input').locator('input').fill('P@ssw0rd.');
+  await expect(page.locator('.login-button')).toBeEnabled();
+  await page.locator('.login-button').click();
+  await expect(page.locator('#connected-header')).toContainText('My workspaces');
+  await expect(page.locator('.topbar-right').locator('.text-content-name')).toHaveText('Alicey McAliceFace');
+  await expect(page).toBeWorkspacePage();
+
+  const trialMenu = page.locator('.sidebar').locator('.trial-card');
+  await expect(trialMenu).toBeVisible();
+  await expect(trialMenu.locator('.trial-card__tag')).toHaveText('Trial version');
+  await expect(trialMenu.locator('.trial-card-text__time')).toHaveText('Expired');
+  await expect(trialMenu.locator('.trial-card__button')).toHaveText('Subscribe now');
+  await openExternalLink(page, trialMenu.locator('.trial-card__button'), /^https:\/\/parsec\.cloud\/en\/pricing\/?.*$/);
+
+  await logout(page);
+  await expect(topBar.locator('.topbar-left-text__title')).toHaveText('Welcome to Parsec');
+
+  await expect(page.locator('.organization-card').first().locator('.organization-card-expiration')).toBeVisible();
+  await expect(page.locator('.organization-card').first().locator('.organization-card-expiration')).toHaveText('Expired');
+  await page.locator('.organization-card').first().click();
+
+  await answerQuestion(page, false, {
+    expectedTitleText: 'Expired organization',
+    expectedQuestionText: "This device belongs to an expired organization. Do you wish to archive it (it won't be visible anymore)?",
+    expectedPositiveText: 'Archive',
+    expectedNegativeText: 'No, proceed to login',
+  });
+
+  await page.release();
+});


### PR DESCRIPTION
Closes #8405 

The detection of a trial server is done via an environment variable, so if you have devices, it's possible to edit `.env.development.local` to change the trial server (for example, `PARSEC_APP_TRIAL_SERVERS="localhost:6770?no_ssl=true;localhost:6770"` will detect the local server as a trial server).

We can also modify the function that returns the creation date. This bypasses the bindings, so it's not a complete test, but it lets you see how the GUI reacts.
```
diff --git a/client/src/parsec/organization.ts b/client/src/parsec/organization.ts
index ac79f5cf1..0de288128 100644
--- a/client/src/parsec/organization.ts
+++ b/client/src/parsec/organization.ts
@@ -169,7 +169,7 @@ export async function getOrganizationCreationDate(
   }
   const result = await libparsec.clientGetOrganizationBootstrapDate(handle);
   if (result.ok) {
-    result.value = DateTime.fromSeconds(result.value as any as number);
+    result.value =  DateTime.now().minus({ days: 4 }); //DateTime.fromSeconds(result.value as any as number);
   }
   return result;
 }
```
for example, to set the creation date to 4 days in the past.