### PR TITLE
[MS] Fix sidebar menu visibility management for file viewers

### DIFF
--- a/client/src/services/sidebarMenu.ts
+++ b/client/src/services/sidebarMenu.ts
@@ -1,38 +1,123 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { ref } from 'vue';
+import { StorageManager, StorageManagerKey } from '@/services/storageManager';
+import { SIDEBAR_MENU_DATA_KEY, SidebarDefaultData, SidebarSavedData } from '@/views/menu';
+import { computed, ComputedRef, inject, Ref, ref } from 'vue';
 
-const defaultWidth = 300;
-const hiddenWidth = 0;
-const computedWidth = ref<number>(defaultWidth);
-const storedWidth = ref<number>(defaultWidth);
+const DEFAULT_WIDTH = 300;
+const HIDDEN_WIDTH = 0;
+const computedWidth = ref<number>(DEFAULT_WIDTH);
+const storedWidth = ref<number>(DEFAULT_WIDTH);
+const isInitialized = ref<boolean>(false);
+const isVisible = computed(() => {
+  return !isInitialized.value ? false : computedWidth.value > HIDDEN_WIDTH;
+});
 
-export default function useSidebarMenu(): any {
-  function isVisible(): boolean {
-    return computedWidth.value > 4;
-  }
+interface SidebarMenu {
+  width: Ref<number>;
+  isVisible: ComputedRef<boolean>;
+  reset: (persist?: boolean) => void;
+  hide: (persist?: boolean) => void;
+  show: (persist?: boolean) => void;
+  setWidth: (width: number, persist?: boolean) => void;
+}
 
-  function reset(): void {
-    computedWidth.value = storedWidth.value;
-  }
+export default function useSidebarMenu(): SidebarMenu {
+  const storageManager: StorageManager | null = inject(StorageManagerKey, null);
 
-  function hide(): void {
-    if (isVisible()) {
-      storedWidth.value = computedWidth.value;
-      computedWidth.value = hiddenWidth;
+  // Start async initialization
+  init()
+    .then()
+    .catch((error) => {
+      console.warn('Failed to initialize sidebar menu:', error);
+    })
+    .finally(() => {
+      isInitialized.value = true;
+    });
+
+  async function init(): Promise<void> {
+    if (!storageManager) {
+      return;
+    }
+
+    try {
+      const savedData = await storageManager.retrieveComponentData<SidebarSavedData>(SIDEBAR_MENU_DATA_KEY, SidebarDefaultData);
+
+      const savedWidth = savedData.width || DEFAULT_WIDTH;
+      const isVisible = savedData.visible !== undefined ? savedData.visible : true; // Default to visible
+
+      if (isVisible) {
+        computedWidth.value = savedWidth;
+        storedWidth.value = savedWidth;
+      } else {
+        computedWidth.value = HIDDEN_WIDTH;
+        storedWidth.value = savedWidth;
+      }
+    } catch (error) {
+      console.warn('Failed to load sidebar state from storage:', error);
+      // Default to visible state with default width on storage errors
+      computedWidth.value = DEFAULT_WIDTH;
+      storedWidth.value = DEFAULT_WIDTH;
     }
   }
 
-  function show(): void {
+  async function _saveToStorage(): Promise<void> {
+    if (!storageManager) {
+      return;
+    }
+
+    try {
+      await storageManager.updateComponentData<SidebarSavedData>(
+        SIDEBAR_MENU_DATA_KEY,
+        {
+          width: computedWidth.value <= HIDDEN_WIDTH ? storedWidth.value : computedWidth.value,
+          visible: isVisible.value,
+        },
+        SidebarDefaultData,
+      );
+    } catch (error) {
+      console.warn('Failed to save sidebar state to storage:', error);
+    }
+  }
+
+  function reset(persist = true): void {
+    computedWidth.value = DEFAULT_WIDTH;
+    storedWidth.value = DEFAULT_WIDTH;
+    if (persist) {
+      _saveToStorage();
+    }
+  }
+
+  function hide(persist = true): void {
+    if (isVisible.value) {
+      storedWidth.value = computedWidth.value;
+      computedWidth.value = HIDDEN_WIDTH;
+      if (persist) {
+        _saveToStorage();
+      }
+    }
+  }
+
+  function show(persist = true): void {
     computedWidth.value = storedWidth.value;
+    if (persist) {
+      _saveToStorage();
+    }
+  }
+
+  function setWidth(width: number, persist = true): void {
+    computedWidth.value = width;
+    if (persist) {
+      _saveToStorage();
+    }
   }
 
   return {
-    computedWidth,
-    storedWidth,
+    width: computedWidth,
     isVisible,
     reset,
     hide,
     show,
+    setWidth,
   };
 }

--- a/client/src/views/client-area/ClientAreaPage.vue
+++ b/client/src/views/client-area/ClientAreaPage.vue
@@ -8,7 +8,7 @@
     <div
       class="resize-divider"
       ref="divider"
-      v-show="isVisible()"
+      v-show="isSidebarVisible"
     />
     <ion-split-pane
       when="xs"
@@ -161,7 +161,7 @@ import { useSmallDisplayWarning } from '@/services/smallDisplayWarning';
 
 const injectionProvider: InjectionProvider = inject(InjectionProviderKey)!;
 const informationManager: InformationManager = injectionProvider.getDefault().informationManager;
-const { computedWidth: computedWidth, isVisible: isVisible } = useSidebarMenu();
+const { width: sidebarWidth, isVisible: isSidebarVisible } = useSidebarMenu();
 const organizations = ref<Array<BmsOrganization>>([]);
 const dividerRef = useTemplateRef<HTMLDivElement>('divider');
 const currentPage = ref<ClientAreaPages>(ClientAreaPages.Dashboard);
@@ -173,7 +173,7 @@ const querying = ref(true);
 
 useSmallDisplayWarning(informationManager);
 
-const watchSidebarWidthCancel = watch(computedWidth, (value: number) => {
+const watchSidebarWidthCancel = watch(sidebarWidth, (value: number) => {
   sidebarWidthProperty.value = `${value}px`;
   // set toast offset
   setToastOffset(value);
@@ -195,9 +195,9 @@ async function _isCustomOrderProvisioned(organization: BmsOrganization): Promise
 
 onMounted(async () => {
   // Set the sidebar width property for the layout
-  sidebarWidthProperty.value = `${computedWidth.value}px`;
+  sidebarWidthProperty.value = `${sidebarWidth.value}px`;
   // Set the toast offset for the sidebar
-  setToastOffset(computedWidth.value);
+  setToastOffset(sidebarWidth.value);
 
   // Enable the gesture for resizing the sidebar
   if (dividerRef.value) {
@@ -290,11 +290,11 @@ async function switchPage(page: ClientAreaPages): Promise<void> {
 function onMove(detail: GestureDetail): void {
   requestAnimationFrame(() => {
     if (detail.currentX < 250) {
-      computedWidth.value = 250;
+      sidebarWidth.value = 250;
     } else if (detail.currentX > 370) {
-      computedWidth.value = 370;
+      sidebarWidth.value = 370;
     } else {
-      computedWidth.value = detail.currentX;
+      sidebarWidth.value = detail.currentX;
     }
   });
 }

--- a/client/src/views/header/HeaderPage.vue
+++ b/client/src/views/header/HeaderPage.vue
@@ -14,7 +14,7 @@
           slot="start"
           id="trigger-toggle-menu-button"
           class="topbar-button__item"
-          @click="isSidebarMenuVisible() ? hideSidebarMenu() : resetSidebarMenu()"
+          @click="isSidebarMenuVisible ? hideSidebarMenu() : resetSidebarMenu()"
           :image="SidebarToggle"
         />
         <div

--- a/client/src/views/menu/utils.ts
+++ b/client/src/views/menu/utils.ts
@@ -4,7 +4,7 @@ import { Ref, ref } from 'vue';
 
 export interface SidebarSavedData {
   width?: number;
-  hidden?: boolean;
+  visible?: boolean;
   organizationVisible?: boolean;
   workspacesVisible?: boolean;
   favoritesVisible?: boolean;
@@ -16,7 +16,7 @@ export const SIDEBAR_MENU_DATA_KEY = 'SidebarMenu';
 
 export const SidebarDefaultData: Required<SidebarSavedData> = {
   width: 300,
-  hidden: false,
+  visible: true,
   organizationVisible: true,
   workspacesVisible: true,
   favoritesVisible: true,

--- a/client/tests/e2e/specs/sidebar.spec.ts
+++ b/client/tests/e2e/specs/sidebar.spec.ts
@@ -1,7 +1,16 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 import { Locator } from '@playwright/test';
-import { DisplaySize, expect, fillInputModal, login, msTest } from '@tests/e2e/helpers';
+import { DisplaySize, expect, fillInputModal, login, MsPage, msTest, openFileType, setupNewPage } from '@tests/e2e/helpers';
+
+async function toggleSidebar(page: MsPage): Promise<void> {
+  // Look for toggle button in standard locations - simplified approach
+  const toggleButton = page.locator('#trigger-toggle-menu-button').first();
+
+  // Wait for button to be available and click it
+  await expect(toggleButton).toBeVisible();
+  await toggleButton.click();
+}
 
 msTest('Sidebar in organization management', async ({ organizationPage }) => {
   const sidebar = organizationPage.locator('.sidebar');
@@ -320,4 +329,181 @@ msTest('Recent and pinned workspaces are updated when workspace is renamed', asy
   await expect(sidebarFavoriteWorkspaces.locator('.sidebar-item').locator('.sidebar-item-workspace').nth(0)).toHaveText('Newer-wksp1');
   await expect(bobSidebarRecentWorkspaces.locator('.sidebar-item').locator('.sidebar-item-workspace').nth(0)).toHaveText('Newer-wksp1');
   await expect(bobSidebarFavoriteWorkspaces.locator('.sidebar-item').locator('.sidebar-item-workspace').nth(0)).toHaveText('Newer-wksp1');
+});
+
+// Sidebar visibility management tests
+msTest('Sidebar toggle functionality', async ({ documents }) => {
+  const sidebar = documents.locator('.sidebar');
+  const toggleButton = documents.locator('#trigger-toggle-menu-button');
+
+  // Initially sidebar should be visible
+  await expect(sidebar).toBeVisible();
+
+  // Hide sidebar
+  await toggleButton.click();
+  await expect(sidebar).toBeHidden();
+
+  // Show sidebar
+  await toggleButton.click();
+  await expect(sidebar).toBeVisible();
+});
+
+msTest('Sidebar visibility persists during same session navigation', async ({ documents, workspaces }) => {
+  const toggleButton = documents.locator('#trigger-toggle-menu-button');
+
+  // Hide sidebar on documents page
+  await toggleButton.click();
+  await expect(documents.locator('.sidebar')).toBeHidden();
+
+  // Navigate to workspaces
+  await documents.locator('#connected-header').locator('.topbar-left').locator('ion-breadcrumb').nth(0).click();
+  await expect(workspaces.locator('.workspaces-container')).toBeVisible();
+
+  // Sidebar should remain hidden
+  await expect(workspaces.locator('.sidebar')).toBeHidden();
+
+  // Show sidebar on workspaces page
+  const workspaceToggleButton = workspaces.locator('#trigger-toggle-menu-button');
+  await workspaceToggleButton.click();
+  await expect(workspaces.locator('.sidebar')).toBeVisible();
+
+  // Navigate back to documents
+  await workspaces.locator('.workspace-card-item').nth(0).click();
+  await expect(documents.locator('.folder-container')).toBeVisible();
+
+  // Sidebar should remain visible
+  await expect(documents.locator('.sidebar')).toBeVisible();
+});
+
+msTest('Sidebar responsive behavior', async ({ documents }) => {
+  const sidebar = documents.locator('.sidebar');
+  const toggleButton = documents.locator('#trigger-toggle-menu-button');
+
+  // Test in large display
+  await expect(sidebar).toBeVisible();
+  await expect(toggleButton).toBeVisible();
+
+  // Hide sidebar in large display
+  await toggleButton.click();
+  await expect(sidebar).toBeHidden();
+
+  // Switch to small display
+  await documents.setDisplaySize(DisplaySize.Small);
+  await expect(toggleButton).toBeHidden();
+  await expect(sidebar).toBeHidden();
+
+  // Switch back to large display
+  await documents.setDisplaySize(DisplaySize.Large);
+
+  // Verify sidebar state is consistent - should still be hidden
+  await expect(toggleButton).toBeVisible();
+  await expect(sidebar).toBeHidden();
+
+  // Test that toggle still works after display size change
+  await toggleButton.click();
+  await expect(sidebar).toBeVisible();
+});
+
+msTest('Sidebar state persists across page navigation', async ({ documents }) => {
+  // Start on documents page
+  await expect(documents.locator('.sidebar')).toBeVisible();
+
+  // Hide sidebar
+  await toggleSidebar(documents);
+  await expect(documents.locator('.sidebar')).toBeHidden();
+
+  // Navigate to workspaces
+  await documents.locator('#connected-header').locator('.topbar-left').locator('ion-breadcrumb').nth(0).click();
+  await expect(documents.locator('.workspaces-container')).toBeVisible();
+
+  // Verify sidebar stays hidden
+  await expect(documents.locator('.sidebar')).toBeHidden();
+
+  // Navigate back to documents
+  await documents.locator('.workspace-card-item').nth(0).click();
+  await expect(documents.locator('.folder-container')).toBeVisible();
+
+  // Verify sidebar still hidden
+  await expect(documents.locator('.sidebar')).toBeHidden();
+});
+
+// Tests for sidebar persistence after page reload
+msTest('Sidebar persistence after reload - basic visible case', async ({ documents }) => {
+  // Ensure sidebar is visible initially in documents page
+  const sidebar = documents.locator('.sidebar');
+  await expect(sidebar).toBeVisible();
+
+  // Directly reload without opening file viewer to test basic persistence
+  await documents.reload();
+  await setupNewPage(documents);
+  await expect(documents).toBeHomePage();
+  await login(documents, 'Alicey McAliceFace');
+
+  // Verify sidebar visibility is preserved after reload
+  await expect(documents.locator('.sidebar')).toBeVisible();
+});
+
+msTest('Sidebar persistence after reload - basic hidden case', async ({ documents }) => {
+  // Hide sidebar initially on documents page
+  const sidebar = documents.locator('.sidebar');
+  const toggleButton = documents.locator('#trigger-toggle-menu-button');
+
+  await expect(sidebar).toBeVisible();
+  await toggleButton.click();
+  await expect(sidebar).toBeHidden();
+
+  // Directly reload to test basic persistence
+  await documents.reload();
+  await setupNewPage(documents);
+  await expect(documents).toBeHomePage();
+  await login(documents, 'Alicey McAliceFace');
+
+  // Verify sidebar remains hidden after reload
+  await expect(documents.locator('.sidebar')).toBeHidden();
+});
+
+msTest('Sidebar persistence with file handler navigation and reload', async ({ documents }) => {
+  // Start with sidebar visible on documents page
+  const sidebar = documents.locator('.sidebar');
+  await expect(sidebar).toBeVisible();
+
+  // Open a file to enter file handler view
+  await openFileType(documents, 'docx');
+  await expect(documents).toBeViewerPage();
+  await expect(sidebar).toBeHidden();
+
+  // Reload the page (simulating F5)
+  await documents.reload();
+  await setupNewPage(documents);
+  await expect(documents).toBeHomePage();
+  await login(documents, 'Alicey McAliceFace');
+  await expect(documents.locator('.sidebar')).toBeVisible();
+});
+
+msTest('Sidebar state change in file handler persists after reload', async ({ documents }) => {
+  // Start with sidebar hidden on documents page
+  const sidebar = documents.locator('.sidebar');
+  const toggleButton = documents.locator('#trigger-toggle-menu-button');
+
+  await expect(sidebar).toBeVisible();
+  await toggleButton.click();
+  await expect(sidebar).toBeHidden();
+
+  // Open a file to enter file handler view
+  await openFileType(documents, 'docx');
+  await expect(documents).toBeViewerPage();
+  await expect(sidebar).toBeHidden();
+
+  // Try to show sidebar in file handler
+  const fileHandlerToggle = documents.locator('.file-handler-topbar').locator('#trigger-toggle-menu-button');
+  await fileHandlerToggle.click();
+  await expect(sidebar).toBeVisible();
+
+  // Reload the page (simulating F5)
+  await documents.reload();
+  await setupNewPage(documents);
+  await expect(documents).toBeHomePage();
+  await login(documents, 'Alicey McAliceFace');
+
+  await expect(documents.locator('.sidebar')).toBeVisible();
 });

--- a/client/tests/unit/specs/testSidebarMenu.spec.ts
+++ b/client/tests/unit/specs/testSidebarMenu.spec.ts
@@ -1,0 +1,202 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { SIDEBAR_MENU_DATA_KEY, SidebarDefaultData, SidebarSavedData } from '@/views/menu';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
+
+// Mock Vue's inject function
+vi.mock('vue', async () => {
+  const actual = await vi.importActual('vue');
+  return {
+    ...actual,
+    inject: vi.fn(),
+  };
+});
+
+// Mock the storage manager
+const mockStorageManager = {
+  retrieveComponentData: vi.fn(),
+  updateComponentData: vi.fn(),
+};
+
+async function waitForInitialization(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await nextTick();
+}
+
+describe('useSidebarMenu', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { inject } = await import('vue');
+    vi.mocked(inject).mockReturnValue(mockStorageManager);
+
+    // Provide default mock behavior
+    mockStorageManager.retrieveComponentData.mockResolvedValue(SidebarDefaultData);
+    mockStorageManager.updateComponentData.mockResolvedValue(undefined);
+
+    // Reset service global state by reimporting the module
+    await vi.resetModules();
+  });
+
+  describe('initialization', () => {
+    it('should start with default values before loading', async () => {
+      const { default: useSidebarMenu } = await import('@/services/sidebarMenu');
+      const sidebar = useSidebarMenu();
+
+      expect(sidebar.width.value).toBe(300); // DEFAULT_WIDTH
+      expect(sidebar.isVisible.value).toBe(false); // Hidden during loading
+    });
+
+    it('should load visible state from storage', async () => {
+      const savedData: SidebarSavedData = {
+        width: 400,
+        visible: true,
+      };
+      mockStorageManager.retrieveComponentData.mockResolvedValue(savedData);
+
+      const { default: useSidebarMenu } = await import('@/services/sidebarMenu');
+      const sidebar = useSidebarMenu();
+      await waitForInitialization();
+
+      expect(sidebar.width.value).toBe(400);
+      expect(sidebar.isVisible.value).toBe(true);
+    });
+
+    it('should load hidden state from storage', async () => {
+      const savedData: SidebarSavedData = {
+        width: 350,
+        visible: false,
+      };
+      mockStorageManager.retrieveComponentData.mockResolvedValue(savedData);
+
+      const { default: useSidebarMenu } = await import('@/services/sidebarMenu');
+      const sidebar = useSidebarMenu();
+      await waitForInitialization();
+
+      expect(sidebar.width.value).toBe(0); // HIDDEN_WIDTH
+      expect(sidebar.isVisible.value).toBe(false);
+    });
+
+    it('should handle storage errors gracefully', async () => {
+      mockStorageManager.retrieveComponentData.mockRejectedValue(new Error('Storage error'));
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { default: useSidebarMenu } = await import('@/services/sidebarMenu');
+      const sidebar = useSidebarMenu();
+      await waitForInitialization();
+
+      expect(sidebar.width.value).toBe(300); // DEFAULT_WIDTH
+      expect(sidebar.isVisible.value).toBe(true);
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to load sidebar state from storage:', expect.any(Error));
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('hide function', () => {
+    it('should hide visible sidebar and persist by default', async () => {
+      const savedData: SidebarSavedData = { width: 400, visible: true };
+      mockStorageManager.retrieveComponentData.mockResolvedValue(savedData);
+      mockStorageManager.updateComponentData.mockResolvedValue(undefined);
+
+      const { default: useSidebarMenu } = await import('@/services/sidebarMenu');
+      const sidebar = useSidebarMenu();
+      await waitForInitialization();
+
+      expect(sidebar.isVisible.value).toBe(true);
+
+      sidebar.hide();
+
+      expect(sidebar.width.value).toBe(0);
+      expect(sidebar.isVisible.value).toBe(false);
+      expect(mockStorageManager.updateComponentData).toHaveBeenCalledWith(
+        SIDEBAR_MENU_DATA_KEY,
+        { width: 400, visible: false },
+        SidebarDefaultData,
+      );
+    });
+
+    it('should hide without persisting when persist=false', async () => {
+      const savedData: SidebarSavedData = { width: 400, visible: true };
+      mockStorageManager.retrieveComponentData.mockResolvedValue(savedData);
+
+      const { default: useSidebarMenu } = await import('@/services/sidebarMenu');
+      const sidebar = useSidebarMenu();
+      await waitForInitialization();
+
+      sidebar.hide(false);
+
+      expect(sidebar.isVisible.value).toBe(false);
+      expect(mockStorageManager.updateComponentData).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing if already hidden', async () => {
+      const savedData: SidebarSavedData = { width: 400, visible: false };
+      mockStorageManager.retrieveComponentData.mockResolvedValue(savedData);
+
+      const { default: useSidebarMenu } = await import('@/services/sidebarMenu');
+      const sidebar = useSidebarMenu();
+      await waitForInitialization();
+
+      expect(sidebar.isVisible.value).toBe(false);
+
+      sidebar.hide();
+
+      expect(mockStorageManager.updateComponentData).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('show function', () => {
+    it('should show hidden sidebar with stored width', async () => {
+      const savedData: SidebarSavedData = { width: 450, visible: false };
+      mockStorageManager.retrieveComponentData.mockResolvedValue(savedData);
+      mockStorageManager.updateComponentData.mockResolvedValue(undefined);
+
+      const { default: useSidebarMenu } = await import('@/services/sidebarMenu');
+      const sidebar = useSidebarMenu();
+      await waitForInitialization();
+
+      expect(sidebar.isVisible.value).toBe(false);
+
+      sidebar.show();
+
+      expect(sidebar.width.value).toBe(450);
+      expect(sidebar.isVisible.value).toBe(true);
+      expect(mockStorageManager.updateComponentData).toHaveBeenCalledWith(
+        SIDEBAR_MENU_DATA_KEY,
+        { width: 450, visible: true },
+        SidebarDefaultData,
+      );
+    });
+  });
+
+  describe('loading state behavior', () => {
+    it('should show isVisible as false during loading', async () => {
+      mockStorageManager.retrieveComponentData.mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve({ width: 400, visible: true }), 100)),
+      );
+
+      const { default: useSidebarMenu } = await import('@/services/sidebarMenu');
+      const sidebar = useSidebarMenu();
+
+      // During loading
+      expect(sidebar.isVisible.value).toBe(false);
+    });
+
+    it('should update isVisible after loading completes', async () => {
+      const savedData: SidebarSavedData = { width: 400, visible: true };
+      mockStorageManager.retrieveComponentData.mockResolvedValue(savedData);
+
+      const { default: useSidebarMenu } = await import('@/services/sidebarMenu');
+      const sidebar = useSidebarMenu();
+
+      // During loading
+      expect(sidebar.isVisible.value).toBe(false);
+
+      // After loading
+      await waitForInitialization();
+
+      expect(sidebar.isVisible.value).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Describe the issue
The existing problem:
- A file is uploaded (visible sidebar ✅ )
- It is opened with the viewer (invisible sidebar ✅ ) <-- should not be visible if the user has not performed any actions
- The page is reloaded
- The user goes to the workspaces page (invisible sidebar :x:)


https://github.com/user-attachments/assets/fff1d980-9f3e-42fc-9d00-b19e1d1a749e



<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
