### PR TITLE
feat(server): Add `template-dir` option

### DIFF
--- a/docs/hosting/custom_branding.rst
+++ b/docs/hosting/custom_branding.rst
@@ -62,3 +62,27 @@ You can also customize some specific texts in Parsec. To do so, simply:
 
     .. literalinclude:: custom_fr-FR.json
       :language: json
+
+Server emails & HTML pages
+--------------------------
+
+Parsec server emails and HTML pages (index, 404) are based on the `Jinja template syntax`_.
+
+.. _Jinja template syntax: https://jinja.palletsprojects.com/en/stable/templates/
+
+You can customize them by providing a custom template directory when running the server with ``--template-dir`` or by setting the environment variable ``PARSEC_TEMPLATE_DIR``.
+
+The directory should contain the following files:
+
+- ``index.html``: default landing page when you access the server.
+- ``404.html``: resource not found page.
+- ``email/account_create.[html|txt].j2``: HTML and TEXT templates for the email send to confirm Parsec account creation.
+- ``email/account_delete.[html|txt].j2``: HTML and TEXT email templates to confirm Parsec account deletion.
+- ``email/account_recover.[html|txt].j2``: HTML and TEXT email templates to confirm Parsec account recovery.
+- ``email/invitation.[html|txt].j2``: HTML and TEXT email templates to send invitation to join an organization.
+
+.. note::
+
+   You can base your customization on the default server's templates `found here <parsec-server-template-src_>`_.
+
+.. _parsec-server-template-src: https://github.com/Scille/parsec-cloud/tree/v3.4.1-a.0+dev/server/parsec/templates

--- a/docs/locale/fr/LC_MESSAGES/hosting/custom_branding.po
+++ b/docs/locale/fr/LC_MESSAGES/hosting/custom_branding.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Parsec 3.4.1-a.0+dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-07 09:23+0200\n"
+"POT-Creation-Date: 2025-07-25 06:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -187,3 +187,78 @@ msgstr "custom_en-US.json"
 #: ../../hosting/custom_branding.rst:61
 msgid "custom_fr-FR.json"
 msgstr "custom_fr-FR.json"
+
+#: ../../hosting/custom_branding.rst:67
+msgid "Server emails & HTML pages"
+msgstr "Emails et pages HTML du serveur"
+
+#: ../../hosting/custom_branding.rst:69
+msgid ""
+"Parsec server emails and HTML pages (index, 404) are based on the `Jinja "
+"template syntax`_."
+msgstr ""
+"Les courriels du serveur Parsec et les pages HTML (index, 404) sont basés "
+"sur `la syntaxe de template Jinja <Jinja template syntax_>`_."
+
+#: ../../hosting/custom_branding.rst:73
+msgid ""
+"You can customize them by providing a custom template directory when running "
+"the server with ``--template-dir`` or by setting the environment variable "
+"``PARSEC_TEMPLATE_DIR``."
+msgstr ""
+"Vous pouvez les personnaliser en fournissant un répertoire de modèles "
+"personnalisé lors de l'exécution du serveur avec ``--template-dir`` ou en "
+"définissant la variable d'environnement ``PARSEC_TEMPLATE_DIR``."
+
+#: ../../hosting/custom_branding.rst:75
+msgid "The directory should contain the following files:"
+msgstr "Le dossier doit contenir les fichiers suivants :"
+
+#: ../../hosting/custom_branding.rst:77
+msgid "``index.html``: default landing page when you access the server."
+msgstr ""
+"``index.html`` : page d'accueil par défaut lorsque vous accédez au serveur."
+
+#: ../../hosting/custom_branding.rst:78
+msgid "``404.html``: resource not found page."
+msgstr "``404.html`` : page de ressource non trouvée."
+
+#: ../../hosting/custom_branding.rst:79
+msgid ""
+"``email/account_create.[html|txt].j2``: HTML and TEXT templates for the "
+"email send to confirm Parsec account creation."
+msgstr ""
+"``email/account_create.[html|txt].j2`` : Modèles HTML et TEXTE pour le "
+"courriel envoyé afin de confirmer la création d'un compte Parsec."
+
+#: ../../hosting/custom_branding.rst:80
+msgid ""
+"``email/account_delete.[html|txt].j2``: HTML and TEXT email templates to "
+"confirm Parsec account deletion."
+msgstr ""
+"``email/account_delete.[html|txt].j2``: Modèles d'e-mail HTML et TEXTE pour "
+"confirmer la suppression du compte Parsec."
+
+#: ../../hosting/custom_branding.rst:81
+msgid ""
+"``email/account_recover.[html|txt].j2``: HTML and TEXT email templates to "
+"confirm Parsec account recovery."
+msgstr ""
+"``email/account_recover.[html|txt].j2`` : modèles d'e-mails HTML et TEXTE "
+"pour confirmer la récupération du compte Parsec."
+
+#: ../../hosting/custom_branding.rst:82
+msgid ""
+"``email/invitation.[html|txt].j2``: HTML and TEXT email templates to send "
+"invitation to join an organization."
+msgstr ""
+"``email/invitation.[html|txt].j2`` : modèles d'e-mails HTML et TEXTE pour "
+"envoyer une invitation à rejoindre une organisation."
+
+#: ../../hosting/custom_branding.rst:86
+msgid ""
+"You can base your customization on the default server's templates `found "
+"here <parsec-server-template-src_>`_."
+msgstr ""
+"Vous pouvez baser votre personnalisation sur les modèles du serveur par "
+"défaut `disponibles ici <parsec-server-template-src_>`_."

