### PR TITLE
[MS] Responsive file folder table

### DIFF
--- a/client/src/components/files/explorer/FileListDisplay.vue
+++ b/client/src/components/files/explorer/FileListDisplay.vue
@@ -23,7 +23,7 @@
           lines="full"
           v-if="isLargeDisplay"
         >
-          <ion-label class="folder-list-header__label ion-text-nowrap label-selected">
+          <ion-label class="folder-list-header__label ion-text-nowrap header-label-selected">
             <ms-checkbox
               @change="selectAll"
               :checked="allSelected"
@@ -31,56 +31,56 @@
             />
           </ion-label>
           <ion-text
-            class="folder-list-header__label cell-title ion-text-nowrap label-name"
+            class="folder-list-header__label cell-title ion-text-nowrap header-label-name"
             @click="onHeaderSortChange(SortProperty.Name)"
-            :class="{ 'label-name-sorted': currentSortProperty === SortProperty.Name }"
+            :class="{ 'header-label-name-sorted': currentSortProperty === SortProperty.Name }"
           >
-            {{ $msTranslate('FoldersPage.listDisplayTitles.name') }}
+            <span class="header-label-name__text">{{ $msTranslate('FoldersPage.listDisplayTitles.name') }}</span>
             <ion-icon
               :icon="currentSortOrder ? arrowUp : arrowDown"
-              class="label-name__sort-icon"
+              class="header-label-name__sort-icon"
             />
           </ion-text>
           <ion-text
-            class="folder-list-header__label cell-title ion-text-nowrap label-updatedBy"
+            class="folder-list-header__label cell-title ion-text-nowrap header-label-updated-by"
             v-if="ownProfile !== UserProfile.Outsider"
           >
             {{ $msTranslate('FoldersPage.listDisplayTitles.updatedBy') }}
           </ion-text>
           <ion-text
-            class="folder-list-header__label cell-title ion-text-nowrap label-lastUpdate"
+            class="folder-list-header__label cell-title ion-text-nowrap header-label-last-update"
             @click="onHeaderSortChange(SortProperty.LastUpdate)"
-            :class="{ 'label-lastUpdate-sorted': currentSortProperty === SortProperty.LastUpdate }"
+            :class="{ 'header-label-last-update-sorted': currentSortProperty === SortProperty.LastUpdate }"
           >
-            {{ $msTranslate('FoldersPage.listDisplayTitles.lastUpdate') }}
+            <span class="header-label-last-update__text">{{ $msTranslate('FoldersPage.listDisplayTitles.lastUpdate') }}</span>
             <ion-icon
               :icon="currentSortOrder ? arrowUp : arrowDown"
-              class="label-lastUpdate__sort-icon"
+              class="header-label-last-update__sort-icon"
             />
           </ion-text>
           <ion-text
-            class="folder-list-header__label cell-title ion-text-nowrap label-creationDate"
+            class="folder-list-header__label cell-title ion-text-nowrap header-label-creation-date"
             @click="onHeaderSortChange(SortProperty.CreationDate)"
-            :class="{ 'label-creationDate-sorted': currentSortProperty === SortProperty.CreationDate }"
+            :class="{ 'header-label-creation-date-sorted': currentSortProperty === SortProperty.CreationDate }"
           >
-            {{ $msTranslate('FoldersPage.listDisplayTitles.creation') }}
+            <span class="header-label-creation-date__text">{{ $msTranslate('FoldersPage.listDisplayTitles.creation') }}</span>
             <ion-icon
               :icon="currentSortOrder ? arrowUp : arrowDown"
-              class="label-creationDate__sort-icon"
+              class="header-label-creation-date__sort-icon"
             />
           </ion-text>
           <ion-text
-            class="folder-list-header__label cell-title ion-text-nowrap label-size"
+            class="folder-list-header__label cell-title ion-text-nowrap header-label-size"
             @click="onHeaderSortChange(SortProperty.Size)"
-            :class="{ 'label-size-sorted': currentSortProperty === SortProperty.Size }"
+            :class="{ 'header-label-size-sorted': currentSortProperty === SortProperty.Size }"
           >
-            {{ $msTranslate('FoldersPage.listDisplayTitles.size') }}
+            <span class="header-label-size__text">{{ $msTranslate('FoldersPage.listDisplayTitles.size') }}</span>
             <ion-icon
               :icon="currentSortOrder ? arrowUp : arrowDown"
-              class="label-size__sort-icon"
+              class="header-label-size__sort-icon"
             />
           </ion-text>
-          <ion-text class="folder-list-header__label cell-title ion-text-nowrap label-space" />
+          <ion-text class="folder-list-header__label cell-title ion-text-nowrap header-label-space" />
         </ion-list-header>
         <div>
           <file-list-item
@@ -243,24 +243,15 @@ async function scrollToSelected(): Promise<void> {
   margin-bottom: 0;
 }
 
+.header-label-selected {
+  justify-content: flex-end;
+}
+
 .file-list-mobile {
   padding-top: 1rem;
 }
 
