### PR TITLE
chore(parsec): Update to `pyo3@0.23`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3253,9 +3253,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
 dependencies = [
  "cfg-if 1.0.0",
  "indoc",
@@ -3272,9 +3272,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -3282,9 +3282,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3292,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3304,9 +3304,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ pretty_assertions = { version = "1.4.1", default-features = false }
 proc-macro2 = { version = "1.0.95", default-features = false }
 proptest = { version = "1.7.0", default-features = false }
 proptest-state-machine = { version = "0.3.1", default-features = false }
-pyo3 = { version = "0.22.6", default-features = false }
+pyo3 = { version = "0.23.5", default-features = false }
 quote = { version = "1.0.40", default-features = false }
 rand = { version = "0.8.5", default-features = false }
 regex = { version = "1.11.1", default-features = false }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,11 +16,6 @@ name = "parsec"
 crate-type = ["cdylib"]
 
 [features]
-default = ["gil-refs"]
-# FIXME: create_exception gen code gated behind feature `gil-refs` causing warning about unexpected feature
-# https://github.com/PyO3/pyo3/issues/4743
-# Should be fixed in pyo3@0.23
-gil-refs = ["pyo3/gil-refs"]
 # Remember kid: RustCrypto is used if `use-sodiumoxide` is not set !
 use-sodiumoxide = ["libparsec_crypto/use-sodiumoxide"]
 vendored-openssl = ["libparsec_crypto/vendored-openssl"]
@@ -35,12 +30,7 @@ libparsec_testbed = { workspace = true, optional = true }
 
 regex = { workspace = true, features = ["std", "perf", "unicode"] }
 paste = { workspace = true }
-pyo3 = { workspace = true, features = [
-    "multiple-pymethods",
-    "extension-module",
-    "macros",
-    "gil-refs",
-] }
+pyo3 = { workspace = true, features = ["multiple-pymethods", "extension-module", "macros"] }
 uuid = { workspace = true, features = ["serde", "v4", "fast-rng"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 lazy_static = { workspace = true }

--- a/server/src/data/certif.rs
+++ b/server/src/data/certif.rs
@@ -15,7 +15,7 @@ use pyo3::{
     exceptions::{PyAttributeError, PyValueError},
     prelude::*,
     types::{PyBytes, PyDict, PySet, PyTuple, PyType},
-    Bound,
+    Bound, IntoPyObjectExt,
 };
 
 use libparsec_types::{CertificateSigner, IndexInt, UnsecureSkipValidationReason};
@@ -108,7 +108,7 @@ impl UserCertificate {
         author_signkey: &SigningKey,
         py: Python<'py>,
     ) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.dump_and_sign(&author_signkey.0))
+        PyBytes::new(py, &self.0.dump_and_sign(&author_signkey.0))
     }
 
     #[classmethod]
@@ -277,7 +277,7 @@ impl DeviceCertificate {
         author_signkey: &SigningKey,
         py: Python<'py>,
     ) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.dump_and_sign(&author_signkey.0))
+        PyBytes::new(py, &self.0.dump_and_sign(&author_signkey.0))
     }
 
     #[classmethod]
@@ -417,7 +417,7 @@ impl RevokedUserCertificate {
         author_signkey: &SigningKey,
         py: Python<'py>,
     ) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.dump_and_sign(&author_signkey.0))
+        PyBytes::new(py, &self.0.dump_and_sign(&author_signkey.0))
     }
 
     #[classmethod]
@@ -495,7 +495,7 @@ impl UserUpdateCertificate {
         author_signkey: &SigningKey,
         py: Python<'py>,
     ) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.dump_and_sign(&author_signkey.0))
+        PyBytes::new(py, &self.0.dump_and_sign(&author_signkey.0))
     }
 
     #[classmethod]
@@ -582,7 +582,7 @@ impl RealmRoleCertificate {
         author_signkey: &SigningKey,
         py: Python<'py>,
     ) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.dump_and_sign(&author_signkey.0))
+        PyBytes::new(py, &self.0.dump_and_sign(&author_signkey.0))
     }
 
     #[classmethod]
@@ -672,7 +672,7 @@ impl RealmNameCertificate {
         author_signkey: &SigningKey,
         py: Python<'py>,
     ) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.dump_and_sign(&author_signkey.0))
+        PyBytes::new(py, &self.0.dump_and_sign(&author_signkey.0))
     }
 
     #[classmethod]
