### PR TITLE
Update `pki_enrollment_accept` following RFC 1020

### DIFF
--- a/libparsec/crates/protocol/schema/authenticated_cmds/pki_enrollment_accept.json5
+++ b/libparsec/crates/protocol/schema/authenticated_cmds/pki_enrollment_accept.json5
@@ -6,39 +6,44 @@
         "cmd": "pki_enrollment_accept",
         "req": {
             "fields": [
-                // Signature should be checked before loading.
                 {
-                    "name": "accept_payload",
-                    "type": "Bytes"
-                },
-                {
-                    "name": "accept_payload_signature",
-                    "type": "Bytes"
-                },
-                {
-                    "name": "accepter_der_x509_certificate",
-                    "type": "Bytes"
-                },
-                {
+                    // The enrollment ID to be accepted
                     "name": "enrollment_id",
                     "type": "EnrollmentID"
                 },
                 {
-                    "name": "device_certificate",
+                    // `PkiEnrollmentAnswerPayload` in msgpack format
+                    "name": "payload",
                     "type": "Bytes"
                 },
                 {
-                    "name": "user_certificate",
+                    // The payload signature, should be checked before loading
+                    "name": "payload_signature",
                     "type": "Bytes"
                 },
-                // Same certificate than `device_certificate` but expunged of `device_label`.
                 {
-                    "name": "redacted_device_certificate",
+                    // Certificate used by the accepter to sign the payload
+                    "name": "accepter_der_x509_certificate",
                     "type": "Bytes"
                 },
-                // Same certificate than `user_certificate` but expunged of `human_handle`.
                 {
-                    "name": "redacted_user_certificate",
+                    // User certificate for the submitter (created by the accepter)
+                    "name": "submitter_user_certificate",
+                    "type": "Bytes"
+                },
+                {
+                    // Device certificate for the submitter (created by the accepter)
+                    "name": "submitter_device_certificate",
+                    "type": "Bytes"
+                },
+                {
+                    // Same certificate than `submitter_user_certificate` but expunged of `human_handle`
+                    "name": "submitter_redacted_user_certificate",
+                    "type": "Bytes"
+                },
+                {
+                    // Same certificate than `submitter_device_certificate` but expunged of `device_label`
+                    "name": "submitter_redacted_device_certificate",
                     "type": "Bytes"
                 }
             ]
@@ -48,32 +53,39 @@
                 "status": "ok"
             },
             {
-                "status": "invalid_payload_data"
-            },
-            {
-                "status": "enrollment_not_found"
-            },
-            {
-                "status": "enrollment_no_longer_available"
-            },
-            {
+                // The user does not have the permission required to perform this action
                 "status": "author_not_allowed"
             },
             {
-                "status": "active_users_limit_reached"
+                // The payload is not correctly formatted
+                "status": "invalid_payload_data"
             },
             {
-                "status": "user_already_exists"
-            },
-            {
-                "status": "human_handle_already_taken"
-            },
-            {
+                // The provided certificate is not valid
                 "status": "invalid_certificate"
             },
             {
-                // Returned if the timestamp in the certificate is too far away compared
-                // to server clock.
+                // The server did not found a request for the provided ID
+                "status": "enrollment_not_found"
+            },
+            {
+                // The request is no longer in pending state (either accepted or rejected)
+                "status": "enrollment_no_longer_available"
+            },
+            {
+                // The organization has reached the maximum number of active users
+                "status": "active_users_limit_reached"
+            },
+            {
+                // The user already exist in the organization
+                "status": "user_already_exists"
+            },
+            {
+                // The user's human handle is already taken
+                "status": "human_handle_already_taken"
+            },
+            {
+                // The timestamp in the certificate is too far away compared to server clock
                 "status": "timestamp_out_of_ballpark",
                 "fields": [
                     {
@@ -95,8 +107,7 @@
                 ]
             },
             {
-                // Returned if another certificate in the server has a timestamp
-                // posterior or equal to our current one.
+                // The timestamp is earlier or equal to an existing certificate in the server
                 "status": "require_greater_timestamp",
                 "fields": [
                     {

--- a/libparsec/crates/protocol/tests/authenticated_cmds/v5/pki_enrollment_accept.rs
+++ b/libparsec/crates/protocol/tests/authenticated_cmds/v5/pki_enrollment_accept.rs
@@ -12,49 +12,48 @@ use super::authenticated_cmds;
 // Request
 
 pub fn req() {
-    // Generated from Python implementation (Parsec v2.14.0)
+    // Generated from Parsec 3.5.1-a.0+dev
     // Content:
-    //   accept_payload: hex!("3c64756d6d793e")
-    //   accept_payload_signature: hex!("3c7369676e61747572653e")
-    //   accepter_der_x509_certificate: hex!("3c61636365707465725f6465725f783530395f63657274696669636174653e")
-    //   cmd: "pki_enrollment_accept"
-    //   device_certificate: hex!("3c64756d6d793e")
-    //   enrollment_id: ext(2, hex!("e89621b91f8e4a7c8d3182ee513e380f"))
-    //   redacted_device_certificate: hex!("3c64756d6d793e")
-    //   redacted_user_certificate: hex!("3c64756d6d793e")
-    //   user_certificate: hex!("3c64756d6d793e")
-    //
+    //   cmd: 'pki_enrollment_accept'
+    //   enrollment_id: ext(2, 0x56f48ed307984f10830e197287399c22)
+    //   payload: 0x3c64756d6d793e
+    //   payload_signature: 0x3c7369676e61747572653e
+    //   accepter_der_x509_certificate: 0x3c61636365707465725f6465725f783530395f63657274696669636174653e
+    //   submitter_user_certificate: 0x3c64756d6d793e
+    //   submitter_device_certificate: 0x3c64756d6d793e
+    //   submitter_redacted_user_certificate: 0x3c64756d6d793e
+    //   submitter_redacted_device_certificate: 0x3c64756d6d793e
     let raw = hex!(
-        "89ae6163636570745f7061796c6f6164c4073c64756d6d793eb86163636570745f7061796c"
-        "6f61645f7369676e6174757265c40b3c7369676e61747572653ebd61636365707465725f64"
-        "65725f783530395f6365727469666963617465c41f3c61636365707465725f6465725f7835"
-        "30395f63657274696669636174653ea3636d64b5706b695f656e726f6c6c6d656e745f6163"
-        "63657074b26465766963655f6365727469666963617465c4073c64756d6d793ead656e726f"
-        "6c6c6d656e745f6964d80256f48ed307984f10830e197287399c22bb72656461637465645f"
-        "6465766963655f6365727469666963617465c4073c64756d6d793eb972656461637465645f"
-        "757365725f6365727469666963617465c4073c64756d6d793eb0757365725f636572746966"
-        "6963617465c4073c64756d6d793e"
+        "89a3636d64b5706b695f656e726f6c6c6d656e745f616363657074ad656e726f6c6c6d"
+        "656e745f6964d80256f48ed307984f10830e197287399c22a77061796c6f6164c4073c"
+        "64756d6d793eb17061796c6f61645f7369676e6174757265c40b3c7369676e61747572"
+        "653ebd61636365707465725f6465725f783530395f6365727469666963617465c41f3c"
+        "61636365707465725f6465725f783530395f63657274696669636174653eba7375626d"
+        "69747465725f757365725f6365727469666963617465c4073c64756d6d793ebc737562"
+        "6d69747465725f6465766963655f6365727469666963617465c4073c64756d6d793ed9"
+        "237375626d69747465725f72656461637465645f757365725f63657274696669636174"
+        "65c4073c64756d6d793ed9257375626d69747465725f72656461637465645f64657669"
+        "63655f6365727469666963617465c4073c64756d6d793e"
     );
 
-    let expected = authenticated_cmds::AnyCmdReq::PkiEnrollmentAccept(
-        authenticated_cmds::pki_enrollment_accept::Req {
-            accept_payload: hex!("3c64756d6d793e").as_ref().into(),
-            accept_payload_signature: hex!("3c7369676e61747572653e").as_ref().into(),
-            accepter_der_x509_certificate: hex!(
-                "3c61636365707465725f6465725f783530395f63657274696669636174653e"
-            )
-            .as_ref()
-            .into(),
-            device_certificate: hex!("3c64756d6d793e").as_ref().into(),
-            enrollment_id: EnrollmentID::from_hex("56f48ed307984f10830e197287399c22").unwrap(),
-            redacted_device_certificate: hex!("3c64756d6d793e").as_ref().into(),
-            redacted_user_certificate: hex!("3c64756d6d793e").as_ref().into(),
-            user_certificate: hex!("3c64756d6d793e").as_ref().into(),
-        },
-    );
+    let req = authenticated_cmds::pki_enrollment_accept::Req {
+        payload: hex!("3c64756d6d793e").as_ref().into(),
+        payload_signature: hex!("3c7369676e61747572653e").as_ref().into(),
+        accepter_der_x509_certificate: hex!(
+            "3c61636365707465725f6465725f783530395f63657274696669636174653e"
+        )
+        .as_ref()
+        .into(),
+        submitter_device_certificate: hex!("3c64756d6d793e").as_ref().into(),
+        enrollment_id: EnrollmentID::from_hex("56f48ed307984f10830e197287399c22").unwrap(),
+        submitter_redacted_device_certificate: hex!("3c64756d6d793e").as_ref().into(),
+        submitter_redacted_user_certificate: hex!("3c64756d6d793e").as_ref().into(),
+        submitter_user_certificate: hex!("3c64756d6d793e").as_ref().into(),
+    };
+    let expected = authenticated_cmds::AnyCmdReq::PkiEnrollmentAccept(req.clone());
+    println!("***expected: {:?}", req.dump().unwrap());
 
     let data = authenticated_cmds::AnyCmdReq::load(&raw).unwrap();
-
     p_assert_eq!(data, expected);
 
     // Also test serialization round trip

--- a/server/parsec/_parsec_pyi/protocol/authenticated_cmds/v5/pki_enrollment_accept.pyi
+++ b/server/parsec/_parsec_pyi/protocol/authenticated_cmds/v5/pki_enrollment_accept.pyi
@@ -9,32 +9,32 @@ from parsec._parsec import DateTime, EnrollmentID
 class Req:
     def __init__(
         self,
-        accept_payload: bytes,
-        accept_payload_signature: bytes,
-        accepter_der_x509_certificate: bytes,
         enrollment_id: EnrollmentID,
-        device_certificate: bytes,
-        user_certificate: bytes,
-        redacted_device_certificate: bytes,
-        redacted_user_certificate: bytes,
+        payload: bytes,
+        payload_signature: bytes,
+        accepter_der_x509_certificate: bytes,
+        submitter_user_certificate: bytes,
+        submitter_device_certificate: bytes,
+        submitter_redacted_user_certificate: bytes,
+        submitter_redacted_device_certificate: bytes,
     ) -> None: ...
     def dump(self) -> bytes: ...
     @property
-    def accept_payload(self) -> bytes: ...
-    @property
-    def accept_payload_signature(self) -> bytes: ...
-    @property
     def accepter_der_x509_certificate(self) -> bytes: ...
-    @property
-    def device_certificate(self) -> bytes: ...
     @property
     def enrollment_id(self) -> EnrollmentID: ...
     @property
-    def redacted_device_certificate(self) -> bytes: ...
+    def payload(self) -> bytes: ...
     @property
-    def redacted_user_certificate(self) -> bytes: ...
+    def payload_signature(self) -> bytes: ...
     @property
-    def user_certificate(self) -> bytes: ...
+    def submitter_device_certificate(self) -> bytes: ...
+    @property
+    def submitter_redacted_device_certificate(self) -> bytes: ...
+    @property
+    def submitter_redacted_user_certificate(self) -> bytes: ...
+    @property
+    def submitter_user_certificate(self) -> bytes: ...
 
 class Rep:
     @staticmethod
@@ -53,7 +53,17 @@ class RepOk(Rep):
         self,
     ) -> None: ...
 
+class RepAuthorNotAllowed(Rep):
+    def __init__(
+        self,
+    ) -> None: ...
+
 class RepInvalidPayloadData(Rep):
+    def __init__(
+        self,
+    ) -> None: ...
+
+class RepInvalidCertificate(Rep):
     def __init__(
         self,
     ) -> None: ...
@@ -64,11 +74,6 @@ class RepEnrollmentNotFound(Rep):
     ) -> None: ...
 
 class RepEnrollmentNoLongerAvailable(Rep):
-    def __init__(
-        self,
-    ) -> None: ...
-
-class RepAuthorNotAllowed(Rep):
     def __init__(
         self,
     ) -> None: ...
@@ -84,11 +89,6 @@ class RepUserAlreadyExists(Rep):
     ) -> None: ...
 
 class RepHumanHandleAlreadyTaken(Rep):
-    def __init__(
-        self,
-    ) -> None: ...
-
-class RepInvalidCertificate(Rep):
     def __init__(
         self,
     ) -> None: ...

--- a/server/parsec/components/memory/pki.py
+++ b/server/parsec/components/memory/pki.py
@@ -298,13 +298,13 @@ class MemoryPkiEnrollmentComponent(BasePkiEnrollmentComponent):
         author: DeviceID,
         author_verify_key: VerifyKey,
         enrollment_id: EnrollmentID,
-        accept_payload: bytes,
-        accept_payload_signature: bytes,
+        payload: bytes,
+        payload_signature: bytes,
         accepter_der_x509_certificate: bytes,
-        user_certificate: bytes,
-        redacted_user_certificate: bytes,
-        device_certificate: bytes,
-        redacted_device_certificate: bytes,
+        submitter_user_certificate: bytes,
+        submitter_redacted_user_certificate: bytes,
+        submitter_device_certificate: bytes,
+        submitter_redacted_device_certificate: bytes,
     ) -> (
         tuple[UserCertificate, DeviceCertificate]
         | PkiEnrollmentAcceptValidateBadOutcome
@@ -334,7 +334,7 @@ class MemoryPkiEnrollmentComponent(BasePkiEnrollmentComponent):
                 return PkiEnrollmentAcceptStoreBadOutcome.AUTHOR_NOT_ALLOWED
 
             try:
-                PkiEnrollmentAnswerPayload.load(accept_payload)
+                PkiEnrollmentAnswerPayload.load(payload)
             except ValueError:
                 return PkiEnrollmentAcceptStoreBadOutcome.INVALID_ACCEPT_PAYLOAD
 
@@ -342,10 +342,10 @@ class MemoryPkiEnrollmentComponent(BasePkiEnrollmentComponent):
                 now=now,
                 expected_author=author,
                 author_verify_key=author_verify_key,
-                user_certificate=user_certificate,
-                device_certificate=device_certificate,
-                redacted_user_certificate=redacted_user_certificate,
-                redacted_device_certificate=redacted_device_certificate,
+                user_certificate=submitter_user_certificate,
+                device_certificate=submitter_device_certificate,
+                redacted_user_certificate=submitter_redacted_user_certificate,
+                redacted_device_certificate=submitter_redacted_device_certificate,
             ):
                 case (u_certif, d_certif):
                     pass
@@ -385,16 +385,16 @@ class MemoryPkiEnrollmentComponent(BasePkiEnrollmentComponent):
 
             org.users[u_certif.user_id] = MemoryUser(
                 cooked=u_certif,
-                user_certificate=user_certificate,
-                redacted_user_certificate=redacted_user_certificate,
+                user_certificate=submitter_user_certificate,
+                redacted_user_certificate=submitter_redacted_user_certificate,
             )
 
             # Sanity check, should never occurs given user doesn't exist yet !
             assert d_certif.device_id not in org.devices
             org.devices[d_certif.device_id] = MemoryDevice(
                 cooked=d_certif,
-                device_certificate=device_certificate,
-                redacted_device_certificate=redacted_device_certificate,
+                device_certificate=submitter_device_certificate,
+                redacted_device_certificate=submitter_redacted_device_certificate,
             )
 
             enrollment.enrollment_state = MemoryPkiEnrollmentState.ACCEPTED
@@ -403,8 +403,8 @@ class MemoryPkiEnrollmentComponent(BasePkiEnrollmentComponent):
             enrollment.submitter_accepted_device_id = d_certif.device_id
             enrollment.info_accepted = MemoryPkiEnrollmentInfoAccepted(
                 accepted_on=now,
-                accept_payload=accept_payload,
-                accept_payload_signature=accept_payload_signature,
+                accept_payload=payload,
+                accept_payload_signature=payload_signature,
                 accepter_der_x509_certificate=accepter_der_x509_certificate,
             )
 

--- a/server/parsec/components/pki.py
+++ b/server/parsec/components/pki.py
@@ -243,13 +243,13 @@ class BasePkiEnrollmentComponent:
         author: DeviceID,
         author_verify_key: VerifyKey,
         enrollment_id: EnrollmentID,
-        accept_payload: bytes,
-        accept_payload_signature: bytes,
+        payload: bytes,
+        payload_signature: bytes,
         accepter_der_x509_certificate: bytes,
-        user_certificate: bytes,
-        redacted_user_certificate: bytes,
-        device_certificate: bytes,
-        redacted_device_certificate: bytes,
+        submitter_user_certificate: bytes,
+        submitter_redacted_user_certificate: bytes,
+        submitter_device_certificate: bytes,
+        submitter_redacted_device_certificate: bytes,
     ) -> (
         tuple[UserCertificate, DeviceCertificate]
         | PkiEnrollmentAcceptValidateBadOutcome
@@ -421,13 +421,13 @@ class BasePkiEnrollmentComponent:
             author=client_ctx.device_id,
             author_verify_key=client_ctx.device_verify_key,
             enrollment_id=req.enrollment_id,
-            accept_payload=req.accept_payload,
-            accept_payload_signature=req.accept_payload_signature,
+            payload=req.payload,
+            payload_signature=req.payload_signature,
             accepter_der_x509_certificate=req.accepter_der_x509_certificate,
-            device_certificate=req.device_certificate,
-            user_certificate=req.user_certificate,
-            redacted_device_certificate=req.redacted_device_certificate,
-            redacted_user_certificate=req.redacted_user_certificate,
+            submitter_device_certificate=req.submitter_device_certificate,
+            submitter_user_certificate=req.submitter_user_certificate,
+            submitter_redacted_device_certificate=req.submitter_redacted_device_certificate,
+            submitter_redacted_user_certificate=req.submitter_redacted_user_certificate,
         )
         match outcome:
             case (_, _):

