### PR TITLE
[MS] Manage click behavior for file and folder items

### DIFF
--- a/client/src/components/files/explorer/FileCard.vue
+++ b/client/src/components/files/explorer/FileCard.vue
@@ -7,11 +7,11 @@
       selected: entry.isSelected,
       'file-hovered': !entry.isSelected && (menuOpened || isHovered),
     }"
-    @dblclick="$emit('click', $event, entry)"
+    @dblclick="$emit('openItem', $event, entry)"
     @mouseenter="isHovered = true"
     @mouseleave="isHovered = false"
     @contextmenu="onOptionsClick"
-    @click="onCardClick"
+    @click="$emit('update:modelValue', !props.entry.isSelected)"
   >
     <file-drop-zone
       :disabled="entry.isFile()"
@@ -25,7 +25,6 @@
         <ms-checkbox
           v-model="entry.isSelected"
           v-show="entry.isSelected || isHovered || showCheckbox"
-          @ion-change="$emit('select')"
           @click.stop
           @dblclick.stop
         />
@@ -52,7 +51,10 @@
           />
         </div>
 
-        <ion-text class="file-card__title body">
+        <ion-text
+          class="file-card__title cell"
+          @click="$emit('openItem', $event, entry)"
+        >
           {{ entry.name }}
         </ion-text>
 
@@ -92,27 +94,20 @@ const props = defineProps<{
   entry: EntryModel;
   showCheckbox: boolean;
   isWorkspaceReader?: boolean;
-  modelValue?: boolean;
+  modelValue: boolean;
 }>();
 
 const emits = defineEmits<{
-  (e: 'click', event: Event, entry: EntryModel): void;
+  (e: 'openItem', event: Event, entry: EntryModel): void;
   (e: 'menuClick', event: Event, entry: EntryModel, onFinished: () => void): void;
   (e: 'filesAdded', imports: FileImportTuple[]): void;
   (e: 'dropAsReader'): void;
-  (e: 'select'): void;
   (e: 'update:modelValue', value: boolean): void;
 }>();
 
 defineExpose({
   props,
 });
