### PR TITLE
Remove clippy allow where it was not needed anymore.

### DIFF
--- a/server/src/addrs.rs
+++ b/server/src/addrs.rs
@@ -1,10 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-// FIXME: Remove me once we migrate to pyo3@0.24
-// Pyo3 generate useless conversion in the generated code, it was fixed in
-// https://github.com/PyO3/pyo3/pull/4838 that was release in 0.24
-#![allow(clippy::useless_conversion)]
-
 use pyo3::{
     exceptions::PyValueError,
     prelude::{pyclass, pymethods, IntoPyObject, PyObject, PyResult, Python},

--- a/server/src/crypto.rs
+++ b/server/src/crypto.rs
@@ -1,10 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-// FIXME: Remove me once we migrate to pyo3@0.24
-// Pyo3 generate useless conversion in the generated code, it was fixed in
-// https://github.com/PyO3/pyo3/pull/4838 that was release in 0.24
-#![allow(clippy::useless_conversion)]
-
 use pyo3::{
     create_exception,
     exceptions::{PyException, PyValueError},

--- a/server/src/data/certif.rs
+++ b/server/src/data/certif.rs
@@ -1,10 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-// FIXME: Remove me once we migrate to pyo3@0.24
-// Pyo3 generate useless conversion in the generated code, it was fixed in
-// https://github.com/PyO3/pyo3/pull/4838 that was release in 0.24
-#![allow(clippy::useless_conversion)]
-
 use std::{
     collections::{HashMap, HashSet},
     num::NonZeroU8,

--- a/server/src/data/manifest.rs
+++ b/server/src/data/manifest.rs
@@ -1,10 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-// FIXME: Remove me once we migrate to pyo3@0.24
-// Pyo3 generate useless conversion in the generated code, it was fixed in
-// https://github.com/PyO3/pyo3/pull/4838 that was release in 0.24
-#![allow(clippy::useless_conversion)]
-
 use pyo3::{
     exceptions::PyValueError,
     pyclass, pyfunction, pymethods,

--- a/server/src/data/pki.rs
+++ b/server/src/data/pki.rs
@@ -1,10 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-// FIXME: Remove me once we migrate to pyo3@0.24
-// Pyo3 generate useless conversion in the generated code, it was fixed in
-// https://github.com/PyO3/pyo3/pull/4838 that was release in 0.24
-#![allow(clippy::useless_conversion)]
-
 use pyo3::{
     exceptions::PyValueError,
     pyclass, pymethods,

--- a/server/src/ids.rs
+++ b/server/src/ids.rs
@@ -1,10 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-// FIXME: Remove me once we migrate to pyo3@0.24
-// Pyo3 generate useless conversion in the generated code, it was fixed in
-// https://github.com/PyO3/pyo3/pull/4838 that was release in 0.24
-#![cfg_attr(feature = "test-utils", allow(clippy::useless_conversion))]
-
 use std::str::FromStr;
 
 use pyo3::{exceptions::PyValueError, prelude::*, types::PyType};

--- a/server/src/misc.rs
+++ b/server/src/misc.rs
@@ -1,10 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-// FIXME: Remove me once we migrate to pyo3@0.24
-// Pyo3 generate useless conversion in the generated code, it was fixed in
-// https://github.com/PyO3/pyo3/pull/4838 that was release in 0.24
-#![allow(clippy::useless_conversion)]
-
 use pyo3::{
     exceptions::PyValueError,
     pyclass, pymethods,

--- a/server/src/protocol.rs
+++ b/server/src/protocol.rs
@@ -1,10 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-// FIXME: Remove me once we migrate to pyo3@0.24
-// Pyo3 generate useless conversion in the generated code, it was fixed in
-// https://github.com/PyO3/pyo3/pull/4838 that was release in 0.24
-#![allow(clippy::useless_conversion)]
-
 use pyo3::{
     exceptions::PyValueError,
     prelude::{PyAnyMethods, PyModuleMethods},

--- a/server/src/testbed.rs
+++ b/server/src/testbed.rs
@@ -1,10 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-// FIXME: Remove me once we migrate to pyo3@0.24
-// Pyo3 generate useless conversion in the generated code, it was fixed in
-// https://github.com/PyO3/pyo3/pull/4838 that was release in 0.24
-#![allow(clippy::useless_conversion)]
-
 use pyo3::{
     exceptions::PyValueError,
     prelude::*,

--- a/server/src/time.rs
+++ b/server/src/time.rs
@@ -1,10 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-// FIXME: Remove me once we migrate to pyo3@0.24
-// Pyo3 generate useless conversion in the generated code, it was fixed in
-// https://github.com/PyO3/pyo3/pull/4838 that was release in 0.24
-#![allow(clippy::useless_conversion)]
-
 use pyo3::{exceptions::PyValueError, prelude::*, types::PyType, PyResult};
 
 crate::binding_utils::gen_py_wrapper_class!(


### PR DESCRIPTION
Following the merge of https://github.com/PyO3/pyo3/pull/4838 and the update to pyo3@0.24 or above.
