### PR TITLE
fix(pki): Verify pending requests

### DIFF
--- a/bindings/electron/src/index.d.ts
+++ b/bindings/electron/src/index.d.ts
@@ -312,10 +312,7 @@ export interface PkiEnrollmentAnswerPayload {
 export interface PkiEnrollmentListItem {
     enrollmentId: string
     submittedOn: number
-    derX509Certificate: Uint8Array
-    payloadSignature: Uint8Array
-    payloadSignatureAlgorithm: string
-    payload: Uint8Array
+    payload: PkiEnrollmentSubmitPayload
 }
 
 

--- a/bindings/electron/src/meths.rs
+++ b/bindings/electron/src/meths.rs
@@ -2735,63 +2735,13 @@ fn struct_pki_enrollment_list_item_js_to_rs<'a>(
             }
         }
     };
-    let der_x509_certificate = {
-        let js_val: Handle<JsTypedArray<u8>> = obj.get(cx, "derX509Certificate")?;
-        {
-            let custom_from_rs_bytes =
-                |v: &[u8]| -> Result<libparsec::Bytes, String> { Ok(v.to_vec().into()) };
-            #[allow(clippy::unnecessary_mut_passed)]
-            match custom_from_rs_bytes(js_val.as_slice(cx)) {
-                Ok(val) => val,
-                // err can't infer type in some case, because of the previous `try_into`
-                #[allow(clippy::useless_format)]
-                Err(err) => return cx.throw_type_error(format!("{}", err)),
-            }
-        }
-    };
-    let payload_signature = {
-        let js_val: Handle<JsTypedArray<u8>> = obj.get(cx, "payloadSignature")?;
-        {
-            let custom_from_rs_bytes =
-                |v: &[u8]| -> Result<libparsec::Bytes, String> { Ok(v.to_vec().into()) };
-            #[allow(clippy::unnecessary_mut_passed)]
-            match custom_from_rs_bytes(js_val.as_slice(cx)) {
-                Ok(val) => val,
-                // err can't infer type in some case, because of the previous `try_into`
-                #[allow(clippy::useless_format)]
-                Err(err) => return cx.throw_type_error(format!("{}", err)),
-            }
-        }
-    };
-    let payload_signature_algorithm = {
-        let js_val: Handle<JsString> = obj.get(cx, "payloadSignatureAlgorithm")?;
-        {
-            match js_val.value(cx).parse() {
-                Ok(val) => val,
-                Err(err) => return cx.throw_type_error(err),
-            }
-        }
-    };
     let payload = {
-        let js_val: Handle<JsTypedArray<u8>> = obj.get(cx, "payload")?;
-        {
-            let custom_from_rs_bytes =
-                |v: &[u8]| -> Result<libparsec::Bytes, String> { Ok(v.to_vec().into()) };
-            #[allow(clippy::unnecessary_mut_passed)]
-            match custom_from_rs_bytes(js_val.as_slice(cx)) {
-                Ok(val) => val,
-                // err can't infer type in some case, because of the previous `try_into`
-                #[allow(clippy::useless_format)]
-                Err(err) => return cx.throw_type_error(format!("{}", err)),
-            }
-        }
+        let js_val: Handle<JsObject> = obj.get(cx, "payload")?;
+        struct_pki_enrollment_submit_payload_js_to_rs(cx, js_val)?
     };
     Ok(libparsec::PkiEnrollmentListItem {
         enrollment_id,
         submitted_on,
-        der_x509_certificate,
-        payload_signature,
-        payload_signature_algorithm,
         payload,
     })
 }
@@ -2822,37 +2772,7 @@ fn struct_pki_enrollment_list_item_rs_to_js<'a>(
         }
     });
     js_obj.set(cx, "submittedOn", js_submitted_on)?;
