### PR TITLE
[MS] Manage `openInEditor` error cases

### DIFF
--- a/client/src/components/files/FileOpenFallbackChoice.vue
+++ b/client/src/components/files/FileOpenFallbackChoice.vue
@@ -2,12 +2,13 @@
 
 <template>
   <ms-modal
-    title="openFallback.title"
-    subtitle="openFallback.subtitle"
-    :class="viewerOption ? 'has-viewer-option' : ''"
+    :title="title ?? 'openFallback.title'"
+    :subtitle="subtitle ?? 'openFallback.subtitleDownload'"
+    :close-button="{ visible: true }"
   >
     <div class="open-fallback-buttons">
       <ion-button
+        v-if="!viewerOption"
         @click="onClose"
         fill="clear"
         class="button-default open-fallback-buttons__item"
@@ -44,13 +45,15 @@
 import { IonButton, modalController } from '@ionic/vue';
 import { isDesktop, isWeb } from '@/parsec';
 import { OpenFallbackChoice } from '@/components/files';
-import { MsModal, MsModalResult } from 'megashark-lib';
+import { MsModal, MsModalResult, Translatable } from 'megashark-lib';
 import { StorageManager, StorageManagerKey } from '@/services/storageManager';
 import { inject } from 'vue';
 import { openDownloadConfirmationModal } from '@/views/files';
 
 defineProps<{
   viewerOption?: boolean;
+  title?: Translatable;
+  subtitle?: Translatable;
 }>();
 
 const storageManager: StorageManager = inject(StorageManagerKey)!;

