### PR TITLE
Add startup check in `parsec run` to ensure the DB has applied all migrations

### DIFF
--- a/newsfragments/8709.feature.rst
+++ b/newsfragments/8709.feature.rst
@@ -1,0 +1,1 @@
+The database's datamodel is now checked during server startup to ensure all migrations have been applied.


### PR DESCRIPTION
close #8709