### PR TITLE
[MS] Editing `.csv` files as code files

### DIFF
--- a/client/src/services/cryptpad.ts
+++ b/client/src/services/cryptpad.ts
@@ -162,7 +162,6 @@ export function getDocumentTypeFromExtension(extension: string): CryptpadDocumen
     case 'txt':
     case 'rtf':
       return CryptpadDocumentType.Pad;
-    case 'csv':
     case 'xlsx':
       return CryptpadDocumentType.Sheet;
     case 'docx':

--- a/client/tests/unit/specs/testCryptpad.spec.ts
+++ b/client/tests/unit/specs/testCryptpad.spec.ts
@@ -257,7 +257,6 @@ describe('CryptPad Service', () => {
     });
 
     it('should return correct document type for spreadsheet files', () => {
-      expectExtensionToGiveDocumentType('csv', CryptpadDocumentType.Sheet);
       expectExtensionToGiveDocumentType('xlsx', CryptpadDocumentType.Sheet);
       expectExtensionToGiveDocumentType('XLSX', CryptpadDocumentType.Sheet);
     });
@@ -300,7 +299,6 @@ describe('CryptPad Service', () => {
 
     it('should return true for enabled document types', () => {
       expectDocumentTypeToBeEnabled('txt', true);
-      expectDocumentTypeToBeEnabled('csv', true);
       expectDocumentTypeToBeEnabled('docx', true);
       expectDocumentTypeToBeEnabled('pptx', true);
       expectDocumentTypeToBeEnabled('js', true);


### PR DESCRIPTION
While investigated CSV file issue on CryptPad, I found out `.csv` cannot be opened as spreadsheet file but code file only.

⚠️ As editing is not displayed properly, we have decided to suppress editing for CSV files.

closes #10876

<img width="1451" height="550" alt="image" src="https://github.com/user-attachments/assets/5c891671-e2b4-4d82-97b8-ab7c7d2ae057" />
<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->