### PR TITLE
feat(pki): Allow to verify signature using a certificate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,6 +2416,9 @@ dependencies = [
  "data-encoding",
  "error_set",
  "percent-encoding",
+ "rsa",
+ "rustls-pki-types",
+ "rustls-webpki",
  "schannel",
  "sha2",
  "windows-sys 0.61.1",
@@ -3790,6 +3793,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "getrandom 0.2.15",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3933,6 +3950,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -5022,6 +5050,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,8 @@ rsa = { version = "0.8.2", default-features = false }
 rstest = { version = "0.24.0", default-features = false }
 rstest_reuse = { version = "0.7.0", default-features = false }
 ruzstd = { version = "0.7.3", default-features = true }
+rustls-webpki = { version = "0.103.6", default-features = false }
+rustls-pki-types = { version = "1.12.0", default-features = false }
 # Crate to interact with windows credential store, it's used notably in `native-tls` crate.
 schannel = { version = "0.1.28", default-features = false }
 sentry = { version = "0.34.0", default-features = false }

--- a/libparsec/crates/platform_pki/Cargo.toml
+++ b/libparsec/crates/platform_pki/Cargo.toml
@@ -19,16 +19,18 @@ hash-sri-display = ["dep:data-encoding"]
 bytes = { workspace = true }
 data-encoding = { workspace = true, optional = true }
 error_set = { workspace = true }
+rustls-webpki = { workspace = true, features = ["std"] }
+rustls-pki-types = { workspace = true }
+rsa = { workspace = true }
+sha2 = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 schannel = { workspace = true }
 windows-sys = { workspace = true, features = ["Win32_Security_Cryptography_UI"] }
-sha2 = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 cryptoki = { workspace = true }
 percent-encoding = { workspace = true }
-sha2 = { workspace = true }
 
 [dev-dependencies]
 # We use clap to provide a CLI for examples.

--- a/libparsec/crates/platform_pki/examples/encrypt_message.rs
+++ b/libparsec/crates/platform_pki/examples/encrypt_message.rs
@@ -1,7 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 mod utils;
-use std::path::PathBuf;
 
 use anyhow::Context;
 use clap::Parser;
@@ -13,16 +12,7 @@ struct Args {
     #[arg(value_parser = utils::CertificateSRIHashParser)]
     certificate_hash: CertificateHash,
     #[command(flatten)]
-    content: ContentOpts,
-}
-
-#[derive(Debug, Clone, clap::Args)]
-#[group(required = true, multiple = false)]
-struct ContentOpts {
-    #[arg(long, conflicts_with = "content_file")]
-    content: Option<String>,
-    #[arg(long)]
-    content_file: Option<PathBuf>,
+    content: utils::ContentOpts,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -30,11 +20,7 @@ fn main() -> anyhow::Result<()> {
     println!("args={args:?}");
 
     let cert_ref = CertificateReference::Hash(args.certificate_hash);
-    let data: Vec<u8> = match (args.content.content, args.content.content_file) {
-        (Some(content), None) => content.into(),
-        (None, Some(filepath)) => std::fs::read(filepath).context("Failed to read file")?,
-        (Some(_), Some(_)) | (None, None) => unreachable!("Handled by clap"),
-    };
+    let data = args.content.into_bytes()?;
 
     let res = encrypt_message(&data, &cert_ref).context("Failed to encrypt message")?;
 

--- a/libparsec/crates/platform_pki/examples/utils/mod.rs
+++ b/libparsec/crates/platform_pki/examples/utils/mod.rs
@@ -1,5 +1,8 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
+use std::path::PathBuf;
+
+use anyhow::Context;
 use clap::{
     builder::{NonEmptyStringValueParser, TypedValueParser},
     error::{Error, ErrorKind},
@@ -35,6 +38,29 @@ impl TypedValueParser for CertificateSRIHashParser {
                 ErrorKind::InvalidValue,
                 format!("Unsupported hash type `{hash_ty}`"),
             ))
+        }
+    }
+}
+
+#[derive(Debug, Clone, clap::Args)]
+#[group(required = true, multiple = false)]
+pub struct ContentOpts {
+    /// The content to use.
+    #[arg(long)]
+    pub content: Option<String>,
+    /// Read content from a file
+    #[arg(long)]
+    pub content_file: Option<PathBuf>,
+}
+
+impl ContentOpts {
+    // Not all examples uses `ContentOpts` so `into_bytes` is not always used.
+    #[allow(dead_code)]
+    pub fn into_bytes(self) -> anyhow::Result<Vec<u8>> {
+        match (self.content, self.content_file) {
+            (Some(content), None) => Ok(content.into()),
+            (None, Some(filepath)) => std::fs::read(filepath).context("Failed to read file"),
+            (Some(_), Some(_)) | (None, None) => unreachable!("Handled by clap"),
         }
     }
 }