--- a/misc/version_updater.py
+++ b/misc/version_updater.py
@@ -76,6 +76,10 @@ RUSTUP_INSTALL = ReplaceRegex(
     r"curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \| sh -s -- -y --default-toolchain [0-9.]+",
     "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain {version}",
 )
+PARSEC_REPO_SRC_BASE_URL = ReplaceRegex(
+    r"github.com/Scille/parsec-cloud/tree/v.*?/",
+    "github.com/Scille/parsec-cloud/tree/v{version}/",
+)
 
 
 @enum.unique
@@ -366,6 +370,7 @@ FILES_WITH_VERSION_INFO: dict[Path, dict[Tool, RawRegexes]] = {
             )
         ],
     },
+    ROOT_DIR / "docs/hosting/custom_branding.rst": {Tool.Parsec: [PARSEC_REPO_SRC_BASE_URL]},
     ROOT_DIR / "docs/hosting/install_cli.rst": {
         Tool.Parsec: [
             ReplaceRegex(

--- a/server/parsec/asgi/__init__.py
+++ b/server/parsec/asgi/__init__.py
@@ -19,16 +19,10 @@ from parsec._version import __version__ as parsec_version
 from parsec.asgi.administration import administration_router
 from parsec.asgi.redirect import redirect_router
 from parsec.asgi.rpc import Backend, rpc_router
-from parsec.templates import JINJA_ENV_CONFIG
 
 logger = get_logger()
 
 type AsgiApp = FastAPI
-
-
-templates = Jinja2Templates(
-    directory=(Path(__file__) / "../../templates").resolve(), **JINJA_ENV_CONFIG
-)
 
 tags_metadata = [
     {
@@ -80,6 +74,8 @@ def app_factory(
         allow_headers=["api-version", "authorization", "user-agent"],
     )
     app.state.backend = backend
+
+    templates = Jinja2Templates(env=backend.config.jinja_env)
 
     if with_client_web_app:
 

--- a/server/parsec/cli/export_email.py
+++ b/server/parsec/cli/export_email.py
@@ -14,6 +14,7 @@ from parsec.components.account import (
     _generate_account_delete_validation_email,
 )
 from parsec.components.invite import generate_invite_email
+from parsec.templates import get_environment
 
 DEFAULT_SENDER_EMAIL = EmailAddress("parsec@example.com")
 DEFAULT_RECIPIENT_EMAIL = EmailAddress("alice@example.com")
@@ -82,6 +83,11 @@ def mail_templates_shared_options[**P, T](fn: Callable[P, T]) -> Callable[P, T]:
             show_default=True,
             help="The base server url used to access static resources",
         ),
+        click.option(
+            "--template-dir",
+            type=click.Path(dir_okay=True, file_okay=False, exists=True, path_type=Path),
+            help="Load templates from the specified directory instead of using the default one",
+        ),
     ]
     for decorator in decorators:
         fn = decorator(fn)
@@ -123,8 +129,11 @@ def invite(
     reply_to: EmailAddress | None,
     server_url: str,
     output_dir: Path,
+    template_dir: Path | None,
 ):
+    jinja_env = get_environment(template_dir)
     message = generate_invite_email(
+        jinja_env=jinja_env,
         from_addr=sender,
         to_addr=recipient,
         invitation_type=invitation_type,
@@ -152,8 +161,11 @@ def account_create(
     validation_code: ValidationCode,
     server_url: str,
     output_dir: Path,
+    template_dir: Path | None,
 ):
+    jinja_env = get_environment(template_dir)
     message = _generate_account_create_validation_email(
+        jinja_env=jinja_env,
         from_addr=sender,
         to_addr=recipient,
         validation_code=validation_code,
@@ -177,8 +189,11 @@ def account_delete(
     validation_code: ValidationCode,
     server_url: str,
     output_dir: Path,
+    template_dir: Path | None,
 ):
+    jinja_env = get_environment(template_dir)
     message = _generate_account_delete_validation_email(
+        jinja_env=jinja_env,
         from_addr=sender,
         to_addr=recipient,
         validation_code=validation_code,

--- a/server/parsec/cli/run.py
+++ b/server/parsec/cli/run.py
@@ -36,6 +36,7 @@ from parsec.config import (
     SmtpEmailConfig,
 )
 from parsec.logging import get_logger
+from parsec.templates import get_environment
 
 logger = get_logger()
 
@@ -301,6 +302,12 @@ for any given email address).
     help="URL to reach this server (typically used in invitation emails)",
 )
 @click.option(
+    "--template-dir",
+    type=click.Path(dir_okay=True, file_okay=False, exists=True, path_type=Path),
+    help="Load templates from the specified directory instead of using the default one",
+    envvar="PARSEC_TEMPLATE_DIR",
+)
+@click.option(
     "--email-host",
     envvar="PARSEC_EMAIL_HOST",
     show_envvar=True,
@@ -470,6 +477,7 @@ def run_cmd(
     validation_email_rate_limit: tuple[int, int],
     fake_account_password_algorithm_seed: SecretKey,
     server_addr: ParsecAddr,
+    template_dir: Path | None,
     email_host: str,
     email_port: int,
     email_host_user: str | None,
@@ -514,7 +522,10 @@ def run_cmd(
             )
         logger.debug("Email config", config=email_config)
 
+        jinja_env = get_environment(template_dir)
+
         app_config = BackendConfig(
+            jinja_env=jinja_env,
             administration_token=administration_token,
             db_config=db,
             sse_keepalive=sse_keepalive,

--- a/server/parsec/cli/testbed.py
+++ b/server/parsec/cli/testbed.py
@@ -24,6 +24,7 @@ from parsec._parsec import (
     SecretKey,
     ValidationCode,
 )
+from parsec.templates import get_environment
 
 try:
     from parsec._parsec import testbed
@@ -360,7 +361,10 @@ async def testbed_backend_factory(
             url=with_postgresql, min_connections=1, max_connections=5
         )
 
+    jinja_env = get_environment(None)
+
     config = BackendConfig(
+        jinja_env=jinja_env,
         debug=True,
         db_config=db_config,
         sse_keepalive=30,

--- a/server/parsec/components/account.py
+++ b/server/parsec/components/account.py
@@ -8,6 +8,8 @@ from email.mime.text import MIMEText
 from enum import auto
 from typing import Literal
 
+from jinja2 import Environment
+
 from parsec._parsec import (
     AccountAuthMethodID,
     DateTime,
@@ -28,7 +30,6 @@ from parsec.api import api
 from parsec.client_context import AnonymousAccountClientContext, AuthenticatedAccountClientContext
 from parsec.components.email import SendEmailBadOutcome, send_email
 from parsec.config import BackendConfig
-from parsec.templates import get_template
 from parsec.types import BadOutcomeEnum
 
 
@@ -171,6 +172,7 @@ class BaseAccountComponent:
             return SendEmailBadOutcome.BAD_SMTP_CONFIG
 
         message = _generate_account_create_validation_email(
+            jinja_env=self._config.jinja_env,
             from_addr=self._config.email_config.sender,
             to_addr=email,
             validation_code=validation_code,
@@ -193,6 +195,7 @@ class BaseAccountComponent:
             return SendEmailBadOutcome.BAD_SMTP_CONFIG
 
         message = _generate_account_delete_validation_email(
+            jinja_env=self._config.jinja_env,
             from_addr=self._config.email_config.sender,
             to_addr=email,
             validation_code=validation_code,
@@ -213,6 +216,7 @@ class BaseAccountComponent:
             return SendEmailBadOutcome.BAD_SMTP_CONFIG
 
         message = _generate_account_recover_validation_email(
+            jinja_env=self._config.jinja_env,
             from_addr=self._config.email_config.sender,
             to_addr=email,
             validation_code=validation_code,
@@ -727,6 +731,7 @@ class BaseAccountComponent:
 
 
 def _generate_account_create_validation_email(
+    jinja_env: Environment,
     from_addr: EmailAddress,
     to_addr: EmailAddress,
     validation_code: ValidationCode,
@@ -735,11 +740,11 @@ def _generate_account_create_validation_email(
     # Quick fix to have a similar behavior between Rust and Python
     server_url = server_url.removesuffix("/")
 
-    html = get_template("email/account_create.html.j2").render(
+    html = jinja_env.get_template("email/account_create.html.j2").render(
         validation_code=validation_code.str,
         server_url=server_url,
     )
-    text = get_template("email/account_create.txt.j2").render(
+    text = jinja_env.get_template("email/account_create.txt.j2").render(
         validation_code=validation_code.str,
         server_url=server_url,
     )
@@ -764,6 +769,7 @@ def _generate_account_create_validation_email(
 
 
 def _generate_account_delete_validation_email(
+    jinja_env: Environment,
     from_addr: EmailAddress,
     to_addr: EmailAddress,
     validation_code: ValidationCode,
@@ -772,11 +778,11 @@ def _generate_account_delete_validation_email(
     # Quick fix to have a similar behavior between Rust and Python
     server_url = server_url.removesuffix("/")
 
-    html = get_template("email/account_delete.html.j2").render(
+    html = jinja_env.get_template("email/account_delete.html.j2").render(
         validation_code=validation_code.str,
         server_url=server_url,
     )
-    text = get_template("email/account_delete.txt.j2").render(
+    text = jinja_env.get_template("email/account_delete.txt.j2").render(
         validation_code=validation_code.str,
         server_url=server_url,
     )
@@ -801,6 +807,7 @@ def _generate_account_delete_validation_email(
 
 
 def _generate_account_recover_validation_email(
+    jinja_env: Environment,
     from_addr: EmailAddress,
     to_addr: EmailAddress,
     validation_code: ValidationCode,
@@ -809,11 +816,11 @@ def _generate_account_recover_validation_email(
     # Quick fix to have a similar behavior between Rust and Python
     server_url = server_url.removesuffix("/")
 
-    html = get_template("email/account_recover.html.j2").render(
+    html = jinja_env.get_template("email/account_recover.html.j2").render(
         validation_code=validation_code.str,
         server_url=server_url,
     )
-    text = get_template("email/account_recover.txt.j2").render(
+    text = jinja_env.get_template("email/account_recover.txt.j2").render(
         validation_code=validation_code.str,
         server_url=server_url,
     )

--- a/server/parsec/config.py
+++ b/server/parsec/config.py
@@ -7,6 +7,8 @@ from enum import Enum
 from typing import TYPE_CHECKING, Literal
 from urllib.parse import urlparse, urlunparse
 
+from jinja2.environment import Environment
+
 from parsec._parsec import ActiveUsersLimit, DateTime, EmailAddress, ParsecAddr, SecretKey
 from parsec.email_rate_limit import EmailRateLimit
 
@@ -230,6 +232,7 @@ class AccountVaultStrategy(Enum):
 @dataclass(slots=True, kw_only=True)
 class BackendConfig:
     debug: bool
+    jinja_env: Environment
     db_config: BaseDatabaseConfig
     blockstore_config: BaseBlockStoreConfig
     email_config: SmtpEmailConfig | MockedEmailConfig

--- a/server/parsec/templates/__init__.py
+++ b/server/parsec/templates/__init__.py
@@ -1,34 +1,20 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 from __future__ import annotations
 
-import importlib.resources
-from collections.abc import Callable
-from typing import Any
+import functools
+from pathlib import Path
 
-from jinja2 import BaseLoader, Environment, StrictUndefined, Template, TemplateNotFound
-
-
-class PackageLoader(BaseLoader):
-    def __init__(self, path: str) -> None:
-        self.path = path
-
-    def get_source(self, environment: Any, template: str) -> tuple[str, str, Callable[[], bool]]:
-        from parsec import templates  # Self import \o/
-
-        try:
-            source = importlib.resources.files(templates).joinpath(template).read_text()
-        except FileNotFoundError as exc:
-            raise TemplateNotFound(template) from exc
-        return source, self.path, lambda: True
+from jinja2 import (
+    Environment,
+    FileSystemLoader,
+    StrictUndefined,
+)
+from jinja2 import PackageLoader as JinjaPackageLoader
 
 
-# Env config is also needed to configure the ASGI app
-JINJA_ENV_CONFIG = {
-    "loader": PackageLoader("parsec.backend.http.templates"),
-    "undefined": StrictUndefined,
-}
-JINJA_ENV = Environment(**JINJA_ENV_CONFIG)
-
-
-def get_template(name: str | Template) -> Template:
-    return JINJA_ENV.get_template(name)
+def get_environment(template_dir: Path | None) -> Environment:
+    environment_builder = functools.partial(Environment, undefined=StrictUndefined)
+    if template_dir is None:
+        return environment_builder(loader=JinjaPackageLoader("parsec", "templates"))
+    else:
+        return environment_builder(loader=FileSystemLoader(template_dir))

--- a/server/tests/common/backend.py
+++ b/server/tests/common/backend.py
@@ -16,6 +16,7 @@ from parsec.config import (
     BaseDatabaseConfig,
     MockedEmailConfig,
 )
+from parsec.templates import get_environment
 from tests.common.postgresql import reset_postgresql_testbed
 
 SERVER_DOMAIN = "parsec.invalid"
@@ -33,6 +34,7 @@ def backend_config(
     backend_mocked_data: dict[OrganizationID, MemoryOrganization],
 ) -> BackendConfig:
     return BackendConfig(
+        jinja_env=get_environment(None),
         debug=True,
         db_config=db_config,
         sse_keepalive=30,


### PR DESCRIPTION
That option allow to set a folder where Jinja will look for the template files. Otherwise, it'll use the default templates included by the project.

Closes #10707

---

Rendered documentation pages:

- EN: https://parsec-cloud--10818.org.readthedocs.build/en/10818/hosting/custom_branding.html
- FR: https://parsec-cloud--10818.org.readthedocs.build/fr/10818/hosting/custom_branding.html