--- a/server/tests/api_v5/anonymous/test_pki_enrollment_info.py
+++ b/server/tests/api_v5/anonymous/test_pki_enrollment_info.py
@@ -82,13 +82,13 @@ async def test_anonymous_pki_enrollment_info_ok(
                 author=coolorg.alice.device_id,
                 author_verify_key=coolorg.alice.signing_key.verify_key,
                 enrollment_id=enrollment_id,
-                accept_payload=accept_payload,
-                accept_payload_signature=b"<alice accept payload signature>",
+                payload=accept_payload,
+                payload_signature=b"<alice accept payload signature>",
                 accepter_der_x509_certificate=b"<alice der x509 certificate>",
-                user_certificate=u_certif,
-                redacted_user_certificate=redacted_u_certif,
-                device_certificate=d_certif,
-                redacted_device_certificate=redacted_d_certif,
+                submitter_user_certificate=u_certif,
+                submitter_redacted_user_certificate=redacted_u_certif,
+                submitter_device_certificate=d_certif,
+                submitter_redacted_device_certificate=redacted_d_certif,
             )
             assert isinstance(outcome, tuple)
 

--- a/server/tests/api_v5/anonymous/test_pki_enrollment_submit.py
+++ b/server/tests/api_v5/anonymous/test_pki_enrollment_submit.py
@@ -279,7 +279,7 @@ async def test_anonymous_pki_enrollment_submit_already_enrolled(
         author=coolorg.alice.device_id,
         author_verify_key=coolorg.alice.signing_key.verify_key,
         enrollment_id=existing_enrollment.enrollment_id,
-        accept_payload=PkiEnrollmentAnswerPayload(
+        payload=PkiEnrollmentAnswerPayload(
             user_id=u_certif.user_id,
             device_id=d_certif.device_id,
             human_handle=u_certif.human_handle,
@@ -287,12 +287,12 @@ async def test_anonymous_pki_enrollment_submit_already_enrolled(
             device_label=d_certif.device_label,
             root_verify_key=coolorg.root_verify_key,
         ).dump(),
-        accept_payload_signature=b"<accept payload signature>",
+        payload_signature=b"<accept payload signature>",
         accepter_der_x509_certificate=b"<accepter der x509 certificate>",
-        user_certificate=user_certificate,
-        redacted_user_certificate=redacted_user_certificate,
-        device_certificate=device_certificate,
-        redacted_device_certificate=redacted_device_certificate,
+        submitter_user_certificate=user_certificate,
+        submitter_redacted_user_certificate=redacted_user_certificate,
+        submitter_device_certificate=device_certificate,
+        submitter_redacted_device_certificate=redacted_device_certificate,
     )
     assert isinstance(outcome, tuple)
 

--- a/server/tests/api_v5/authenticated/test_pki_enrollment_accept.py
+++ b/server/tests/api_v5/authenticated/test_pki_enrollment_accept.py
@@ -66,14 +66,13 @@ async def enrollment_id(
 
 class AcceptParams(TypedDict):
     enrollment_id: EnrollmentID
-    accept_payload: bytes
-    accept_payload_signature: bytes
+    payload: bytes
+    payload_signature: bytes
     accepter_der_x509_certificate: bytes
-    enrollment_id: EnrollmentID
-    device_certificate: bytes
-    user_certificate: bytes
-    redacted_device_certificate: bytes
-    redacted_user_certificate: bytes
+    submitter_device_certificate: bytes
+    submitter_user_certificate: bytes
+    submitter_redacted_device_certificate: bytes
+    submitter_redacted_user_certificate: bytes
 
 
 def generate_accept_params(
@@ -102,7 +101,7 @@ def generate_accept_params(
         device_id=device_id,
     )
 
-    accept_payload = PkiEnrollmentAnswerPayload(
+    payload = PkiEnrollmentAnswerPayload(
         user_id=user_id,
         device_id=device_id,
         device_label=device_label,
@@ -113,13 +112,13 @@ def generate_accept_params(
 
     return {
         "enrollment_id": enrollment_id,
-        "accept_payload": accept_payload,
-        "accept_payload_signature": b"<alice accept payload signature>",
+        "payload": payload,
+        "payload_signature": b"<alice accept payload signature>",
         "accepter_der_x509_certificate": b"<alice der x509 certificate>",
-        "user_certificate": u_certif,
-        "redacted_user_certificate": redacted_u_certif,
-        "device_certificate": d_certif,
-        "redacted_device_certificate": redacted_d_certif,
+        "submitter_user_certificate": u_certif,
+        "submitter_device_certificate": d_certif,
+        "submitter_redacted_user_certificate": redacted_u_certif,
+        "submitter_redacted_device_certificate": redacted_d_certif,
     }
 
 
@@ -217,7 +216,7 @@ async def test_authenticated_pki_enrollment_accept_invalid_certificate(
     enrollment_id: EnrollmentID,
 ) -> None:
     params = generate_accept_params(coolorg, enrollment_id)
-    params["user_certificate"] = b"<dummy>"
+    params["submitter_user_certificate"] = b"<dummy>"
     rep = await coolorg.alice.pki_enrollment_accept(**params)
     assert rep == authenticated_cmds.latest.pki_enrollment_accept.RepInvalidCertificate()
 
@@ -227,7 +226,7 @@ async def test_authenticated_pki_enrollment_accept_invalid_payload_data(
     enrollment_id: EnrollmentID,
 ) -> None:
     params = generate_accept_params(coolorg, enrollment_id)
-    params["accept_payload"] = b"<dummy>"
+    params["payload"] = b"<dummy>"
     rep = await coolorg.alice.pki_enrollment_accept(**params)
     assert rep == authenticated_cmds.latest.pki_enrollment_accept.RepInvalidPayloadData()
 

--- a/server/tests/common/rpc.py
+++ b/server/tests/common/rpc.py
@@ -298,24 +298,24 @@ class BaseAuthenticatedRpcClient:
 
     async def pki_enrollment_accept(
         self,
-        accept_payload: bytes,
-        accept_payload_signature: bytes,
-        accepter_der_x509_certificate: bytes,
         enrollment_id: EnrollmentID,
-        device_certificate: bytes,
-        user_certificate: bytes,
-        redacted_device_certificate: bytes,
-        redacted_user_certificate: bytes,
+        payload: bytes,
+        payload_signature: bytes,
+        accepter_der_x509_certificate: bytes,
+        submitter_user_certificate: bytes,
+        submitter_device_certificate: bytes,
+        submitter_redacted_user_certificate: bytes,
+        submitter_redacted_device_certificate: bytes,
     ) -> authenticated_cmds.latest.pki_enrollment_accept.Rep:
         req = authenticated_cmds.latest.pki_enrollment_accept.Req(
-            accept_payload=accept_payload,
-            accept_payload_signature=accept_payload_signature,
-            accepter_der_x509_certificate=accepter_der_x509_certificate,
             enrollment_id=enrollment_id,
-            device_certificate=device_certificate,
-            user_certificate=user_certificate,
-            redacted_device_certificate=redacted_device_certificate,
-            redacted_user_certificate=redacted_user_certificate,
+            payload=payload,
+            payload_signature=payload_signature,
+            accepter_der_x509_certificate=accepter_der_x509_certificate,
+            submitter_user_certificate=submitter_user_certificate,
+            submitter_device_certificate=submitter_device_certificate,
+            submitter_redacted_user_certificate=submitter_redacted_user_certificate,
+            submitter_redacted_device_certificate=submitter_redacted_device_certificate,
         )
         raw_rep = await self._do_request(req.dump(), "authenticated")
         return authenticated_cmds.latest.pki_enrollment_accept.Rep.load(raw_rep)


### PR DESCRIPTION
This PR updates API `authenticated_cmds/pki_enrollment_accept` according to [RFC 1020](https://github.com/Scille/parsec-cloud/blob/master/docs/rfcs/1020-pki-support.md)

fix #11323 