### PR TITLE
fix: sphinx pdflatex generation was not working

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,7 +19,11 @@ endif
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
-LATEXMKOPTS     = -interaction=nonstopmode
+# Using '-halt-on-error' allows `make pdflatex` to finish (instead of hanging)
+# even if there are errors. In case of errors a message is displayed pointing
+# to the log file (usually '_build/latex/parsec.log')
+#LATEXMKOPTS     = -interaction=nonstopmode
+LATEXMKOPTS     = -halt-on-error
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -215,6 +215,7 @@ htmlhelp_basename = "parsecdoc"
 
 latex_engine = "lualatex"
 
+# https://sphinx-themed.readthedocs.io/en/latest/latex.html
 latex_elements = {
     #  Additional stuff for the LaTeX preamble.
     "preamble": "\n".join(
@@ -250,20 +251,6 @@ latex_documents = [
         "parsec.tex",
         "Parsec Documentation",
         "dev-parsec+fullguide@scille.fr",
-        "howto",
-    ),
-    (
-        "userguide/index",
-        "parsec-userguide.tex",
-        "Parsec User Guide",
-        "dev-parsec+userguide@scille.fr",
-        "howto",
-    ),
-    (
-        "hosting/index",
-        "parsec-hosting-guide.tex",
-        "Parsec Hosting Guide",
-        "dev-parsec+hostingguide@scille.fr",
         "howto",
     ),
 ]

--- a/docs/hosting/deployment/gen-admin-token.sh
+++ b/docs/hosting/deployment/gen-admin-token.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck disable=SC2148
 set -euo pipefail
 
 ENV_FILE=parsec-admin-token.env

--- a/docs/hosting/deployment/index.rst
+++ b/docs/hosting/deployment/index.rst
@@ -333,8 +333,6 @@ Start the server
 
   .. code-block:: bash
 
-    #!/bin/bash
-
     # Load the virtualenv.
     source venv/bin/activate
 

--- a/docs/hosting/deployment/ping-mailhog.sh
+++ b/docs/hosting/deployment/ping-mailhog.sh
@@ -1,5 +1,4 @@
-#!/usr/bin/env bash
-
+# shellcheck disable=SC2148
 set -a
 source parsec-smtp.env
 

--- a/docs/hosting/deployment/setup-tls.sh
+++ b/docs/hosting/deployment/setup-tls.sh
@@ -1,5 +1,4 @@
-#!/usr/bin/env bash
-
+# shellcheck disable=SC2148
 function generate_cert_conf() {
     local name=$1
     local san=$2


### PR DESCRIPTION
The shebangs in code-block and literalinclude make pdflatex fail.

I couldn't find the reason after some time (much more than wanted) analyzing latex log output, so this commit removes shebang and disables warning from shellcheck. These are only code examples anyway.

The issue may be related to the fonts used for code blocks, or it may be related to anything else (LaTeX!)