-    let js_der_x509_certificate = {
-        let rs_buff = { rs_obj.der_x509_certificate.as_ref() };
-        let js_buff = JsTypedArray::from_slice(cx, rs_buff.as_ref())?;
-        js_buff
-    };
-    js_obj.set(cx, "derX509Certificate", js_der_x509_certificate)?;
-    let js_payload_signature = {
-        let rs_buff = { rs_obj.payload_signature.as_ref() };
-        let js_buff = JsTypedArray::from_slice(cx, rs_buff.as_ref())?;
-        js_buff
-    };
-    js_obj.set(cx, "payloadSignature", js_payload_signature)?;
-    let js_payload_signature_algorithm = JsString::try_new(cx, {
-        let custom_to_rs_string =
-            |v| -> Result<_, std::convert::Infallible> { Ok(std::string::ToString::to_string(&v)) };
-        match custom_to_rs_string(rs_obj.payload_signature_algorithm) {
-            Ok(ok) => ok,
-            Err(err) => return cx.throw_type_error(err.to_string()),
-        }
-    })
-    .or_throw(cx)?;
-    js_obj.set(
-        cx,
-        "payloadSignatureAlgorithm",
-        js_payload_signature_algorithm,
-    )?;
-    let js_payload = {
-        let rs_buff = { rs_obj.payload.as_ref() };
-        let js_buff = JsTypedArray::from_slice(cx, rs_buff.as_ref())?;
-        js_buff
-    };
+    let js_payload = struct_pki_enrollment_submit_payload_rs_to_js(cx, rs_obj.payload)?;
     js_obj.set(cx, "payload", js_payload)?;
     Ok(js_obj)
 }

--- a/bindings/generator/api/pki.py
+++ b/bindings/generator/api/pki.py
@@ -39,13 +39,32 @@ async def show_certificate_selection_dialog_windows_only() -> Result[
     raise NotImplementedError
 
 
+class VerifyKey(BytesBasedType): ...
+
+
+class PublicKey(BytesBasedType): ...
+
+
+class PkiEnrollmentAnswerPayload(Structure):
+    user_id: UserID
+    device_id: DeviceID
+    device_label: DeviceLabel
+    human_handle: HumanHandle
+    profile: UserProfile
+    root_verify_key: VerifyKey
+
+
+class PkiEnrollmentSubmitPayload(Structure):
+    verify_key: VerifyKey
+    public_key: PublicKey
+    device_label: DeviceLabel
+    human_handle: HumanHandle
+
+
 class PkiEnrollmentListItem(Structure):
     enrollment_id: PKIEnrollmentID
     submitted_on: DateTime
-    der_x509_certificate: Bytes
-    payload_signature: Bytes
-    payload_signature_algorithm: PkiSignatureAlgorithm
-    payload: Bytes
+    payload: PkiEnrollmentSubmitPayload
 
 
 class PkiEnrollmentListError(ErrorVariant):
@@ -117,28 +136,6 @@ class PkiEnrollmentAcceptError(ErrorVariant):
     class HumanHandleAlreadyTaken: ...
 
     class PkiOperationError: ...
-
-
-class VerifyKey(BytesBasedType): ...
-
-
-class PublicKey(BytesBasedType): ...
-
-
-class PkiEnrollmentAnswerPayload(Structure):
-    user_id: UserID
-    device_id: DeviceID
-    device_label: DeviceLabel
-    human_handle: HumanHandle
-    profile: UserProfile
-    root_verify_key: VerifyKey
-
-
-class PkiEnrollmentSubmitPayload(Structure):
-    verify_key: VerifyKey
-    public_key: PublicKey
-    device_label: DeviceLabel
-    human_handle: HumanHandle
 
 
 class PKIEncryptionAlgorithm(StrBasedType):

--- a/bindings/web/src/meths.rs
+++ b/bindings/web/src/meths.rs
@@ -2876,58 +2876,13 @@ fn struct_pki_enrollment_list_item_js_to_rs(
             v
         }
     };
