### PR TITLE
refactor(binding/gen): Use union type format

### DIFF
--- a/bindings/generator/api/account.py
+++ b/bindings/generator/api/account.py
@@ -1,34 +1,34 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 
+from .addr import ParsecAddr, ParsecInvitationAddr
+from .client import ActiveUsersLimit
 from .common import (
+    AccountAuthMethodID,
+    AccountVaultItemOpaqueKeyID,
+    DateTime,
+    DeviceLabel,
+    EmailAddress,
+    Enum,
+    EnumItemUnit,
+    ErrorVariant,
+    Handle,
     HumanHandle,
     InvitationToken,
     InvitationType,
-    Password,
-    Ref,
-    Path,
-    Result,
-    EmailAddress,
-    ErrorVariant,
-    Handle,
-    OrganizationID,
-    UserID,
-    DeviceLabel,
     KeyDerivation,
-    DateTime,
+    OrganizationID,
+    Password,
+    Path,
+    Ref,
+    Result,
     SecretKey,
-    AccountAuthMethodID,
-    AccountVaultItemOpaqueKeyID,
-    Variant,
     Structure,
+    UserID,
     UserProfile,
-    Enum,
-    EnumItemUnit,
+    Variant,
 )
-from .addr import ParsecAddr, ParsecInvitationAddr
-from .device import DeviceAccessStrategy, DeviceSaveStrategy, AvailableDevice
-from .client import ActiveUsersLimit
+from .device import AvailableDevice, DeviceAccessStrategy, DeviceSaveStrategy
 
 
 def list_started_accounts() -> list[Handle]:

