### PR TITLE
[MS] Update lib action bar responsive

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -32,7 +32,7 @@
                 "file-type": "^20.4.1",
                 "fs-extra": "^11.3.0",
                 "luxon": "^3.5.0",
-                "megashark-lib": "git+https://github.com/Scille/megashark-lib.git#8f30b3aed45c1820bfb790f6023910cc4b5e6cc3",
+                "megashark-lib": "git+https://github.com/Scille/megashark-lib.git#c123d03e0bf90d2c1514960e2109398b4d4e8778",
                 "monaco-editor": "^0.52.2",
                 "native-file-system-adapter": "^3.0.1",
                 "pdfjs-dist": "^5.0.375",
@@ -9025,8 +9025,8 @@
         },
         "node_modules/megashark-lib": {
             "version": "0.0.1",
-            "resolved": "git+ssh://git@github.com/Scille/megashark-lib.git#8f30b3aed45c1820bfb790f6023910cc4b5e6cc3",
-            "integrity": "sha512-2c43+LOYf48219XuUyKorN20zyivHzF3gdz0qQu9lhP6RSezeS/YCbzPxPANfdceZa3+OSNAIRb+kp/PC7FUGA==",
+            "resolved": "git+ssh://git@github.com/Scille/megashark-lib.git#c123d03e0bf90d2c1514960e2109398b4d4e8778",
+            "integrity": "sha512-lE1KDFInEw9cmdlep8ubGAT2U2QR5XKpt48XaafEosdDH75E3kiIyxoaYu5/BoeGO7MYD8oJsl71T/1Mcl5C/w==",
             "dependencies": {
                 "@ionic/vue": "^8.6.2",
                 "@stripe/stripe-js": "^4.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -58,7 +58,7 @@
         "file-type": "^20.4.1",
         "fs-extra": "^11.3.0",
         "luxon": "^3.5.0",
-        "megashark-lib": "git+https://github.com/Scille/megashark-lib.git#8f30b3aed45c1820bfb790f6023910cc4b5e6cc3",
+        "megashark-lib": "git+https://github.com/Scille/megashark-lib.git#c123d03e0bf90d2c1514960e2109398b4d4e8778",
         "monaco-editor": "^0.52.2",
         "native-file-system-adapter": "^3.0.1",
         "pdfjs-dist": "^5.0.375",

--- a/client/tests/e2e/helpers/utils.ts
+++ b/client/tests/e2e/helpers/utils.ts
@@ -399,3 +399,8 @@ export async function renameDocument(documentsPage: MsPage, entry: Locator, newN
   // Can't check if the entry's been renamed, since the renaming may change the sort order and therefore,
   // what element the entry points to.
 }
+
+export async function resizePage(page: Page, width: number, height?: number): Promise<void> {
+  await page.setViewportSize({ width, height: height ?? 900 });
+  await page.waitForTimeout(100);
+}

--- a/client/tests/e2e/specs/small_display_fab_menu.spec.ts
+++ b/client/tests/e2e/specs/small_display_fab_menu.spec.ts
@@ -6,7 +6,7 @@ msTest('Fab button and menu as administrator and read/write', async ({ workspace
   await workspaces.setDisplaySize(DisplaySize.Small);
   const fabButton = workspaces.locator('#add-menu-fab-button');
   const tabBarButtons = workspaces.locator('#tab-bar').locator('.tab-bar-menu-button');
-  const fabModalOptions = workspaces.locator('#fab-modal').getByRole('listitem');
+  const fabModalOptions = workspaces.locator('#fab-modal').locator('.list-group-item');
 
   // WorkspacesPage
   await expect(fabButton).toBeVisible();

--- a/client/tests/e2e/specs/workspaces_actions.spec.ts
+++ b/client/tests/e2e/specs/workspaces_actions.spec.ts
@@ -1,7 +1,7 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 import { Page } from '@playwright/test';
-import { expect, fillInputModal, getClipboardText, login, msTest } from '@tests/e2e/helpers';
+import { expect, fillInputModal, getClipboardText, login, msTest, resizePage } from '@tests/e2e/helpers';
 
 type Mode = 'grid' | 'list' | 'sidebar';
 
@@ -218,4 +218,22 @@ msTest('Check workspace rename in header breadcrumb', async ({ workspaces }) => 
   await expect(workspaces).toShowToast('Workspace has been successfully renamed to New-wksp1.', 'Success');
   await expect(bobTab).toHaveHeader(['New-wksp1'], true, true);
   await expect(workspaces).toHaveHeader(['New-wksp1'], true, true);
+});
+
+msTest('Check if action bar updates when resizing the window', async ({ connected }) => {
+  const actionBar = connected.locator('#workspaces-ms-action-bar');
+  const actionsBarButtons = actionBar.locator('.ms-action-bar-button');
+  const actionBarMoreButton = actionBar.locator('#action-bar-more-button');
+  await expect(actionBar).toBeVisible();
+  await expect(actionsBarButtons).toBeVisible();
+  await expect(actionsBarButtons).toHaveCount(1);
+  await expect(actionsBarButtons.nth(0)).toHaveText('New workspace');
+  await resizePage(connected, 1100);
+  await expect(actionsBarButtons).toHaveCount(1);
+  await expect(actionsBarButtons.nth(0)).toBeHidden();
+  await expect(actionBarMoreButton).toBeVisible();
+  await actionBarMoreButton.click();
+  await expect(connected.locator('.popover-viewport').getByRole('listitem').nth(0)).toHaveText('New workspace');
+  await connected.keyboard.press('Escape');
+  await expect(connected.locator('.popover-viewport')).toBeHidden();
 });

--- a/newsfragments/11391.feature.rst
+++ b/newsfragments/11391.feature.rst
@@ -1,0 +1,1 @@
+Update component library (megashark-lib) and show/hide action bar buttons based on the screen size


### PR DESCRIPTION
## What's changed
Now, the user should always access to the action bar buttons. Whether, there is not enough space for all buttons, the hidden buttons will be available through a popover (after clicking on the `•••` button)

## How to test 
Play around with everything that can affect the size of the action bar:
- resizing the window
- resizing the sidebar
- hiding the sidebar
- selecting a file, deselecting it
- loading the page with a reduced size

## What to except 
https://github.com/user-attachments/assets/444029ba-8114-48ba-a18c-73929607d5a4



closes https://github.com/Scille/megashark-lib/issues/204
