### PR TITLE
feat(pki): Add new errors to `pki_submit` protocol

### DIFF
--- a/libparsec/crates/client/src/client/pki_enrollment_submit.rs
+++ b/libparsec/crates/client/src/client/pki_enrollment_submit.rs
@@ -82,6 +82,9 @@ pub async fn pki_enrollment_submit(
         Rep::EmailAlreadyUsed => Err(PkiEnrollmentSubmitError::EmailAlreadyUsed),
         Rep::IdAlreadyUsed => Err(PkiEnrollmentSubmitError::IdAlreadyUsed),
         Rep::InvalidPayload => Err(PkiEnrollmentSubmitError::InvalidPayload),
+        Rep::InvalidPayloadSignature
+        | Rep::InvalidDerX509Certificate
+        | Rep::InvalidX509Trustchain => todo!(),
         bad_rep @ Rep::UnknownStatus { .. } => {
             Err(anyhow::anyhow!("Unexpected server response: {:?}", bad_rep).into())
         }

--- a/libparsec/crates/protocol/schema/anonymous_cmds/pki_enrollment_submit.json5
+++ b/libparsec/crates/protocol/schema/anonymous_cmds/pki_enrollment_submit.json5
@@ -78,6 +78,17 @@
             {
                 // The server tries to deserialize the payload to check if it use the correct format.
                 "status": "invalid_payload"
+            },
+            {
+                // A provided x509 certificate is invalid
+                "status": "invalid_der_x509_certificate"
+            },
+            {
+                "status": "invalid_payload_signature"
+            },
+            {
+                // Cannot trust provided trustchain
+                "status": "invalid_x509_trustchain"
             }
         ]
     }

--- a/libparsec/crates/protocol/tests/anonymous_cmds/v5/pki_enrollment_submit.rs
+++ b/libparsec/crates/protocol/tests/anonymous_cmds/v5/pki_enrollment_submit.rs
@@ -162,3 +162,54 @@ pub fn rep_invalid_payload() {
     let data2 = anonymous_cmds::pki_enrollment_submit::Rep::load(&raw2).unwrap();
     p_assert_eq!(data2, expected);
 }
+
+pub fn rep_invalid_payload_signature() {
+    // Generated from Parsec 3.5.3-a.0+dev
+    // Content:
+    //   status: 'invalid_payload_signature'
+    let raw: &[u8] =
+        hex!("81a6737461747573b9696e76616c69645f7061796c6f61645f7369676e6174757265").as_ref();
+    let expected = anonymous_cmds::pki_enrollment_submit::Rep::InvalidPayloadSignature {};
+    println!("***expected: {:?}", expected.dump().unwrap());
+
+    let data = anonymous_cmds::pki_enrollment_submit::Rep::load(raw).unwrap();
+    p_assert_eq!(data, expected);
+    let raw2 = data.dump().unwrap();
+    let data2 = anonymous_cmds::pki_enrollment_submit::Rep::load(&raw2).unwrap();
+    p_assert_eq!(data2, expected);
+}
+
+pub fn rep_invalid_x509_trustchain() {
+    // Generated from Parsec 3.5.3-a.0+dev
+    // Content:
+    //   status: 'invalid_x509_trustchain'
+    let raw: &[u8] =
+        hex!("81a6737461747573b7696e76616c69645f783530395f7472757374636861696e").as_ref();
+    let expected = anonymous_cmds::pki_enrollment_submit::Rep::InvalidX509Trustchain {};
+    println!("***expected: {:?}", expected.dump().unwrap());
+
+    let data = anonymous_cmds::pki_enrollment_submit::Rep::load(raw).unwrap();
+    p_assert_eq!(data, expected);
+    let raw2 = data.dump().unwrap();
+    let data2 = anonymous_cmds::pki_enrollment_submit::Rep::load(&raw2).unwrap();
+    p_assert_eq!(data2, expected);
+}
+
+pub fn rep_invalid_der_x509_certificate() {
+    // Generated from Parsec 3.5.3-a.0+dev
+    // Content:
+    //   status: 'invalid_der_x509_certificate'
+    let raw: &[u8] = hex!(
+        "81a6737461747573bc696e76616c69645f6465725f783530395f636572746966696361"
+        "7465"
+    )
+    .as_ref();
+    let expected = anonymous_cmds::pki_enrollment_submit::Rep::InvalidDerX509Certificate {};
+    println!("***expected: {:?}", expected.dump().unwrap());
+
+    let data = anonymous_cmds::pki_enrollment_submit::Rep::load(raw).unwrap();
+    p_assert_eq!(data, expected);
+    let raw2 = data.dump().unwrap();
+    let data2 = anonymous_cmds::pki_enrollment_submit::Rep::load(&raw2).unwrap();
+    p_assert_eq!(data2, expected);
+}

--- a/server/parsec/_parsec_pyi/protocol/anonymous_cmds/v5/pki_enrollment_submit.pyi
+++ b/server/parsec/_parsec_pyi/protocol/anonymous_cmds/v5/pki_enrollment_submit.pyi
@@ -74,3 +74,18 @@ class RepInvalidPayload(Rep):
     def __init__(
         self,
     ) -> None: ...
+
+class RepInvalidDerX509Certificate(Rep):
+    def __init__(
+        self,
+    ) -> None: ...
+
+class RepInvalidPayloadSignature(Rep):
+    def __init__(
+        self,
+    ) -> None: ...
+
+class RepInvalidX509Trustchain(Rep):
+    def __init__(
+        self,
+    ) -> None: ...

--- a/server/tests/api_v5/anonymous/test_pki_enrollment_submit.py
+++ b/server/tests/api_v5/anonymous/test_pki_enrollment_submit.py
@@ -419,3 +419,18 @@ async def test_anonymous_pki_enrollment_submit_http_common_errors(
         )
 
     await anonymous_http_common_errors_tester(do)
+
+
+@pytest.mark.xfail(reason="TODO: https://github.com/Scille/parsec-cloud/issues/11648")
+async def test_anonymous_pki_enrollment_submit_invalid_der_x509_certificate() -> None:
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="TODO: https://github.com/Scille/parsec-cloud/issues/11648")
+async def test_anonymous_pki_enrollment_submit_invalid_payload_signature() -> None:
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="TODO: https://github.com/Scille/parsec-cloud/issues/11648")
+async def test_anonymous_pki_enrollment_submit_invalid_x509_trustchain() -> None:
+    raise NotImplementedError


### PR DESCRIPTION
Currently not used since the server does not check for x509 signature & trust

Closes #11675

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
