### PR TITLE
ci(q&a): Chech newsfragment now take GH token

### DIFF
--- a/.github/scripts/check_newsfragments.py
+++ b/.github/scripts/check_newsfragments.py
@@ -10,6 +10,7 @@ directory are valid:
 
 import argparse
 import json
+import os
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Optional
@@ -17,6 +18,15 @@ from urllib.request import HTTPError, Request, urlopen
 
 # This list should be keep up to date with `misc/releaser.py::FRAGMENT_TYPES.keys()`
 VALID_TYPES = ["feature", "bugfix", "doc", "removal", "api", "misc", "empty"]
+HEADERS: dict[str, str] = {
+    "Accept": "application/vnd.github.v3+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    **(
+        {"Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}"}
+        if "GITHUB_TOKEN" in os.environ
+        else {}
+    ),
+}
 
 
 def check_newsfragment(fragment: Path) -> Optional[bool]:
@@ -38,7 +48,7 @@ def check_newsfragment(fragment: Path) -> Optional[bool]:
     req = Request(
         method="GET",
         url=url,
-        headers={"Accept": "application/vnd.github.v3+json"},
+        headers=HEADERS,
     )
     try:
         response = urlopen(req)
@@ -58,7 +68,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     args = parser.parse_args()
 
-    print(f"Checking news fragments...")
+    print("Checking news fragments...")
 
     with ThreadPoolExecutor() as pool:
         ret = list(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,8 @@ jobs:
           && steps.newsfragment-have-changed.outputs.newsfragments == 'true'
         run: |
           python .github/scripts/check_newsfragments.py
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         timeout-minutes: 5
 
       - name: Patch pre-commit for line-ending


### PR DESCRIPTION
During certain run of `check_newsfragments` in the CI, we had some `rate limited exceeded`. We get those errors because we make anonymous request, adding `Authorization` header to each HTTP request with a valid token make them authenticated with a much greater rate limit.

I've also added `X-GitHub-Api-Version` header to make the script more robust in case of API version bump on GitHub side.
