### PR TITLE
[MS] Auto-register at login

### DIFF
--- a/client/src/services/environment.ts
+++ b/client/src/services/environment.ts
@@ -108,6 +108,9 @@ const ENABLE_ACCOUNT_ENV_VARIABLE = 'PARSEC_APP_ENABLE_ACCOUNT';
 const ENABLE_ACCOUNT_AUTO_LOGIN_ENV_VARIABLE = 'PARSEC_APP_ENABLE_ACCOUNT_AUTO_LOGIN';
 
 function getAccountServer(): string {
+  if ((window as any).TESTING_ACCOUNT_SERVER) {
+    return (window as any).TESTING_ACCOUNT_SERVER;
+  }
   if (import.meta.env[ACCOUNT_SERVER_ENV_VARIABLE]) {
     return import.meta.env[ACCOUNT_SERVER_ENV_VARIABLE];
   }

--- a/client/src/views/home/HomePage.vue
+++ b/client/src/views/home/HomePage.vue
@@ -509,20 +509,23 @@ async function handleLoginError(device: AvailableDevice, error: ClientStartError
       );
     }
   } else {
-    window.electronAPI.log('error', `Unhandled device authentication type ${device.ty}`);
+    window.electronAPI.log('error', `Unhandled error for device authentication type ${device.ty.tag}`);
   }
 }
 
 async function handleRegistration(device: AvailableDevice, access: DeviceAccessStrategy): Promise<void> {
   if (ParsecAccount.isLoggedIn()) {
+    // Check if the device is already among the registration devices
     const isRegResult = await ParsecAccount.isDeviceRegistered(device);
     if (isRegResult.ok && !isRegResult.value) {
+      // Ask the user if they want to create a registration device
       const answer = await askQuestion('loginPage.storeAccountTitle', 'loginPage.storeAccountQuestion', {
         yesText: 'loginPage.storeAccountYes',
       });
       if (answer === Answer.Yes) {
-        const regResult = await ParsecAccount.createRegistrationDevice(access);
-        if (regResult.ok) {
+        // Create the registration device
+        const createRegResult = await ParsecAccount.createRegistrationDevice(access);
+        if (createRegResult.ok) {
           informationManager.present(
             new Information({
               message: 'loginPage.storeSuccess',
@@ -530,8 +533,15 @@ async function handleRegistration(device: AvailableDevice, access: DeviceAccessS
             }),
             PresentationMode.Toast,
           );
+          const regResult = await ParsecAccount.registerNewDevice({ organizationId: device.organizationId, userId: device.userId });
+          if (!regResult.ok) {
+            window.electronAPI.log('error', `Failed to register new device: ${regResult.error.tag} (${regResult.error.error})`);
+          }
         } else {
-          window.electronAPI.log('error', `Failed to register the device: ${regResult.error.tag} (${regResult.error.error})`);
+          window.electronAPI.log(
+            'error',
+            `Failed to create the registration device: ${createRegResult.error.tag} (${createRegResult.error.error})`,
+          );
           informationManager.present(
             new Information({
               message: 'loginPage.storeFailed',
@@ -559,7 +569,9 @@ async function login(device: AvailableDevice, access: DeviceAccessStrategy): Pro
     }
     await storageManager.storeDevicesData(toRaw(storedDeviceDataDict.value));
 
-    await handleRegistration(device, access);
+    if (device.ty.tag !== AvailableDeviceTypeTag.AccountVault) {
+      await handleRegistration(device, access);
+    }
 
     const query = getCurrentRouteQuery();
     const routeData: RouteBackup = {

--- a/client/tests/e2e/specs/account_create.spec.ts
+++ b/client/tests/e2e/specs/account_create.spec.ts
@@ -16,6 +16,7 @@ msTest('Parsec account create account', async ({ parsecAccount }) => {
   }
 
   const EMAIL = generateUniqueEmail();
+  const PASSWORD = 'BigP@ssw0rd.';
 
   const container = parsecAccount.locator('.homepage-content');
   await expect(container.locator('.account-login__title')).toHaveText('My Parsec account');
@@ -81,9 +82,9 @@ msTest('Parsec account create account', async ({ parsecAccount }) => {
   await expect(title).toHaveText('Choose your authentication method');
   const passwordNext = passwordContainer.locator('ion-button');
   await expect(passwordNext).toBeTrulyDisabled();
-  await fillIonInput(passwordContainer.locator('ion-input').nth(0), 'BigP@ssw0rd.');
+  await fillIonInput(passwordContainer.locator('ion-input').nth(0), PASSWORD);
   await expect(passwordNext).toBeTrulyDisabled();
-  await fillIonInput(passwordContainer.locator('ion-input').nth(1), 'BigP@ssw0rd.');
+  await fillIonInput(passwordContainer.locator('ion-input').nth(1), PASSWORD);
   await expect(passwordNext).toBeTrulyEnabled();
   await passwordNext.click();
 
@@ -97,4 +98,28 @@ msTest('Parsec account create account', async ({ parsecAccount }) => {
   await expect(createdNext).toHaveText('Access organizations');
   await createdNext.click();
   await expect(parsecAccount).toBeHomePage();
+
+  await expect(parsecAccount.locator('.profile-header-homepage')).toHaveText(
+    `${DEFAULT_USER_INFORMATION.firstName} ${DEFAULT_USER_INFORMATION.lastName}`,
+  );
+  const profilePopover = parsecAccount.locator('.profile-header-homepage-popover');
+  await expect(profilePopover).toBeHidden();
+  await parsecAccount.locator('.profile-header-homepage').click();
+  await expect(profilePopover).toBeVisible();
+  await profilePopover.locator('.logout').click();
+  await expect(container.locator('.account-login__title')).toHaveText('My Parsec account');
+  await expect(parsecAccount).toHaveURL(/.+\/account$/);
+
+  const loginContainer = parsecAccount.locator('.account-login-container');
+  const loginButton = loginContainer.locator('.account-login-button').locator('ion-button');
+  await expect(loginButton).toBeTrulyDisabled();
+  await fillIonInput(loginContainer.locator('ion-input').nth(1), EMAIL);
+  await expect(loginButton).toBeTrulyDisabled();
+  await fillIonInput(loginContainer.locator('ion-input').nth(2), PASSWORD);
+  await expect(loginButton).toBeTrulyEnabled();
+  await loginButton.click();
+  await expect(parsecAccount).toBeHomePage();
+  await expect(parsecAccount.locator('.profile-header-homepage')).toHaveText(
+    `${DEFAULT_USER_INFORMATION.firstName} ${DEFAULT_USER_INFORMATION.lastName}`,
+  );
 });

--- a/client/tests/e2e/specs/account_login.spec.ts
+++ b/client/tests/e2e/specs/account_login.spec.ts
@@ -1,13 +1,13 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { expect, msTest } from '@tests/e2e/helpers';
+import { answerQuestion, expect, fillIonInput, logout, msTest } from '@tests/e2e/helpers';
 
-msTest.skip('Parsec account login initial page', async ({ parsecAccount }) => {
+msTest('Parsec account login initial page', async ({ parsecAccount }) => {
   const container = parsecAccount.locator('.homepage-content');
   await expect(container.locator('.account-login__title')).toHaveText('My Parsec account');
 });
 
-msTest.skip('Parsec account skip login', async ({ parsecAccount }) => {
+msTest('Parsec account skip login', async ({ parsecAccount }) => {
   const container = parsecAccount.locator('.homepage-content');
   await expect(container.locator('.homepage-skip__button')).toHaveText('Skip this step');
   await container.locator('.homepage-skip__button').click();
@@ -15,7 +15,7 @@ msTest.skip('Parsec account skip login', async ({ parsecAccount }) => {
   await expect(parsecAccount.locator('.organization-content')).toBeVisible();
 });
 
-msTest.skip('Parsec account go to customer area', async ({ parsecAccount }) => {
+msTest('Parsec account go to customer area', async ({ parsecAccount }) => {
   const container = parsecAccount.locator('.homepage-content');
   const customerAreaContainer = container.locator('.homepage-client-area');
   await expect(customerAreaContainer.locator('.homepage-client-area__title')).toHaveText('Customer area');
@@ -25,29 +25,14 @@ msTest.skip('Parsec account go to customer area', async ({ parsecAccount }) => {
   await expect(parsecAccount.locator('.saas-login-container')).toBeVisible();
 });
 
-msTest.skip('Parsec account go to creation', async ({ parsecAccount }) => {
+msTest('Parsec account go to creation', async ({ parsecAccount }) => {
   const container = parsecAccount.locator('.homepage-content');
   await expect(container.locator('.account-create__button')).toHaveText('Create an account');
   await container.locator('.account-create__button').click();
   await expect(parsecAccount).toHaveURL(/.+\/createAccount$/);
 });
 
-msTest.skip('Account login', async ({ parsecAccount }) => {
-  const accountLogin = parsecAccount.locator('.account-login-container');
-  await expect(accountLogin.locator('.account-login-content__input').nth(2).locator('#label')).toBeVisible();
-  await expect(accountLogin.locator('.account-login-content__input').nth(2).locator('#label')).toHaveText('Email address');
-  await accountLogin.locator('.account-login-content__input').nth(2).locator('input').fill('a@b.c');
-  await expect(accountLogin.locator('.account-login-content__input').locator('#passwordLabel')).toHaveText('Password');
-  await accountLogin.locator('.account-login-content__input').nth(4).locator('input').fill('BigP@ssw0rd.');
-  await accountLogin.locator('.account-login-button__item').click();
-  await expect(parsecAccount).toHaveURL(/.+\/home$/);
-
-  const accountNameButton = parsecAccount.locator('.profile-header-homepage');
-  await expect(accountNameButton).toBeVisible();
-  await expect(accountNameButton).toHaveText('Gordon Freeman');
-});
-
-msTest.skip('Open settings in profile homepage popover ', async ({ parsecAccountLoggedIn }) => {
+msTest('Open settings in profile homepage popover ', async ({ parsecAccountLoggedIn }) => {
   const accountNameButton = parsecAccountLoggedIn.locator('.profile-header-homepage');
   await expect(accountNameButton).toBeVisible();
   await expect(accountNameButton).toHaveText(/^Agent\d+$/);
@@ -63,14 +48,14 @@ msTest.skip('Open settings in profile homepage popover ', async ({ parsecAccount
   await popover.locator('.main-list').getByRole('listitem').nth(0).click();
 });
 
-msTest.skip('Open settings from header (secondary menu) ', async ({ parsecAccountLoggedIn }) => {
+msTest('Open settings from header (secondary menu) ', async ({ parsecAccountLoggedIn }) => {
   const settingsButton = parsecAccountLoggedIn.locator('.menu-secondary').locator('#trigger-settings-button');
   await expect(settingsButton).toBeVisible();
   await settingsButton.click();
   await expect(parsecAccountLoggedIn.locator('.profile-content-item').nth(0).locator('.item-header__title')).toHaveText('Settings');
 });
 
-msTest.skip('Switch tab from popover ', async ({ parsecAccountLoggedIn }) => {
+msTest('Switch tab from popover ', async ({ parsecAccountLoggedIn }) => {
   const accountNameButton = parsecAccountLoggedIn.locator('.profile-header-homepage');
   await expect(accountNameButton).toBeVisible();
   await expect(accountNameButton).toHaveText(/^Agent\d+$/);
@@ -86,4 +71,22 @@ msTest.skip('Switch tab from popover ', async ({ parsecAccountLoggedIn }) => {
   await expect(parsecAccountLoggedIn.locator('.profile-header-homepage-popover')).toBeVisible();
   await popover.locator('.main-list').getByRole('listitem').nth(2).click();
   await expect(parsecAccountLoggedIn.locator('.profile-content-item').nth(0).locator('.item-header__title')).toHaveText('Authentication');
+});
+
+msTest('Account auto-register device', async ({ parsecAccountLoggedIn }) => {
+  const home = parsecAccountLoggedIn;
+  await home.locator('.organization-list').locator('.organization-card').nth(0).click();
+  await fillIonInput(home.locator('#password-input').locator('ion-input'), 'P@ssw0rd.');
+  await home.locator('.login-card-footer').locator('.login-button').click();
+  await answerQuestion(home, true, {
+    expectedNegativeText: 'No',
+    expectedPositiveText: 'Store to Parsec Account',
+    expectedQuestionText: "This device is not stored in Parsec Account. Do you want to store it so that it'll be available everywhere?",
+    expectedTitleText: 'Store this device to Parsec Account',
+  });
+  await expect(home).toBeWorkspacePage();
+  await logout(home);
+  await home.locator('.organization-list').locator('.organization-card').nth(0).click();
+  // Doesn't ask for the password, using parsec account to authenticate
+  await expect(home).toBeWorkspacePage();
 });


### PR DESCRIPTION
Closes #10300
Closes #10301

Easiest way to test is to use the testbed and to have those variables inside the `.env.development.local`:
```
PARSEC_APP_MOCK_ACCOUNT=false
PARSEC_APP_ENABLE_ACCOUNT=true
PARSEC_APP_ACCOUNT_SERVER="parsec3://localhost:6770?no_ssl=true"
PARSEC_APP_ENABLE_ACCOUNT_AUTO_LOGIN=true
```
This will create a default Parsec Account and log in to it automatically, and then list the testbed devices as usual. What should happen:
- on clicking on a device while being logged to Parsec Account, pop up to create a new registration device
- when logging out from the device and trying to log back in, the password step should be skipped, since the registration device is used instead.
- when logging out of Parsec Account, the device used should be the original one with the password.
