### PR TITLE
refactor(pki): Move&Rename `SignatureAlgorithm`

### DIFF
--- a/libparsec/crates/platform_pki/examples/verify_message.rs
+++ b/libparsec/crates/platform_pki/examples/verify_message.rs
@@ -3,8 +3,8 @@
 
 use anyhow::Context;
 use clap::Parser;
-use libparsec_platform_pki::{verify_message, SignatureAlgorithm, SignedMessage};
-use libparsec_types::X509CertificateHash;
+use libparsec_platform_pki::{verify_message, SignedMessage};
+use libparsec_types::{PkiSignatureAlgorithm, X509CertificateHash};
 use sha2::Digest;
 
 mod utils;
@@ -15,7 +15,7 @@ struct Args {
     cert: utils::CertificateOrRef,
     #[command(flatten)]
     content: utils::ContentOpts,
-    signature_header: SignatureAlgorithm,
+    signature_header: PkiSignatureAlgorithm,
     /// Signature in base64
     signature: String,
 }

--- a/libparsec/crates/platform_pki/src/lib.rs
+++ b/libparsec/crates/platform_pki/src/lib.rs
@@ -10,8 +10,7 @@ pub mod x509;
 #[path = "../tests/units/mod.rs"]
 mod test;
 
-use libparsec_types::{EncryptionAlgorithm, X509CertificateReference};
-use std::{fmt::Display, str::FromStr};
+use libparsec_types::{EncryptionAlgorithm, PkiSignatureAlgorithm, X509CertificateReference};
 
 use bytes::Bytes;
 
@@ -114,38 +113,8 @@ pub struct CertificateDer {
 pub use errors::ListTrustedRootCertificatesError;
 pub use platform::list_trusted_root_certificate_anchor;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SignatureAlgorithm {
-    RsassaPssSha256,
-}
-
-impl From<SignatureAlgorithm> for &'static str {
-    fn from(value: SignatureAlgorithm) -> Self {
-        match value {
-            SignatureAlgorithm::RsassaPssSha256 => "RSASSA-PSS-SHA256",
-        }
-    }
-}
-
-impl Display for SignatureAlgorithm {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str((*self).into())
-    }
-}
-
-impl FromStr for SignatureAlgorithm {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "RSASSA-PSS-SHA256" => Ok(Self::RsassaPssSha256),
-            _ => Err("Unknown signature algorithm"),
-        }
-    }
-}
-
 pub struct SignedMessageFromPki {
-    pub algo: SignatureAlgorithm,
+    pub algo: PkiSignatureAlgorithm,
     pub cert_ref: X509CertificateReference,
     pub signature: Bytes,
 }

--- a/libparsec/crates/platform_pki/src/shared/mod.rs
+++ b/libparsec/crates/platform_pki/src/shared/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         VerifySignatureError,
     },
     shared::signature_verification::{RsassaPssSha256SignatureVerifier, SUPPORTED_SIG_ALGS},
-    EncryptedMessage, SignatureAlgorithm,
+    EncryptedMessage, PkiSignatureAlgorithm,
 };
 use libparsec_types::{
     DateTime, EnrollmentID, LocalPendingEnrollment, ParsecPkiEnrollmentAddr,
@@ -60,7 +60,7 @@ impl AsRef<[u8]> for Certificate<'_> {
 }
 
 pub struct SignedMessage {
-    pub algo: SignatureAlgorithm,
+    pub algo: PkiSignatureAlgorithm,
     pub signature: Vec<u8>,
     pub message: Vec<u8>,
 }
@@ -70,7 +70,7 @@ pub fn verify_message<'message, 'a>(
     certificate: &'a EndEntityCert<'a>,
 ) -> Result<&'message [u8], VerifySignatureError> {
     let verifier = match signed_message.algo {
-        SignatureAlgorithm::RsassaPssSha256 => &RsassaPssSha256SignatureVerifier,
+        PkiSignatureAlgorithm::RsassaPssSha256 => &RsassaPssSha256SignatureVerifier,
     };
     certificate
         .verify_signature(verifier, &signed_message.message, &signed_message.signature)

--- a/libparsec/crates/platform_pki/src/windows/mod.rs
+++ b/libparsec/crates/platform_pki/src/windows/mod.rs
@@ -4,12 +4,14 @@ use std::ffi::c_void;
 
 use crate::{
     CertificateDer, DecryptMessageError, DecryptedMessage, EncryptMessageError, EncryptedMessage,
-    EncryptionAlgorithm, GetDerEncodedCertificateError, ListTrustedRootCertificatesError,
-    ShowCertificateSelectionDialogError, SignMessageError, SignatureAlgorithm,
-    SignedMessageFromPki,
+    GetDerEncodedCertificateError, ListTrustedRootCertificatesError,
+    ShowCertificateSelectionDialogError, SignMessageError, SignedMessageFromPki,
 };
 use bytes::Bytes;