@@ -705,7 +705,7 @@ impl RealmNameCertificate {
 
     #[getter]
     fn encrypted_name<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.encrypted_name)
+        PyBytes::new(py, &self.0.encrypted_name)
     }
 }
 
@@ -784,7 +784,7 @@ impl RealmKeyRotationCertificate {
         author_signkey: &SigningKey,
         py: Python<'py>,
     ) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.dump_and_sign(&author_signkey.0))
+        PyBytes::new(py, &self.0.dump_and_sign(&author_signkey.0))
     }
 
     #[classmethod]
@@ -827,7 +827,7 @@ impl RealmKeyRotationCertificate {
 
     #[getter]
     fn key_canary<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.key_canary)
+        PyBytes::new(py, &self.0.key_canary)
     }
 }
 
@@ -857,7 +857,9 @@ impl RealmArchivingConfiguration {
         lazy_static::lazy_static! {
             static ref VALUE: PyObject = {
                 Python::with_gil(|py| {
-                    RealmArchivingConfiguration(libparsec_types::RealmArchivingConfiguration::Available).into_py(py)
+                    RealmArchivingConfiguration(libparsec_types::RealmArchivingConfiguration::Available)
+                        .into_py_any(py)
+                        .expect("Cannot create static value for RealmArchivingConfiguration::available")
                 })
             };
         };
@@ -871,7 +873,9 @@ impl RealmArchivingConfiguration {
         lazy_static::lazy_static! {
             static ref VALUE: PyObject = {
                 Python::with_gil(|py| {
-                    RealmArchivingConfiguration(libparsec_types::RealmArchivingConfiguration::Archived).into_py(py)
+                    RealmArchivingConfiguration(libparsec_types::RealmArchivingConfiguration::Archived)
+                        .into_py_any(py)
+                        .expect("Cannot create static value for RealmArchivingConfiguration::archived")
                 })
             };
         };
@@ -943,7 +947,7 @@ impl RealmArchivingCertificate {
         author_signkey: &SigningKey,
         py: Python<'py>,
     ) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.dump_and_sign(&author_signkey.0))
+        PyBytes::new(py, &self.0.dump_and_sign(&author_signkey.0))
     }
 
     #[classmethod]
@@ -1035,7 +1039,7 @@ impl ShamirRecoveryBriefCertificate {
         author_signkey: &SigningKey,
         py: Python<'py>,
     ) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.dump_and_sign(&author_signkey.0))
+        PyBytes::new(py, &self.0.dump_and_sign(&author_signkey.0))
     }
 
     #[classmethod]
@@ -1068,11 +1072,11 @@ impl ShamirRecoveryBriefCertificate {
 
     #[getter]
     fn per_recipient_shares<'py>(&self, py: Python<'py>) -> Bound<'py, PyDict> {
-        let d = PyDict::new_bound(py);
+        let d = PyDict::new(py);
 
         for (k, v) in &self.0.per_recipient_shares {
-            let py_k = UserID(*k).into_py(py);
-            let py_v = (*v).into_py(py);
+            let py_k = UserID(*k);
+            let py_v = *v;
             let _ = d.set_item(py_k, py_v);
         }
 
@@ -1135,7 +1139,7 @@ impl ShamirRecoveryShareCertificate {
         author_signkey: &SigningKey,
         py: Python<'py>,
     ) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.dump_and_sign(&author_signkey.0))
+        PyBytes::new(py, &self.0.dump_and_sign(&author_signkey.0))
     }
 
     #[classmethod]
@@ -1168,7 +1172,7 @@ impl ShamirRecoveryShareCertificate {
 
     #[getter]
     fn ciphered_share<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.ciphered_share)
+        PyBytes::new(py, &self.0.ciphered_share)
     }
 }
 
@@ -1231,7 +1235,7 @@ impl ShamirRecoveryDeletionCertificate {
         author_signkey: &SigningKey,
         py: Python<'py>,
     ) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.dump_and_sign(&author_signkey.0))
+        PyBytes::new(py, &self.0.dump_and_sign(&author_signkey.0))
     }
 
     #[classmethod]
@@ -1264,9 +1268,9 @@ impl ShamirRecoveryDeletionCertificate {
 
     #[getter]
     fn share_recipients<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PySet>> {
-        let py_recipients = PySet::empty_bound(py)?;
+        let py_recipients = PySet::empty(py)?;
         for recipient in &self.0.share_recipients {
-            py_recipients.add(UserID(*recipient).into_py(py))?;
+            py_recipients.add(UserID(*recipient))?;
         }
         Ok(py_recipients)
     }
@@ -1310,7 +1314,7 @@ impl SequesterAuthorityCertificate {
         author_signkey: &SigningKey,
         py: Python<'py>,
     ) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.dump_and_sign(&author_signkey.0))