--- a/client/src/components/files/index.ts
+++ b/client/src/components/files/index.ts
@@ -8,6 +8,7 @@ export * from '@/components/files/utils';
 export { EntryCollection, ImportType, OpenFallbackChoice, SortProperty, WorkspaceHistoryEntryCollection } from '@/components/files/types';
 export type {
   EntryModel,
+  FallbackCustomParams,
   FileModel,
   FileOperationProgress,
   FolderModel,

--- a/client/src/components/files/types.ts
+++ b/client/src/components/files/types.ts
@@ -2,6 +2,7 @@
 
 import { EntryID, EntryStatFile, EntryStatFolder, WorkspaceHistoryEntryStatFile, WorkspaceHistoryEntryStatFolder } from '@/parsec';
 import { FileOperationData } from '@/services/fileOperationManager';
+import { Translatable } from 'megashark-lib';
 
 export enum SortProperty {
   Name,
@@ -21,6 +22,11 @@ export enum OpenFallbackChoice {
   View,
 }
 
+export interface FallbackCustomParams {
+  title: Translatable;
+  subtitle: Translatable;
+  viewerOption: boolean;
+}
 export interface FileOperationProgress {
   data: FileOperationData;
   progress: number;

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -2289,13 +2289,22 @@
         "showMenu": "Show menu",
         "menu": "Menu",
         "openingFile": "Opening file...",
-        "fileTooBig": "File is too big to be opened using a viewer.",
-        "unknownFileType": "Cannot preview this file type.",
-        "noFolderPreview": "Cannot preview folders.",
-        "genericError": "Failed to open the file.",
-        "mediaNotSupported": "This media is not supported.",
+        "errors": {
+            "titles": {
+                "fileTooBig": "File size is too big",
+                "impossibleToOpen": "Cannot edit this file",
+                "genericError": "Failed to open the file",
+                "unSupportedFileType": "File not supported by Parsec"
+            },
+            "informationEditDownload": "If you want to edit this file, you can download it and open it locally on your device.",
+            "informationPreviewDownload": "If you want to preview this file, you can download it and open it locally on your device.",
+            "unknownFileExtension": "This file type extension could not be identified. Please check that it's correctly written (.txt, .pdf, .doc, etc.).",
+            "noContentFileType": "Could not open this file in the Parsec editor as its type could not be identified.",
+            "noFolderPreview": "Cannot preview folders.",
+            "mediaNotSupported": "This media is not supported.",
+            "statsFailed": "Cannot get file information."
+        },
         "retrievingFileContent": "Retrieving the file content...",
-        "statsFailed": "Can not get file information.",
         "openLink": {
             "title": "Open an external link",
             "question": "This will open the link outside of the application. Do you want to continue?",
@@ -2344,11 +2353,14 @@
         }
     },
     "openFallback": {
-        "title": "File editor is not available",
-        "subtitle": "Please choose an action for this file.",
+        "title": "Parsec Edition not available",
+        "subtitle": {
+            "download": "If you want to edit this file, you can download it and open it locally on your device.",
+            "previewDownload": "If you want to preview this file, you can do so in Parsec or download it to open it locally on your device."
+        },
         "actions": {
-            "viewer": "Open in viewer",
-            "download": "Download file",
+            "viewer": "Preview (in Parsec)",
+            "download": "Download",
             "open": "Open in explorer",
             "cancel": "Cancel"
         }

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -2288,13 +2288,22 @@
         "showMenu": "Afficher le menu",
         "menu": "Menu",
         "openingFile": "Ouverture du fichier...",
-        "fileTooBig": "Le fichier est trop large pour être ouvert avec un visualiseur.",
-        "unknownFileType": "Impossible de prévisualiser ce type de fichier.",
-        "noFolderPreview": "Impossible de prévisualiser les dossiers.",
-        "genericError": "Impossible d'ouvrir le fichier.",
-        "mediaNotSupported": "Ce média ne peut pas être joué.",
+        "errors": {
+            "titles": {
+                "fileTooBig": "Fichier trop volumineux",
+                "impossibleToOpen": "Impossible d'éditer ce fichier",
+                "genericError": "Impossible d'ouvrir ce fichier",
+                "unSupportedFileType": "Type de fichier non pris en charge par Parsec"
+            },
+            "informationEditDownload": "Si vous souhaitez modifier ce fichier, vous pouvez le télécharger et l'ouvrir localement sur votre appareil.",
+            "informationPreviewDownload": "Si vous souhaitez prévisualiser ce fichier, vous pouvez le faire dans Parsec ou le télécharger pour l'ouvrir localement sur votre appareil.",
+            "unknownFileExtension": "L'extension de ce fichier n'a pas pu être reconnue. Veuillez vérifier qu'elle est correctement écrite (.txt, .pdf, .doc, etc.).",
+            "noContentFileType": "Impossible d'ouvrir ce fichier, son type n'ayant pas pu être reconnu dans l'éditeur de Parsec.",
+            "noFolderPreview": "Impossible d'afficher l'aperçu d'un dossier.",
+            "mediaNotSupported": "Ce média ne peut pas être joué.",
+            "statsFailed": "Impossible de récupérer les informations du fichier."
+        },
         "retrievingFileContent": "Récupération du contenu du fichier...",
-        "statsFailed": "Impossible de récupérer les informations du fichier.",
         "openLink": {
             "title": "Ouvrir un lien externe",
             "question": "Ce lien sera ouvert en dehors de l'application. Voulez-vous continuer ?",
@@ -2343,8 +2352,9 @@
         }
     },
     "openFallback": {
-        "title": "L'éditeur de fichier n'est pas disponible",
-        "subtitle": "Veuillez choisir une action pour ce fichier.",
+        "title": "Parsec Edition n'est pas disponible",
+        "subtitleDownload": "Si vous souhaitez modifier ce fichier, vous pouvez le télécharger et l'ouvrir localement sur votre appareil.",
+        "subtitlePreviewDownload": "Si vous souhaitez prévisualiser ce fichier, vous pouvez le faire dans Parsec ou le télécharger pour l'ouvrir localement sur votre appareil.",
         "actions": {
             "viewer": "Ouvrir dans le visualiseur",
             "download": "Télécharger le fichier",

--- a/client/src/views/files/handler/FileHandler.vue
+++ b/client/src/views/files/handler/FileHandler.vue
@@ -508,7 +508,7 @@ async function showDetails(): Promise<void> {
     if (!entry.ok) {
       await informationManager.present(
         new Information({
-          message: 'fileViewers.statsFailed',
+          message: 'fileViewers.errors.statsFailed',
           level: InformationLevel.Error,
         }),
         PresentationMode.Modal,

--- a/client/src/views/files/handler/viewer/AudioViewer.vue
+++ b/client/src/views/files/handler/viewer/AudioViewer.vue
@@ -139,7 +139,7 @@ onUnmounted(() => {
 
 async function onError(): Promise<void> {
   loading.value = false;
-  error.value = 'fileViewers.mediaNotSupported';
+  error.value = 'fileViewers.errors.mediaNotSupported';
 }
 
 function onTimeUpdate(): void {

--- a/client/src/views/files/handler/viewer/VideoViewer.vue
+++ b/client/src/views/files/handler/viewer/VideoViewer.vue
@@ -156,7 +156,7 @@ onUnmounted(() => {
 });
 
 async function onError(): Promise<void> {
-  error.value = 'fileViewers.mediaNotSupported';
+  error.value = 'fileViewers.errors.mediaNotSupported';
 }
 
 function onTimeUpdate(): void {
@@ -216,7 +216,7 @@ function updateMediaData(event: Event): void {
   // trying to update the media data, we check if the `duration`
   // is set or not.
   if (Number.isNaN((event.target as HTMLVideoElement).duration)) {
-    error.value = 'fileViewers.mediaNotSupported';
+    error.value = 'fileViewers.errors.mediaNotSupported';
   } else {
     volume.value = Math.floor((event.target as HTMLAudioElement).volume * 100);
     muted.value = (event.target as HTMLAudioElement).muted;


### PR DESCRIPTION
### Editics not available
<img width="2898" height="1640" alt="image" src="https://github.com/user-attachments/assets/a30f2691-7085-4199-8e15-da01dc430ba1" />

### Cannot edit this file
<img width="1449" height="819" alt="Screenshot 2025-08-12 at 09 28 08" src="https://github.com/user-attachments/assets/f5780aa5-c6af-414a-bdb2-59178d7590c4" />

### File not supported (or unknow)
<img width="1447" height="823" alt="Screenshot 2025-08-12 at 09 17 44" src="https://github.com/user-attachments/assets/b6cbeddd-0e7d-459a-8d52-75dfbf40e67d" />

### File too big
<img width="1450" height="823" alt="Screenshot 2025-08-12 at 09 12 26" src="https://github.com/user-attachments/assets/bae8b8a2-b805-4601-a92d-7d5047bac163" />

<!--
Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->

closes #10894 