### PR TITLE
[MS] Implemented logic for device auth/registration for parsec account

### DIFF
--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -327,6 +327,7 @@
         "saas": "Parsec SaaS",
         "customServer": "Custom Server",
         "keyringChoice": "System authentication",
+        "accountChoice": "Parsec Account",
         "passwordChoice": "Password",
         "acceptTOS": {
             "label": "By using Parsec, I accept the ",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -326,6 +326,7 @@
         "saas": "Parsec SaaS",
         "customServer": "Serveur personnel",
         "keyringChoice": "Authentification du système",
+        "accountChoice": "Parsec Account",
         "passwordChoice": "Mot de passe",
         "acceptTOS": {
             "label": "En utilisant Parsec, j'accepte les",

--- a/client/src/parsec/login.ts
+++ b/client/src/parsec/login.ts
@@ -4,6 +4,7 @@ import {
   AvailableDeviceTypeTag,
   DeviceAccessStrategyAccountVault,
   DeviceAccessStrategyKeyring,
+  DeviceSaveStrategyAccountVault,
   DeviceSaveStrategyKeyring,
   DeviceSaveStrategyPassword,
   libparsec,
@@ -286,6 +287,20 @@ export const SaveStrategy = {
   useKeyring(): DeviceSaveStrategyKeyring {
     return {
       tag: DeviceSaveStrategyTag.Keyring,
+    };
+  },
+  async useAccountVault(): Promise<Result<DeviceSaveStrategyAccountVault, any>> {
+    const keyResult = await ParsecAccount.uploadKeyInVault();
+    if (!keyResult.ok) {
+      return keyResult;
+    }
+    return {
+      ok: true,
+      value: {
+        tag: DeviceSaveStrategyTag.AccountVault,
+        ciphertextKeyId: keyResult.value[0],
+        ciphertextKey: keyResult.value[1],
+      },
     };
   },
 };

--- a/client/src/parsec/types.ts
+++ b/client/src/parsec/types.ts
@@ -109,6 +109,8 @@ export type {
   AccountRecoverProceedError,
   AccountRecoverSendValidationEmailError,
   AccountRegisterNewDeviceError,
+  AccountUploadOpaqueKeyInVaultError,
+  AccountVaultItemOpaqueKeyID,
   AnyClaimRetrievedInfoDevice,
   AnyClaimRetrievedInfoUser,
   ApiVersion,

--- a/client/src/views/organizations/creation/OrganizationSummaryPage.vue
+++ b/client/src/views/organizations/creation/OrganizationSummaryPage.vue
@@ -103,12 +103,23 @@
           <ion-text class="summary-item__label subtitles-sm">
             {{ $msTranslate('CreateOrganization.overview.authentication') }}
           </ion-text>
-          <ion-text class="summary-item__text body-lg">
-            {{
-              saveStrategy === DeviceSaveStrategyTag.Keyring
-                ? $msTranslate('CreateOrganization.keyringChoice')
-                : $msTranslate('CreateOrganization.passwordChoice')
-            }}
+          <ion-text
+            class="summary-item__text body-lg"
+            v-if="saveStrategy === DeviceSaveStrategyTag.Keyring"
+          >
+            {{ $msTranslate('CreateOrganization.keyringChoice') }}
+          </ion-text>
+          <ion-text
+            class="summary-item__text body-lg"
+            v-if="saveStrategy === DeviceSaveStrategyTag.Password"
+          >
+            {{ $msTranslate('CreateOrganization.passwordChoice') }}
+          </ion-text>
+          <ion-text
+            class="summary-item__text body-lg"
+            v-if="saveStrategy === DeviceSaveStrategyTag.AccountVault"
+          >
+            {{ $msTranslate('CreateOrganization.accountChoice') }}
           </ion-text>
           <ion-button
             fill="clear"

--- a/client/tests/e2e/specs/account_create_org.spec.ts
+++ b/client/tests/e2e/specs/account_create_org.spec.ts
@@ -1,0 +1,171 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import {
+  DEFAULT_USER_INFORMATION,
+  expect,
+  fillIonInput,
+  getTestbedBootstrapAddr,
+  MockBms,
+  MsPage,
+  msTest,
+  setupNewPage,
+} from '@tests/e2e/helpers';
+import { randomInt } from 'crypto';
+
+msTest('Account create org custom server with server matching', async ({ context }) => {
+  const page = (await context.newPage()) as MsPage;
+
+  await setupNewPage(page, { withParsecAccount: true, parsecAccountAutoLogin: true, location: '/page' });
+  await expect(page).toHaveURL(/.+\/home$/);
+
+  await page.locator('#create-organization-button').click();
+  await page.locator('.popover-viewport').getByRole('listitem').nth(0).click();
+  const modal = page.locator('.create-organization-modal');
+  await modal.locator('.server-page-footer').locator('ion-button').nth(0).click();
+
+  const uniqueOrgName = `${page.orgInfo.name}-${randomInt(2 ** 47)}`;
+
+  const orgServerContainer = modal.locator('.organization-name-and-server-page');
+  const orgPrevious = orgServerContainer.locator('.organization-name-and-server-page-footer').locator('ion-button').nth(0);
+  const orgNext = orgServerContainer.locator('.organization-name-and-server-page-footer').locator('ion-button').nth(1);
+  await expect(orgPrevious).toBeVisible();
+  await fillIonInput(orgServerContainer.locator('ion-input').nth(0), uniqueOrgName);
+  await fillIonInput(orgServerContainer.locator('ion-input').nth(1), page.orgInfo.serverAddr);
+  await expect(orgNext).toNotHaveDisabledAttribute();
+  await orgNext.click();
+
+  // Auto-filled by Parsec Account
+  const userInfoContainer = modal.locator('.user-information-page');
+  await expect(userInfoContainer).toBeHidden();
+
+  // Taken care of by Parsec Account
+  const authContainer = modal.locator('.authentication-page');
+  await expect(authContainer).toBeHidden();
+
+  const summaryContainer = modal.locator('.summary-page');
+  const summaryNext = modal.locator('.summary-page-footer').locator('ion-button').nth(1);
+  const summaryEditButtons = modal.locator('.summary-item__button');
+  await expect(summaryContainer).toBeVisible();
+  await expect(summaryNext).toBeVisible();
+
+  await expect(summaryEditButtons.nth(0)).toBeVisible();
+  await expect(summaryEditButtons.nth(1)).toBeHidden();
+  await expect(summaryEditButtons.nth(2)).toBeHidden();
+  await expect(summaryEditButtons.nth(3)).toBeVisible();
+  await expect(summaryEditButtons.nth(4)).toBeHidden();
+
+  await expect(summaryContainer.locator('.summary-item__label')).toHaveText([
+    'Organization',
+    'Full name',
+    'Email',
+    'Server choice',
+    'Authentication method',
+  ]);
+  await expect(summaryContainer.locator('.summary-item__text')).toHaveText([
+    uniqueOrgName,
+    /^Agent\d+$/,
+    /^agent\d+@example\.com$/,
+    'Custom Server',
+    'Parsec Account',
+  ]);
+  await summaryNext.click();
+
+  await expect(userInfoContainer).toBeHidden();
+  await expect(authContainer).toBeHidden();
+  await expect(summaryContainer).toBeHidden();
+  await expect(modal.locator('.creation-page')).toBeVisible();
+  await expect(modal.locator('.creation-page').locator('.closeBtn')).toBeHidden();
+  await page.waitForTimeout(1000);
+
+  await expect(modal.locator('.created-page')).toBeVisible();
+  await expect(modal.locator('.creation-page')).toBeHidden();
+  await expect(modal.locator('.created-page').locator('.closeBtn')).toBeHidden();
+  await modal.locator('.created-page-footer').locator('ion-button').click();
+  await expect(modal).toBeHidden();
+  await page.waitForTimeout(1000);
+  await expect(page).toBeWorkspacePage();
+  await page.release();
+});
+
+msTest('Account create org saas with server matching', async ({ context }) => {
+  const page = (await context.newPage()) as MsPage;
+
+  await setupNewPage(page, {
+    withParsecAccount: true,
+    parsecAccountAutoLogin: true,
+    location: '/page',
+    saasServers: process.env.TESTBED_SERVER?.replace('parsec3://', ''),
+  });
+  await expect(page).toHaveURL(/.+\/home$/);
+
+  await page.locator('#create-organization-button').click();
+  await page.locator('.popover-viewport').getByRole('listitem').nth(0).click();
+  const modal = page.locator('.create-organization-modal');
+  await modal.locator('.server-choice-item').nth(0).click();
+  await modal.locator('.server-page-footer').locator('ion-button').nth(1).click();
+
+  const uniqueOrgName = `${page.orgInfo.name}-${randomInt(2 ** 47)}`;
+
+  await MockBms.mockLogin(page);
+  await MockBms.mockUserRoute(page);
+  await MockBms.mockCreateOrganization(page, getTestbedBootstrapAddr(uniqueOrgName));
+
+  const bmsContainer = modal.locator('.saas-login');
+  await expect(bmsContainer.locator('.modal-header-title__text')).toHaveText('Link your customer account to your new organization');
+  const bmsNext = bmsContainer.locator('.saas-login-button').locator('.saas-login-button__item').nth(1);
+  await fillIonInput(bmsContainer.locator('ion-input').nth(0), DEFAULT_USER_INFORMATION.email);
+  await fillIonInput(bmsContainer.locator('ion-input').nth(1), DEFAULT_USER_INFORMATION.password);
+  await bmsNext.click();
+
+  const orgNameContainer = modal.locator('.organization-name-page');
+  await expect(orgNameContainer).toBeVisible();
+  const orgNameNext = modal.locator('.organization-name-page-footer').locator('ion-button').nth(1);
+  await fillIonInput(orgNameContainer.locator('ion-input'), uniqueOrgName);
+  await orgNameNext.click();
+
+  // Auth is skipped, we're using Parsec Account
+  const authContainer = modal.locator('.authentication-page');
+  await expect(orgNameContainer).toBeHidden();
+  await expect(authContainer).toBeHidden();
+
+  const summaryContainer = modal.locator('.summary-page');
+  const summaryNext = modal.locator('.summary-page-footer').locator('ion-button').nth(1);
+  const summaryEditButtons = modal.locator('.summary-item__button');
+  await expect(summaryContainer).toBeVisible();
+
+  // Only the org name field can be updated
+  await expect(summaryEditButtons.nth(0)).toBeVisible();
+  await expect(summaryEditButtons.nth(1)).not.toBeVisible();
+  await expect(summaryEditButtons.nth(2)).not.toBeVisible();
+  await expect(summaryEditButtons.nth(3)).not.toBeVisible();
+  await expect(summaryEditButtons.nth(4)).not.toBeVisible();
+
+  await expect(summaryContainer.locator('.summary-item__label')).toHaveText([
+    'Organization',
+    'Full name',
+    'Email',
+    'Server choice',
+    'Authentication method',
+  ]);
+  await expect(summaryContainer.locator('.summary-item__text')).toHaveText([
+    uniqueOrgName,
+    DEFAULT_USER_INFORMATION.name,
+    DEFAULT_USER_INFORMATION.email,
+    'Parsec SaaS',
+    // Using Parsec Account as auth
+    'Parsec Account',
+  ]);
+  await summaryNext.click();
+
+  await expect(summaryContainer).toBeHidden();
+  await expect(modal.locator('.creation-page')).toBeVisible();
+  await page.waitForTimeout(1000);
+
+  await expect(modal.locator('.creation-page')).toBeHidden();
+  await expect(modal.locator('.created-page')).toBeVisible();
+  await modal.locator('.created-page-footer').locator('ion-button').click();
+  await expect(modal).toBeHidden();
+  await page.waitForTimeout(1000);
+  await expect(page).toBeWorkspacePage();
+  await page.release();
+});

--- a/client/tests/e2e/specs/account_invitation.spec.ts
+++ b/client/tests/e2e/specs/account_invitation.spec.ts
@@ -1,8 +1,8 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { expect, fillInputModal, login, msTest, setWriteClipboardPermission } from '@tests/e2e/helpers';
+import { expect, fillInputModal, login, msTest } from '@tests/e2e/helpers';
 
-msTest('Manage account state', async ({ parsecAccountLoggedIn }) => {
+msTest('Display account invitations', async ({ parsecAccountLoggedIn }) => {
   // Get the account email, check that we don't have an invitation
   await parsecAccountLoggedIn.locator('.profile-header-homepage').click();
   await expect(parsecAccountLoggedIn.locator('.profile-header-homepage-popover')).toBeVisible();
@@ -26,13 +26,15 @@ msTest('Manage account state', async ({ parsecAccountLoggedIn }) => {
   await expect(noAccountPage).toShowToast(`An invitation to join the organization has been sent to ${email}.`, 'Success');
   await noAccountPage.locator('.topbar').locator('#invitations-button').click();
   const popover = noAccountPage.locator('.invitations-list-popover');
-  await setWriteClipboardPermission(noAccountPage.context(), true);
   const inv = popover.locator('.invitation-list-item').nth(1);
   await inv.locator('.invitation-header__greet-button').click();
   const greetModal = noAccountPage.locator('.greet-organization-modal');
   await expect(greetModal).toBeVisible();
+  await noAccountPage.release();
 
   // Account tab, check if the invitation appeared
+  await parsecAccountLoggedIn.waitForTimeout(500);
+  await expect(parsecAccountLoggedIn.locator('.account-invitations__title')).toHaveText('One invitation pending');
   await expect(invitations).toHaveCount(1);
   await invitations.nth(0).click();
   const joinModal = parsecAccountLoggedIn.locator('.join-organization-modal');

--- a/client/tests/e2e/specs/create_organization_custom.spec.ts
+++ b/client/tests/e2e/specs/create_organization_custom.spec.ts
@@ -206,6 +206,8 @@ msTest('Go through custom org creation process', async ({ home }) => {
   await expect(modal.locator('.created-page').locator('.closeBtn')).toBeHidden();
   await modal.locator('.created-page-footer').locator('ion-button').click();
   await expect(modal).toBeHidden();
+  await home.waitForTimeout(1000);
+  await expect(home).toBeWorkspacePage();
 });
 
 msTest('Go through custom org creation process from bootstrap link', async ({ context }) => {
@@ -215,7 +217,8 @@ msTest('Go through custom org creation process from bootstrap link', async ({ co
 
   await page.locator('#create-organization-button').click();
   await page.locator('.popover-viewport').getByRole('listitem').nth(1).click();
-  await fillInputModal(page, getTestbedBootstrapAddr(page.orgInfo.name));
+  const uniqueOrgName = `${page.orgInfo.name}-${randomInt(2 ** 47)}`;
+  await fillInputModal(page, getTestbedBootstrapAddr(uniqueOrgName));
   const modal = page.locator('.create-organization-modal');
 
   const orgServerContainer = modal.locator('.organization-name-and-server-page');
@@ -226,7 +229,7 @@ msTest('Go through custom org creation process from bootstrap link', async ({ co
   await expect(orgNext).toNotHaveDisabledAttribute();
 
   await expect(orgServerContainer.locator('ion-input').nth(0)).toHaveTheClass('input-disabled');
-  await expect(orgServerContainer.locator('ion-input').nth(0).locator('input')).toHaveValue(page.orgInfo.name);
+  await expect(orgServerContainer.locator('ion-input').nth(0).locator('input')).toHaveValue(uniqueOrgName);
   await expect(orgServerContainer.locator('ion-input').nth(1)).toHaveTheClass('input-disabled');
   await expect(orgServerContainer.locator('ion-input').nth(1).locator('input')).toHaveValue(
     `parsec3://${new URL(page.orgInfo.serverAddr).host}`,
@@ -294,12 +297,19 @@ msTest('Go through custom org creation process from bootstrap link', async ({ co
     'Authentication method',
   ]);
   await expect(summaryContainer.locator('.summary-item__text')).toHaveText([
-    page.orgInfo.name,
+    uniqueOrgName,
     DEFAULT_USER_INFORMATION.name,
     DEFAULT_USER_INFORMATION.email,
     'Custom Server',
     'Password',
   ]);
   await summaryNext.click();
+  await page.waitForTimeout(1000);
+  await expect(summaryContainer).toBeHidden();
+  await expect(modal.locator('.created-page')).toBeVisible();
+  await expect(modal.locator('.created-page-footer').locator('ion-button')).toHaveText('Access to your organization');
+  await modal.locator('.created-page-footer').locator('ion-button').click();
+  await page.waitForTimeout(1000);
+  await expect(page).toBeWorkspacePage();
   await page.release();
 });

--- a/client/tests/e2e/specs/create_organization_saas.spec.ts
+++ b/client/tests/e2e/specs/create_organization_saas.spec.ts
@@ -172,6 +172,8 @@ msTest('Go through saas org creation process', async ({ home }) => {
   await expect(modal.locator('.created-page').locator('.closeBtn')).toBeHidden();
   await modal.locator('.created-page-footer').locator('ion-button').click();
   await expect(modal).toBeHidden();
+  await home.waitForTimeout(1000);
+  await expect(home).toBeWorkspacePage();
 });
 
 for (const testInfo of [
@@ -333,7 +335,8 @@ msTest('Go through saas org creation process from bootstrap link', async ({ cont
   await expect(modal.locator('.created-page').locator('.closeBtn')).toBeHidden();
   await modal.locator('.created-page-footer').locator('ion-button').click();
   await expect(modal).toBeHidden();
-
+  await page.waitForTimeout(1000);
+  await expect(page).toBeWorkspacePage();
   await page.release();
 });
 

--- a/client/tests/e2e/specs/create_organization_trial.spec.ts
+++ b/client/tests/e2e/specs/create_organization_trial.spec.ts
@@ -11,6 +11,7 @@ import {
   msTest,
   setupNewPage,
 } from '@tests/e2e/helpers';
+import { randomInt } from 'crypto';
 
 async function openCreateOrganizationModal(page: Page): Promise<Locator> {
   await page.locator('#create-organization-button').click();
@@ -127,6 +128,8 @@ msTest('Go through trial org creation process', async ({ home }) => {
   await expect(modal.locator('.created-page').locator('.closeBtn')).toBeHidden();
   await modal.locator('.created-page-footer').locator('ion-button').click();
   await expect(modal).toBeHidden();
+  await home.waitForTimeout(1000);
+  await expect(home).toBeWorkspacePage();
 });
 
 msTest('Go through trial org creation process from bootstrap link', async ({ context }) => {
@@ -137,7 +140,8 @@ msTest('Go through trial org creation process from bootstrap link', async ({ con
 
   await page.locator('#create-organization-button').click();
   await page.locator('.popover-viewport').getByRole('listitem').nth(1).click();
-  const bootstrapAddr = getTestbedBootstrapAddr('CustomOrg');
+  const uniqueOrgName = `${page.orgInfo.name}-${randomInt(2 ** 47)}`;
+  const bootstrapAddr = getTestbedBootstrapAddr(uniqueOrgName);
   await fillInputModal(page, bootstrapAddr);
   const modal = page.locator('.create-organization-modal');
 
@@ -182,5 +186,7 @@ msTest('Go through trial org creation process from bootstrap link', async ({ con
   await expect(modal.locator('.creation-page')).toBeHidden();
   await modal.locator('.created-page-footer').locator('ion-button').click();
   await expect(modal).toBeHidden();
+  await page.waitForTimeout(1000);
+  await expect(page).toBeWorkspacePage();
   await page.release();
 });


### PR DESCRIPTION
Closes #10851

Quite a nightmare to test. Be mindful of server with `127.0.0.1` and server with `localhost`, those are not considered the same (no DNS resolution or anything). Be also mindful of the port.
- testbed server === account server, log into a device -> should ask if you want to register the device, yes. Logout, log back in, shouldn't need a password.
- testbed server !== account server, log into a device -> nothing
- custom server === account server, without testbed, create an org, then electron, log in to parsec account, the device should be here and accessible.
- create an org with custom server (=== account server), should skip name/email and auth. Should log in automatically while logged into Parsec Account.

Technically the last one is also true with the saas, but it's next to impossible to test locally (it is tested in playwright though).