### PR TITLE
fix(server): Email sender not been `EmailAddress` type

### DIFF
--- a/server/parsec/cli/run.py
+++ b/server/parsec/cli/run.py
@@ -364,6 +364,7 @@ for any given email address).
     "--email-sender",
     envvar="PARSEC_EMAIL_SENDER",
     show_envvar=True,
+    type=EmailAddress,
     metavar="EMAIL",
     help="Sender address used in sent emails",
 )


### PR DESCRIPTION
This caused a type error when sending an email

Fix #10927