### PR TITLE
feat(pki): Manually calculate sha256 fingerprint in `get der` example

### DIFF
--- a/libparsec/crates/platform_pki/examples/get_certificate_der.rs
+++ b/libparsec/crates/platform_pki/examples/get_certificate_der.rs
@@ -9,6 +9,7 @@ use anyhow::Context;
 use clap::Parser;
 use libparsec_platform_pki::get_der_encoded_certificate;
 use libparsec_types::{X509CertificateHash, X509CertificateReference};
+use sha2::Digest;
 
 #[derive(Debug, Parser)]
 struct Args {
@@ -40,6 +41,11 @@ fn main() -> anyhow::Result<()> {
 
     println!("id: {}", &cert.cert_ref.uris().next().unwrap());
     println!("fingerprint: {}", cert.cert_ref.hash);
+    {
+        let digest = sha2::Sha256::digest(&cert.der_content);
+        let hash = X509CertificateHash::SHA256(Box::new(digest.into()));
+        println!("Manually calculated fingerprint: {hash}");
+    }
     println!(
         "content: {}",
         data_encoding::BASE64.encode_display(&cert.der_content)


### PR DESCRIPTION
Used to verify if the provided fingerprint provided by windows effectively correspond to `sha256(cert der)`

Closes #11332

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