--- a/libparsec/crates/platform_pki/examples/verify_message.rs
+++ b/libparsec/crates/platform_pki/examples/verify_message.rs
@@ -1,0 +1,97 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use std::path::PathBuf;
+
+use anyhow::Context;
+use clap::Parser;
+use libparsec_platform_pki::{
+    get_der_encoded_certificate, verify_message, Certificate, CertificateHash, SignatureAlgorithm,
+    SignedMessage,
+};
+use sha2::Digest;
+
+mod utils;
+
+#[derive(Debug, Parser)]
+struct Args {
+    #[command(flatten)]
+    cert: CertificateOrRef,
+    #[command(flatten)]
+    content: utils::ContentOpts,
+    signature_header: SignatureAlgorithm,
+    /// Signature in base64
+    signature: String,
+}
+
+#[derive(Debug, Clone, clap::Args)]
+#[group(required = true, multiple = false)]
+struct CertificateOrRef {
+    /// Hash of the certificate from the store to use to verify the signature.
+    #[arg(long, value_parser = utils::CertificateSRIHashParser)]
+    certificate_hash: Option<CertificateHash>,
+    /// Path to a file containing the certificate in DER format.
+    #[arg(long)]
+    der_file: Option<PathBuf>,
+    /// Path to a file containing the certificate in PEM format.
+    #[arg(long)]
+    pem_file: Option<PathBuf>,
+    /// Certificate in PEM format but without headers.
+    #[arg(long)]
+    pem: Option<String>,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    println!("args={args:?}");
+
+    let data = args.content.into_bytes()?;
+
+    let signature = data_encoding::BASE64
+        .decode(args.signature.as_bytes())
+        .context("Invalid signature format")?;
+
+    let cert = if let Some(hash) = args.cert.certificate_hash {
+        let res =
+            get_der_encoded_certificate(&libparsec_platform_pki::CertificateReference::Hash(hash))?;
+        println!(
+            "Will verify signature using cert with id {{{}}}",
+            data_encoding::BASE64.encode_display(&res.cert_ref.id)
+        );
+        Certificate::from_der_owned(res.der_content.into())
+    } else if let Some(der_file) = args.cert.der_file {
+        let raw = std::fs::read(der_file).context("Failed to read file")?;
+        Certificate::from_der_owned(raw)
+    } else if let Some(pem_file) = args.cert.pem_file {
+        let raw = std::fs::read(pem_file).context("Failed to read file")?;
+        Certificate::try_from_pem(&r#raw)?.into_owned()
+    } else if let Some(pem) = args.cert.pem {
+        let raw = data_encoding::BASE64
+            .decode(pem.as_bytes())
+            .context("Invalid pem base64")?;
+        Certificate::from_der_owned(raw)
+    } else {
+        unreachable!("Should be handle by clap")
+    };
+
+    #[cfg(feature = "hash-sri-display")]
+    {
+        let fingerprint =
+            CertificateHash::SHA256(Box::new(sha2::Sha256::digest(cert.as_ref()).into()));
+        println!("Certificate fingerprint: {fingerprint}");
+    }
+
+    let signed_message = SignedMessage {
+        algo: args.signature_header,
+        signature,
+        message: data,
+    };
+
+    match verify_message(&signed_message, cert) {
+        Ok(_) => {
+            println!("The message as a correct signature")
+        }
+        Err(e) => println!("The message as an incorrect signature: {e}"),
+    }
+
+    Ok(())
+}

--- a/libparsec/crates/platform_pki/examples/windows_encrypt_roundtrip.ps1
+++ b/libparsec/crates/platform_pki/examples/windows_encrypt_roundtrip.ps1
@@ -1,0 +1,19 @@
+cargo build --examples -p libparsec_platform_pki
+
+$certificate_fingerprint = cargo run -p libparsec_platform_pki --example get_certificate_der | Select-String -Pattern '^fingerprint: .*$' | ForEach-Object { $_.line.Split(': ')[-1] }
+
+$content_string = "Hello world"
+
+if ($content_string.Length > 2048) {
+    echo "The content to encrypt is too big for the 2048-RSA key"
+    exit
+}
+
+$encrypt_algo, $ciphered = cargo run -p libparsec_platform_pki --example encrypt_message -- $certificate_fingerprint --content $content_string | Select-String -Pattern 'using the algorithm .*','^Encrypted data: .*$' | ForEach-Object { $_.line.Split(': ')[-1] }
+
+echo "Encrypt message: $content_string"
+echo "using algo: $encrypt_algo"
+echo "and certificate: $certificate_fingerprint"
+echo "Result in ciphered: $ciphered"
+
+cargo run -p libparsec_platform_pki --example decrypt_message -- $certificate_fingerprint --content $ciphered --algorithm $encrypt_algo

--- a/libparsec/crates/platform_pki/examples/windows_signature_roundtrip.ps1
+++ b/libparsec/crates/platform_pki/examples/windows_signature_roundtrip.ps1
@@ -1,0 +1,12 @@
+cargo build --examples -p libparsec_platform_pki
+
+$certificate_fingerprint = cargo run -p libparsec_platform_pki --example get_certificate_der | Select-String -Pattern '^fingerprint: .*$' | ForEach-Object { $_.line.Split(': ')[-1] }
+
+$sign_algo, $signature = cargo run -p libparsec_platform_pki --example sign_message -- $certificate_fingerprint --content-file Cargo.toml | Select-String -Pattern 'with algorithm .*','^Signature: .*$' | ForEach-Object { $_.line.Split(': ')[-1] }
+
+echo "Signing content of Cargo.toml"
+echo "using algo: $sign_algo"
+echo "and certificate: $certificate_fingerprint"
+echo "Result in signature: $signature"
+
+cargo run -p libparsec_platform_pki --example verify_message -- --certificate-hash $certificate_fingerprint --content-file Cargo.toml $sign_algo $signature

--- a/libparsec/crates/platform_pki/src/errors.rs
+++ b/libparsec/crates/platform_pki/src/errors.rs
@@ -26,4 +26,18 @@ error_set::error_set! {
         #[display("Cannot decrypt message: {0}")]
         CannotDecrypt(std::io::Error),
     };
+    InvalidCertificateDer = {
+        #[display("Invalid certificate: {0}")]
+        InvalidCertificateDer(webpki::Error),
+    };
+    VerifySignatureError = InvalidCertificateDer || {
+        #[display("Invalid signature for the given message and certificate")]
+        InvalidSignature,
+        #[display("Unexpected signature will verifying signature of a message: {0}")]
+        UnexpectedError(webpki::Error)
+    };
+    InvalidPemContent = {
+        #[display("Invalid PEM content: {0}")]
+        InvalidPemContent(rustls_pki_types::pem::Error)
+    };
 }