+        PyBytes::new(py, &self.0.dump_and_sign(&author_signkey.0))
     }
 
     #[getter]
@@ -1358,7 +1362,7 @@ impl SequesterServiceCertificate {
     }
 
     fn dump<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.dump())
+        PyBytes::new(py, &self.0.dump())
     }
 
     #[getter]
@@ -1411,7 +1415,7 @@ impl SequesterRevokedServiceCertificate {
     }
 
     fn dump<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.dump())
+        PyBytes::new(py, &self.0.dump())
     }
 
     #[getter]

--- a/server/src/data/pki.rs
+++ b/server/src/data/pki.rs
@@ -90,7 +90,7 @@ impl PkiEnrollmentAnswerPayload {
     }
 
     fn dump<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.dump())
+        PyBytes::new(py, &self.0.dump())
     }
 }
 
@@ -141,7 +141,7 @@ impl PkiEnrollmentSubmitPayload {
     }
 
     fn dump<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.dump())
+        PyBytes::new(py, &self.0.dump())
     }
 }
 
@@ -228,23 +228,23 @@ impl X509Certificate {
     }
 
     #[getter]
-    fn issuer<'py>(&self, py: Python<'py>) -> Bound<'py, PyDict> {
-        self.0.issuer.clone().into_py_dict_bound(py)
+    fn issuer<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        self.0.issuer.clone().into_py_dict(py)
     }
 
     #[getter]
-    fn subject<'py>(&self, py: Python<'py>) -> Bound<'py, PyDict> {
-        self.0.subject.clone().into_py_dict_bound(py)
+    fn subject<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        self.0.subject.clone().into_py_dict(py)
     }
 
     #[getter]
     fn der_x509_certificate<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.der_x509_certificate)
+        PyBytes::new(py, &self.0.der_x509_certificate)
     }
 
     #[getter]
     fn certificate_sha1<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.certificate_sha1)
+        PyBytes::new(py, &self.0.certificate_sha1)
     }
 
     #[getter]
@@ -294,7 +294,7 @@ impl LocalPendingEnrollment {
     }
 
     fn dump<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.dump())
+        PyBytes::new(py, &self.0.dump())
     }
 
     fn save(&self, config_dir: Bound<'_, PyAny>) -> PyResult<String> {
@@ -410,11 +410,11 @@ impl LocalPendingEnrollment {
 
     #[getter]
     fn encrypted_key<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.encrypted_key)
+        PyBytes::new(py, &self.0.encrypted_key)
     }
 
     #[getter]
     fn ciphertext<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
-        PyBytes::new_bound(py, &self.0.ciphertext)
+        PyBytes::new(py, &self.0.ciphertext)
     }
 }

