### PR TITLE
Prevent client using API < 5.2 from using `invite_(claimer|greeter)_step` commands

### DIFF
--- a/libparsec/crates/protocol/src/version.rs
+++ b/libparsec/crates/protocol/src/version.rs
@@ -23,6 +23,11 @@ use libparsec_types::prelude::*;
 // - v5.1 (Parsec 3.5+):
 //   * Add `allowed_client_agent` field to `events_listen` response
 //   * Add `account_vault_strategy` field to `events_listen` response
+// - v5.2 (Parsec 3.6+):
+//   * Incompatible change in SASCode algorithm and shared secret key. This doesn't actually
+//     impact the protocol (as SASCode and shared secret key are computed client-side),
+//     however a server supporting API 5.2 will reject any `(invite|greeter)_claimer_step`
+//     made by clients with API < 5.2.
 pub const API_V1_VERSION: &ApiVersion = &ApiVersion {
     version: 1,
     revision: 3,
@@ -41,7 +46,7 @@ pub const API_V4_VERSION: &ApiVersion = &ApiVersion {
 };
 pub const API_V5_VERSION: &ApiVersion = &ApiVersion {
     version: 5,
-    revision: 0,
+    revision: 2,
 };
 pub const API_LATEST_VERSION: &ApiVersion = API_V5_VERSION;
 

--- a/newsfragments/11017.bugfix.rst
+++ b/newsfragments/11017.bugfix.rst
@@ -1,0 +1,3 @@
+Breaking change: server rejects any invitation enrollment attempt from a client using
+Parsec < 3.6. This is to avoid SAS codes appearing as different when doing an enrollment
+with a client using Parsec >= 3.6.

--- a/server/parsec/asgi/rpc.py
+++ b/server/parsec/asgi/rpc.py
@@ -284,6 +284,14 @@ def _handshake_abort_bad_content(api_version: ApiVersion) -> NoReturn:
     _handshake_abort(CustomHttpStatus.BadContentTypeOrInvalidBodyOrUnknownCommand, api_version)
 
 
+def _handshake_abort_unsupported_api_version() -> NoReturn:
+    supported_api_versions = ";".join(str(api_version) for api_version in SUPPORTED_API_VERSIONS)
+    raise HTTPException(
+        status_code=CustomHttpStatus.UnsupportedApiVersion.value,
+        headers={"Supported-Api-Versions": supported_api_versions},
+    )
+
+
 @dataclass
 class ParsedAuthHeaders:
     organization_id: OrganizationID
@@ -317,13 +325,7 @@ def _parse_auth_headers_or_abort(
             SUPPORTED_API_VERSIONS, [client_api_version]
         )
     except (ValueError, IncompatibleAPIVersionsError):
-        supported_api_versions = ";".join(
-            str(api_version) for api_version in SUPPORTED_API_VERSIONS
-        )
-        raise HTTPException(
-            status_code=CustomHttpStatus.UnsupportedApiVersion.value,
-            headers={"Supported-Api-Versions": supported_api_versions},
-        )
+        _handshake_abort_unsupported_api_version()
 
     # From now on the version is settled, our reply must have the `Api-Version` header
 

--- a/server/parsec/client_context.py
+++ b/server/parsec/client_context.py
@@ -112,6 +112,11 @@ class InvitedClientContext:
             api_version=self.settled_api_version,
         )
 
+    def unsupported_api_version_abort(self) -> NoReturn:
+        from parsec.asgi.rpc import _handshake_abort_unsupported_api_version
+
+        _handshake_abort_unsupported_api_version()
+
 
 @dataclass(slots=True)
 class AuthenticatedClientContext:
@@ -168,6 +173,11 @@ class AuthenticatedClientContext:
             CustomHttpStatus.UserRevoked,
             api_version=self.settled_api_version,
         )
+
+    def unsupported_api_version_abort(self) -> NoReturn:
+        from parsec.asgi.rpc import _handshake_abort_unsupported_api_version
+
+        _handshake_abort_unsupported_api_version()
 
 
 @dataclass(slots=True)

--- a/server/parsec/components/invite.py
+++ b/server/parsec/components/invite.py
@@ -12,6 +12,7 @@ from enum import auto
 from jinja2 import Environment
 
 from parsec._parsec import (
+    ApiVersion,
     CancelledGreetingAttemptReason,
     DateTime,
     DeviceID,
@@ -44,6 +45,9 @@ UserOnlineStatus = invited_cmds.latest.invite_info.UserOnlineStatus
 UserGreetingAdministrator = invited_cmds.latest.invite_info.UserGreetingAdministrator
 InviteInfoInvitationCreatedBy = invited_cmds.latest.invite_info.InvitationCreatedBy
 InviteListInvitationCreatedBy = authenticated_cmds.latest.invite_list.InvitationCreatedBy
+
+
+NEW_SAS_CODE_ALGORITHM_INTRODUCED_IN_VERSION = ApiVersion(version=5, revision=2)
 
 
 @dataclass(slots=True)
@@ -1166,6 +1170,9 @@ class BaseInviteComponent:
         client_ctx: AuthenticatedClientContext,
         req: authenticated_cmds.latest.invite_greeter_step.Req,
     ) -> authenticated_cmds.latest.invite_greeter_step.Rep:
+        if client_ctx.client_api_version < NEW_SAS_CODE_ALGORITHM_INTRODUCED_IN_VERSION:
+            client_ctx.unsupported_api_version_abort()
+
         step_index, greeter_data, load_claimer_data = process_greeter_step(req.greeter_step)
         outcome = await self.greeter_step(
             now=DateTime.now(),
@@ -1233,6 +1240,9 @@ class BaseInviteComponent:
         client_ctx: InvitedClientContext,
         req: invited_cmds.latest.invite_claimer_step.Req,
     ) -> invited_cmds.latest.invite_claimer_step.Rep:
+        if client_ctx.client_api_version < NEW_SAS_CODE_ALGORITHM_INTRODUCED_IN_VERSION:
+            client_ctx.unsupported_api_version_abort()
+
         step_index, claimer_data, load_greeter_data = process_claimer_step(req.claimer_step)
         outcome = await self.claimer_step(
             now=DateTime.now(),


### PR DESCRIPTION
closes #11017