### PR TITLE
[MS] Hide and unmount workspace from contextual menu

### DIFF
--- a/client/src/components/workspaces/WorkspaceCard.vue
+++ b/client/src/components/workspaces/WorkspaceCard.vue
@@ -3,7 +3,10 @@
 <template>
   <div
     class="workspace-card-item ion-no-padding"
-    :class="{ 'workspace-hovered': isHovered || menuOpened }"
+    :class="{
+      'workspace-hovered': isHovered || menuOpened,
+      'workspace-card-item--hidden': isHidden,
+    }"
     @click="$emit('click', workspace, $event)"
     @mouseenter="isHovered = true"
     @mouseleave="isHovered = false"
@@ -44,6 +47,17 @@
         >
           {{ $msTranslate(formatFileSize(workspace.size)) }}
         </ion-text>
+
+        <div
+          class="workspace-hidden subtitles-sm"
+          v-if="isHidden"
+        >
+          <ion-icon
+            class="cloud-overlay"
+            :icon="eyeOff"
+          />
+          <ion-text>{{ $msTranslate('WorkspacesPage.Workspace.hidden') }}</ion-text>
+        </div>
       </div>
     </div>
     <div class="workspace-card-bottom">
@@ -81,7 +95,7 @@ import { formatFileSize } from '@/common/file';
 import { WorkspaceRoleTag } from '@/components/workspaces';
 import { UserProfile, WorkspaceInfo } from '@/parsec';
 import { IonIcon, IonText } from '@ionic/vue';
-import { cloudDone, cloudOffline, ellipsisHorizontal, shareSocial, star } from 'ionicons/icons';
+import { cloudDone, cloudOffline, ellipsisHorizontal, eyeOff, shareSocial, star } from 'ionicons/icons';
 import { formatTimeSince } from 'megashark-lib';
 import { ref } from 'vue';
 
