### PR TITLE
fix(ci-publish): Only publish on edited release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,6 @@ on:
         required: true
   release:
     types:
-      - published
       - edited
   pull_request:
     paths:


### PR DESCRIPTION
When publishing a draft release it triggered this workflow 2 times: One for the `published` event and another time for the `edited` event causing concurrency on the uploading task to Snapcraft and Pypi.

Even tho we had configured `concurrency.group` and `concurrency.cancel-in-progress`, it was not enough as one workflow could be stopped when it as already finished uploading everything causing the second workflow to fail when the receiver check for duplicate artifacts (notably Snapcraft).

By reading the documentation about the [`release` event](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#release) The `edited` activity type is only triggered for published release (so when a draft is published and a release edited latter on).

Closes #11142