### PR TITLE
ci(python): Allow rust warnings in ci-python

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -147,6 +147,7 @@ jobs:
         with:
           # We setup the cache by hand, see below
           cache: false
+          rustflags: "" # Set value to prevent default which deny cargo check warnings.
         timeout-minutes: 5
 
       - name: Retrieve Rust cache


### PR DESCRIPTION
`ci-rust` will still fail if they're compilation warnings. This change allow for `ci-python` to go further and help focus the developer to not try to look for a python error when it's on the rust code.

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