-
-async function onCardClick(): Promise<void> {
-  if (props.showCheckbox) {
-    emits('update:modelValue', !props.entry.isSelected);
-  }
-}
 
 function isFileSynced(): boolean {
   return !props.entry.needSync;
@@ -210,6 +205,11 @@ async function onOptionsClick(event: Event): Promise<void> {
     -webkit-box-orient: vertical;
     overflow: hidden;
     text-overflow: ellipsis;
+
+    &:hover {
+      text-decoration: underline;
+      cursor: pointer !important;
+    }
   }
 
   &-last-update {

--- a/client/src/components/files/explorer/FileGridDisplay.vue
+++ b/client/src/components/files/explorer/FileGridDisplay.vue
@@ -22,12 +22,12 @@
           :key="folder.id"
           :entry="folder"
           :show-checkbox="hasSelected() || selectionEnabled === true"
-          @click="$emit('click', folder, $event)"
+          @open-item="$emit('openItem', folder, $event)"
+          @open-item.stop
           @menu-click="onMenuClick"
           @files-added="onFilesAdded"
           :is-workspace-reader="ownRole === WorkspaceRole.Reader"
           @drop-as-reader="$emit('dropAsReader')"
-          @select="$emit('checkboxClick')"
           v-model="folder.isSelected"
         />
         <file-card
@@ -37,11 +37,11 @@
           :key="file.id"
           :entry="file"
           :show-checkbox="hasSelected() || selectionEnabled === true"
-          @click="$emit('click', file, $event)"
+          @open-item="$emit('openItem', file, $event)"
+          @open-item.stop
           @menu-click="onMenuClick"
           @files-added="onFilesAdded"
           @drop-as-reader="$emit('dropAsReader')"
-          @select="$emit('checkboxClick')"
           v-model="file.isSelected"
         />
 
@@ -80,10 +80,9 @@ const fileItemsRef = useTemplateRef<Array<typeof FileCard>>('fileItems');
 const folderItemsRef = useTemplateRef<Array<typeof FileCard>>('folderItems');
 
 const emits = defineEmits<{
-  (e: 'click', entry: EntryModel, event: Event): void;
+  (e: 'openItem', entry: EntryModel, event: Event): void;
   (e: 'menuClick', event: Event, entry: EntryModel, onFinished: () => void): void;
   (e: 'globalMenuClick', event: Event): void;
-  (e: 'checkboxClick'): void;
   (e: 'filesAdded', imports: FileImportTuple[]): void;
   (e: 'dropAsReader'): void;
 }>();

--- a/client/src/components/files/explorer/FileListDisplay.vue
+++ b/client/src/components/files/explorer/FileListDisplay.vue
@@ -83,25 +83,27 @@
           <file-list-item
             v-for="folder in folders.getEntries()"
             ref="folderItems"
+            v-model="folder.isSelected"
             :key="folder.id"
             :entry="folder"
             :show-checkbox="someSelected || selectionEnabled === true"
-            @click="$emit('click', folder, $event)"
-            @menu-click="onMenuClick"
-            @selected-change="onSelectedChange"
-            @files-added="onFilesAdded"
             :is-workspace-reader="ownRole === WorkspaceRole.Reader"
+            @open-item="$emit('openItem', folder, $event)"
+            @open-item.stop
+            @menu-click="onMenuClick"
+            @files-added="onFilesAdded"
             @drop-as-reader="$emit('dropAsReader')"
           />
           <file-list-item
             v-for="file in files.getEntries()"
             ref="fileItems"
+            v-model="file.isSelected"
             :key="file.id"
             :entry="file"
             :show-checkbox="someSelected || selectionEnabled === true"
-            @click="$emit('click', file, $event)"
+            @open-item="$emit('openItem', file, $event)"
+            @open-item.stop
             @menu-click="onMenuClick"
-            @selected-change="onSelectedChange"
             @files-added="onFilesAdded"
             @drop-as-reader="$emit('dropAsReader')"
           />
@@ -143,7 +145,7 @@ const props = defineProps<{
 }>();
 
 const emits = defineEmits<{
-  (e: 'click', entry: EntryModel, event: Event): void;
+  (e: 'openItem', entry: EntryModel, event: Event): void;
   (e: 'sortChange', event: MsSorterChangeEvent): void;
   (e: 'menuClick', event: Event, entry: EntryModel, onFinished: () => void): void;
   (e: 'globalMenuClick', event: Event): void;
@@ -177,8 +179,6 @@ async function onContextMenu(event: Event): Promise<void> {
 async function onMenuClick(event: Event, entry: EntryModel, onFinished: () => void): Promise<void> {
   emits('menuClick', event, entry, onFinished);
 }
-
-async function onSelectedChange(_entry: EntryModel, _checked: boolean): Promise<void> {}
 
 function onFilesAdded(imports: FileImportTuple[]): void {
   fileDropZoneRef.value?.reset();

--- a/client/src/components/files/explorer/FileListItem.vue
+++ b/client/src/components/files/explorer/FileListItem.vue
@@ -19,7 +19,8 @@
         'file-hovered': !entry.isSelected && (menuOpened || isHovered),
         'file-list-item-mobile': isSmallDisplay,
       }"
-      @dblclick="$emit('click', $event, entry)"
+      @dblclick="$emit('openItem', $event, entry)"
+      @click="$emit('update:modelValue', !props.entry.isSelected)"
       @mouseenter="isHovered = true"
       @mouseleave="isHovered = false"
       @contextmenu="onOptionsClick"
@@ -32,7 +33,6 @@
         <ms-checkbox
           v-model="entry.isSelected"
           v-show="entry.isSelected || isHovered || showCheckbox"
-          @change="$emit('selectedChange', entry, $event)"
           @click.stop
           @dblclick.stop
         />
@@ -48,7 +48,10 @@
           class="file-icon"
         />
         <div class="file-mobile-text">
-          <ion-text class="file-name__label cell">
+          <ion-text
+            class="file-name__label cell"
+            @click="$emit('openItem', $event, entry)"
+          >
             {{ entry.name }}
           </ion-text>
           <ion-text
@@ -148,14 +151,16 @@ const props = defineProps<{
   showCheckbox: boolean;
   isWorkspaceReader?: boolean;
   disableDrop?: boolean;
+  modelValue: boolean;
 }>();
 
 const emits = defineEmits<{
   (e: 'click', event: Event, entry: EntryModel): void;
+  (e: 'openItem', event: Event, entry: EntryModel): void;
   (e: 'menuClick', event: Event, entry: EntryModel, onFinished: () => void): void;
-  (e: 'selectedChange', entry: EntryModel, checked: boolean): void;
   (e: 'filesAdded', imports: FileImportTuple[]): void;
   (e: 'dropAsReader'): void;
+  (e: 'update:modelValue', value: boolean): void;
 }>();
 
 defineExpose({
@@ -207,6 +212,13 @@ async function onOptionsClick(event: PointerEvent): Promise<void> {
     overflow: hidden;
     text-overflow: ellipsis;
     text-wrap: nowrap;
+    width: fit-content;
+
+    &:hover {
+      border-top: 1px solid transparent;
+      border-bottom: 1px solid var(--parsec-color-light-secondary-grey);
+      cursor: pointer !important;
+    }
   }
 
   .cloud-overlay {

--- a/client/src/components/header/SmallDisplayHeaderTitle.vue
+++ b/client/src/components/header/SmallDisplayHeaderTitle.vue
@@ -117,6 +117,7 @@ defineEmits<{
 
 .title__button {
   padding: 0.8rem;
+  flex-shrink: 0;
 
   &:hover {
     cursor: pointer;

--- a/client/tests/component/specs/testFileCard.spec.ts
+++ b/client/tests/component/specs/testFileCard.spec.ts
@@ -43,6 +43,7 @@ describe('File Card Item', () => {
       props: {
         entry: FILE,
         showCheckbox: true,
+        modelValue: true,
       },
       global: {
         provide: getDefaultProvideConfig(),
@@ -83,6 +84,7 @@ describe('File Card Item', () => {
       props: {
         entry: FOLDER,
         showCheckbox: true,
+        modelValue: true,
       },
       global: {
         provide: getDefaultProvideConfig(),

--- a/client/tests/component/specs/testFileListItem.spec.ts
+++ b/client/tests/component/specs/testFileListItem.spec.ts
@@ -46,6 +46,7 @@ describe('File List Item', () => {
       props: {
         entry: FILE,
         showCheckbox: false,
+        modelValue: true,
       },
       global: {
         provide: getDefaultProvideConfig(),
@@ -88,6 +89,7 @@ describe('File List Item', () => {
       props: {
         entry: FOLDER,
         showCheckbox: false,
+        modelValue: true,
       },
       global: {
         provide: getDefaultProvideConfig(),

--- a/client/tests/e2e/specs/documents_list.spec.ts
+++ b/client/tests/e2e/specs/documents_list.spec.ts
@@ -315,7 +315,7 @@ msTest('Import context menu', async ({ documents }) => {
   await expect(popover.getByRole('listitem')).toHaveText(['Import files', 'Import a folder']);
 });
 
-msTest('Selection in grid mode', async ({ documents }) => {
+msTest('Selection in grid mode by by clicking on the checkbox', async ({ documents }) => {
   await documents.locator('.folder-container').locator('.folder-list-header').locator('ion-checkbox').click();
   await toggleViewMode(documents);
   const entries = documents.locator('.folder-container').locator('.file-card-item');
@@ -334,6 +334,29 @@ msTest('Selection in grid mode', async ({ documents }) => {
   await expect(entries.nth(2).locator('ion-checkbox')).toHaveState('checked');
   await expect(entries.nth(3).locator('ion-checkbox')).toHaveState('unchecked');
 });
+
+for (const gridMode of [false, true]) {
+  msTest(`Selection in ${gridMode ? 'grid' : 'list'} mode by clicking on the item`, async ({ documents }) => {
+    if (gridMode) {
+      await toggleViewMode(documents);
+    }
+
+    const entries = documents.locator('.folder-container').locator(gridMode ? '.file-card-item' : '.file-list-item');
+    const actionBar = documents.locator('#folders-ms-action-bar');
+    const entriesCount = await entries.count();
+
+    for (let i = 0; i < entriesCount; i++) {
+      await entries.nth(i).click();
+
+      for (let j = 0; j <= i; j++) {
+        await expect(entries.nth(j).locator('ion-checkbox')).toHaveState('checked');
+      }
+
+      const counterText = i === 0 ? '1 selected item' : `${i + 1} selected items`;
+      await expect(actionBar.locator('.counter')).toHaveText(counterText, { useInnerText: true });
+    }
+  });
+}
 
 for (const gridMode of [false, true]) {
   msTest(`Open file in ${gridMode ? 'grid' : 'list'} mode`, async ({ documents }) => {

--- a/client/tests/e2e/specs/file_viewers_document.spec.ts
+++ b/client/tests/e2e/specs/file_viewers_document.spec.ts
@@ -2,6 +2,14 @@
 
 import { expect, msTest, openFileType } from '@tests/e2e/helpers';
 
+msTest('Open file viewer with single click', async ({ documents }) => {
+  const entries = documents.locator('.folder-container').locator('.file-list-item');
+  await entries.nth(0).locator('.file-name__label').click();
+  await documents.locator('.topbar-left-content').locator('.back-button').click();
+  await entries.nth(1).locator('.file-name__label').click();
+  await expect(documents).toBeViewerPage();
+});
+
 msTest('Document viewer: content', async ({ documents }) => {
   await openFileType(documents, 'docx');
   await expect(documents).toBeViewerPage();


### PR DESCRIPTION
Here's how files and folders behave when clicked:
- Click on the item: Select item (check mark active)
- Click on folder name: Open folder
- Click on file name: Preview (viewer)

I've harmonized the interaction between `FileCard` (and thus `FileGridDisplay`) and `FileListItem` (and thus `FileListDisplay`).

https://github.com/user-attachments/assets/5a9e87f4-0eaf-4f0a-8ba5-599fd1c573e1

closes #10820