--- a/bindings/generator/api/addr.py
+++ b/bindings/generator/api/addr.py
@@ -1,10 +1,10 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-from typing import Optional
 
 from .common import (
     U32,
     ErrorVariant,
+    IndexInt,
     InvitationToken,
     OrganizationID,
     Ref,
@@ -12,7 +12,6 @@ from .common import (
     StrBasedType,
     Variant,
     VlobID,
-    IndexInt,
 )
 
 
@@ -70,7 +69,7 @@ class ParsedParsecAddr(Variant):
         port: U32
         use_ssl: bool
         organization_id: OrganizationID
-        token: Optional[str]
+        token: str | None
 
     class WorkspacePath:
         hostname: str

--- a/bindings/generator/api/client.py
+++ b/bindings/generator/api/client.py
@@ -1,6 +1,5 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-from typing import Optional
 
 from .addr import ParsecOrganizationAddr
 from .common import (
@@ -9,11 +8,16 @@ from .common import (
     DeviceID,
     DeviceLabel,
     EntryName,
+    Enum,
+    EnumItemUnit,
     ErrorVariant,
     Handle,
     HumanHandle,
+    NonZeroU8,
     OrganizationID,
     Path,
+    RealmRole,
+    Ref,
     Result,
     SizeInt,
     Structure,
@@ -23,15 +27,10 @@ from .common import (
     VariantItemTuple,
     VariantItemUnit,
     VlobID,
-    RealmRole,
-    Ref,
-    Enum,
-    EnumItemUnit,
-    NonZeroU8,
 )
-from .device import DeviceAccessStrategy
-from .invite import DeviceSaveStrategy, AvailableDevice
 from .config import ClientConfig
+from .device import DeviceAccessStrategy
+from .invite import AvailableDevice, DeviceSaveStrategy
 
 
 def list_started_clients() -> list[tuple[Handle, DeviceID]]:
@@ -169,9 +168,9 @@ class UserInfo(Structure):
     human_handle: HumanHandle
     current_profile: UserProfile
     created_on: DateTime
-    created_by: Optional[DeviceID]
-    revoked_on: Optional[DateTime]
-    revoked_by: Optional[DeviceID]
+    created_by: DeviceID | None
+    revoked_on: DateTime | None
+    revoked_by: DeviceID | None
 
 
 class DevicePurpose(Enum):
@@ -186,7 +185,7 @@ class DeviceInfo(Structure):
     purpose: DevicePurpose
     device_label: DeviceLabel
     created_on: DateTime
-    created_by: Optional[DeviceID]
+    created_by: DeviceID | None
 
 
 class ClientRevokeUserError(ErrorVariant):
@@ -440,7 +439,7 @@ async def client_share_workspace(
     client: Handle,
     realm_id: VlobID,
     recipient: UserID,
-    role: Optional[RealmRole],
+    role: RealmRole | None,
 ) -> Result[None, ClientShareWorkspaceError]:
     raise NotImplementedError
 

--- a/bindings/generator/api/config.py
+++ b/bindings/generator/api/config.py
@@ -1,7 +1,7 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-from typing import Optional
-from .common import EnumItemUnit, Path, Structure, U32BasedType, Variant, VariantItemUnit, Enum
+
+from .common import Enum, EnumItemUnit, Path, Structure, U32BasedType, Variant, VariantItemUnit
 
 
 class CacheSize(U32BasedType):
@@ -40,8 +40,8 @@ class ClientConfig(Structure):
     mountpoint_mount_strategy: MountpointMountStrategy
     workspace_storage_cache_size: WorkspaceStorageCacheSize
     with_monitors: bool
-    prevent_sync_pattern: Optional[str]
-    log_level: Optional[LogLevel]
+    prevent_sync_pattern: str | None
+    log_level: LogLevel | None
 
 
 def get_default_data_base_dir() -> Path:

--- a/bindings/generator/api/events.py
+++ b/bindings/generator/api/events.py
@@ -1,18 +1,18 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-from typing import Callable
+from collections.abc import Callable
 
 from .common import (
     ApiVersion,
     DateTime,
+    DeviceID,
+    GreetingAttemptID,
     Handle,
     IndexInt,
     InvitationStatus,
     InvitationToken,
-    GreetingAttemptID,
     SizeInt,
     Variant,
-    DeviceID,
     VlobID,
 )
 

--- a/bindings/generator/api/invite.py
+++ b/bindings/generator/api/invite.py
@@ -1,6 +1,5 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-from typing import Optional
 
 from .addr import (
     ParsecInvitationAddr,
@@ -81,7 +80,7 @@ async def bootstrap_organization(
     save_strategy: DeviceSaveStrategy,
     human_handle: HumanHandle,
     device_label: DeviceLabel,
-    sequester_authority_verify_key_pem: Optional[Ref[str]],
+    sequester_authority_verify_key_pem: Ref[str] | None,
 ) -> Result[AvailableDevice, BootstrapOrganizationError]:
     raise NotImplementedError
 
@@ -172,7 +171,7 @@ class UserOnlineStatus(Enum):
 class ShamirRecoveryRecipient(Structure):
     user_id: UserID
     human_handle: HumanHandle
-    revoked_on: Optional[DateTime]
+    revoked_on: DateTime | None
     shares: NonZeroU8
     online_status: UserOnlineStatus
 
@@ -190,7 +189,7 @@ class UserGreetingAdministrator(Structure):
     user_id: UserID
     human_handle: HumanHandle
     online_status: UserOnlineStatus
-    last_greeting_attempt_joined_on: Optional[DateTime]
+    last_greeting_attempt_joined_on: DateTime | None
 
 
 class AnyClaimRetrievedInfo(Variant):
@@ -199,7 +198,7 @@ class AnyClaimRetrievedInfo(Variant):
         claimer_email: EmailAddress
         created_by: InviteInfoInvitationCreatedBy
         administrators: list[UserGreetingAdministrator]
-        preferred_greeter: Optional[UserGreetingAdministrator]
+        preferred_greeter: UserGreetingAdministrator | None
 
     class Device:
         handle: Handle
@@ -229,7 +228,7 @@ class UserClaimInitialInfo(Structure):
     greeter_user_id: UserID
     greeter_human_handle: HumanHandle
     online_status: UserOnlineStatus
-    last_greeting_attempt_joined_on: Optional[DateTime]
+    last_greeting_attempt_joined_on: DateTime | None
 
 
 class UserClaimListInitialInfosError(ErrorVariant):

--- a/bindings/generator/api/path.py
+++ b/bindings/generator/api/path.py
@@ -1,6 +1,5 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-from typing import Optional
 
 from .common import EntryName, FsPath, Ref
 
@@ -13,7 +12,7 @@ def path_parent(path: Ref[FsPath]) -> FsPath:
     raise NotImplementedError
 
 
-def path_filename(path: Ref[FsPath]) -> Optional[EntryName]:
+def path_filename(path: Ref[FsPath]) -> EntryName | None:
     raise NotImplementedError
 
 

--- a/bindings/generator/api/pki.py
+++ b/bindings/generator/api/pki.py
@@ -1,6 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 from .common import (
     BytesBasedType,
@@ -72,6 +72,6 @@ class ShowCertificateSelectionDialogError(ErrorVariant):
 
 
 async def show_certificate_selection_dialog_windows_only() -> Result[
-    Optional[X509CertificateReference], ShowCertificateSelectionDialogError
+    X509CertificateReference | None, ShowCertificateSelectionDialogError
 ]:
     raise NotImplementedError

--- a/bindings/generator/api/testbed.py
+++ b/bindings/generator/api/testbed.py
@@ -1,18 +1,17 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-from typing import Optional
 
 from .addr import ParsecAddr, ParsecOrganizationBootstrapAddr
 from .common import (
+    DateTime,
+    EmailAddress,
+    ErrorVariant,
+    HumanHandle,
+    KeyDerivation,
     OrganizationID,
     Path,
     Ref,
-    ErrorVariant,
     Result,
-    EmailAddress,
-    DateTime,
-    KeyDerivation,
-    HumanHandle,
 )
 
 
@@ -25,20 +24,20 @@ class TestbedError(ErrorVariant):
 
 
 async def test_new_testbed(
-    template: Ref[str], test_server: Optional[Ref[ParsecAddr]]
+    template: Ref[str], test_server: Ref[ParsecAddr] | None
 ) -> Result[Path, TestbedError]:
     raise NotImplementedError
 
 
 def test_get_testbed_organization_id(
     discriminant_dir: Ref[Path],
-) -> Result[Optional[OrganizationID], TestbedError]:
+) -> Result[OrganizationID | None, TestbedError]:
     raise NotImplementedError
 
 
 def test_get_testbed_bootstrap_organization_addr(
     discriminant_dir: Ref[Path],
-) -> Result[Optional[ParsecOrganizationBootstrapAddr], TestbedError]:
+) -> Result[ParsecOrganizationBootstrapAddr | None, TestbedError]:
     raise NotImplementedError
 
 

--- a/bindings/generator/api/workspace.py
+++ b/bindings/generator/api/workspace.py
@@ -1,7 +1,9 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-from typing import Optional
 
+from .addr import (
+    ParsecWorkspacePathAddr,
+)
 from .common import (
     U64,
     DateTime,
@@ -10,20 +12,17 @@ from .common import (
     ErrorVariant,
     FsPath,
     Handle,
+    Path,
+    RealmRole,
     Ref,
     Result,
     SizeInt,
+    Structure,
+    U32BasedType,
     Variant,
     VariantItemUnit,
     VersionInt,
     VlobID,
-    Structure,
-    RealmRole,
-    U32BasedType,
-    Path,
-)
-from .addr import (
-    ParsecWorkspacePathAddr,
 )
 
 
@@ -308,7 +307,7 @@ class WorkspaceStatEntryError(ErrorVariant):
 
 class EntryStat(Variant):
     class File:
-        confinement_point: Optional[VlobID]
+        confinement_point: VlobID | None
         id: VlobID
         parent: VlobID
         created: DateTime
@@ -320,7 +319,7 @@ class EntryStat(Variant):
         last_updater: DeviceID
 
     class Folder:
-        confinement_point: Optional[VlobID]
+        confinement_point: VlobID | None
         id: VlobID
         parent: VlobID
         created: DateTime

--- a/bindings/generator/api/workspace_history.py
+++ b/bindings/generator/api/workspace_history.py
@@ -1,5 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
+from .client import ClientConfig, DeviceAccessStrategy
 from .common import (
     U64,
     DateTime,
@@ -8,19 +9,17 @@ from .common import (
     ErrorVariant,
     FsPath,
     Handle,
+    Path,
     Ref,
     Result,
+    SequesterServiceID,
     SizeInt,
+    Structure,
     Variant,
     VersionInt,
     VlobID,
-    Structure,
-    Path,
-    SequesterServiceID,
 )
 from .workspace import FileDescriptor
-from .client import ClientConfig, DeviceAccessStrategy
-
 
 #
 # Start workspace history

--- a/bindings/generator/test_api.py
+++ b/bindings/generator/test_api.py
@@ -1,7 +1,7 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 # Dummy API for testing the generator in different use cases
-from typing import Generic, List, Optional, TypeVar
+from typing import Generic, TypeVar
 
 # Meta-types, not part of the API but to be used to describe the API
 
@@ -167,7 +167,7 @@ class Data(Structure):
     p4: str
     p5: bytes
     p6: SubData
-    p7: Optional[SubData]
+    p7: SubData | None
 
 
 class V1or2(Variant):
@@ -210,7 +210,7 @@ def f_r7() -> bytes:
     raise NotImplementedError
 
 
-def f_r8() -> Optional[Data]:
+def f_r8() -> Data | None:
     raise NotImplementedError
 
 
@@ -247,15 +247,15 @@ def f_p9() -> Data:
     raise NotImplementedError
 
 
-def f_p10(_a: Optional[bool]) -> None:
+def f_p10(_a: bool | None) -> None:
     raise NotImplementedError
 
 
-def f_p11(_a: Ref[Optional[Data]]) -> None:
+def f_p11(_a: Ref[Data | None]) -> None:
     raise NotImplementedError
 
 
-def f_p111(_a: Optional[Ref[Data]]) -> None:
+def f_p111(_a: Ref[Data] | None) -> None:
     raise NotImplementedError
 
 
@@ -272,11 +272,11 @@ def f_p14() -> Result[bool, V1or2]:
     raise NotImplementedError
 
 
-def f_p15(_a: Ref[List[Data]]) -> None:
+def f_p15(_a: Ref[list[Data]]) -> None:
     raise NotImplementedError
 
 
-def f_p16() -> List[Data]:
+def f_p16() -> list[Data]:
     raise NotImplementedError
 
 
@@ -333,7 +333,7 @@ async def af_p7(_a: Ref[bytes]) -> None:
     raise NotImplementedError
 
 
-async def af_r8() -> Optional[Data]:
+async def af_r8() -> Data | None:
     raise NotImplementedError
 
 
@@ -345,11 +345,11 @@ async def af_p9() -> Data:
     raise NotImplementedError
 
 
-async def af_p10(_a: Optional[bool]) -> None:
+async def af_p10(_a: bool | None) -> None:
     raise NotImplementedError
 
 
-async def af_p11(_a: Ref[Optional[Data]]) -> None:
+async def af_p11(_a: Ref[Data | None]) -> None:
     raise NotImplementedError
 
 
@@ -365,9 +365,9 @@ async def af_p14() -> Result[bool, V1or2]:
     raise NotImplementedError
 
 
-async def af_p15(_a: Ref[List[Data]]) -> None:
+async def af_p15(_a: Ref[list[Data]]) -> None:
     raise NotImplementedError
 
 
-async def af_p16() -> List[Data]:
+async def af_p16() -> list[Data]:
     raise NotImplementedError


### PR DESCRIPTION
`ruff` keep rewriting `Optional[T]` to `T | None`, this make `generate.py` support the `UnionType`.

Additionally:

- List `ruff` sort import order & remove unused imports
- Use `list`, `dict`, ... over their `type.[..]` equivalent

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