-use libparsec_types::{X509CertificateHash, X509CertificateReference, X509WindowsCngURI};
+use libparsec_types::{
+    EncryptionAlgorithm, PkiSignatureAlgorithm, X509CertificateHash, X509CertificateReference,
+    X509WindowsCngURI,
+};
 use schannel::{
     cert_context::{CertContext, HashAlgorithm, PrivateKey},
     cert_store::CertStore,
@@ -256,8 +258,8 @@ fn get_keypair(context: &CertContext) -> Result<PrivateKey, crate::errors::BaseK
 fn ncrypt_sign_message_with_rsa(
     message: &[u8],
     handle: &NcryptKey,
-) -> std::io::Result<(SignatureAlgorithm, Vec<u8>)> {
-    const ALGO: SignatureAlgorithm = SignatureAlgorithm::RsassaPssSha256;
+) -> std::io::Result<(PkiSignatureAlgorithm, Vec<u8>)> {
+    const ALGO: PkiSignatureAlgorithm = PkiSignatureAlgorithm::RsassaPssSha256;
     let hash = sha2::Sha256::digest(message);
     // SAFETY: NcryptKey is obtain from an NCRYPT_KEY_HANDLE, here we retrieve the underlying
     // handle.

--- a/libparsec/crates/serialization_format/src/protocol_python_bindings.rs
+++ b/libparsec/crates/serialization_format/src/protocol_python_bindings.rs
@@ -945,6 +945,9 @@ fn quote_type_as_fn_getter_conversion(field_path: &TokenStream, ty: &FieldType) 
             quote_rs_to_py_class!(crate::data::X509CertificateReference)
         }
         FieldType::EncryptionAlgorithm => quote_rs_to_py_class!(crate::data::EncryptionAlgorithm),
+        FieldType::PkiSignatureAlgorithm => {
+            quote_rs_to_py_class!(crate::data::PkiSignatureAlgorithm)
+        }
         FieldType::ShamirRecoveryShareData => {
             quote_rs_to_py_class!(crate::shamir::ShamirRecoveryShareData)
         }
@@ -1045,6 +1048,7 @@ fn quote_type_as_fn_new_param(ty: &FieldType) -> TokenStream {
         FieldType::X509Certificate => quote! { crate::data::X509Certificate },
         FieldType::X509CertificateReference => quote! { crate::data::X509CertificateReference },
         FieldType::EncryptionAlgorithm => quote! { crate::data::EncryptionAlgorithm },
+        FieldType::PkiSignatureAlgorithm => quote! { crate::data::PkiSignatureAlgorithm },
         FieldType::ShamirRecoveryShareData => {
             quote! { crate::shamir::ShamirRecoveryShareData}
         }
@@ -1191,6 +1195,7 @@ fn internal_quote_field_as_fn_new_conversion(field_name: &Ident, ty: &FieldType)
         | FieldType::X509Certificate
         | FieldType::X509CertificateReference
         | FieldType::EncryptionAlgorithm
+        | FieldType::PkiSignatureAlgorithm
         | FieldType::GreetingAttemptID
         | FieldType::CancelledGreetingAttemptReason
         | FieldType::GreeterOrClaimer

--- a/libparsec/crates/serialization_format/src/types.rs
+++ b/libparsec/crates/serialization_format/src/types.rs
@@ -258,6 +258,7 @@ generate_field_type_enum!(
     X509Certificate => libparsec_types::X509Certificate,
     X509CertificateReference => libparsec_types::X509CertificateReference,
     EncryptionAlgorithm => libparsec_types::EncryptionAlgorithm,
+    PkiSignatureAlgorithm => libparsec_types::PkiSignatureAlgorithm,
     GreetingAttemptID => libparsec_types::GreetingAttemptID,
     GreeterOrClaimer => libparsec_types::GreeterOrClaimer,
     CancelledGreetingAttemptReason => libparsec_types::CancelledGreetingAttemptReason,

--- a/libparsec/crates/types/src/pki/mod.rs
+++ b/libparsec/crates/types/src/pki/mod.rs
@@ -314,6 +314,38 @@ impl Display for EncryptionAlgorithm {
     }
 }
 
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, serde_with::DeserializeFromStr, serde_with::SerializeDisplay,
+)]
+pub enum PkiSignatureAlgorithm {
+    RsassaPssSha256,
+}
+
+impl From<PkiSignatureAlgorithm> for &'static str {
+    fn from(value: PkiSignatureAlgorithm) -> Self {
+        match value {
+            PkiSignatureAlgorithm::RsassaPssSha256 => "RSASSA-PSS-SHA256",
+        }
+    }
+}
+
+impl Display for PkiSignatureAlgorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str((*self).into())
+    }
+}
+
+impl FromStr for PkiSignatureAlgorithm {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RSASSA-PSS-SHA256" => Ok(Self::RsassaPssSha256),
+            _ => Err("Unknown signature algorithm"),
+        }
+    }
+}
+
 #[cfg(test)]
 #[path = "../../tests/unit/pki.rs"]
 #[allow(clippy::unwrap_used)]


### PR DESCRIPTION
- Add prefix `Pki`
- Move type to `libparsec_types`
- Add support for `serialization_format`

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
