### PR TITLE
ci(releaser): Fix expected artifact for macos wheel

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -132,8 +132,8 @@ jobs:
           # Python Files
           cp ${CP_ARGS} artifacts/Linux-X64-wheel/parsec_cloud-${{ needs.version.outputs.pep440 }}-*.whl release-files
           cp ${CP_ARGS} artifacts/Linux-X64-wheel/requirements.txt release-files/python-linux-requirements.txt
-          cp ${CP_ARGS} artifacts/macOS-X64-wheel/parsec_cloud-${{ needs.version.outputs.pep440 }}-*.whl release-files
-          cp ${CP_ARGS} artifacts/macOS-X64-wheel/requirements.txt release-files/python-macos-requirements.txt
+          cp ${CP_ARGS} artifacts/macOS-ARM64-wheel/parsec_cloud-${{ needs.version.outputs.pep440 }}-*.whl release-files
+          cp ${CP_ARGS} artifacts/macOS-ARM64-wheel/requirements.txt release-files/python-macos-requirements.txt
           cp ${CP_ARGS} artifacts/Windows-X64-wheel/parsec_cloud-${{ needs.version.outputs.pep440 }}-*.whl release-files
           cp ${CP_ARGS} artifacts/Windows-X64-wheel/requirements.txt release-files/python-win-requirements.txt
 


### PR DESCRIPTION
Forget to update expected artifacts for parsec wheel for macos since we have update to macos-15 in 14c490cc493cd2b400696ceaa9dbfddb1238e5c3

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
