### PR TITLE
[MS] Fix settings list UI bug

### DIFF
--- a/client/src/components/settings/SettingsList.vue
+++ b/client/src/components/settings/SettingsList.vue
@@ -84,6 +84,7 @@
         <!-- synchro wifi -->
         <settings-option
           v-if="false"
+          class="settings-list__item"
           title="SettingsModal.meteredConnection.label"
           description="SettingsModal.meteredConnection.description"
         >
@@ -131,6 +132,7 @@
         <!-- display unsync files -->
         <settings-option
           v-if="false"
+          class="settings-list__item"
           title="SettingsModal.unsyncFiles.label"
           description="SettingsModal.unsyncFiles.description"
         >
@@ -139,6 +141,7 @@
         <!-- skip file viewers -->
         <settings-option
           v-if="isDesktop()"
+          class="settings-list__item"
           title="SettingsModal.skipViewers.label"
           description="SettingsModal.skipViewers.description"
         >
@@ -239,6 +242,7 @@ onUnmounted(async (): Promise<void> => {
 .settings-list {
   display: flex;
   flex-direction: column;
+  background: none;
   padding-top: 0px;
   padding-bottom: 0px;
   gap: 2rem;


### PR DESCRIPTION

<img width="685" height="298" alt="image" src="https://github.com/user-attachments/assets/f343e3b8-0d0c-411d-8c0a-abbeaca8a38b" />

## The issue
- Border radius wasn't apply on setting lists (Electron)
- Missing class on a setting list item (missing padding)

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
