### PR TITLE
refactor(pki): Remove `submitter_der_x509_certificate_sha1`

### DIFF
--- a/server/parsec/components/memory/datamodel.py
+++ b/server/parsec/components/memory/datamodel.py
@@ -744,7 +744,6 @@ class MemoryPkiEnrollmentInfoCancelled:
 class MemoryPkiEnrollment:
     enrollment_id: PKIEnrollmentID
     submitter_der_x509_certificate: bytes = field(repr=False)
-    submitter_der_x509_certificate_sha1: bytes = field(repr=False)
 
     submit_payload_signature: bytes = field(repr=False)
     submit_payload_signature_algorithm: PkiSignatureAlgorithm

--- a/server/parsec/components/memory/pki.py
+++ b/server/parsec/components/memory/pki.py
@@ -1,7 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 from __future__ import annotations
 
-from hashlib import sha1
 from typing import override
 
 from parsec._parsec import (
@@ -152,11 +151,9 @@ class MemoryPkiEnrollmentComponent(BasePkiEnrollmentComponent):
 
             # 7) All checks are good, now we do the actual insertion
 
-            submitter_der_x509_certificate_sha1 = sha1(submitter_der_x509_certificate).digest()
             org.pki_enrollments[enrollment_id] = MemoryPkiEnrollment(
                 enrollment_id=enrollment_id,
                 submitter_der_x509_certificate=submitter_der_x509_certificate,
-                submitter_der_x509_certificate_sha1=submitter_der_x509_certificate_sha1,
                 submit_payload_signature=submit_payload_signature,
                 submit_payload_signature_algorithm=submit_payload_signature_algorithm,
                 submit_payload=submit_payload,

--- a/server/parsec/components/postgresql/migrations/0017_rm_pki_enrollment_submit_der_cert_sha1.sql
+++ b/server/parsec/components/postgresql/migrations/0017_rm_pki_enrollment_submit_der_cert_sha1.sql
@@ -1,0 +1,9 @@
+-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+-------------------------------------------------------
+--  Migration
+--
+-- Remove column `submitter_der_x509_certificate_sha1` to the `pki_enrollment` table
+-------------------------------------------------------
+
+ALTER TABLE pki_enrollment DROP submitter_der_x509_certificate_sha1;

--- a/server/parsec/components/postgresql/migrations/datamodel.sql
+++ b/server/parsec/components/postgresql/migrations/datamodel.sql
@@ -458,7 +458,6 @@ CREATE TABLE pki_enrollment (
 
     enrollment_id UUID NOT NULL,
     submitter_der_x509_certificate BYTEA NOT NULL,
-    submitter_der_x509_certificate_sha1 BYTEA NOT NULL,
 
     submit_payload_signature BYTEA NOT NULL,
     submit_payload BYTEA NOT NULL,

--- a/server/parsec/components/postgresql/pki_submit.py
+++ b/server/parsec/components/postgresql/pki_submit.py
@@ -1,8 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 from __future__ import annotations
 
-from hashlib import sha1
-
 from parsec._parsec import (
     DateTime,
     OrganizationID,
@@ -97,7 +95,6 @@ INSERT INTO pki_enrollment (
     organization,
     enrollment_id,
     submitter_der_x509_certificate,
-    submitter_der_x509_certificate_sha1,
     submit_payload_signature,
     submit_payload_signature_algorithm,
     submit_payload,
@@ -108,7 +105,6 @@ VALUES (
     $organization_internal_id,
     $enrollment_id,
     $submitter_der_x509_certificate,
-    $submitter_der_x509_certificate_sha1,
     $submit_payload_signature,
     $submit_payload_signature_algorithm,
     $submit_payload,
@@ -285,14 +281,11 @@ async def pki_submit(
 
     # 7) All checks are good, now we do the actual insertion
 
-    submitter_der_x509_certificate_sha1 = sha1(submitter_der_x509_certificate).digest()
-
     await conn.execute(
         *_q_insert_enrollment(
             organization_internal_id=organization_internal_id,
             enrollment_id=enrollment_id,
             submitter_der_x509_certificate=submitter_der_x509_certificate,
-            submitter_der_x509_certificate_sha1=submitter_der_x509_certificate_sha1,
             submit_payload_signature=submit_payload_signature,
             submit_payload_signature_algorithm=submit_payload_signature_algorithm.str,
             submit_payload=submit_payload,


### PR DESCRIPTION
This field does not appear to be used as we look through the pki enrollment using their IDs. This will also prevent raising false alarm about using sha1 on a cert.

Fix #11586

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
