### PR TITLE
feat(editor): Enhance error management

### DIFF
--- a/client/src/components/files/FileOpenFallbackChoice.vue
+++ b/client/src/components/files/FileOpenFallbackChoice.vue
@@ -3,7 +3,7 @@
 <template>
   <ms-modal
     :title="title ?? 'openFallback.title'"
-    :subtitle="subtitle ?? 'openFallback.subtitleDownload'"
+    :subtitle="subtitle ?? 'openFallback.subtitle.download'"
     :close-button="{ visible: true }"
   >
     <div class="open-fallback-buttons">

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -2503,10 +2503,13 @@
                 "impossibleToOpen": "Cannot edit this file",
                 "genericError": "Failed to open the file",
                 "unsupportedFileType": "File not supported by Parsec",
-                "editionNotAvailable": "Parsec Edition unavailable"
+                "editionNotAvailable": "Document editing is unavailable",
+                "tooLongToOpen": "The file is taking too long to open"
             },
             "informationEditDownload": "If you want to edit this file, you can download it and open it locally on your device.",
             "informationPreviewDownload": "If you want to preview this file, you can download it and open it locally on your device.",
+            "tooLongToOpenOnWeb": "You can try downloading it and opening with default app (right click on file > 'Download').",
+            "tooLongToOpenOnDesktop": "You can try opening it with default app (right click on file > 'Open with default app').",
             "unknownFileExtension": "This file type extension could not be identified. Please check that it's correctly written (.txt, .pdf, .doc, etc.).",
             "noContentFileType": "Could not open this file in the Parsec editor as its type could not be identified.",
             "noFolderPreview": "Cannot preview folders.",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -2504,10 +2504,13 @@
                 "impossibleToOpen": "Impossible d'éditer ce fichier",
                 "genericError": "Impossible d'ouvrir ce fichier",
                 "unsupportedFileType": "Type de fichier non pris en charge par Parsec",
-                "editionNotAvailable": "Parsec Edition indisponible"
+                "editionNotAvailable": "L'édition de documents n'est pas disponible",
+                "tooLongToOpen": "Le fichier met trop de temps à s'ouvrir"
             },
             "informationEditDownload": "Si vous souhaitez modifier ce fichier, vous pouvez le télécharger et l'ouvrir localement sur votre appareil.",
             "informationPreviewDownload": "Si vous souhaitez prévisualiser ce fichier, vous pouvez le faire dans Parsec ou le télécharger pour l'ouvrir localement sur votre appareil.",
+            "tooLongToOpenOnWeb": "Vous pouvez essayer de le télécharger et de l'ouvrir avec l'application par défaut (clic droit sur le fichier > 'Télécharger').",
+            "tooLongToOpenOnDesktop": "Vous pouvez essayer de l'ouvrir avec l'application par défaut (clic droit sur le fichier > 'Ouvrir avec l'app par défaut').",
             "unknownFileExtension": "L'extension de ce fichier n'a pas pu être reconnue. Veuillez vérifier qu'elle est correctement écrite (.txt, .pdf, .doc, etc.).",
             "noContentFileType": "Impossible d'ouvrir ce fichier, son type n'ayant pas pu être reconnu dans l'éditeur de Parsec.",
             "noFolderPreview": "Impossible d'afficher l'aperçu d'un dossier.",
@@ -2600,11 +2603,13 @@
     },
     "openFallback": {
         "title": "Parsec Edition n'est pas disponible",
-        "subtitleDownload": "Si vous souhaitez modifier ce fichier, vous pouvez le télécharger et l'ouvrir localement sur votre appareil.",
-        "subtitlePreviewDownload": "Si vous souhaitez prévisualiser ce fichier, vous pouvez le faire dans Parsec ou le télécharger pour l'ouvrir localement sur votre appareil.",
+        "subtitle": {
+            "download": "Si vous souhaitez modifier ce fichier, vous pouvez le télécharger et l'ouvrir localement sur votre appareil.",
+            "previewDownload": "Si vous souhaitez prévisualiser ce fichier, vous pouvez le faire dans Parsec ou le télécharger pour l'ouvrir localement sur votre appareil."
+        },
         "actions": {
-            "viewer": "Ouvrir dans le visualiseur",
-            "download": "Télécharger le fichier",
+            "viewer": "Prévisualiser (dans Parsec)",
+            "download": "Télécharger",
             "open": "Afficher dans l'explorateur",
             "cancel": "Annuler"
         }

--- a/client/tests/unit/specs/testCryptpad.spec.ts
+++ b/client/tests/unit/specs/testCryptpad.spec.ts
@@ -189,12 +189,28 @@ describe('CryptPad Service', () => {
         autosave: 5000,
         events: {
           onSave: vi.fn(),
+          onReady: vi.fn(),
         },
       };
 
+      // Mock CryptPadAPI to call onReady immediately
+      mockCryptPadAPI.mockImplementation((_containerId: string, cfg: any) => {
+        if (cfg.events.onReady) {
+          cfg.events.onReady();
+        }
+      });
+
       await cryptpad.open(config);
 
-      expect(mockCryptPadAPI).toHaveBeenCalledWith(containerElement.id, config);
+      expect(mockCryptPadAPI).toHaveBeenCalledWith(
+        containerElement.id,
+        expect.objectContaining({
+          document: config.document,
+          documentType: config.documentType,
+          editorConfig: config.editorConfig,
+          autosave: config.autosave,
+        }),
+      );
     });
 
     it('should throw error for unsupported document types', async () => {


### PR DESCRIPTION
- add structured error titles and messages
- adapt modal level to info / warning depending on use case
- show info modal for unsupported document types
- show warning modal for timeout loading error cases
- redirect the user to previous location in modals
- show error page instead of toast / modal for init, load, opening error cases
- delete script node when script loading fails
- add onError callback on cryptpad api

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
