### PR TITLE
test(server): Add fixture for administration route

### DIFF
--- a/server/tests/administration/test_list_users.py
+++ b/server/tests/administration/test_list_users.py
@@ -4,52 +4,40 @@ import httpx
 
 from parsec._parsec import RevokedUserCertificate
 from parsec.components.user import UserInfo
-from tests.common import Backend, CoolorgRpcClients, alice_gives_profile
+from tests.common import AdminUnauthErrorsTester, Backend, CoolorgRpcClients, alice_gives_profile
 
 
-async def test_bad_auth(client: httpx.AsyncClient, coolorg: CoolorgRpcClients) -> None:
+async def test_bad_auth(
+    client: httpx.AsyncClient,
+    coolorg: CoolorgRpcClients,
+    administration_route_unauth_errors_tester: AdminUnauthErrorsTester,
+) -> None:
     url = f"http://parsec.invalid/administration/organizations/{coolorg.organization_id.str}/users"
-    # No Authorization header
-    response = await client.get(url)
-    assert response.status_code == 403, response.content
-    # Invalid Authorization header
-    response = await client.get(
-        url,
-        headers={
-            "Authorization": "DUMMY",
-        },
-    )
-    assert response.status_code == 403, response.content
-    # Bad bearer token
-    response = await client.get(
-        url,
-        headers={
-            "Authorization": "Bearer BADTOKEN",
-        },
-    )
-    assert response.status_code == 403, response.content
+
+    async def do(client: httpx.AsyncClient):
+        return await client.get(url)
+
+    await administration_route_unauth_errors_tester(do)
 
 
 async def test_bad_method(
-    client: httpx.AsyncClient, backend: Backend, coolorg: CoolorgRpcClients
+    administration_client: httpx.AsyncClient, coolorg: CoolorgRpcClients
 ) -> None:
     url = f"http://parsec.invalid/administration/organizations/{coolorg.organization_id.str}/users"
-    response = await client.post(
+    response = await administration_client.post(
         url,
-        headers={"Authorization": f"Bearer {backend.config.administration_token}"},
     )
     assert response.status_code == 405, response.content
 
 
 async def test_ok(
-    client: httpx.AsyncClient,
+    administration_client: httpx.AsyncClient,
     backend: Backend,
     coolorg: CoolorgRpcClients,
 ) -> None:
     url = f"http://parsec.invalid/administration/organizations/{coolorg.organization_id.str}/users"
-    response = await client.get(
+    response = await administration_client.get(
         url,
-        headers={"Authorization": f"Bearer {backend.config.administration_token}"},
     )
     assert response.status_code == 200, response.content
     assert response.json() == {
@@ -88,9 +76,8 @@ async def test_ok(
     assert isinstance(outcome, UserInfo)
 
     url = f"http://parsec.invalid/administration/organizations/{coolorg.organization_id.str}/users"
-    response = await client.get(
+    response = await administration_client.get(
         url,
-        headers={"Authorization": f"Bearer {backend.config.administration_token}"},
     )
     assert response.status_code == 200, response.content
     assert response.json() == {
@@ -112,12 +99,10 @@ async def test_ok(
 
 
 async def test_unknown_organization(
-    client: httpx.AsyncClient,
-    backend: Backend,
+    administration_client: httpx.AsyncClient,
 ) -> None:
     url = "http://parsec.invalid/administration/organizations/Dummy/users"
-    response = await client.get(
+    response = await administration_client.get(
         url,
-        headers={"Authorization": f"Bearer {backend.config.administration_token}"},
     )
     assert response.status_code == 404, response.content

--- a/server/tests/common/__init__.py
+++ b/server/tests/common/__init__.py
@@ -7,6 +7,7 @@ from parsec.cli.testbed import next_organization_id
 
 # ruff: noqa: F403
 from .account import *
+from .administration import *
 from .backend import *
 from .client import *
 from .data import *

--- a/server/tests/common/administration.py
+++ b/server/tests/common/administration.py
@@ -1,0 +1,66 @@
+# Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+from collections.abc import AsyncGenerator, Callable, Coroutine, Generator
+
+import pytest
+from httpx import AsyncClient, Auth, Request, Response
+
+from parsec.backend import Backend
+
+
+class AdministrationTokenAuth(Auth):
+    def __init__(self, token: str) -> None:
+        self.set_token(token)
+
+    def set_token(self, token: str) -> None:
+        self.authorization_header = f"Bearer {token}"
+
+    def auth_flow(self, request: Request) -> Generator[Request, Response, None]:
+        request.headers["Authorization"] = self.authorization_header
+        yield request
+
+
+@pytest.fixture
+def administration_token_auth(backend: Backend) -> AdministrationTokenAuth:
+    return AdministrationTokenAuth(backend.config.administration_token)
+
+
+@pytest.fixture
+def administration_client(
+    client: AsyncClient, administration_token_auth: AdministrationTokenAuth
+) -> AsyncClient:
+    client.auth = administration_token_auth
+    return client
+
+
+type AdminUnauthErrorsTesterDoCallback = Callable[[AsyncClient], Coroutine[None, None, Response]]
+type AdminUnauthErrorsTester = Callable[
+    [AdminUnauthErrorsTesterDoCallback], Coroutine[None, None, None]
+]
+
+
+@pytest.fixture(params=("no_authentication", "invalid_authorization_header", "bad_bearer_token"))
+async def administration_route_unauth_errors_tester(
+    request: pytest.FixtureRequest, client: AsyncClient
+) -> AsyncGenerator[AdminUnauthErrorsTester, None]:
+    tester_called = False
+
+    async def _administration_route_unauth_error_tester(do: AdminUnauthErrorsTesterDoCallback):
+        nonlocal tester_called
+        tester_called = True
+
+        match request.param:
+            case "no_authentication":
+                pass
+            case "invalid_authorization_header":
+                client.headers["Authorization"] = "DUMMY"
+            case "bad_bearer_token":
+                client.auth = AdministrationTokenAuth("BADTOKEN")
+            case param:
+                assert False, param
+
+        response = await do(client)
+        assert response.status_code == 403, response.content
+
+    yield _administration_route_unauth_error_tester
+    assert tester_called


### PR DESCRIPTION
- Add fixture to perform unauthenticated tests similar to RPC API tests
- Add fixture to provide an authenticated client for the administration APIs