### PR TITLE
[MS] Filtered menu and header actions depending on profile and role

### DIFF
--- a/client/src/components/organizations/OrganizationUserInformation.vue
+++ b/client/src/components/organizations/OrganizationUserInformation.vue
@@ -11,6 +11,7 @@
         fill="clear"
         class="card-header__button user-invite-button"
         @click="inviteUser"
+        v-show="userInfo.currentProfile === UserProfile.Admin"
       >
         <ion-icon
           :icon="personAdd"
@@ -93,7 +94,10 @@
         </ion-button>
       </div>
 
-      <div class="invitation-card-list">
+      <div
+        class="invitation-card-list"
+        v-show="userInfo.currentProfile === UserProfile.Admin"
+      >
         <div
           button
           class="invitation-card-list-item"

--- a/client/src/views/menu/MainMenu.vue
+++ b/client/src/views/menu/MainMenu.vue
@@ -106,7 +106,7 @@
 
         <!-- organisation content -->
         <sidebar-menu-list
-          v-if="userInfo && userInfo.currentProfile != UserProfile.Outsider"
+          v-if="userInfo && userInfo.currentProfile !== UserProfile.Outsider"
           title="SideMenu.organization"
           v-model:is-content-visible="menusVisible.organization"
           @update:is-content-visible="onOrganizationMenuVisibilityChanged"
@@ -418,7 +418,7 @@ import { Resources, ResourcesManager } from '@/services/resourcesManager';
 import { FileOperationManager, FileOperationManagerKey } from '@/services/fileOperationManager';
 import { copyToClipboard } from '@/common/clipboard';
 