-    let der_x509_certificate = {
-        let js_val = Reflect::get(&obj, &"derX509Certificate".into())?;
-        js_val
-            .dyn_into::<Uint8Array>()
-            .map(|x| x.to_vec())
-            .map_err(|_| TypeError::new("Not a Uint8Array"))
-            .and_then(|x| {
-                let custom_from_rs_bytes =
-                    |v: &[u8]| -> Result<libparsec::Bytes, String> { Ok(v.to_vec().into()) };
-                custom_from_rs_bytes(&x).map_err(|e| TypeError::new(e.as_ref()))
-            })?
-    };
-    let payload_signature = {
-        let js_val = Reflect::get(&obj, &"payloadSignature".into())?;
-        js_val
-            .dyn_into::<Uint8Array>()
-            .map(|x| x.to_vec())
-            .map_err(|_| TypeError::new("Not a Uint8Array"))
-            .and_then(|x| {
-                let custom_from_rs_bytes =
-                    |v: &[u8]| -> Result<libparsec::Bytes, String> { Ok(v.to_vec().into()) };
-                custom_from_rs_bytes(&x).map_err(|e| TypeError::new(e.as_ref()))
-            })?
-    };
-    let payload_signature_algorithm = {
-        let js_val = Reflect::get(&obj, &"payloadSignatureAlgorithm".into())?;
-        js_val
-            .dyn_into::<JsString>()
-            .ok()
-            .and_then(|s| s.as_string())
-            .ok_or_else(|| TypeError::new("Not a string"))?
-            .parse()
-            .map_err(|_| TypeError::new("Not a valid PkiSignatureAlgorithm"))?
-    };
     let payload = {
         let js_val = Reflect::get(&obj, &"payload".into())?;
-        js_val
-            .dyn_into::<Uint8Array>()
-            .map(|x| x.to_vec())
-            .map_err(|_| TypeError::new("Not a Uint8Array"))
-            .and_then(|x| {
-                let custom_from_rs_bytes =
-                    |v: &[u8]| -> Result<libparsec::Bytes, String> { Ok(v.to_vec().into()) };
-                custom_from_rs_bytes(&x).map_err(|e| TypeError::new(e.as_ref()))
-            })?
+        struct_pki_enrollment_submit_payload_js_to_rs(js_val)?
     };
     Ok(libparsec::PkiEnrollmentListItem {
         enrollment_id,
         submitted_on,
-        der_x509_certificate,
-        payload_signature,
-        payload_signature_algorithm,
         payload,
     })
 }
@@ -2958,30 +2913,7 @@ fn struct_pki_enrollment_list_item_rs_to_js(
         JsValue::from(v)
     };
     Reflect::set(&js_obj, &"submittedOn".into(), &js_submitted_on)?;
-    let js_der_x509_certificate =
-        JsValue::from(Uint8Array::from(rs_obj.der_x509_certificate.as_ref()));
-    Reflect::set(
-        &js_obj,
-        &"derX509Certificate".into(),
-        &js_der_x509_certificate,
-    )?;
-    let js_payload_signature = JsValue::from(Uint8Array::from(rs_obj.payload_signature.as_ref()));
-    Reflect::set(&js_obj, &"payloadSignature".into(), &js_payload_signature)?;
-    let js_payload_signature_algorithm = JsValue::from_str({
-        let custom_to_rs_string =
-            |v| -> Result<_, std::convert::Infallible> { Ok(std::string::ToString::to_string(&v)) };
-        match custom_to_rs_string(rs_obj.payload_signature_algorithm) {
-            Ok(ok) => ok,
-            Err(err) => return Err(JsValue::from(TypeError::new(&err.to_string()))),
-        }
-        .as_ref()
-    });
-    Reflect::set(
-        &js_obj,
-        &"payloadSignatureAlgorithm".into(),
-        &js_payload_signature_algorithm,
-    )?;
-    let js_payload = JsValue::from(Uint8Array::from(rs_obj.payload.as_ref()));
+    let js_payload = struct_pki_enrollment_submit_payload_rs_to_js(rs_obj.payload)?;
     Reflect::set(&js_obj, &"payload".into(), &js_payload)?;
     Ok(js_obj)
 }