--- a/libparsec/crates/platform_pki/src/shared.rs
+++ b/libparsec/crates/platform_pki/src/shared.rs
@@ -1,0 +1,120 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use crate::{
+    errors::{InvalidPemContent, VerifySignatureError},
+    SignatureAlgorithm,
+};
+use rsa::{
+    pkcs1,
+    pss::{Signature, VerifyingKey},
+    signature::Verifier,
+    RsaPublicKey,
+};
+use rustls_pki_types::{
+    pem::PemObject, CertificateDer, InvalidSignature, SignatureVerificationAlgorithm,
+};
+use sha2::Sha256;
+use webpki::{EndEntityCert, Error as WebPkiError};
+
+pub struct Certificate<'a> {
+    internal: CertificateDer<'a>,
+}
+
+impl<'a> Certificate<'a> {
+    pub fn try_from_pem(raw: &'a [u8]) -> Result<Self, InvalidPemContent> {
+        CertificateDer::from_pem_slice(raw)
+            .map(Self::new)
+            .map_err(Into::into)
+    }
+
+    pub fn from_der(raw: &'a [u8]) -> Self {
+        Self::new(raw.into())
+    }
+
+    pub fn new(cert: CertificateDer<'a>) -> Self {
+        Self { internal: cert }
+    }
+
+    pub fn into_owned(&self) -> Certificate<'static> {
+        Certificate::new(self.internal.clone().into_owned())
+    }
+}
+
+impl Certificate<'static> {
+    pub fn from_der_owned(raw: Vec<u8>) -> Self {
+        Self::new(raw.into())
+    }
+}
+
+impl AsRef<[u8]> for Certificate<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.internal.as_ref()
+    }
+}
+
+pub struct SignedMessage {
+    pub algo: SignatureAlgorithm,
+    pub signature: Vec<u8>,
+    pub message: Vec<u8>,
+}
+
+pub fn verify_message<'message>(
+    signed_message: &'message SignedMessage,
+    certificate: Certificate<'_>,
+) -> Result<&'message [u8], VerifySignatureError> {
+    let verifier = match signed_message.algo {
+        SignatureAlgorithm::RsassaPssSha256 => &RsassaPssSha256SignatureVerifier,
+    };
+    EndEntityCert::try_from(&certificate.internal)
+        .map_err(VerifySignatureError::InvalidCertificateDer)?
+        .verify_signature(verifier, &signed_message.message, &signed_message.signature)
+        .map(|_| signed_message.message.as_ref())
+        .map_err(|e| match e {
+            WebPkiError::InvalidSignatureForPublicKey => VerifySignatureError::InvalidSignature,
+            e => VerifySignatureError::UnexpectedError(e),
+        })
+}
+
+#[derive(Debug)]
+struct RsassaPssSha256SignatureVerifier;
+
+impl SignatureVerificationAlgorithm for RsassaPssSha256SignatureVerifier {
+    fn verify_signature(
+        &self,
+        public_key: &[u8],
+        message: &[u8],
+        signature: &[u8],
+    ) -> Result<(), InvalidSignature> {
+        // Webpki already checked that the key part correspond to an RSA public key.
+        //
+        // We are not using `pkcs8::DecodePublicKey::from_public_key_der` as
+        // `public_key` is already the unwrapped key from the `subjectPublicKeyInfo` structure
+        // which it's the expected data from the above method.
+        //
+        // Instead, we use `pkcs1::RsaPublicKey::try_from(&[u8])` which only expect the key element
+        // (without the algorithm identifier).
+        let pubkey = pkcs1::RsaPublicKey::try_from(public_key)
+            .map_err(|_| InvalidSignature)
+            // But `rsa` does not provide a conversion between the `pkcs1` and its `RsaPublicKey`, so
+            // we need to perform the manual conversion
+            .and_then(|pubkey| {
+                let n = rsa::BigUint::from_bytes_be(pubkey.modulus.as_bytes());
+                let e = rsa::BigUint::from_bytes_be(pubkey.public_exponent.as_bytes());
+                RsaPublicKey::new(n, e).map_err(|_| InvalidSignature)
+            })?;
+        let verifying_key = VerifyingKey::<Sha256>::new(pubkey);
+
+        let signature = Signature::try_from(signature).map_err(|_| InvalidSignature)?;
+        verifying_key
+            .verify(message, &signature)
+            .map_err(|_| InvalidSignature)
+    }
+
+    fn public_key_alg_id(&self) -> rustls_pki_types::AlgorithmIdentifier {
+        rustls_pki_types::alg_id::RSA_ENCRYPTION
+    }
+
+    fn signature_alg_id(&self) -> rustls_pki_types::AlgorithmIdentifier {
+        rustls_pki_types::alg_id::RSA_PSS_SHA256
+    }
+}


### PR DESCRIPTION
- Use `rustls` crates to provide the parsing of a DER/PEM certificate
- Add example to verify a generated signature (will work on allow platforms, but on unix, we are currently not integrated with a cert store)
