### PR TITLE
feat(editor): Detect network disconnection while editing

### DIFF
--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -2572,6 +2572,10 @@
     "fileEditors": {
         "globalTitle": "Cannot open file",
         "errors": {
+            "titles": {
+                "networkOffline": "Network connection lost"
+            },
+            "networkOfflineMessage": "Your network connection has been lost. Please check your internet connection and try again. Any unsaved changes may be lost.",
             "contentInfoMissing": "The file content information is empty or missing.",
             "fileExtensionMissing": "The file type (extension) is missing or empty.",
             "fileNameMissing": "The file name is empty or missing.",
@@ -2612,7 +2616,7 @@
             "previewDownload": "If you want to preview this file, you can do so in Parsec or download it to open it locally on your device."
         },
         "actions": {
-            "viewer": "Preview (in Parsec)",
+            "viewer": "Preview",
             "download": "Download",
             "open": "Show in explorer",
             "cancel": "Cancel"

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -2573,6 +2573,10 @@
     "fileEditors": {
         "globalTitle": "Impossible d'ouvrir le fichier",
         "errors": {
+            "titles": {
+                "networkOffline": "Connexion réseau perdue"
+            },
+            "networkOfflineMessage": "Votre connexion réseau a été perdue. Veuillez vérifier votre connexion internet et réessayer. Les modifications non enregistrées peuvent être perdues.",
             "contentInfoMissing": "Les informations sur le contenu du fichier sont vides ou manquantes.",
             "fileExtensionMissing": "Le type de fichier (extension) est manquant ou vide.",
             "fileNameMissing": "Le nom du fichier est vide ou manquant.",
@@ -2613,7 +2617,7 @@
             "previewDownload": "Si vous souhaitez prévisualiser ce fichier, vous pouvez le faire dans Parsec ou le télécharger pour l'ouvrir localement sur votre appareil."
         },
         "actions": {
-            "viewer": "Prévisualiser (dans Parsec)",
+            "viewer": "Prévisualiser",
             "download": "Télécharger",
             "open": "Afficher dans l'explorateur",
             "cancel": "Annuler"

--- a/client/src/views/files/handler/editor/FileEditor.vue
+++ b/client/src/views/files/handler/editor/FileEditor.vue
@@ -140,8 +140,18 @@ onMounted(async () => {
 
   eventCbId = await eventDistributor.registerCallback(Events.Online | Events.Offline, async (event: Events) => {
     if (event === Events.Offline) {
+      window.electronAPI.log('warn', 'Network connection lost while editing');
       emits('onSaveStateChange', SaveState.Offline);
+      await informationManager.present(
+        new Information({
+          title: 'fileEditors.errors.titles.networkOffline',
+          message: 'fileEditors.errors.networkOfflineMessage',
+          level: InformationLevel.Warning,
+        }),
+        PresentationMode.Modal,
+      );
     } else if (event === Events.Online) {
+      window.electronAPI.log('info', 'Network connection restored');
       emits('onSaveStateChange', SaveState.None);
     }
   });


### PR DESCRIPTION
- Show warning modal when connection is lost during CryptPad editing
- Update save state indicator to show offline status
- Add translations for network offline error (EN/FR)

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
