### PR TITLE
[MS] Fix organization summary label width

### DIFF
--- a/client/src/views/organizations/creation/OrganizationSummaryPage.vue
+++ b/client/src/views/organizations/creation/OrganizationSummaryPage.vue
@@ -295,7 +295,8 @@ defineEmits<{
   }
 
   &__label {
-    min-width: 8rem;
+    max-width: 9rem;
+    width: 100%;
     background: var(--parsec-color-light-secondary-premiere);
     color: var(--parsec-color-light-secondary-grey);
     align-items: center;


### PR DESCRIPTION
### Before 
<img width="720" height="583" alt="image" src="https://github.com/user-attachments/assets/9009ee68-81c1-406d-b0c6-817d2ccad389" />

### After 
<img width="704" height="430" alt="image" src="https://github.com/user-attachments/assets/b7f023a1-2124-445f-b0e1-647547286368" />

