### PR TITLE
Update server dependencies

### DIFF
--- a/server/poetry.lock
+++ b/server/poetry.lock
@@ -117,21 +117,6 @@ asyncpg = ">=0.29,<0.30"
 typing-extensions = ">=4.7.0,<5.0.0"
 
 [[package]]
-name = "babel"
-version = "2.17.0"
-description = "Internationalization utilities"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2"},
-    {file = "babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d"},
-]
-
-[package.extras]
-dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)", "jinja2 (>=3.0)", "pytest (>=6.0)", "pytest-cov", "pytz", "setuptools", "tzdata ; sys_platform == \"win32\""]
-
-[[package]]
 name = "bashlex"
 version = "0.16"
 description = "Python parser for bash"
@@ -2497,4 +2482,4 @@ test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "~=3.12.0"
-content-hash = "512a5e86b012d9d8abc220d0a07224781f692cfb7192fc3f737af534f19dfe78"
+content-hash = "5a2affa66a212d32d02bb1a9816acb15174ebdec1d3da898629dd337ea6c13ec"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -82,7 +82,6 @@ asyncpg-stubs = "^0.29.1"
 boto3-stubs = "^1.40.45"
 types-requests = "^2.32.4"
 # other dependencies
-Babel = "^2.10"                # TODO: unused?
 poetry-lock-package = "^0.5.2"
 
 [tool.poetry.group.testbed-server]


### PR DESCRIPTION
Changes in server dependencies:

- Bump `starlette` to 0.49.3 [changelog](https://starlette.dev/release-notes/)
- Bump `fastapi` to 0.121.2 [changelog](https://fastapi.tiangolo.com/release-notes/)
- Remove `pydantic-core`, now included in `pydantic` (see https://github.com/pydantic/pydantic-core/blob/main/README.md)
- Remove `Babel`, not used in server code