### PR TITLE
fix(snap): Remove `fusermount` from included bin

### DIFF
--- a/client/electron/snap/snapcraft.yaml
+++ b/client/electron/snap/snapcraft.yaml
@@ -66,7 +66,6 @@ parts:
     stage:
       - libparsec.d.ts
       - libparsec.node
-      - bin/fusermount* # include fusermount bin
       - lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libfuse3* # include libfuse3
     prime:
       - -libparsec.d.ts


### PR DESCRIPTION
The `fusermount` provided by snap does not seems to work, so instead, we will use the one provided by the OS (if any). That should not cause any issue given that we will use `umount` as a fallback (in #11205)

Closes #11207