--- a/client/src/plugins/libparsec/definitions.ts
+++ b/client/src/plugins/libparsec/definitions.ts
@@ -332,10 +332,7 @@ export interface PkiEnrollmentAnswerPayload {
 export interface PkiEnrollmentListItem {
     enrollmentId: PKIEnrollmentID
     submittedOn: DateTime
-    derX509Certificate: Bytes
-    payloadSignature: Bytes
-    payloadSignatureAlgorithm: PkiSignatureAlgorithm
-    payload: Bytes
+    payload: PkiEnrollmentSubmitPayload
 }
 
 export interface PkiEnrollmentSubmitPayload {

--- a/libparsec/crates/client/src/client/pki_enrollment_list.rs
+++ b/libparsec/crates/client/src/client/pki_enrollment_list.rs
@@ -1,5 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
+use libparsec_types::anyhow::Context;
 use libparsec_types::prelude::*;
 
 use libparsec_client_connection::{
@@ -20,7 +21,12 @@ pub enum PkiEnrollmentListError {
     Internal(#[from] anyhow::Error),
 }
 
-pub use authenticated_cmds::latest::pki_enrollment_list::PkiEnrollmentListItem;
+#[derive(Debug, PartialEq, Eq)]
+pub struct PkiEnrollmentListItem {
+    pub enrollment_id: PKIEnrollmentID,
+    pub submitted_on: DateTime,
+    pub payload: PkiEnrollmentSubmitPayload,
+}
 
 pub async fn list_enrollments(
     cmds: &AuthenticatedCmds,
@@ -29,11 +35,58 @@ pub async fn list_enrollments(
 
     let rep = cmds.send(Req).await?;
 
-    match rep {
-        Rep::Ok { enrollments } => Ok(enrollments),
-        Rep::AuthorNotAllowed => Err(PkiEnrollmentListError::AuthorNotAllowed),
+    let pki_requests = match rep {
+        Rep::Ok { enrollments } => enrollments,
+        Rep::AuthorNotAllowed => return Err(PkiEnrollmentListError::AuthorNotAllowed),
         rep @ Rep::UnknownStatus { .. } => {
-            Err(anyhow::anyhow!("Unexpected server response: {:?}", rep).into())
+            return Err(anyhow::anyhow!("Unexpected server response: {:?}", rep).into())
         }
+    };
+
+    // Early stop
+    if pki_requests.is_empty() {
+        return Ok(Vec::new());
     }
+
+    let now = cmds.time_provider.now();
+    // Potentially expensive check, spawning a new task
+    libparsec_platform_async::spawn(async move {
+        let root_certs = libparsec_platform_pki::list_trusted_root_certificate_anchor()
+            .context("Failed to list trusted root certificates")
+            .map_err(PkiEnrollmentListError::Internal)?;
+
+        let items = pki_requests
+            .into_iter()
+            .filter_map(|req| {
+                let message = libparsec_platform_pki::SignedMessage {
+                    algo: req.payload_signature_algorithm,
+                    signature: req.payload_signature,
+                    message: req.payload,
+                };
+                let Ok(payload) = libparsec_platform_pki::load_submit_payload(
+                    &req.der_x509_certificate,
+                    &message,
+                    &root_certs,
+                    now,
+                )
+                .inspect_err(|err| log::debug!(err:%; "Cannot validate submit payload")) else {
+                    return None;
+                };
+
+                // We successfully parsed the payload, we can drop the message.
+                drop(message);
+
+                Some(PkiEnrollmentListItem {
+                    enrollment_id: req.enrollment_id,
+                    submitted_on: req.submitted_on,
+                    payload,
+                })
+            })
+            .collect::<Vec<_>>();
+        Ok(items)
+    })
+    .await
+    .context("Failed to verify pending pki requests")
+    .map_err(PkiEnrollmentListError::Internal)
+    .and_then(std::convert::identity)
 }

--- a/libparsec/crates/client/tests/unit/client/pki_enrollment_list.rs
+++ b/libparsec/crates/client/tests/unit/client/pki_enrollment_list.rs
@@ -8,20 +8,33 @@ use libparsec_types::prelude::*;
 
 use super::utils::client_factory;
 
+#[ignore = "TODO: (#11269) Need to generate a valid payload & signature with a cert that is trusted by it's root certificate"]
 #[parsec_test(testbed = "minimal")]
 async fn ok(env: &TestbedEnv) {
     let alice_device = env.local_device("alice@dev1");
     let alice_client = client_factory(&env.discriminant_dir, alice_device).await;
 
-    // Test data from libparsec/crates/protocol/tests/authenticated_cmds/v5/pki_enrollment_list.rs
-    let pki_enrollment_item = PkiEnrollmentListItem {
-        der_x509_certificate: hex!("3c78353039206365727469663e").as_ref().into(),
-        enrollment_id: PKIEnrollmentID::from_hex("e1fe88bd0f054261887a6c8039710b40").unwrap(),
-        payload: hex!("3c64756d6d793e").as_ref().into(),
-        payload_signature: hex!("3c7369676e61747572653e").as_ref().into(),
-        payload_signature_algorithm: PkiSignatureAlgorithm::RsassaPssSha256,
-        submitted_on: DateTime::from_timestamp_micros(1668594983390001).unwrap(),
+    let payload = PkiEnrollmentSubmitPayload {
+        // For this test, we do not need to keep the private part
+        verify_key: SigningKey::generate().verify_key(),
+        public_key: PrivateKey::generate().public_key(),
+        // We reuse alice device label and human handle for simplicity
+        device_label: alice_client.device_label().clone(),
+        human_handle: alice_client.human_handle().clone(),
     };
+
+    let raw_payload = payload.dump();
+
+    // Test data from libparsec/crates/protocol/tests/authenticated_cmds/v5/pki_enrollment_list.rs
+    let pki_enrollment_item =
+        authenticated_cmds::latest::pki_enrollment_list::PkiEnrollmentListItem {
+            der_x509_certificate: hex!("3c78353039206365727469663e").as_ref().into(),
+            enrollment_id: PKIEnrollmentID::from_hex("e1fe88bd0f054261887a6c8039710b40").unwrap(),
+            payload: raw_payload.into(),
+            payload_signature: hex!("3c7369676e61747572653e").as_ref().into(),
+            payload_signature_algorithm: PkiSignatureAlgorithm::RsassaPssSha256,
+            submitted_on: DateTime::from_timestamp_micros(1668594983390001).unwrap(),
+        };
     let pki_enrollment_item_clone = pki_enrollment_item.clone();
 
     test_register_send_hook(&env.discriminant_dir, {
@@ -33,7 +46,14 @@ async fn ok(env: &TestbedEnv) {
     });
 
     let enrollments = alice_client.pki_list_enrollments();
-    p_assert_eq!(enrollments.await.unwrap(), vec![pki_enrollment_item_clone])
+    p_assert_eq!(
+        enrollments.await.unwrap(),
+        vec![PkiEnrollmentListItem {
+            enrollment_id: pki_enrollment_item_clone.enrollment_id,
+            submitted_on: pki_enrollment_item_clone.submitted_on,
+            payload
+        }]
+    )
 }
 
 #[parsec_test(testbed = "minimal")]

--- a/libparsec/crates/platform_pki/examples/sign_message.rs
+++ b/libparsec/crates/platform_pki/examples/sign_message.rs
@@ -22,7 +22,7 @@ fn main() -> anyhow::Result<()> {
     println!("args={args:?}");
 
     let cert_ref = args.certificate_hash.into();
-    let data: Vec<u8> = args.content.into_bytes()?;
+    let data = args.content.into_bytes()?;
     let res = sign_message(&data, &cert_ref).context("Failed to sign message")?;
 
     println!(

--- a/libparsec/crates/platform_pki/examples/utils/mod.rs
+++ b/libparsec/crates/platform_pki/examples/utils/mod.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 
 use anyhow::Context;
+use bytes::Bytes;
 use clap::{
     builder::{NonEmptyStringValueParser, TypedValueParser},
     error::{Error, ErrorKind},
@@ -44,10 +45,12 @@ pub struct ContentOpts {
 impl ContentOpts {
     // Not all examples uses `ContentOpts` so `into_bytes` is not always used.
     #[allow(dead_code)]
-    pub fn into_bytes(self) -> anyhow::Result<Vec<u8>> {
+    pub fn into_bytes(self) -> anyhow::Result<Bytes> {
         match (self.content, self.content_file) {
             (Some(content), None) => Ok(content.into()),
-            (None, Some(filepath)) => std::fs::read(filepath).context("Failed to read file"),
+            (None, Some(filepath)) => std::fs::read(filepath)
+                .context("Failed to read file")
+                .map(Into::into),
             (Some(_), Some(_)) | (None, None) => unreachable!("Handled by clap"),
         }
     }

--- a/libparsec/crates/platform_pki/examples/verify_message.rs
+++ b/libparsec/crates/platform_pki/examples/verify_message.rs
@@ -28,6 +28,7 @@ fn main() -> anyhow::Result<()> {
 
     let signature = data_encoding::BASE64
         .decode(args.signature.as_bytes())
+        .map(Into::into)
         .context("Invalid signature format")?;
 
     let cert = args.cert.get_certificate()?;

--- a/libparsec/crates/platform_pki/src/lib.rs
+++ b/libparsec/crates/platform_pki/src/lib.rs
@@ -148,6 +148,7 @@ pub use platform::is_available;
 
 pub use errors::VerifyCertificateError;
 pub use shared::verify_certificate;
+pub use webpki::KeyUsage;
 
 pub use errors::LoadSubmitPayloadError;
 pub use shared::load_submit_payload;


### PR DESCRIPTION
`client::pki_enrollment_list` did not check pending request for trust and valid payload. Now invalid request is skipped by `pki_enrollment_list`.

Closes #11567

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