-defineProps<{
+const props = defineProps<{
   userInfo: ClientInfo;
 }>();
 
@@ -550,25 +550,28 @@ async function updateDividerPosition(value?: number): Promise<void> {
 }
 
 function setActions(): void {
-  if (currentRouteIs(Routes.Documents)) {
+  if (currentRouteIs(Routes.Documents) && currentWorkspace.value && currentWorkspace.value.currentSelfRole !== WorkspaceRole.Reader) {
     actions.value = [
       [{ action: FolderGlobalAction.CreateFolder, label: 'FoldersPage.createFolder', icon: folderOpen }],
       [
         { action: FolderGlobalAction.ImportFolder, label: 'FoldersPage.ImportFile.importFolderAction', icon: cloudUpload },
         { action: FolderGlobalAction.ImportFiles, label: 'FoldersPage.ImportFile.importFilesAction', icon: cloudUpload },
       ],
-      [{ action: UserAction.Invite, label: 'UsersPage.inviteUser', icon: personAdd }],
     ];
-  } else if (currentRouteIs(Routes.Workspaces)) {
-    actions.value = [
-      [{ action: WorkspaceAction.CreateWorkspace, label: 'WorkspacesPage.createWorkspace', icon: addCircle }],
-      [{ action: UserAction.Invite, label: 'UsersPage.inviteUser', icon: personAdd }],
-    ];
+    if (props.userInfo.currentProfile === UserProfile.Admin) {
+      actions.value.push([{ action: UserAction.Invite, label: 'UsersPage.inviteUser', icon: personAdd }]);
+    }
+  } else if (currentRouteIs(Routes.Workspaces) && props.userInfo.currentProfile !== UserProfile.Outsider) {
+    actions.value = [[{ action: WorkspaceAction.CreateWorkspace, label: 'WorkspacesPage.createWorkspace', icon: addCircle }]];
+    if (props.userInfo.currentProfile === UserProfile.Admin) {
+      actions.value.push([{ action: UserAction.Invite, label: 'UsersPage.inviteUser', icon: personAdd }]);
+    }
   } else if (
-    currentRouteIs(Routes.Users) ||
-    currentRouteIs(Routes.MyProfile) ||
-    currentRouteIs(Routes.Organization) ||
-    currentRouteIs(Routes.Invitations)
+    (currentRouteIs(Routes.Users) ||
+      currentRouteIs(Routes.MyProfile) ||
+      currentRouteIs(Routes.Organization) ||
+      currentRouteIs(Routes.Invitations)) &&
+    props.userInfo.currentProfile === UserProfile.Admin
   ) {
     actions.value = [
       [{ action: UserAction.Invite, label: 'UsersPage.inviteUser', icon: personAdd }],

--- a/client/src/views/menu/TabBarMenu.vue
+++ b/client/src/views/menu/TabBarMenu.vue
@@ -3,6 +3,11 @@
 <template>
   <div
     class="tab-bar-menu"
+    v-if="userInfo"
+    :class="{
+      'tab-bar-menu--outsider': userInfo.currentProfile === UserProfile.Outsider,
+      'tab-bar-menu--outsider-file': userInfo.currentProfile === UserProfile.Outsider && currentRouteIs(Routes.Documents),
+    }"
     id="tab-bar"
   >
     <div
@@ -37,9 +42,11 @@
       </ion-text>
     </div>
 
-    <div class="tab-bar-menu fab-button-container">
+    <div
+      class="tab-bar-menu fab-button-container"
+      v-show="actions.length > 0"
+    >
       <ion-fab
-        v-show="actions.length > 0"
         class="fab-content"
         size="small"
         id="add-menu-fab-button"
@@ -62,6 +69,7 @@
       class="tab-bar-menu-button"
       :class="currentRouteIs(Routes.Organization) ? 'active' : ''"
       @click="switchTab(Routes.Organization)"
+      v-show="userInfo && userInfo.currentProfile !== UserProfile.Outsider"
     >
       <ion-icon
         :icon="prism"
@@ -91,7 +99,7 @@
 import { IonFab, IonFabButton, IonIcon, IonText, modalController } from '@ionic/vue';
 import { folder, prism, personCircle, business } from 'ionicons/icons';
 import { hasVisited, Routes, navigateTo, currentRouteIs, getLastVisited } from '@/router';
-import { ClientInfo, getClientInfo as parsecGetClientInfo } from '@/parsec';
+import { ClientInfo, getClientInfo as parsecGetClientInfo, UserProfile } from '@/parsec';
 import { ref, Ref, onMounted } from 'vue';
 import { AddIcon, MsImage, MsModalResult } from 'megashark-lib';
 import TabBarMenuModal from '@/views/menu/TabBarMenuModal.vue';
@@ -193,6 +201,14 @@ async function openMenuModal(): Promise<void> {
   width: 100%;
   display: grid;
   grid-template-columns: repeat(5, 1fr);
+
+  &--outsider {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  &--outsider-file {
+    grid-template-columns: repeat(4, 1fr);
+  }
 
   &-button {
     display: flex;

--- a/client/src/views/workspaces/WorkspacesPage.vue
+++ b/client/src/views/workspaces/WorkspacesPage.vue
@@ -91,7 +91,7 @@
               }}
             </ion-text>
             <ion-button
-              v-show="clientProfile != UserProfile.Outsider"
+              v-show="clientProfile !== UserProfile.Outsider"
               id="new-workspace"
               fill="outline"
               @click="openCreateWorkspaceModal()"
@@ -510,6 +510,10 @@ function onMsSorterChange(event: MsSorterChangeEvent): void {
 }
 
 async function createWorkspace(name: WorkspaceName): Promise<void> {
+  // Externals shouldn't be able to access here, but putting this as safety
+  if (clientProfile.value === UserProfile.Outsider) {
+    return;
+  }
   const result = await parsecCreateWorkspace(name);
   if (result.ok) {
     informationManager.present(
@@ -595,14 +599,16 @@ async function onOpenWorkspaceContextMenu(workspace: WorkspaceInfo, event: Event
 const actionBarOptionsWorkspacesPage = computed(() => {
   const actionsArray = [];
 
-  actionsArray.push({
-    id: 'button-new-workspace',
-    label: 'WorkspacesPage.createWorkspace',
-    icon: addCircle,
-    onClick: async (): Promise<void> => {
-      await openCreateWorkspaceModal();
-    },
-  });
+  if (clientProfile.value !== UserProfile.Outsider) {
+    actionsArray.push({
+      id: 'button-new-workspace',
+      label: 'WorkspacesPage.createWorkspace',
+      icon: addCircle,
+      onClick: async (): Promise<void> => {
+        await openCreateWorkspaceModal();
+      },
+    });
+  }
   return actionsArray;
 });
 

--- a/client/tests/e2e/helpers/fixtures.ts
+++ b/client/tests/e2e/helpers/fixtures.ts
@@ -225,12 +225,14 @@ export const msTest = debugTest.extend<{
   secondTab: MsPage;
   connected: MsPage;
   workspacesStandard: MsPage;
+  workspacesExternal: MsPage;
   workspaces: MsPage;
   documentsOptions: any;
   documents: MsPage;
   documentsReadOnly: MsPage;
   usersPage: MsPage;
   organizationPage: MsPage;
+  organizationPageStandard: MsPage;
   invitationsPage: MsPage;
   myProfilePage: MsPage;
   userJoinModal: Locator;
@@ -295,6 +297,22 @@ export const msTest = debugTest.extend<{
     await home.locator('.login-button').click();
     await expect(home.locator('#connected-header')).toContainText('My workspaces');
     await expect(home.locator('.topbar-right').locator('.text-content-name')).toHaveText('Boby McBobFace');
+    await expect(home).toBeWorkspacePage();
+
+    await use(home);
+  },
+
+  workspacesExternal: async ({ home }, use) => {
+    await home.locator('.organization-card').nth(2).click();
+    await expect(home.locator('#password-input')).toBeVisible();
+
+    await expect(home.locator('.login-button')).toHaveDisabledAttribute();
+
+    await home.locator('#password-input').locator('input').fill('P@ssw0rd.');
+    await expect(home.locator('.login-button')).toBeEnabled();
+    await home.locator('.login-button').click();
+    await expect(home.locator('#connected-header')).toContainText('My workspaces');
+    await expect(home.locator('.topbar-right').locator('.text-content-name')).toHaveText('Malloryy McMalloryFace');
     await expect(home).toBeWorkspacePage();
 
     await use(home);
@@ -394,6 +412,13 @@ export const msTest = debugTest.extend<{
     await expect(connected).toHavePageTitle('Information');
     await expect(connected).toBeOrganizationPage();
     use(connected);
+  },
+
+  organizationPageStandard: async ({ workspacesStandard }, use) => {
+    await workspacesStandard.locator('.sidebar').locator('#sidebar-organization-information').click();
+    await expect(workspacesStandard).toHavePageTitle('Information');
+    await expect(workspacesStandard).toBeOrganizationPage();
+    use(workspacesStandard);
   },
 
   invitationsPage: async ({ connected }, use) => {

--- a/client/tests/e2e/specs/organization_information.spec.ts
+++ b/client/tests/e2e/specs/organization_information.spec.ts
@@ -7,6 +7,7 @@ for (const displaySize of [DisplaySize.Large, DisplaySize.Small]) {
     const container = organizationPage.locator('.organization-page-content');
     const configContainer = container.locator('.organization-info');
     const usersContainer = container.locator('.organization-users');
+    const inviteButton = usersContainer.locator('.user-invite-button');
     const storageContainer = container.locator('.organization-storage');
     const emailInvitationCard = usersContainer.locator('.invitation-card-list-item').nth(0);
     const PkiRequestCard = usersContainer.locator('.invitation-card-list-item').nth(1);
@@ -22,6 +23,7 @@ for (const displaySize of [DisplaySize.Large, DisplaySize.Small]) {
     await expect(PkiRequestCard).toBeVisible();
     await expect(PkiRequestCard.locator('.invitation-card-list-item__title')).toContainText('PKI requests');
     await expect(PkiRequestCard.locator('.invitation-card-list-item__number')).toHaveText('3');
+    await expect(inviteButton).toBeVisible();
 
     if (displaySize === DisplaySize.Small) {
       await organizationPage.locator('.tab-bar-menu').locator('.tab-bar-menu-button').nth(2).click();
@@ -36,12 +38,58 @@ for (const displaySize of [DisplaySize.Large, DisplaySize.Small]) {
     await expect(configContainer.locator('.info-list-item').nth(1).locator('.info-list-item__value')).toHaveText(['Unlimited']);
     await expect(configContainer.locator('.info-list-item').nth(2).locator('.server-address-value__text')).toHaveText(/^parsec3:\/\/.+$/);
 
-    await expect(usersContainer.locator('.users-list-item').nth(0).locator('.users-list-item__title')).toHaveText('3');
-    await expect(usersContainer.locator('.users-list-item').nth(0).locator('.users-list-item__description')).toHaveText('Active');
-    await expect(usersContainer.locator('.users-list-item').nth(1).locator('.users-list-item__title')).toHaveText('0');
-    await expect(usersContainer.locator('.users-list-item').nth(1).locator('.users-list-item__description')).toHaveText('Revoked');
-    await expect(usersContainer.locator('.users-list-item').nth(2).locator('.users-list-item__title')).toHaveText('0');
-    await expect(usersContainer.locator('.users-list-item').nth(2).locator('.users-list-item__description')).toHaveText('Frozen');
+    const userCategories = usersContainer.locator('.users-list-item');
+    await expect(userCategories.nth(0).locator('.users-list-item__title')).toHaveText('3');
+    await expect(userCategories.nth(0).locator('.users-list-item__description')).toHaveText('Active');
+    await expect(userCategories.nth(1).locator('.users-list-item__title')).toHaveText('0');
+    await expect(userCategories.nth(1).locator('.users-list-item__description')).toHaveText('Revoked');
+    await expect(userCategories.nth(2).locator('.users-list-item__title')).toHaveText('0');
+    await expect(userCategories.nth(2).locator('.users-list-item__description')).toHaveText('Frozen');
+    await expect(usersContainer.locator('.user-active-list').locator('.label-profile')).toHaveText(['Administrator', 'Member', 'External']);
+    await expect(usersContainer.locator('.user-active-list').locator('.user-active-list-item__value')).toHaveText(['1', '1', '1']);
+
+    await expect(storageContainer.locator('.storage-list-item__value').nth(0)).toHaveText(/^\d+(\.\d{2})? (B|KB|MB)$/);
+    await expect(storageContainer.locator('.storage-list-item__value').nth(1)).toHaveText(/^\d+(\.\d{2})? (B|KB|MB)$/);
+  });
+
+  msTest(`Org info default state on ${displaySize} display on standard user`, async ({ organizationPageStandard }) => {
+    const container = organizationPageStandard.locator('.organization-page-content');
+    const configContainer = container.locator('.organization-info');
+    const usersContainer = container.locator('.organization-users');
+    const inviteButton = usersContainer.locator('.user-invite-button');
+    const storageContainer = container.locator('.organization-storage');
+    const emailInvitationCard = usersContainer.locator('.invitation-card-list-item').nth(0);
+    const PkiRequestCard = usersContainer.locator('.invitation-card-list-item').nth(1);
+    await usersContainer.locator('#invitations-button').isVisible();
+
+    if (displaySize === DisplaySize.Small) {
+      await organizationPageStandard.setDisplaySize(DisplaySize.Small);
+    }
+
+    await expect(emailInvitationCard).toBeHidden();
+    await expect(PkiRequestCard).toBeHidden();
+    await expect(inviteButton).toBeHidden();
+
+    if (displaySize === DisplaySize.Small) {
+      await organizationPageStandard.locator('.tab-bar-menu').locator('.tab-bar-menu-button').nth(2).click();
+    }
+
+    await expect(configContainer.locator('.info-list-item').locator('.info-list-item__title')).toHaveText([
+      'External profile',
+      'User limit (excluding users with External profile)',
+      'Server address',
+    ]);
+    await expect(configContainer.locator('.info-list-item').nth(0).locator('.info-list-item__value')).toHaveText(['Enabled']);
+    await expect(configContainer.locator('.info-list-item').nth(1).locator('.info-list-item__value')).toHaveText(['Unlimited']);
+    await expect(configContainer.locator('.info-list-item').nth(2).locator('.server-address-value__text')).toHaveText(/^parsec3:\/\/.+$/);
+
+    const userCategories = usersContainer.locator('.users-list-item');
+    await expect(userCategories.nth(0).locator('.users-list-item__title')).toHaveText('3');
+    await expect(userCategories.nth(0).locator('.users-list-item__description')).toHaveText('Active');
+    await expect(userCategories.nth(1).locator('.users-list-item__title')).toHaveText('0');
+    await expect(userCategories.nth(1).locator('.users-list-item__description')).toHaveText('Revoked');
+    await expect(userCategories.nth(2).locator('.users-list-item__title')).toHaveText('0');
+    await expect(userCategories.nth(2).locator('.users-list-item__description')).toHaveText('Frozen');
     await expect(usersContainer.locator('.user-active-list').locator('.label-profile')).toHaveText(['Administrator', 'Member', 'External']);
     await expect(usersContainer.locator('.user-active-list').locator('.user-active-list-item__value')).toHaveText(['1', '1', '1']);
 
@@ -116,3 +164,11 @@ for (const displaySize of [DisplaySize.Large, DisplaySize.Small]) {
     }
   });
 }
+
+msTest('No access to organization info as external', async ({ workspacesExternal }) => {
+  await expect(workspacesExternal.locator('.sidebar').locator('#sidebar-organization-information')).toBeHidden();
+  await workspacesExternal.setDisplaySize(DisplaySize.Small);
+  const tabBarButtons = workspacesExternal.locator('#tab-bar').locator('.tab-bar-menu-button');
+  await expect(tabBarButtons.nth(2)).toHaveText('Organization');
+  await expect(tabBarButtons.nth(2)).toBeHidden();
+});

--- a/client/tests/e2e/specs/small_display_fab_menu.spec.ts
+++ b/client/tests/e2e/specs/small_display_fab_menu.spec.ts
@@ -1,0 +1,86 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { DisplaySize, expect, msTest } from '@tests/e2e/helpers';
+
+msTest('Fab button and menu as administrator and read/write', async ({ workspaces }) => {
+  await workspaces.setDisplaySize(DisplaySize.Small);
+  const fabButton = workspaces.locator('#add-menu-fab-button');
+  const tabBarButtons = workspaces.locator('#tab-bar').locator('.tab-bar-menu-button');
+  const fabModalOptions = workspaces.locator('#fab-modal').getByRole('listitem');
+
+  // WorkspacesPage
+  await expect(fabButton).toBeVisible();
+  await fabButton.click();
+  await expect(fabModalOptions).toHaveCount(2);
+  await expect(fabModalOptions).toHaveText(['New workspace', 'Invite a user']);
+  await fabButton.click();
+
+  // Read/write workspace + admin
+  await workspaces.locator('.workspaces-container-grid').locator('.workspace-card-item').nth(0).click();
+  await expect(fabButton).toBeVisible();
+  await fabButton.click();
+  await expect(fabModalOptions).toHaveCount(4);
+  await expect(fabModalOptions).toHaveText(['New folder', 'Import a folder', 'Import files', 'Invite a user']);
+  await fabButton.click();
+
+  // Organization management
+  await tabBarButtons.nth(2).click();
+  await expect(workspaces).toBeOrganizationPage();
+  await fabButton.click();
+  await expect(fabModalOptions).toHaveCount(2);
+  await expect(fabModalOptions).toHaveText(['Invite a user', 'Copy link (PKI)']);
+  await fabButton.click();
+
+  // No button in profile page
+  await tabBarButtons.nth(3).click();
+  await expect(workspaces).toBeMyProfilePage();
+  await fabButton.click();
+  await expect(fabModalOptions).toHaveCount(2);
+  await expect(fabModalOptions).toHaveText(['Invite a user', 'Copy link (PKI)']);
+  await fabButton.click();
+});
+
+msTest('Fab button and menu as standard and reader', async ({ workspacesStandard }) => {
+  await workspacesStandard.setDisplaySize(DisplaySize.Small);
+  const fabButton = workspacesStandard.locator('#add-menu-fab-button');
+  const tabBarButtons = workspacesStandard.locator('#tab-bar').locator('.tab-bar-menu-button');
+  const fabModalOptions = workspacesStandard.locator('#fab-modal').getByRole('listitem');
+
+  // WorkspacesPage
+  await expect(fabButton).toBeVisible();
+  await fabButton.click();
+  await expect(fabModalOptions).toHaveCount(1);
+  await expect(fabModalOptions).toHaveText(['New workspace']);
+  await fabButton.click();
+
+  // No button in reader workspace
+  await workspacesStandard.locator('.workspaces-container-grid').locator('.workspace-card-item').nth(0).click();
+  await expect(fabButton).toBeHidden();
+
+  // No button in organization management
+  await tabBarButtons.nth(2).click();
+  await expect(workspacesStandard).toBeOrganizationPage();
+  await expect(fabButton).toBeHidden();
+
+  // No button in profile page
+  await tabBarButtons.nth(3).click();
+  await expect(workspacesStandard).toBeMyProfilePage();
+  await expect(fabButton).toBeHidden();
+});
+
+msTest('Fab button and menu as external', async ({ workspacesExternal }) => {
+  await workspacesExternal.setDisplaySize(DisplaySize.Small);
+  const fabButton = workspacesExternal.locator('#add-menu-fab-button');
+  const tabBarButtons = workspacesExternal.locator('#tab-bar').locator('.tab-bar-menu-button');
+
+  // WorkspacesPage
+  await expect(fabButton).toBeHidden();
+
+  // No button to organization management
+  await expect(tabBarButtons.nth(2)).toBeHidden();
+
+  // No button in profile page
+  await tabBarButtons.nth(3).click();
+  await expect(workspacesExternal).toBeMyProfilePage();
+  await expect(fabButton).toBeHidden();
+});

--- a/client/tests/e2e/specs/workspaces_list.spec.ts
+++ b/client/tests/e2e/specs/workspaces_list.spec.ts
@@ -267,3 +267,11 @@ msTest('Back from files with side menu', async ({ workspaces }) => {
     'My workspaces',
   );
 });
+
+msTest('Check no create workspace button as external', async ({ workspacesExternal }) => {
+  // Header button
+  await expect(workspacesExternal.locator('#workspaces-ms-action-bar').getByText('New workspace')).toBeHidden();
+  // Center button with no workspace
+  await expect(workspacesExternal.locator('.workspaces-container').locator('.workspace-list-item')).toHaveCount(0);
+  await expect(workspacesExternal.locator('#new-workspace')).toBeHidden();
+});

--- a/newsfragments/11232.bugfix.rst
+++ b/newsfragments/11232.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where menus and headers would display actions not available for certain profiles and roles


### PR DESCRIPTION
Closes #11232 
- Removed infos about invitations in the organisation page for `Standard` users
- Removed access to organisation page for `External` users in small display
- Filtered workspace contextual menu options for `Reader` role
- Removed the option to create a workspace for `External` users
- Added tests for these changes