### PR TITLE
[MS] Handle Parsec URLs in web mode

### DIFF
--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -343,6 +343,14 @@
             }
         }
     },
+    "WebRedirectPage": {
+        "title": "Launching Parsec App",
+        "subtitle": "You can choose to open this link in Parsec app or in the browser.",
+        "desktop": "Open in Parsec app",
+        "web": "Continue in browser",
+        "downloadText": "Don't have Parsec app yet?",
+        "downloadLink": "Download Parsec"
+    },
     "CreateOrganization": {
         "fullname": "Full name",
         "fullnamePlaceholder": "John Smith",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -342,6 +342,14 @@
             }
         }
     },
+    "WebRedirectPage": {
+        "title": "Lancement de l'application Parsec",
+        "subtitle": "Vous pouvez choisir d'ouvrir ce lien dans l'application Parsec ou dans votre navigateur web.",
+        "desktop": "Ouvrir dans l'application Parsec",
+        "web": "Continuer dans votre navigateur web",
+        "downloadText": "Vous n'avez pas encore l'application Parsec ?",
+        "downloadLink": "Télécharger Parsec"
+    },
     "CreateOrganization": {
         "fullname": "Nom complet",
         "fullnamePlaceholder": "Jean Martin",

--- a/client/src/router/types.ts
+++ b/client/src/router/types.ts
@@ -27,6 +27,7 @@ export enum Routes {
   RecoverAccount = 'recoverAccount',
   FileHandler = 'fileHandler',
   Invitations = 'invitations',
+  WebRedirect = 'webRedirect',
 }
 
 const routes: Array<RouteRecordRaw> = [
@@ -102,6 +103,11 @@ const routes: Array<RouteRecordRaw> = [
     path: `/${Routes.ClientArea}`,
     name: Routes.ClientArea,
     component: () => import('@/views/client-area/ClientAreaLayout.vue'),
+  },
+  {
+    path: `/${Routes.WebRedirect}`,
+    name: Routes.WebRedirect,
+    component: () => import('@/views/home/WebRedirectPage.vue'),
   },
   {
     // DevLayout is used to login a default device in case the page was
@@ -303,6 +309,7 @@ export interface Query {
   profilePage?: ProfilePages;
   bmsLogin?: true;
   readOnly?: boolean;
+  webRedirectUrl?: string;
 }
 
 export interface ClientAreaQuery {

--- a/client/src/services/linkHandler.ts
+++ b/client/src/services/linkHandler.ts
@@ -1,0 +1,129 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { availableDeviceMatchesServer } from '@/common/device';
+import { bootstrapLinkValidator, claimLinkValidator, fileLinkValidator } from '@/common/validators';
+import { AvailableDevice, getOrganizationHandle, listAvailableDevices, parseFileLink } from '@/parsec';
+import {
+  backupCurrentOrganization,
+  currentRouteIs,
+  getConnectionHandle,
+  navigateTo,
+  RouteBackup,
+  Routes,
+  switchOrganization,
+} from '@/router';
+import { Information, InformationLevel, InformationManager, PresentationMode } from '@/services/informationManager';
+import { modalController, popoverController } from '@ionic/vue';
+import { Base64, Validity } from 'megashark-lib';
+
+async function handleJoinLink(link: string): Promise<void> {
+  if (!currentRouteIs(Routes.Home)) {
+    await switchOrganization(null, true);
+  }
+  await navigateTo(Routes.Home, { query: { claimLink: link } });
+}
+
+async function handleBootstrapLink(link: string): Promise<void> {
+  if (!currentRouteIs(Routes.Home)) {
+    await switchOrganization(null, true);
+  }
+  await navigateTo(Routes.Home, { query: { bootstrapLink: link } });
+}
+
+async function handleFileLink(link: string, informationManager: InformationManager): Promise<void> {
+  const result = await parseFileLink(link);
+  if (!result.ok) {
+    informationManager.present(
+      new Information({
+        message: 'link.invalidFileLink',
+        level: InformationLevel.Error,
+      }),
+      PresentationMode.Toast,
+    );
+    return;
+  }
+  const linkData = result.value;
+  // Check if the org we want is already logged in
+  const handle = await getOrganizationHandle({ id: linkData.organizationId, server: { hostname: linkData.hostname, port: linkData.port } });
+
+  // We have a matching organization already opened
+  if (handle) {
+    if (getConnectionHandle() && handle !== getConnectionHandle()) {
+      await switchOrganization(handle, true);
+    }
+
+    const routeData: RouteBackup = {
+      handle: handle,
+      data: {
+        route: Routes.Workspaces,
+        params: { handle: handle },
+        query: { fileLink: link },
+      },
+    };
+    await navigateTo(Routes.Loading, { skipHandle: true, replace: true, query: { loginInfo: Base64.fromObject(routeData) } });
+  } else {
+    // Check if we have a device with the org
+    const devices = await listAvailableDevices();
+    let matchingDevice: AvailableDevice | undefined;
+    for (const device of devices) {
+      // Pre-matching on org id only, in case we don't find a server match. This could happen
+      // with different DNS, IP addresses instead of hostname, ...
+      if (device.organizationId === linkData.organizationId && !matchingDevice) {
+        matchingDevice = device;
+      }
+      if (
+        (await availableDeviceMatchesServer(device, { hostname: linkData.hostname, port: linkData.port })) &&
+        device.organizationId === linkData.organizationId
+      ) {
+        matchingDevice = device;
+        // Full match takes priority, we can break out the loop
+        break;
+      }
+    }
+    if (!matchingDevice) {
+      await informationManager.present(
+        new Information({
+          message: { key: 'link.orgNotFound', data: { organization: linkData.organizationId } },
+          level: InformationLevel.Error,
+        }),
+        PresentationMode.Modal,
+      );
+      return;
+    }
+    if (!currentRouteIs(Routes.Home)) {
+      await backupCurrentOrganization();
+    }
+    await navigateTo(Routes.Home, { replace: true, skipHandle: true, query: { deviceId: matchingDevice.deviceId, fileLink: link } });
+  }
+}
+
+export async function handleParsecLink(link: string, informationManager: InformationManager): Promise<void> {
+  if (await modalController.getTop()) {
+    informationManager.present(
+      new Information({
+        message: 'link.appIsBusy',
+        level: InformationLevel.Error,
+      }),
+      PresentationMode.Toast,
+    );
+    return;
+  }
+  if (await popoverController.getTop()) {
+    await popoverController.dismiss();
+  }
+  if ((await claimLinkValidator(link)).validity === Validity.Valid) {
+    await handleJoinLink(link);
+  } else if ((await fileLinkValidator(link)).validity === Validity.Valid) {
+    await handleFileLink(link, informationManager);
+  } else if ((await bootstrapLinkValidator(link)).validity === Validity.Valid) {
+    await handleBootstrapLink(link);
+  } else {
+    await informationManager.present(
+      new Information({
+        message: 'link.invalid',
+        level: InformationLevel.Error,
+      }),
+      PresentationMode.Modal,
+    );
+  }
+}

--- a/client/src/views/home/WebRedirectPage.vue
+++ b/client/src/views/home/WebRedirectPage.vue
@@ -1,0 +1,153 @@
+<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+
+<template>
+  <ion-page class="page">
+    <div class="redirect-container">
+      <ms-image
+        :image="LogoIconGradient"
+        class="redirect-logo"
+      />
+
+      <div class="redirect-text">
+        <ion-text class="redirect-text__title title-h1">
+          {{ $msTranslate('WebRedirectPage.title') }}
+        </ion-text>
+        <ion-text class="redirect-text__subtitle body-lg">
+          {{ $msTranslate('WebRedirectPage.subtitle') }}
+        </ion-text>
+      </div>
+
+      <div class="redirect-buttons">
+        <ion-button class="redirect-buttons__item button-large button-primary">
+          <a
+            :href="redirectLink"
+            target="_blank"
+            class="link"
+          >
+            {{ $msTranslate('WebRedirectPage.desktop') }}
+          </a>
+        </ion-button>
+        <ion-button
+          @click="openLinkInWeb()"
+          class="redirect-buttons__item button-large button-default"
+          fill="clear"
+        >
+          {{ $msTranslate('WebRedirectPage.web') }}
+        </ion-button>
+      </div>
+
+      <div class="redirect-download">
+        <ion-text class="redirect-download__text body">
+          {{ $msTranslate('WebRedirectPage.downloadText') }}
+        </ion-text>
+        <a
+          :href="$msTranslate('MenuPage.downloadParsecLink')"
+          target="_blank"
+          class="redirect-download__link button-medium"
+        >
+          {{ $msTranslate('WebRedirectPage.downloadLink') }}
+        </a>
+      </div>
+    </div>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { getCurrentRouteQuery } from '@/router';
+import { InformationManager, InformationManagerKey } from '@/services/informationManager';
+import { handleParsecLink } from '@/services/linkHandler';
+import { IonPage, IonText, IonButton } from '@ionic/vue';
+import { LogoIconGradient, MsImage } from 'megashark-lib';
+import { inject } from 'vue';
+
+const informationManager: InformationManager = inject(InformationManagerKey)!;
+
+const query = getCurrentRouteQuery();
+const redirectLink = query.webRedirectUrl ?? '';
+
+async function openLinkInWeb(): Promise<void> {
+  await handleParsecLink(redirectLink, informationManager);
+}
+</script>
+
+<style lang="scss" scoped>
+.page {
+  background-color: var(--parsec-color-light-secondary-white);
+}
+
+.redirect-container {
+  max-width: 28rem;
+  display: flex;
+  margin: auto;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}
+
+.redirect-logo {
+  width: 4rem;
+  margin-bottom: 1.75rem;
+}
+
+.redirect-text {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+
+  &__title {
+    background-clip: text;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-image: var(--parsec-color-light-gradient-background);
+  }
+
+  &__subtitle {
+    color: var(--parsec-color-light-secondary-hard-grey);
+    text-align: center;
+  }
+}
+
+.redirect-buttons {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  max-width: 22rem;
+  width: 100%;
+
+  &__item {
+    width: 100%;
+
+    .link {
+      color: var(--parsec-color-light-secondary-white);
+    }
+  }
+}
+
+.redirect-download {
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-top: 1px solid var(--parsec-color-light-secondary-medium);
+
+  &__text {
+    color: var(--parsec-color-light-secondary-hard-grey);
+  }
+
+  &__link {
+    color: var(--parsec-color-light-primary-500);
+    transition: all 0.2s ease-in-out;
+
+    &:hover {
+      text-decoration: underline;
+      color: var(--parsec-color-light-primary-600);
+    }
+  }
+}
+</style>

--- a/newsfragments/10379.feature.rst
+++ b/newsfragments/10379.feature.rst
@@ -1,0 +1,1 @@
+Added a redirection page to handle Parsec links in both web and desktop mode

--- a/server/parsec/asgi/__init__.py
+++ b/server/parsec/asgi/__init__.py
@@ -77,7 +77,7 @@ def app_factory(
     )
     logger.debug(f"Allowed origins: {cors_allow_origins}")
     app.state.backend = backend
-
+    app.state.with_client_web_app = with_client_web_app
     templates = Jinja2Templates(env=backend.config.jinja_env)
 
     if with_client_web_app:


### PR DESCRIPTION
Closes https://github.com/Scille/parsec-cloud/issues/10379

How to test:
1.  Build a webapp 
```
BASE_URL=/client npm run web:release
```
2. Run a local server using this webapp
```
poetry -P server run python -m parsec run --dev --with-client-web-app client/dist/ --spontaneous-organization-bootstrap
```
3. Create an organization on this server through the custom server process using `parsec3://localhost:6777?no_ssl=true`
4. Generate any parsec link
5. You can test the redirection page by replacing `parsec3://localhost:6777/` with `http://localhost:6777/redirect/`