--- a/server/src/enumerate.rs
+++ b/server/src/enumerate.rs
@@ -1,11 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use pyo3::{
-    exceptions::PyValueError,
-    pyclass, pymethods,
-    types::{PyTuple, PyType},
-    IntoPy, PyObject, PyResult, Python,
-};
+use pyo3::{pyclass, pymethods, types::PyTuple, Python};
 
 // #[non_exhaustive] macro must be set for every enum like type,
 // because we would like to call `is` in `python`, then

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -43,7 +43,7 @@ fn entrypoint(py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     // Useful to expose `PanicException` for testing
     m.add(
         "PanicException",
-        <pyo3::panic::PanicException as pyo3::PyTypeInfo>::type_object_bound(py),
+        <pyo3::panic::PanicException as pyo3::PyTypeInfo>::type_object(py),
     )?;
 
     m.add_class::<ParsecAddr>()?;
@@ -92,7 +92,7 @@ fn entrypoint(py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     {
         use pyo3::wrap_pyfunction;
 
-        let tm = PyModule::new_bound(py, "testbed")?;
+        let tm = PyModule::new(py, "testbed")?;
         m.add_submodule(&tm)?;
         // tm.add_function(wrap_pyfunction!(test_new_testbed, tm)?)?;
         // tm.add_function(wrap_pyfunction!(test_drop_testbed, tm)?)?;
@@ -132,18 +132,18 @@ fn entrypoint(py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
 /// see https://github.com/PyO3/pyo3/issues/2783
 /// TODO: remove me once (if ?) https://github.com/PyO3/pyo3/pull/3057 is merged
 fn patch_panic_exception_to_inherit_exception(py: Python) {
-    let panic_exception_cls =
-        <pyo3::panic::PanicException as pyo3::PyTypeInfo>::type_object_bound(py).as_ptr()
-            as *mut pyo3::ffi::PyTypeObject;
-    let exception_cls = <PyException as pyo3::PyTypeInfo>::type_object_bound(py);
-    let new_bases = PyTuple::new_bound(py, [exception_cls.clone()]);
+    let panic_exception_cls = <pyo3::panic::PanicException as pyo3::PyTypeInfo>::type_object(py)
+        .as_ptr() as *mut pyo3::ffi::PyTypeObject;
+    let exception_cls = <PyException as pyo3::PyTypeInfo>::type_object(py);
+    let new_bases =
+        PyTuple::new(py, [exception_cls.clone()]).expect("Failed to create tuple for new_bases");
     // SAFETY: `tp_mro` is a pointer to a tuple once the exception structure has been
     // initialized (which is done lazily the first time pyo3 accesses `PanicException`)
     let mro_any = unsafe { Bound::from_borrowed_ptr(py, (*panic_exception_cls).tp_mro) };
     let mro = mro_any
         .downcast::<PyTuple>()
         .expect("PanicException.tp_mro is a tuple");
-    let new_mro = PyTuple::new_bound(
+    let new_mro = PyTuple::new(
         py,
         [
             // 1. Take `PanicException`
@@ -155,7 +155,8 @@ fn patch_panic_exception_to_inherit_exception(py: Python) {
             // 4. Take `<class 'object'>`
             mro.get_item(2).expect("PanicException has 3 items mro"),
         ],
-    );
+    )
+    .expect("Failed to create tuple for new_mro");
     // SAFETY: `tp_base/tp_bases/tp_mro` are pointers that in theory should not be modified
     // once the exception has been initialized. But this is fine as long as `PanicException`
     // has not yet been used (which is the case here since we are initializing the pyo3 module)

--- a/server/src/misc.rs
+++ b/server/src/misc.rs
@@ -30,7 +30,7 @@ impl ApiVersion {
     }
 
     fn dump<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
-        Ok(PyBytes::new_bound(
+        Ok(PyBytes::new(
             py,
             &self
                 .0

--- a/server/src/protocol.rs
+++ b/server/src/protocol.rs
@@ -10,7 +10,7 @@ use pyo3::{
     prelude::{PyAnyMethods, PyModuleMethods},
     pyclass, pymethods,
     types::{PyInt, PyModule, PyType},
-    Bound, IntoPy, PyObject, PyResult, Python,
+    Bound, IntoPyObjectExt, PyObject, PyResult, Python,
 };
 
 use libparsec_serialization_format::python_bindings_parsec_protocol_cmds_family;
@@ -49,7 +49,7 @@ impl ActiveUsersLimit {
             static ref VALUE: PyObject = {
                 Python::with_gil(|py| {
                     ActiveUsersLimit(libparsec_types::ActiveUsersLimit::NoLimit)
-                        .into_py(py)
+                        .into_py_any(py).expect("Failed to generate static value for ActiveUsersLimit::no_limit")
                 })
             };
         };
@@ -65,8 +65,8 @@ impl ActiveUsersLimit {
         count: Option<Bound<'py, PyInt>>,
     ) -> PyResult<PyObject> {
         match count {
-            Some(x) => Self::limited_to(cls, x).map(|x| x.into_py(py)),
-            None => Ok(Self::no_limit().into_py(py)),
+            Some(x) => Self::limited_to(cls, x).and_then(|x| x.into_py_any(py)),
+            None => Self::no_limit().into_py_any(py),
         }
     }
 


### PR DESCRIPTION
- Use `IntoPyObject::into_pyobject` over deprecated `IntoPy::into_py`
- Rename `Py{,Bytes,Tuple,Module,Dict,String,Float,Bool}::new_bound` to `::new`
- Rename `PyTypeInfo::type_object_bound` to `::type_object`
- Rename `PyModule::import_bound` to `::import`
- Rename `Python::get_type_bound` to `::get_type`
- Rename `Py{List,Set}::empty_bound` to `::empty`
- Rename `IntoPyDict::into_py_dict_bound` to `::into_py_dict`
- Rename `PyNone::get_bound` to `::get`

Closes https://github.com/Scille/parsec-cloud/issues/10841