@@ -92,6 +106,7 @@ const props = defineProps<{
   workspace: WorkspaceInfo;
   clientProfile: UserProfile;
   isFavorite: boolean;
+  isHidden: boolean;
 }>();
 
 const emits = defineEmits<{
@@ -180,6 +195,7 @@ async function onOptionsClick(event: Event): Promise<void> {
   flex-direction: column;
   gap: 0.75rem;
   overflow: hidden;
+  position: relative;
 
   &__title {
     color: var(--parsec-color-light-primary-900);
@@ -188,6 +204,8 @@ async function onOptionsClick(event: Event): Promise<void> {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    align-items: center;
+    gap: 0.5rem;
     margin-right: 1.125rem;
 
     ion-text {
@@ -218,6 +236,21 @@ async function onOptionsClick(event: Event): Promise<void> {
 
     .cloud-overlay-ko {
       color: var(--parsec-color-light-secondary-grey);
+    }
+  }
+
+  .workspace-hidden {
+    background: var(--parsec-color-light-secondary-white);
+    color: var(--parsec-color-light-secondary-contrast);
+    text-align: left;
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 3px 0.5rem;
+    border-radius: var(--parsec-radius-8);
+
+    ion-icon {
+      font-size: 0.875rem;
     }
   }
 
@@ -276,6 +309,17 @@ async function onOptionsClick(event: Event): Promise<void> {
 
     @include ms.responsive-breakpoint('sm') {
       padding: 0 0.25rem;
+    }
+  }
+}
+
+.workspace-card-item--hidden {
+  .workspace-card-content {
+    opacity: 0.9;
+    filter: brightness(0.85);
+
+    &:hover {
+      background: var(--parsec-color-light-secondary-premiere) !important;
     }
   }
 }

--- a/client/src/components/workspaces/WorkspaceListItem.vue
+++ b/client/src/components/workspaces/WorkspaceListItem.vue
@@ -5,7 +5,10 @@
     button
     class="workspace-list-item no-padding-end"
     :detail="false"
-    :class="{ 'workspace-hovered': isHovered || menuOpened }"
+    :class="{
+      'workspace-hovered': isHovered || menuOpened,
+      'workspace-list-item--hidden': isHidden,
+    }"
     @click="$emit('click', workspace, $event)"
     @mouseenter="isHovered = true"
     @mouseleave="isHovered = false"
@@ -35,6 +38,16 @@
         <ion-text class="workspace-name__label title-h4">
           {{ workspace.currentName }}
         </ion-text>
+      </div>
+      <div
+        class="workspace-hidden"
+        v-if="isHidden"
+      >
+        <ion-icon
+          class="workspace-hidden__icon"
+          :icon="eyeOff"
+        />
+        <ion-text class="subtitles-sm workspace-hidden__text">{{ $msTranslate('WorkspacesPage.Workspace.hidden') }}</ion-text>
       </div>
 
       <!-- role user -->
@@ -123,7 +136,7 @@ import AvatarGroup from '@/components/workspaces/AvatarGroup.vue';
 import WorkspaceRoleTag from '@/components/workspaces/WorkspaceRoleTag.vue';
 import { UserProfile, WorkspaceInfo } from '@/parsec';
 import { IonButton, IonIcon, IonItem, IonLabel, IonText } from '@ionic/vue';
-import { cloudDone, cloudOffline, ellipsisHorizontal, shareSocial, star } from 'ionicons/icons';
+import { cloudDone, cloudOffline, ellipsisHorizontal, eyeOff, shareSocial, star } from 'ionicons/icons';
 import { formatTimeSince, useWindowSize, WindowSizeBreakpoints } from 'megashark-lib';
 import { ref } from 'vue';
 
@@ -135,6 +148,7 @@ const props = defineProps<{
   workspace: WorkspaceInfo;
   clientProfile: UserProfile;
   isFavorite: boolean;
+  isHidden: boolean;
 }>();
 
 const emits = defineEmits<{
@@ -174,7 +188,7 @@ async function onOptionsClick(event: Event): Promise<void> {
 
   &-content {
     display: flex;
-    background: var(--parsec-color-light-secondary-background);
+    background: var(--parsec-color-light-secondary-premiere);
     border-radius: var(--parsec-radius-8);
     align-items: center;
     width: 100%;
@@ -263,6 +277,29 @@ async function onOptionsClick(event: Event): Promise<void> {
     text-align: left;
     color: var(--parsec-color-light-secondary-text);
     min-width: 0;
+  }
+}
+
+.workspace-hidden {
+  background: var(--parsec-color-light-secondary-white);
+  color: var(--parsec-color-light-secondary-contrast);
+  text-align: left;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 3px 0.5rem;
+  border-radius: var(--parsec-radius-8);
+  flex-shrink: 0;
+
+  &__icon {
+    font-size: 0.875rem;
+    flex-shrink: 0;
+  }
+
+  &__text {
+    @include ms.responsive-breakpoint('xs') {
+      display: none;
+    }
   }
 }
 
@@ -361,6 +398,21 @@ async function onOptionsClick(event: Event): Promise<void> {
       .options-button__icon {
         color: var(--parsec-color-light-primary-500);
       }
+    }
+  }
+}
+
+.workspace-list-item--hidden {
+  border: 1px solid var(--parsec-color-light-secondary-medium);
+
+  .workspace-list-item-content {
+    opacity: 0.9;
+    filter: brightness(0.85);
+  }
+
+  &:hover {
+    .workspace-list-item-content {
+      background: var(--parsec-color-light-secondary-premiere);
     }
   }
 }

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -649,6 +649,8 @@
             "actionHistory": "History",
             "actionShare": "Sharing and roles",
             "actionDetails": "Details",
+            "actionHide": "Hide this workspace",
+            "actionShow": "Show this workspace",
             "actionCopyLink": "Copy link",
             "actionAddFavorite": "Pin",
             "actionRemoveFavorite": "Unpin"
@@ -699,6 +701,15 @@
         "filter": {
             "title": "Filter",
             "roles": "Role"
+        },
+        "showHideWorkspace": {
+            "failedStarted": "Failed to get started workspace information. Please try again.",
+            "successDesktopHidden": "The workspace is now hidden and will no longer appear in your explorer.",
+            "successWebHidden": "The workspace is now hidden in Parsec.",
+            "failedHidden": "Failed to hide the workspace. Please try again.",
+            "successDesktopShown": "The workspace is now visible in Parsec and your explorer.",
+            "successWebShown": "The workspace is now visible in Parsec.",
+            "failedShown": "Failed to show the workspace. Please try again."
         }
     },
     "FoldersPage": {

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -649,6 +649,8 @@
             "actionShare": "Partage et rôles",
             "actionDetails": "Détails",
             "actionCopyLink": "Copier le lien",
+            "actionHide": "Masquer cet espace",
+            "actionShow": "Afficher cet espace",
             "actionAddFavorite": "Épingler",
             "actionRemoveFavorite": "Désépingler"
         },
@@ -698,6 +700,15 @@
         "filter": {
             "title": "Filtrer",
             "roles": "Rôle"
+        },
+        "showHideWorkspace": {
+            "failedStarted": "Impossible d'obtenir les informations relatives à l'espace de travail. Veuillez réessayer.",
+            "successDesktopHidden": "L'espace de travail est maintenant masqué et n'apparaîtra plus dans votre explorateur.",
+            "successWebHidden": "L'espace de travail est maintenant masqué dans Parsec.",
+            "failedHidden": "Impossible de masquer l'espace de travail. Veuillez réessayer.",
+            "successDesktopShown": "L'espace de travail est maintenant visible dans Parsec et votre explorateur.",
+            "successWebShown": "L'espace de travail est maintenant visible dans Parsec.",
+            "failedShown": "Impossible d'afficher l'espace de travail. Veuillez réessayer."
         }
     },
     "FoldersPage": {

--- a/client/src/parsec/workspace.ts
+++ b/client/src/parsec/workspace.ts
@@ -32,7 +32,7 @@ import {
   WorkspaceRole,
 } from '@/parsec/types';
 import { generateNoHandleError } from '@/parsec/utils';
-import { WorkspaceStopError, libparsec } from '@/plugins/libparsec';
+import { MountpointUnmountError, WorkspaceStopError, libparsec } from '@/plugins/libparsec';
 import { getConnectionHandle } from '@/router';
 import { DateTime } from 'luxon';
 
@@ -240,13 +240,32 @@ export async function mountWorkspace(
   const startedWorkspaceResult = await getWorkspaceInfo(workspaceHandle);
   if (!startedWorkspaceResult.ok) {
     console.error(`Failed to get started workspace info: ${startedWorkspaceResult.error}`);
-    return { ok: false, error: { tag: WorkspaceMountErrorTag.Internal, error: '' } };
+    return { ok: false, error: { tag: WorkspaceMountErrorTag.Internal, error: startedWorkspaceResult.error.error } };
   } else {
     if (startedWorkspaceResult.value.mountpoints.length > 0) {
       return { ok: true, value: startedWorkspaceResult.value.mountpoints[0] };
     }
   }
   return await libparsec.workspaceMount(workspaceHandle);
+}
+
+export async function unmountWorkspace(workspace: WorkspaceInfo): Promise<Result<null, MountpointUnmountError>> {
+  let error: MountpointUnmountError | null = null;
+
+  for (let i = workspace.mountpoints.length - 1; i >= 0; i--) {
+    const result = await libparsec.mountpointUnmount(workspace.mountpoints[i][0]);
+    if (result.ok) {
+      workspace.mountpoints.splice(i, 1);
+    } else {
+      error = result.error;
+    }
+  }
+
+  if (error) {
+    return generateNoHandleError<MountpointUnmountError>();
+  }
+
+  return { ok: true, value: null };
 }
 
 export async function getPathLink(

--- a/client/src/views/workspaces/SmallDisplayWorkspaceContextMenu.vue
+++ b/client/src/views/workspaces/SmallDisplayWorkspaceContextMenu.vue
@@ -23,10 +23,7 @@
           </ion-item>
         </ion-item-group>
 
-        <ion-item-group
-          class="list-group"
-          v-show="isDesktop() || clientRole === WorkspaceRole.Owner"
-        >
+        <ion-item-group class="list-group">
           <ion-item
             button
             v-show="clientRole === WorkspaceRole.Owner"
@@ -48,7 +45,10 @@
             @click="onClick(WorkspaceAction.OpenInExplorer)"
             class="ion-no-padding list-group-item"
           >
-            <ion-icon :icon="open" />
+            <ion-icon
+              class="list-group-item__icon"
+              :icon="open"
+            />
             <ion-text class="button-large list-group-item__label-small">
               {{ $msTranslate('WorkspacesPage.workspaceContextMenu.actionOpenInExplorer') }}
             </ion-text>
@@ -81,6 +81,36 @@
             />
             <ion-text class="button-large list-group-item__label-small">
               {{ $msTranslate('WorkspacesPage.workspaceContextMenu.actionDetails') }}
+            </ion-text>
+          </ion-item>
+
+          <ion-item
+            button
+            v-show="!isHidden"
+            @click="onClick(WorkspaceAction.UnMount)"
+            class="ion-no-padding list-group-item"
+          >
+            <ion-icon
+              class="list-group-item__icon"
+              :icon="eyeOff"
+            />
+            <ion-text class="button-large list-group-item__label-small">
+              {{ $msTranslate('WorkspacesPage.workspaceContextMenu.actionHide') }}
+            </ion-text>
+          </ion-item>
+
+          <ion-item
+            button
+            v-show="isHidden"
+            @click="onClick(WorkspaceAction.Mount)"
+            class="ion-no-padding list-group-item"
+          >
+            <ion-icon
+              class="list-group-item__icon"
+              :icon="eye"
+            />
+            <ion-text class="button-large list-group-item__label-small">
+              {{ $msTranslate('WorkspacesPage.workspaceContextMenu.actionShow') }}
             </ion-text>
           </ion-item>
         </ion-item-group>
@@ -144,7 +174,7 @@
 import { UserProfile, WorkspaceName, WorkspaceRole, isDesktop } from '@/parsec';
 import { WorkspaceAction } from '@/views/workspaces/types';
 import { IonContent, IonIcon, IonItem, IonItemGroup, IonList, IonPage, IonText, modalController } from '@ionic/vue';
-import { cloudy, informationCircle, link, open, shareSocial, star, time } from 'ionicons/icons';
+import { cloudy, eye, eyeOff, informationCircle, link, open, shareSocial, star, time } from 'ionicons/icons';
 import { MsImage, RenameIcon } from 'megashark-lib';
 
 function onClick(action: WorkspaceAction): Promise<boolean> {
@@ -156,6 +186,7 @@ defineProps<{
   clientProfile: UserProfile;
   clientRole: WorkspaceRole;
   isFavorite: boolean;
+  isHidden: boolean;
 }>();
 </script>
 

--- a/client/src/views/workspaces/WorkspaceContextMenu.vue
+++ b/client/src/views/workspaces/WorkspaceContextMenu.vue
@@ -37,10 +37,7 @@
         </ion-item>
       </ion-item-group>
 
-      <ion-item-group
-        class="list-group"
-        v-show="isDesktop() || clientRole === WorkspaceRole.Owner"
-      >
+      <ion-item-group class="list-group">
         <ion-item class="list-group-title button-small">
           <ion-text class="list-group-title__label">
             {{ $msTranslate('WorkspacesPage.workspaceContextMenu.titleManage') }}
@@ -104,6 +101,35 @@
           />
           <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('WorkspacesPage.workspaceContextMenu.actionDetails') }}
+          </ion-text>
+        </ion-item>
+
+        <ion-item
+          button
+          v-show="!isHidden"
+          @click="onClick(WorkspaceAction.UnMount)"
+          class="ion-no-padding list-group-item"
+        >
+          <ion-icon
+            class="list-group-item__icon"
+            :icon="eyeOff"
+          />
+          <ion-text class="button-medium list-group-item__label">
+            {{ $msTranslate('WorkspacesPage.workspaceContextMenu.actionHide') }}
+          </ion-text>
+        </ion-item>
+        <ion-item
+          button
+          v-show="isHidden"
+          @click="onClick(WorkspaceAction.Mount)"
+          class="ion-no-padding list-group-item"
+        >
+          <ion-icon
+            class="list-group-item__icon"
+            :icon="eye"
+          />
+          <ion-text class="button-medium list-group-item__label">
+            {{ $msTranslate('WorkspacesPage.workspaceContextMenu.actionShow') }}
           </ion-text>
         </ion-item>
       </ion-item-group>
@@ -176,7 +202,7 @@
 import { UserProfile, WorkspaceName, WorkspaceRole, isDesktop } from '@/parsec';
 import { WorkspaceAction } from '@/views/workspaces/types';
 import { IonContent, IonIcon, IonItem, IonItemGroup, IonList, IonText, popoverController } from '@ionic/vue';
-import { cloudy, informationCircle, link, open, shareSocial, star, time } from 'ionicons/icons';
+import { cloudy, eye, eyeOff, informationCircle, link, open, shareSocial, star, time } from 'ionicons/icons';
 import { MsImage, RenameIcon } from 'megashark-lib';
 
 function onClick(action: WorkspaceAction): Promise<boolean> {
@@ -188,6 +214,7 @@ defineProps<{
   clientProfile: UserProfile;
   clientRole: WorkspaceRole;
   isFavorite: boolean;
+  isHidden: boolean;
 }>();
 </script>
 

--- a/client/src/views/workspaces/WorkspacesPage.vue
+++ b/client/src/views/workspaces/WorkspacesPage.vue
@@ -110,6 +110,7 @@
               :workspace="workspace"
               :client-profile="clientProfile"
               :is-favorite="workspaceAttributes.isFavorite(workspace.id)"
+              :is-hidden="workspaceAttributes.isHidden(workspace.id)"
               @click="onWorkspaceClick"
               @favorite-click="onWorkspaceFavoriteClick"
               @menu-click="onOpenWorkspaceContextMenu"
@@ -127,6 +128,7 @@
             :workspace="workspace"
             :client-profile="clientProfile"
             :is-favorite="workspaceAttributes.isFavorite(workspace.id)"
+            :is-hidden="workspaceAttributes.isHidden(workspace.id)"
             @click="onWorkspaceClick"
             @favorite-click="onWorkspaceFavoriteClick"
             @menu-click="onOpenWorkspaceContextMenu"
@@ -409,6 +411,7 @@ async function refreshWorkspacesList(): Promise<void> {
   querying.value = true;
   window.electronAPI.log('debug', 'Starting Parsec list workspaces');
   const result = await parsecListWorkspaces();
+  const hidden = workspaceAttributes.getHidden();
   if (result.ok) {
     for (const wk of result.value) {
       window.electronAPI.log('debug', `Processing workspace: ${wk.currentName}`);
@@ -418,7 +421,7 @@ async function refreshWorkspacesList(): Promise<void> {
       } else {
         window.electronAPI.log('warn', `Failed to get sharing for ${wk.currentName}`);
       }
-      if (isDesktop() && wk.mountpoints.length === 0) {
+      if (isDesktop() && wk.mountpoints.length === 0 && !hidden.value.includes(wk.id)) {
         const mountResult = await parsecMountWorkspace(wk.handle);
         if (mountResult.ok) {
           wk.mountpoints.push(mountResult.value);

--- a/client/src/views/workspaces/types.ts
+++ b/client/src/views/workspaces/types.ts
@@ -10,6 +10,7 @@ enum WorkspaceAction {
   ShowHistory = 'workspace-show-history',
   OpenInExplorer = 'workspace-open-in-explorer',
   Mount = 'workspace-mount',
+  UnMount = 'workspace-unmount',
   Favorite = 'workspace-favorite',
 }
 

--- a/client/tests/component/specs/testWorkspaceCard.spec.ts
+++ b/client/tests/component/specs/testWorkspaceCard.spec.ts
@@ -72,6 +72,7 @@ describe('Workspace Card', () => {
         workspace: WORKSPACE,
         clientProfile: UserProfile.Admin,
         isFavorite: false,
+        isHidden: false,
       },
       global: {
         provide: getDefaultProvideConfig(),

--- a/client/tests/component/specs/testWorkspaceListItem.spec.ts
+++ b/client/tests/component/specs/testWorkspaceListItem.spec.ts
@@ -72,6 +72,7 @@ describe('Workspace List Item', () => {
         workspace: WORKSPACE,
         clientProfile: UserProfile.Admin,
         isFavorite: false,
+        isHidden: false,
       },
       global: {
         provide: getDefaultProvideConfig(),

--- a/client/tests/e2e/specs/workspaces_actions.spec.ts
+++ b/client/tests/e2e/specs/workspaces_actions.spec.ts
@@ -161,7 +161,7 @@ for (const mode of ['grid', 'list', 'sidebar']) {
     await expect(favorites).toBeVisible();
     await openContextMenu(workspaces, mode as Mode, OpenMenuMethod.Button);
     const popover = workspaces.locator('.workspace-context-menu');
-    await popover.getByRole('listitem').nth(7).click();
+    await popover.getByRole('listitem').nth(8).click();
     await expect(popover).toBeHidden();
 
     let wk;
@@ -182,7 +182,7 @@ for (const mode of ['grid', 'list', 'sidebar']) {
     await expect(workspaces.locator('.workspace-sharing-modal')).toBeHidden();
     await openContextMenu(workspaces, mode as Mode, OpenMenuMethod.Button);
     const popover = workspaces.locator('.workspace-context-menu');
-    await popover.getByRole('listitem').nth(5).click();
+    await popover.getByRole('listitem').nth(6).click();
     await expect(workspaces.locator('.workspace-sharing-modal')).toBeVisible();
     await expect(workspaces.locator('.workspace-sharing-modal').locator('.ms-modal-header__title')).toHaveText('wksp1');
   });

--- a/client/tests/e2e/specs/workspaces_list.spec.ts
+++ b/client/tests/e2e/specs/workspaces_list.spec.ts
@@ -175,6 +175,78 @@ for (const displaySize of [DisplaySize.Small, DisplaySize.Large]) {
       ]);
     }
   });
+
+  msTest(`Show/hide workspace ${displaySize} display`, async ({ workspaces }) => {
+    if (displaySize === DisplaySize.Small) {
+      await workspaces.setDisplaySize(DisplaySize.Small);
+    }
+    const workspaceCard = workspaces.locator('.workspace-card-item').nth(0);
+    await workspaceCard.click({ button: 'right' });
+    let popover;
+    if (displaySize === DisplaySize.Large) {
+      popover = workspaces.locator('#workspace-context-menu');
+      await expect(popover).toBeVisible();
+      await expect(popover.getByRole('group')).toHaveCount(3);
+      await expect(popover.getByRole('listitem')).toHaveText([
+        'Manage workspace',
+        'Rename',
+        'History',
+        'Hide this workspace',
+        'Collaboration',
+        'Copy link',
+        'Sharing and roles',
+        'Miscellaneous',
+        'Pin',
+      ]);
+      await popover.getByRole('listitem').nth(3).click();
+    } else {
+      popover = workspaces.locator('.workspace-context-sheet-modal');
+      await expect(popover).toBeVisible();
+      await expect(popover.getByRole('listitem')).toHaveText([
+        'Rename',
+        'History',
+        'Hide this workspace',
+        'Copy link',
+        'Sharing and roles',
+        'Pin',
+      ]);
+      await popover.getByRole('listitem').nth(2).click();
+    }
+    await expect(workspaces).toShowToast('The workspace is now hidden in Parsec.', 'Success');
+    await expect(workspaceCard.locator('.workspace-hidden')).toHaveText('Hidden');
+    await workspaceCard.click({ button: 'right' });
+    await expect(popover).toBeVisible();
+    if (displaySize === DisplaySize.Large) {
+      popover = workspaces.locator('#workspace-context-menu');
+      await expect(popover).toBeVisible();
+      await expect(popover.getByRole('group')).toHaveCount(3);
+      await expect(popover.getByRole('listitem')).toHaveText([
+        'Manage workspace',
+        'Rename',
+        'History',
+        'Show this workspace',
+        'Collaboration',
+        'Copy link',
+        'Sharing and roles',
+        'Miscellaneous',
+        'Pin',
+      ]);
+      await popover.getByRole('listitem').nth(3).click();
+    } else {
+      popover = workspaces.locator('.workspace-context-sheet-modal');
+      await expect(popover).toBeVisible();
+      await expect(popover.getByRole('listitem')).toHaveText([
+        'Rename',
+        'History',
+        'Show this workspace',
+        'Copy link',
+        'Sharing and roles',
+        'Pin',
+      ]);
+      await popover.getByRole('listitem').nth(2).click();
+    }
+    await expect(workspaces).toShowToast('The workspace is now visible in Parsec.', 'Success');
+  });
 }
 
 for (const gridMode of [false, true]) {


### PR DESCRIPTION
## Describe what's changed
The user can open workspace context menu to hide/unhide "Mount" and "Unmount" based on workspace hidden state.
For now, the only provide the tests for web case.

### on Desktop
https://github.com/user-attachments/assets/d02c2aee-fb09-4f0c-bbce-767000792970

### on Web
https://github.com/user-attachments/assets/a99e61db-8b11-4446-b2e2-353cd2e55e72


closes #11865 

