### PR TITLE
refactor(dependabot): Configure extra groups for rust deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,12 +48,58 @@ updates:
       - dependency-name: rand
         versions:
           - ">=0.9"
+      # The crypto dependencies need to be updated to be compatible with generic-array@v1
+      - dependency-name: generic-array
+        versions:
+          - ">=1.0.0"
     schedule:
       interval: weekly
       day: monday
       time: "04:20"
       timezone: Europe/Paris
     groups:
+      rust-crypto:
+        pattern:
+          - argon2
+          - blahaj
+          - blake2
+          - crypto*
+          - ed25519-dalek
+          - generic-array
+          - getrandom
+          - libsodium-rs
+          - openssl
+          - rand
+          - rsa
+          - schannel
+          - sha2
+          - x25519-dalek
+          - x509-cert
+      rust-test:
+        pattern:
+          - assert_cmd
+          - predicates
+          - pretty_assertions
+          - protest*
+          - rexpect
+          - rstest*
+      rust-js:
+        pattern:
+          - web-*
+          - js-*
+          - neon
+          - wasm-bindgen*
+          - console_error_panic_hook
+          - console_log
+          - gloo-timers
+      rust-windows:
+        pattern:
+          - winfsp*
+          - windows-*
+      rust-android:
+        pattern:
+          - android_logger
+          - jni
       rust-dependencies:
         patterns:
           - "*"


### PR DESCRIPTION
- Add group for crypto, test, js, windows, android type of dependencies
- Also ignore bump of `generic-array` to v1 until crypto deps are update to use it.

  (to prevent compat issues where we need to convert a generic array from v1 to v0)

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