-.folder-list-header {
-  &__label {
-    padding: 0.75rem 1rem;
-  }
-
-  .label-selected {
-    display: flex;
-    align-items: center;
-  }
-
-  .label-space {
-    min-width: 4rem;
-    flex-grow: 0;
-    margin-left: auto;
-  }
+.folder-list-header__label {
+  padding: 0.75rem 1rem;
 }
 </style>

--- a/client/src/components/files/explorer/FileListItem.vue
+++ b/client/src/components/files/explorer/FileListItem.vue
@@ -25,106 +25,109 @@
       @mouseleave="isHovered = false"
       @contextmenu="onOptionsClick"
     >
-      <div
-        class="file-selected"
-        v-if="isLargeDisplay || entry.isSelected || showCheckbox"
-      >
-        <!-- eslint-disable vue/no-mutating-props -->
-        <ms-checkbox
-          v-model="entry.isSelected"
-          v-show="entry.isSelected || isHovered || showCheckbox"
-          @click.stop
-          @dblclick.stop
-        />
-        <!-- eslint-enable vue/no-mutating-props -->
-      </div>
-      <!-- file name -->
-      <div
-        class="file-name"
-        :class="{ 'file-mobile-content': isSmallDisplay }"
-      >
-        <ms-image
-          :image="entry.isFile() ? getFileIcon(entry.name) : Folder"
-          class="file-icon"
-        />
-        <div class="file-mobile-text">
-          <ion-text
-            class="file-name__label cell"
-            @click="$emit('openItem', $event, entry)"
-          >
-            {{ entry.name }}
-          </ion-text>
-          <ion-text
-            v-if="isSmallDisplay"
-            class="file-mobile-text__data body-sm"
-          >
-            <span class="data-date">{{ $msTranslate(formatTimeSince(entry.updated, '--', 'short')) }}</span>
-            <span v-if="entry.isFile()"> &bull; </span>
-            <span
-              class="data-size"
-              v-if="entry.isFile()"
+      <div class="list-item-container">
+        <div
+          class="file-selected"
+          v-if="isLargeDisplay || entry.isSelected || showCheckbox"
+        >
+          <!-- eslint-disable vue/no-mutating-props -->
+          <ms-checkbox
+            v-model="entry.isSelected"
+            v-show="entry.isSelected || isHovered || showCheckbox"
+            @click.stop
+            @dblclick.stop
+          />
+          <!-- eslint-enable vue/no-mutating-props -->
+        </div>
+
+        <!-- file name -->
+        <div
+          class="file-name"
+          :class="{ 'file-mobile-content': isSmallDisplay }"
+        >
+          <ms-image
+            :image="entry.isFile() ? getFileIcon(entry.name) : Folder"
+            class="file-icon"
+          />
+          <div class="file-mobile-text">
+            <ion-text
+              class="label-name cell"
+              @click="$emit('openItem', $event, entry)"
             >
-              {{ $msTranslate(formatFileSize((entry as FileModel).size)) }}
-            </span>
+              {{ entry.name }}
+            </ion-text>
+            <ion-text
+              v-if="isSmallDisplay"
+              class="file-mobile-text__data body-sm"
+            >
+              <span class="data-date">{{ $msTranslate(formatTimeSince(entry.updated, '--', 'short')) }}</span>
+              <span v-if="entry.isFile()"> &bull; </span>
+              <span
+                class="data-size"
+                v-if="entry.isFile()"
+              >
+                {{ $msTranslate(formatFileSize((entry as FileModel).size)) }}
+              </span>
+            </ion-text>
+          </div>
+          <ion-icon
+            class="cloud-overlay"
+            :class="isFileSynced() ? 'cloud-overlay-ok' : 'cloud-overlay-ko'"
+            :icon="isFileSynced() ? cloudDone : cloudOffline"
+          />
+        </div>
+
+        <!-- updated by -->
+        <div
+          class="file-updated-by"
+          v-if="entry.lastUpdater && isLargeDisplay && ownProfile !== UserProfile.Outsider"
+        >
+          <user-avatar-name
+            :user-avatar="entry.lastUpdater.humanHandle.label"
+            :user-name="entry.lastUpdater.humanHandle.label"
+          />
+        </div>
+
+        <!-- last update -->
+        <div class="file-last-update">
+          <ion-text class="label-last-update cell">
+            {{ $msTranslate(formatTimeSince(entry.updated, '--', 'short')) }}
           </ion-text>
         </div>
-        <ion-icon
-          class="cloud-overlay"
-          :class="isFileSynced() ? 'cloud-overlay-ok' : 'cloud-overlay-ko'"
-          :icon="isFileSynced() ? cloudDone : cloudOffline"
-        />
-      </div>
 
-      <!-- updated by -->
-      <div
-        class="file-updatedBy"
-        v-if="entry.lastUpdater && isLargeDisplay && ownProfile !== UserProfile.Outsider"
-      >
-        <user-avatar-name
-          :user-avatar="entry.lastUpdater.humanHandle.label"
-          :user-name="entry.lastUpdater.humanHandle.label"
-        />
-      </div>
+        <!-- creation date -->
+        <div class="file-creation-date">
+          <ion-text class="label-creation-date cell">
+            {{ $msTranslate(formatTimeSince(entry.created, '--', 'short')) }}
+          </ion-text>
+        </div>
 
-      <!-- last update -->
-      <div class="file-lastUpdate">
-        <ion-text class="label-last-update cell">
-          {{ $msTranslate(formatTimeSince(entry.updated, '--', 'short')) }}
-        </ion-text>
-      </div>
+        <!-- file size -->
+        <div class="file-size">
+          <ion-text
+            v-if="entry.isFile()"
+            class="label-size cell"
+          >
+            {{ $msTranslate(formatFileSize((entry as FileModel).size)) }}
+          </ion-text>
+        </div>
 
-      <!-- last update -->
-      <div class="file-creationDate">
-        <ion-text class="label-last-update cell">
-          {{ $msTranslate(formatTimeSince(entry.created, '--', 'short')) }}
-        </ion-text>
-      </div>
-
-      <!-- file size -->
-      <div class="file-size">
-        <ion-text
-          v-if="entry.isFile()"
-          class="label-size cell"
-        >
-          {{ $msTranslate(formatFileSize((entry as FileModel).size)) }}
-        </ion-text>
-      </div>
-
-      <!-- options -->
-      <div class="file-options ion-item-child-clickable">
-        <ion-button
-          fill="clear"
-          v-show="isHovered || menuOpened || isSmallDisplay"
-          class="options-button"
-          @click.stop="onOptionsClick($event)"
-          @dblclick.stop
-        >
-          <ion-icon
-            :icon="ellipsisHorizontal"
-            slot="icon-only"
-            class="options-button__icon"
-          />
-        </ion-button>
+        <!-- options -->
+        <div class="file-options ion-item-child-clickable">
+          <ion-button
+            fill="clear"
+            v-show="isHovered || menuOpened || isSmallDisplay"
+            class="options-button"
+            @click.stop="onOptionsClick($event)"
+            @dblclick.stop
+          >
+            <ion-icon
+              :icon="ellipsisHorizontal"
+              slot="icon-only"
+              class="options-button__icon"
+            />
+          </ion-button>
+        </div>
       </div>
     </ion-item>
   </file-drop-zone>
@@ -208,16 +211,11 @@ async function onOptionsClick(event: PointerEvent): Promise<void> {
     flex-shrink: 0;
   }
 
-  &__label {
+  .label-name {
     color: var(--parsec-color-light-secondary-text);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    text-wrap: nowrap;
-    width: fit-content;
 
     &:hover {
-      border-top: 1px solid transparent;
-      border-bottom: 1px solid var(--parsec-color-light-secondary-grey);
+      text-decoration: underline;
       cursor: pointer !important;
     }
   }
@@ -250,6 +248,7 @@ async function onOptionsClick(event: PointerEvent): Promise<void> {
 
   .file-mobile-content {
     gap: 1rem;
+    width: 100%;
   }
 }
 

--- a/client/src/components/files/explorer/FileListItemProcessing.vue
+++ b/client/src/components/files/explorer/FileListItemProcessing.vue
@@ -6,60 +6,63 @@
     lines="full"
     class="ion-no-padding file-list-item"
   >
-    <!-- file name -->
-    <div class="file-name">
+    <div class="list-item-container">
       <div class="file-loading">
         <ms-spinner class="file-loading__spinner" />
       </div>
-      <ms-image
-        v-if="isLargeDisplay"
-        :image="getFileIcon(fileName)"
-        class="file-icon"
-      />
 
-      <ion-text class="file-name__label cell">
-        {{ fileName }}
-      </ion-text>
+      <!-- file name -->
+      <div class="file-name">
+        <ms-image
+          v-if="isLargeDisplay"
+          :image="getFileIcon(fileName)"
+          class="file-icon"
+        />
+
+        <ion-text class="label-name cell">
+          {{ fileName }}
+        </ion-text>
+      </div>
+
+      <!-- updated by -->
+      <div
+        class="file-updated-by"
+        v-if="clientInfo && isLargeDisplay"
+      >
+        <user-avatar-name
+          :user-avatar="clientInfo.humanHandle.label"
+          :user-name="clientInfo.humanHandle.label"
+        />
+      </div>
+
+      <!-- last update -->
+      <div
+        v-if="clientInfo?.currentProfile !== UserProfile.Outsider"
+        class="file-last-update"
+      >
+        <ion-text class="label-last-update cell" />
+      </div>
+
+      <!-- creation date -->
+      <div class="file-creation-date">
+        <ion-text class="label-creation-date cell">
+          {{ $msTranslate(getFileOperationLabel()) }}
+        </ion-text>
+      </div>
+
+      <!-- file size -->
+      <div
+        class="file-size"
+        v-if="data.getDataType() === FileOperationDataType.Import && isLargeDisplay"
+      >
+        <ion-text class="label-size cell">
+          {{ $msTranslate(formatFileSize((data as ImportData).file.size)) }}
+        </ion-text>
+      </div>
+
+      <!-- options -->
+      <div class="file-empty ion-item-child-clickable" />
     </div>
-
-    <!-- updated by -->
-    <div
-      class="file-updatedBy"
-      v-if="clientInfo && isLargeDisplay"
-    >
-      <user-avatar-name
-        :user-avatar="clientInfo.humanHandle.label"
-        :user-name="clientInfo.humanHandle.label"
-      />
-    </div>
-
-    <!-- last update -->
-    <div
-      v-if="clientInfo?.currentProfile !== UserProfile.Outsider"
-      class="file-creationDate"
-    >
-      <ion-text class="label-last-update cell" />
-    </div>
-
-    <!-- last update -->
-    <div class="file-lastUpdate">
-      <ion-text class="label-last-update cell">
-        {{ $msTranslate(getFileOperationLabel()) }}
-      </ion-text>
-    </div>
-
-    <!-- file size -->
-    <div
-      class="file-size"
-      v-if="data.getDataType() === FileOperationDataType.Import && isLargeDisplay"
-    >
-      <ion-text class="label-size cell">
-        {{ $msTranslate(formatFileSize((data as ImportData).file.size)) }}
-      </ion-text>
-    </div>
-
-    <!-- options -->
-    <div class="file-empty ion-item-child-clickable" />
   </ion-item>
 </template>
 
@@ -108,11 +111,10 @@ function getFileOperationLabel(): Translatable {
 
 <style lang="scss" scoped>
 .file-loading {
-  width: 2rem;
-  height: 2rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  @include ms.responsive-breakpoint('sm') {
+    max-width: 3rem;
+    min-width: 3rem;
+  }
 
   &__spinner {
     width: 1.25rem;
@@ -121,14 +123,17 @@ function getFileOperationLabel(): Translatable {
 }
 
 .file-name {
+  position: relative;
+  display: flex;
+  gap: 1rem;
+
   .file-icon {
-    width: 2rem;
+    min-width: 2rem;
     height: 2rem;
   }
 
-  &__label {
+  .label-name {
     color: var(--parsec-color-light-secondary-text);
-    margin-left: 1em;
   }
 }
 </style>

--- a/client/src/components/files/explorer/FolderSelectionModal.vue
+++ b/client/src/components/files/explorer/FolderSelectionModal.vue
@@ -94,7 +94,7 @@
           </ion-label>
           <!-- last update -->
           <div
-            class="file-lastUpdate"
+            class="file-last-update"
             v-if="isLargeDisplay"
           >
             <ion-label class="label-last-update cell">

--- a/client/src/components/files/explorer/HistoryFileListItem.vue
+++ b/client/src/components/files/explorer/HistoryFileListItem.vue
@@ -14,46 +14,49 @@
     @mouseenter="isHovered = true"
     @mouseleave="isHovered = false"
   >
-    <div class="file-selected">
-      <!-- eslint-disable vue/no-mutating-props -->
-      <ms-checkbox
-        v-model="entry.isSelected"
-        v-show="entry.isSelected || isHovered || showCheckbox"
-        @change="$emit('selectedChange', entry, $event)"
-        @click.stop
-        @dblclick.stop
-      />
-      <!-- eslint-enable vue/no-mutating-props -->
-    </div>
-    <!-- file name -->
-    <div class="file-name">
-      <ms-image
-        :image="entry.isFile() ? getFileIcon(entry.name) : Folder"
-        class="file-icon"
-      />
-      <ion-label class="file-name__label cell">
-        {{ entry.name }}
-      </ion-label>
-    </div>
+    <div class="list-item-container">
+      <div class="file-selected">
+        <!-- eslint-disable vue/no-mutating-props -->
+        <ms-checkbox
+          v-model="entry.isSelected"
+          v-show="entry.isSelected || isHovered || showCheckbox"
+          @change="$emit('selectedChange', entry, $event)"
+          @click.stop
+          @dblclick.stop
+        />
+        <!-- eslint-enable vue/no-mutating-props -->
+      </div>
 
-    <!-- last update -->
-    <div class="file-lastUpdate">
-      <ion-label class="label-last-update cell">
-        {{ $msTranslate(formatTimeSince(entry.updated, '--', 'short')) }}
-      </ion-label>
-    </div>
+      <!-- file name -->
+      <div class="file-name">
+        <ms-image
+          :image="entry.isFile() ? getFileIcon(entry.name) : Folder"
+          class="file-icon"
+        />
+        <ion-label class="label-name cell">
+          {{ entry.name }}
+        </ion-label>
+      </div>
 
-    <!-- file size -->
-    <div class="file-size">
-      <ion-label
-        v-if="entry.isFile()"
-        class="label-size cell"
-      >
-        {{ $msTranslate(formatFileSize((entry as WorkspaceHistoryFileModel).size)) }}
-      </ion-label>
-    </div>
+      <!-- last update -->
+      <div class="file-last-update">
+        <ion-label class="label-last-update cell">
+          {{ $msTranslate(formatTimeSince(entry.updated, '--', 'short')) }}
+        </ion-label>
+      </div>
 
-    <div class="label-space" />
+      <!-- file size -->
+      <div class="file-size">
+        <ion-label
+          v-if="entry.isFile()"
+          class="label-size cell"
+        >
+          {{ $msTranslate(formatFileSize((entry as WorkspaceHistoryFileModel).size)) }}
+        </ion-label>
+      </div>
+
+      <div class="label-space" />
+    </div>
   </ion-item>
 </template>
 
@@ -101,6 +104,10 @@ onMounted(async () => {
 }
 
 .file-name {
+  position: relative;
+  display: flex;
+  gap: 1rem;
+
   .file-icon {
     width: 2rem;
     height: 2rem;
@@ -112,12 +119,9 @@ onMounted(async () => {
     }
   }
 
-  &__label {
+  .label-name {
     color: var(--parsec-color-light-secondary-text);
     margin-left: 1em;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    text-wrap: nowrap;
   }
 }
 </style>

--- a/client/src/components/workspaces/WorkspaceListItem.vue
+++ b/client/src/components/workspaces/WorkspaceListItem.vue
@@ -70,7 +70,7 @@
 
     <!-- last update -->
     <div
-      class="workspace-lastUpdate"
+      class="workspace-last-update"
       v-show="false"
     >
       <ion-label class="label-last-update cell">
@@ -220,7 +220,7 @@ async function onOptionsClick(event: Event): Promise<void> {
   }
 }
 
-.workspace-lastUpdate {
+.workspace-last-update {
   min-width: 11.25rem;
   flex-grow: 0;
 }

--- a/client/src/theme/components/_list.scss
+++ b/client/src/theme/components/_list.scss
@@ -89,7 +89,7 @@
 }
 
 .workspace-list-item > [class^='workspace-'],
-.file-list-item > [class^='file-'],
+.list-item-container > [class^='file-'],
 .user-list-item > [class^='user-'] {
   padding: 0 1rem;
   display: flex;
@@ -150,22 +150,34 @@
 
 // ------- Files/folders only -------
 .folder-container {
-  .file-list-item {
+  .list-item-container {
     display: flex;
     width: 100%;
+    padding: 0;
   }
 
-  .label-name,
-  .label-lastUpdate,
-  .label-creationDate,
-  .label-size {
+  .header-label-selected,
+  .header-label-name,
+  .header-label-last-update,
+  .header-label-creation-date,
+  .header-label-size {
     cursor: pointer;
     display: flex;
     align-items: center;
     gap: 0.375rem;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+
+    &__text {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
 
     &__sort-icon {
       display: none;
+      flex-shrink: 0;
       font-size: 0.875rem;
     }
 
@@ -186,83 +198,122 @@
     }
   }
 
-  .label-selected,
+  .label-name,
+  .label-last-update,
+  .label-creation-date,
+  .label-size {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    width: 100%;
+  }
+
+  // Define the width of each cell
+  --width-cell-selected: 4rem;
+  --width-cell-name: calc(40% - var(--width-cell-selected) - var(--width-cell-options));
+  --width-cell-updated-by: 20%;
+  --width-cell-last-update: 15%;
+  --width-cell-creation-date: 15%;
+  --width-cell-size: 10%;
+  --width-cell-options: 4rem;
+
+  @include ms.responsive-breakpoint('xl') {
+    --width-cell-name: calc(45% - var(--width-cell-selected) - var(--width-cell-options));
+    --width-cell-updated-by: 25%;
+    --width-cell-last-update: 20%;
+    --width-cell-creation-date: 0;
+    --width-cell-size: 10%;
+  }
+
+  @include ms.responsive-breakpoint('lg') {
+    --width-cell-name: calc(60% - var(--width-cell-selected) - var(--width-cell-options));
+    --width-cell-updated-by: 0;
+    --width-cell-last-update: 20%;
+    --width-cell-size: 20%;
+  }
+
+  @include ms.responsive-breakpoint('md') {
+    --width-cell-name: calc(70% - var(--width-cell-selected) - var(--width-cell-options));
+    --width-cell-last-update: 15%;
+    --width-cell-size: 15%;
+  }
+
+  @include ms.responsive-breakpoint('sm') {
+    --width-cell-name: calc(100% - var(--width-cell-selected));
+    --width-cell-last-update: 0;
+    --width-cell-size: 0;
+  }
+
+  .header-label-selected,
   .file-selected,
   .file-loading {
-    min-width: 4rem;
-    width: 4rem;
-    max-width: 4rem;
+    flex-basis: var(--width-cell-selected);
+    max-width: var(--width-cell-selected);
     justify-content: end;
 
     @include ms.responsive-breakpoint('sm') {
-      min-width: 1rem;
-      width: 3rem;
       padding: 0;
     }
   }
 
-  .label-name,
+  .header-label-name,
   .file-name {
-    min-width: 16.25rem;
-    width: 100%;
+    flex-basis: var(--width-cell-name);
     padding: 0.5rem 1rem;
 
     @include ms.responsive-breakpoint('sm') {
-      min-width: 10rem;
       padding: 0.75rem 1rem;
     }
   }
 
-  .label-updatedBy,
-  .file-updatedBy {
-    min-width: 14rem;
-    max-width: 15%;
-    flex-grow: 2;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+  .header-label-updated-by,
+  .file-updated-by {
+    flex-basis: var(--width-cell-updated-by);
+
+    @include ms.responsive-breakpoint('lg') {
+      display: none;
+    }
   }
 
-  .label-lastUpdate,
-  .file-lastUpdate {
-    min-width: 11.25rem;
-    flex-shrink: 1;
+  .header-label-last-update,
+  .file-last-update {
+    flex-basis: var(--width-cell-last-update);
 
     @include ms.responsive-breakpoint('sm') {
       display: none;
     }
   }
 
-  .label-creationDate,
-  .file-creationDate {
-    min-width: 11.25rem;
-    flex-shrink: 1;
+  .header-label-creation-date,
+  .file-creation-date {
+    flex-basis: var(--width-cell-creation-date);
 
     @include ms.responsive-breakpoint('xl') {
       display: none;
     }
   }
 
-  .label-size,
+  .header-label-size,
   .file-size {
-    min-width: 8.25rem;
-    flex-shrink: 1;
+    flex-basis: var(--width-cell-size);
 
-    @include ms.responsive-breakpoint('md') {
+    @include ms.responsive-breakpoint('sm') {
       display: none;
     }
   }
 
   .label-size:is(.cell),
+  .label-creation-date:is(.cell),
   .label-last-update:is(.cell) {
-    color: var(--parsec-color-light-secondary-grey);
+    color: var(--parsec-color-light-secondary-hard-grey);
   }
 
-  .label-space,
+  .header-label-space,
   .file-options,
   .file-empty {
-    min-width: 4rem;
-    flex-shrink: 0;
-    margin-left: auto;
+    flex-basis: var(--width-cell-options);
+    position: sticky;
+    right: 0;
   }
 }
 

--- a/client/tests/component/specs/testFileListItem.spec.ts
+++ b/client/tests/component/specs/testFileListItem.spec.ts
@@ -54,7 +54,7 @@ describe('File List Item', () => {
       },
     });
 
-    expect(wrapper.get('.file-name__label').text()).to.equal('A File.txt');
+    expect(wrapper.get('.label-name').text()).to.equal('A File.txt');
     expect(wrapper.get('.label-last-update').text()).to.equal('now');
     expect(wrapper.get('.label-size').text()).to.equal('40.3 GB');
     wrapper.trigger('dblclick');
@@ -98,7 +98,7 @@ describe('File List Item', () => {
       },
     });
 
-    expect(wrapper.get('.file-name__label').text()).to.equal('A Folder');
+    expect(wrapper.get('.label-name').text()).to.equal('A Folder');
     expect(wrapper.get('.label-last-update').text()).to.equal('now');
     // expect(wrapper.get('.label-size')).not.to.be.visible;
     wrapper.trigger('dblclick');

--- a/client/tests/e2e/helpers/utils.ts
+++ b/client/tests/e2e/helpers/utils.ts
@@ -163,7 +163,7 @@ export async function openFileType(
   const entries = documentsPage.locator('.folder-container').locator('.file-list-item');
 
   for (const entry of await entries.all()) {
-    const entryName = (await entry.locator('.file-name').locator('.file-name__label').textContent()) ?? '';
+    const entryName = (await entry.locator('.file-name').locator('.label-name').textContent()) ?? '';
     if (entryName.endsWith(`.${type}`)) {
       await entry.dblclick();
       await expect(documentsPage.locator('.ms-spinner-modal')).toBeVisible();

--- a/client/tests/e2e/specs/document_context_menu.spec.ts
+++ b/client/tests/e2e/specs/document_context_menu.spec.ts
@@ -282,7 +282,7 @@ for (const gridMode of [false, true]) {
     await clickAction(await openPopover(documents, 1), 'Rename');
     await fillInputModal(documents, 'New Name', true);
     if (!gridMode) {
-      await expect(entry.locator('.file-name').locator('.file-name__label')).toHaveText('New Name');
+      await expect(entry.locator('.file-name').locator('.label-name')).toHaveText('New Name');
     } else {
       await expect(entry.locator('.file-card__title')).toHaveText('New Name');
     }
@@ -303,7 +303,7 @@ for (const gridMode of [false, true]) {
         .locator('.file-list-item')
         .nth(2)
         .locator('.file-name')
-        .locator('.file-name__label')
+        .locator('.label-name')
         .textContent();
       count = await documents.locator('.folder-container').locator('.file-list-item').count();
     }
@@ -632,7 +632,7 @@ for (const gridMode of [false, true]) {
     await clickAction(await openPopover(documents, 1), 'Rename');
     await fillInputModal(documents, 'New Name', true);
     if (!gridMode) {
-      await expect(entry.locator('.file-name').locator('.file-name__label')).toHaveText('New Name');
+      await expect(entry.locator('.file-name').locator('.label-name')).toHaveText('New Name');
     } else {
       await expect(entry.locator('.file-card__title')).toHaveText('New Name');
     }
@@ -654,7 +654,7 @@ for (const gridMode of [false, true]) {
         .locator('.file-list-item')
         .nth(2)
         .locator('.file-name')
-        .locator('.file-name__label')
+        .locator('.label-name')
         .textContent();
       count = await documents.locator('.folder-container').locator('.file-list-item').count();
     }

--- a/client/tests/e2e/specs/documents_list.spec.ts
+++ b/client/tests/e2e/specs/documents_list.spec.ts
@@ -29,7 +29,7 @@ for (const displaySize of ['small', 'large']) {
     const entries = documents.locator('.folder-container').locator('.file-list-item');
     if (displaySize === DisplaySize.Small) {
       await documents.setDisplaySize(DisplaySize.Small);
-      await expect(entries.locator('.file-name').locator('.file-name__label')).toHaveText(NAME_MATCHER_ARRAY);
+      await expect(entries.locator('.file-name').locator('.label-name')).toHaveText(NAME_MATCHER_ARRAY);
       await expect(entries.locator('.data-date')).toHaveText(TIME_MATCHER_ARRAY);
       await expect(entries.locator('.data-size')).toHaveText(SIZE_MATCHER_ARRAY.slice(1));
       for (let i = 0; i < (await entries.count()); i++) {
@@ -44,8 +44,8 @@ for (const displaySize of ['small', 'large']) {
       await expect(actionBar.locator('#grid-view')).toNotHaveDisabledAttribute();
       await expect(actionBar.locator('#list-view')).toHaveDisabledAttribute();
       await expect(entries).toHaveCount(9);
-      await expect(entries.locator('.file-name').locator('.file-name__label')).toHaveText(NAME_MATCHER_ARRAY);
-      await expect(entries.locator('.file-lastUpdate')).toHaveText(TIME_MATCHER_ARRAY);
+      await expect(entries.locator('.file-name').locator('.label-name')).toHaveText(NAME_MATCHER_ARRAY);
+      await expect(entries.locator('.file-last-update')).toHaveText(TIME_MATCHER_ARRAY);
       await expect(entries.locator('.file-size')).toHaveText(SIZE_MATCHER_ARRAY);
     }
   });
@@ -69,9 +69,9 @@ msTest('Documents page default state in a read only workspace', async ({ documen
   await expect(actionBar.locator('#list-view')).toHaveDisabledAttribute();
   const entries = documentsReadOnly.locator('.folder-container').locator('.file-list-item');
   await expect(entries).toHaveCount(9);
-  await expect(entries.locator('.file-name').locator('.file-name__label')).toHaveText(NAME_MATCHER_ARRAY);
-  await expect(entries.locator('.file-lastUpdate')).toHaveText(TIME_MATCHER_ARRAY);
-  await expect(entries.locator('.file-creationDate')).toHaveText(TIME_MATCHER_ARRAY);
+  await expect(entries.locator('.file-name').locator('.label-name')).toHaveText(NAME_MATCHER_ARRAY);
+  await expect(entries.locator('.file-last-update')).toHaveText(TIME_MATCHER_ARRAY);
+  await expect(entries.locator('.file-creation-date')).toHaveText(TIME_MATCHER_ARRAY);
   await expect(entries.locator('.file-size')).toHaveText(SIZE_MATCHER_ARRAY);
   // Useless click just to move the mouse
   await documentsReadOnly.locator('.folder-list-header__label').nth(1).click();
@@ -95,16 +95,16 @@ msTest('Sort document by creation date', async ({ documents }) => {
   await sorterPopover.getByRole('listitem').nth(3).click();
   await expect(sorterPopover).toBeHidden();
 
-  const firstEntryBefore = await entries.nth(1).locator('.file-name__label').textContent();
-  const lastEntryBefore = await entries.nth(8).locator('.file-name__label').textContent();
+  const firstEntryBefore = await entries.nth(1).locator('.label-name').textContent();
+  const lastEntryBefore = await entries.nth(8).locator('.label-name').textContent();
 
   await sorterPopoverButton.click();
   await expect(sorterPopover).toBeVisible();
   await sorterPopover.locator('.order-button').click();
   await expect(sorterPopover).toBeHidden();
 
-  const firstEntryAfter = await entries.nth(1).locator('.file-name__label').textContent();
-  const lastEntryAfter = await entries.nth(8).locator('.file-name__label').textContent();
+  const firstEntryAfter = await entries.nth(1).locator('.label-name').textContent();
+  const lastEntryAfter = await entries.nth(8).locator('.label-name').textContent();
 
   expect(firstEntryAfter).toBe(lastEntryBefore);
   expect(lastEntryAfter).toBe(firstEntryBefore);
@@ -132,10 +132,10 @@ msTest('Sort document with header title', async ({ documents }) => {
     await expect(sorterPopoverButton).toHaveAttribute('sort-ascending', ['false', 'true'][Number(sortOrder)]);
 
     // Folder should stay at the top
-    await expect(entries.nth(0).locator('.file-name__label')).toHaveText('Dir_Folder');
+    await expect(entries.nth(0).locator('.label-name')).toHaveText('Dir_Folder');
 
-    const firstEntryName = await entries.nth(1).locator('.file-name__label').textContent();
-    const lastEntryName = await entries.nth(8).locator('.file-name__label').textContent();
+    const firstEntryName = await entries.nth(1).locator('.label-name').textContent();
+    const lastEntryName = await entries.nth(8).locator('.label-name').textContent();
 
     expect(firstEntryName).not.toBeNull();
     expect(lastEntryName).not.toBeNull();
@@ -145,9 +145,9 @@ msTest('Sort document with header title', async ({ documents }) => {
     sortOrder = !sortOrder;
     await expect(sorterPopoverButton).toHaveAttribute('sort-ascending', ['false', 'true'][Number(sortOrder)]);
     // Folder should stay at the top
-    await expect(entries.nth(0).locator('.file-name__label')).toHaveText('Dir_Folder');
-    await expect(entries.nth(1).locator('.file-name__label')).toHaveText(lastEntryName as string);
-    await expect(entries.nth(8).locator('.file-name__label')).toHaveText(firstEntryName as string);
+    await expect(entries.nth(0).locator('.label-name')).toHaveText('Dir_Folder');
+    await expect(entries.nth(1).locator('.label-name')).toHaveText(lastEntryName as string);
+    await expect(entries.nth(8).locator('.label-name')).toHaveText(firstEntryName as string);
   }
 });
 
@@ -216,7 +216,7 @@ for (const displaySize of [DisplaySize.Small, DisplaySize.Large]) {
 
     const entries = documents.locator('.folder-container').locator('.file-list-item');
     await expect(entries).toHaveCount(9);
-    await expect(entries.locator('.file-name').locator('.file-name__label')).toHaveText(NAME_MATCHER_ARRAY);
+    await expect(entries.locator('.file-name').locator('.label-name')).toHaveText(NAME_MATCHER_ARRAY);
 
     if (displaySize === DisplaySize.Small) {
       const addButton = documents.locator('.tab-bar-menu').locator('#add-menu-fab-button');
@@ -234,7 +234,7 @@ for (const displaySize of [DisplaySize.Small, DisplaySize.Large]) {
 
     await expect(entries).toHaveCount(10);
     // Don't ask.
-    await expect(entries.locator('.file-name').locator('.file-name__label')).toHaveText([
+    await expect(entries.locator('.file-name').locator('.label-name')).toHaveText([
       'My folder',
       ...NAME_MATCHER_ARRAY.slice(0, 1),
       ...NAME_MATCHER_ARRAY.slice(1),

--- a/client/tests/e2e/specs/download_file.spec.ts
+++ b/client/tests/e2e/specs/download_file.spec.ts
@@ -32,7 +32,7 @@ msTest('Download file', async ({ documents }) => {
   let entryName = '';
 
   for (const entry of await entries.all()) {
-    entryName = (await entry.locator('.file-name').locator('.file-name__label').textContent()) ?? '';
+    entryName = (await entry.locator('.file-name').locator('.label-name').textContent()) ?? '';
     if (entryName.endsWith('.mp3')) {
       await entry.hover();
       await entry.locator('.options-button').click();
@@ -88,7 +88,7 @@ msTest('Download multiple files and folder', async ({ documents }, testInfo: Tes
   await documents.waitForTimeout(1000);
 
   for (const entry of await entries.all()) {
-    const entryName = (await entry.locator('.file-name').locator('.file-name__label').textContent()) ?? '';
+    const entryName = (await entry.locator('.file-name').locator('.label-name').textContent()) ?? '';
     if (entryName.endsWith('.mp3') || entryName.endsWith('.xlsx') || entryName.endsWith('.pdf') || entryName === 'Dir_Folder') {
       await entry.hover();
       await entry.locator('ion-checkbox').click();
@@ -144,7 +144,7 @@ msTest('Download warning', async ({ documents }) => {
   const entries = documents.locator('.folder-container').locator('.file-list-item');
 
   for (const entry of await entries.all()) {
-    const entryName = (await entry.locator('.file-name').locator('.file-name__label').textContent()) ?? '';
+    const entryName = (await entry.locator('.file-name').locator('.label-name').textContent()) ?? '';
     if (entryName.endsWith('.mp3')) {
       await entry.hover();
       await entry.locator('.options-button').click();
@@ -187,7 +187,7 @@ msTest('Download warning', async ({ documents }) => {
   }
 
   for (const entry of await entries.all()) {
-    const entryName = (await entry.locator('.file-name').locator('.file-name__label').textContent()) ?? '';
+    const entryName = (await entry.locator('.file-name').locator('.label-name').textContent()) ?? '';
     if (entryName.endsWith('.py')) {
       await entry.hover();
       await entry.locator('.options-button').click();
@@ -242,9 +242,9 @@ msTest.describe(() => {
     // cspell:disable-next-line
     await renameDocument(documents, entries.nth(1), 'Имя файла.png');
     // cspell:disable-next-line
-    await expect(entries.nth(0).locator('.file-name').locator('.file-name__label')).toHaveText('文件名.png');
+    await expect(entries.nth(0).locator('.file-name').locator('.label-name')).toHaveText('文件名.png');
     // cspell:disable-next-line
-    await expect(entries.nth(1).locator('.file-name').locator('.file-name__label')).toHaveText('Имя файла.png');
+    await expect(entries.nth(1).locator('.file-name').locator('.label-name')).toHaveText('Имя файла.png');
 
     await documents.locator('#connected-header').locator('.topbar-left__breadcrumb').locator('ion-breadcrumb').nth(1).click();
     await expect(documents).toHaveHeader(['wksp1'], true, true);
@@ -296,7 +296,7 @@ msTest.describe(() => {
 
     for (let i = 0; i < 15; i++) {
       await createFolder(documents, `Folder${i}`);
-      await expect(entries.nth(0).locator('.file-name').locator('.file-name__label')).toHaveText(`Folder${i}`);
+      await expect(entries.nth(0).locator('.file-name').locator('.label-name')).toHaveText(`Folder${i}`);
       await expect(documents.locator('.folder-container').locator('.no-files')).toBeHidden();
       await entries.nth(0).dblclick();
       await expect(documents.locator('.folder-container').locator('.no-files')).toBeVisible();
@@ -309,7 +309,7 @@ msTest.describe(() => {
     const tabs = uploadMenu.locator('.upload-menu-tabs').getByRole('listitem');
     await expect(tabs.locator('.text-counter')).toHaveText(['0', '1', '0']);
     await uploadMenu.locator('.menu-header-icons').locator('ion-icon').nth(1).click();
-    await expect(entries.nth(0).locator('.file-name').locator('.file-name__label')).toHaveText('hell_yeah.png');
+    await expect(entries.nth(0).locator('.file-name').locator('.label-name')).toHaveText('hell_yeah.png');
 
     await documents.locator('#connected-header').locator('.topbar-left__breadcrumb').locator('ion-breadcrumb').nth(1).click();
     await documents.waitForTimeout(500);

--- a/client/tests/e2e/specs/file_details.spec.ts
+++ b/client/tests/e2e/specs/file_details.spec.ts
@@ -19,8 +19,8 @@ for (const testData of TEST_DATA) {
     await expect(documents.locator('.topbar-left__breadcrumb')).toContainText('wksp1');
     const files = documents.locator('.folder-container').getByRole('listitem');
     await expect(files).toHaveCount(9);
-    await expect(files.nth(testData.index).locator('.file-name').locator('.file-name__label')).toHaveText(new RegExp(`^${nameMatcher}$`));
-    await expect(files.nth(testData.index).locator('.file-lastUpdate')).toHaveText(/^((?:one|\d{1,2}) minutes? ago|< 1 minute|now)$/);
+    await expect(files.nth(testData.index).locator('.file-name').locator('.label-name')).toHaveText(new RegExp(`^${nameMatcher}$`));
+    await expect(files.nth(testData.index).locator('.file-last-update')).toHaveText(/^((?:one|\d{1,2}) minutes? ago|< 1 minute|now)$/);
     expect(documents.locator('.file-context-menu')).toBeHidden();
     expect(documents.locator('.file-details-modal')).toBeHidden();
 

--- a/client/tests/e2e/specs/file_editor.spec.ts
+++ b/client/tests/e2e/specs/file_editor.spec.ts
@@ -43,7 +43,7 @@ msTest('Open editor from viewer', async ({ parsecEditics }) => {
 
 msTest('Check edited file in viewer', async ({ parsecEditics }) => {
   msTest.setTimeout(120_000);
-  await parsecEditics.locator('.label-name').click();
+  await parsecEditics.locator('.header-label-name').click();
 
   const entries = parsecEditics.locator('.folder-container').locator('.file-list-item');
 
@@ -170,7 +170,7 @@ msTest.skip('Edit file in editor with two users', async ({ parsecEditics }) => {
 
 msTest('Check file edited by other user', async ({ parsecEditics }) => {
   msTest.setTimeout(120_000);
-  await parsecEditics.locator('.label-name').click();
+  await parsecEditics.locator('.header-label-name').click();
   const entries = parsecEditics.locator('.folder-container').locator('.file-list-item');
 
   // Promote Bob

--- a/client/tests/e2e/specs/file_viewers.spec.ts
+++ b/client/tests/e2e/specs/file_viewers.spec.ts
@@ -510,10 +510,10 @@ msTest('File viewer sidebar state persists between files', async ({ documents })
   const header = documents.locator('#connected-header');
   await expect(sidebar).toBeVisible();
   await expect(header).toBeVisible();
-  await documents.locator('.label-name').click();
+  await documents.locator('.header-label-name').click();
 
   // Open first file and ensure it's loaded
-  await entries.nth(2).locator('.file-name .file-mobile-text .file-name__label').click();
+  await entries.nth(2).locator('.file-name .file-mobile-text .label-name').click();
   await expect(documents.locator('.ms-spinner-modal')).toBeVisible();
   await expect(documents.locator('.ms-spinner-modal').locator('.spinner-label__text')).toHaveText('Opening file...');
   await expect(documents.locator('.ms-spinner-modal')).toBeHidden();
@@ -551,7 +551,7 @@ msTest('File viewer sidebar state persists between files', async ({ documents })
   await expect(sidebar).toBeHidden();
 
   // Open second file
-  await entries.nth(4).locator('.file-name .file-mobile-text .file-name__label').click();
+  await entries.nth(4).locator('.file-name .file-mobile-text .label-name').click();
   await expect(documents.locator('.ms-spinner-modal')).toBeVisible();
   await expect(documents.locator('.ms-spinner-modal').locator('.spinner-label__text')).toHaveText('Opening file...');
   await expect(documents.locator('.ms-spinner-modal')).toBeHidden();
@@ -585,14 +585,14 @@ msTest('File viewer sidebar state persists between files', async ({ documents })
 msTest('File viewer restores sidebar state on exit', async ({ documents }) => {
   const entries = documents.locator('.folder-container').locator('.file-list-item');
   const toggleButton = documents.locator('#trigger-toggle-menu-button');
-  await documents.locator('.label-name').click();
+  await documents.locator('.header-label-name').click();
 
   // Sidebar starts visible (default state)
   await expect(documents.locator('.sidebar')).toBeVisible();
   await expect(documents.locator('#connected-header .topbar')).toBeVisible();
 
   // Open file viewer
-  await entries.nth(2).locator('.file-name .file-mobile-text .file-name__label').click();
+  await entries.nth(2).locator('.file-name .file-mobile-text .label-name').click();
   await expect(documents).toBeViewerPage();
   await expect(documents.locator('.file-handler-topbar .file-handler-topbar__title')).toHaveText('code.py');
 
@@ -617,7 +617,7 @@ msTest('File viewer restores sidebar state on exit', async ({ documents }) => {
   await expect(documents.locator('.sidebar')).toBeHidden();
 
   // Open file viewer again
-  await entries.nth(4).locator('.file-name .file-mobile-text .file-name__label').click();
+  await entries.nth(4).locator('.file-name .file-mobile-text .label-name').click();
   await expect(documents.locator('.ms-spinner-modal')).toBeVisible();
   await expect(documents.locator('.ms-spinner-modal').locator('.spinner-label__text')).toHaveText('Opening file...');
   await expect(documents.locator('.ms-spinner-modal')).toBeHidden();

--- a/client/tests/e2e/specs/file_viewers_document.spec.ts
+++ b/client/tests/e2e/specs/file_viewers_document.spec.ts
@@ -4,9 +4,9 @@ import { expect, msTest, openFileType } from '@tests/e2e/helpers';
 
 msTest('Open file viewer with single click', async ({ documents }) => {
   const entries = documents.locator('.folder-container').locator('.file-list-item');
-  await entries.nth(0).locator('.file-name__label').click();
+  await entries.nth(0).locator('.label-name').click();
   await documents.locator('.topbar-left-content').locator('.back-button').click();
-  await entries.nth(1).locator('.file-name__label').click();
+  await entries.nth(1).locator('.label-name').click();
   await expect(documents).toBeViewerPage();
 });
 

--- a/client/tests/e2e/specs/options_tab_menu.spec.ts
+++ b/client/tests/e2e/specs/options_tab_menu.spec.ts
@@ -121,7 +121,7 @@ msTest('Files options tab menu display with editics', async ({ parsecEditics }) 
 msTest('Test files options tab menu', async ({ documents, context }) => {
   msTest.setTimeout(45_000);
 
-  await documents.locator('.label-name').click();
+  await documents.locator('.header-label-name').click();
   await toggleViewMode(documents);
   await documents.setDisplaySize(DisplaySize.Small);
   await context.grantPermissions(['clipboard-write']);

--- a/client/tests/e2e/specs/organization_switch_popover.spec.ts
+++ b/client/tests/e2e/specs/organization_switch_popover.spec.ts
@@ -14,7 +14,7 @@ msTest('Switch back and forth', async ({ connected }) => {
   await expect(connected).toBeDocumentPage();
   await expect(connected.locator('.folder-container').locator('.no-files')).toBeVisible();
   await createFolder(connected, 'Folder');
-  const entryNames = connected.locator('.folder-container').locator('.file-list-item').locator('.file-name').locator('.file-name__label');
+  const entryNames = connected.locator('.folder-container').locator('.file-list-item').locator('.file-name').locator('.label-name');
   await expect(entryNames).toHaveText(['Folder']);
   await connected.locator('.topbar-left').locator('.back-button').click();
 

--- a/client/tests/e2e/specs/sidebar.spec.ts
+++ b/client/tests/e2e/specs/sidebar.spec.ts
@@ -268,7 +268,7 @@ msTest('Recent document updates when file is renamed', async ({ documents }) => 
   const popover = documents.locator('.file-context-menu');
   await popover.getByRole('listitem').filter({ hasText: 'Rename' }).click();
   await fillInputModal(documents, `New-${fileName}`, true);
-  await expect(fileItem.locator('.file-name').locator('.file-name__label')).toHaveText(`New-${fileName}`);
+  await expect(fileItem.locator('.file-name').locator('.label-name')).toHaveText(`New-${fileName}`);
   await expect(sidebarRecentFiles.locator('.sidebar-item')).toHaveText([`New-${fileName}`]);
 });
 

--- a/client/tests/e2e/specs/workspace_history.spec.ts
+++ b/client/tests/e2e/specs/workspace_history.spec.ts
@@ -94,7 +94,7 @@ msTest('Test viewer in history', async ({ documents }) => {
   await expect(folderList.locator('.file-list-item')).toHaveCount(9);
 
   for (const entry of await folderList.locator('.file-list-item').all()) {
-    const entryName = (await entry.locator('.file-name').locator('.file-name__label').textContent()) ?? '';
+    const entryName = (await entry.locator('.file-name').locator('.label-name').textContent()) ?? '';
     if (entryName.endsWith('.txt')) {
       await entry.dblclick();
       break;
@@ -128,13 +128,13 @@ msTest('Workspace history breadcrumbs', async ({ documents }) => {
   const entries = documents.locator('.folder-container').locator('.file-list-item');
   await navigateDown();
   await createFolder(documents, 'Subdir 1');
-  await expect(entries.locator('.file-name').locator('.file-name__label')).toHaveText(['Subdir 1']);
+  await expect(entries.locator('.file-name').locator('.label-name')).toHaveText(['Subdir 1']);
   await navigateDown();
   await createFolder(documents, 'Subdir 2');
-  await expect(entries.locator('.file-name').locator('.file-name__label')).toHaveText(['Subdir 2']);
+  await expect(entries.locator('.file-name').locator('.label-name')).toHaveText(['Subdir 2']);
   await navigateDown();
   await createFolder(documents, 'Subdir 3');
-  await expect(entries.locator('.file-name').locator('.file-name__label')).toHaveText(['Subdir 3']);
+  await expect(entries.locator('.file-name').locator('.label-name')).toHaveText(['Subdir 3']);
   await documents.locator('.sidebar').locator('#sidebar-workspaces').locator('.list-sidebar-header-text').click();
   await expect(documents).toBeWorkspacePage();
   await expect(documents.locator('.workspace-card-item')).toHaveCount(1);


### PR DESCRIPTION
The PR should redefined how the file folder responsive is managed. 

This PR includes:
- Global management of the size of each column using percentages to improve responsive rendering.
- Updates of all tests including modified columns.
- Option column is always visible (dot options: `•••`)


https://github.com/user-attachments/assets/7cc9ab31-2ad6-4dcc-92bb-f2abf3dad45d

closes #11200

