### PR TITLE
[MS] Mark a few tests as essential

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
         "lint:fix": "npm run lint:eslint -- --fix && npm run lint:tsc",
         "test:unit": "vitest run --dom",
         "test:e2e": "npx playwright test --headed --timeout=30000",
+        "test:e2e:important": "npx playwright test --timeout=30000 --grep '@important'",
         "test:e2e:headless": "npx playwright test --timeout=30000",
         "web:open": "vite --open",
         "web:release": "vite build",

--- a/client/tests/e2e/specs/client_area_login.spec.ts
+++ b/client/tests/e2e/specs/client_area_login.spec.ts
@@ -2,7 +2,7 @@
 
 import { DEFAULT_USER_INFORMATION, MockBms, answerQuestion, expect, fillIonInput, msTest, setupNewPage } from '@tests/e2e/helpers';
 
-msTest('Log into the customer area', async ({ home }) => {
+msTest('Log into the customer area', { tag: '@important' }, async ({ home }) => {
   await MockBms.mockLogin(home);
   await MockBms.mockUserRoute(home);
   await MockBms.mockListOrganizations(home);

--- a/client/tests/e2e/specs/create_organization_custom.spec.ts
+++ b/client/tests/e2e/specs/create_organization_custom.spec.ts
@@ -40,7 +40,7 @@ async function cancelAndResume(page: Page, currentContainer: Locator): Promise<v
   await expect(page.locator('.create-organization-modal')).toBeVisible();
 }
 
-msTest('Go through custom org creation process', async ({ home }) => {
+msTest('Go through custom org creation process', { tag: '@important' }, async ({ home }) => {
   const modal = await openCreateOrganizationModal(home);
 
   const uniqueOrgName = `${home.orgInfo.name}-${randomInt(2 ** 47)}`;

--- a/client/tests/e2e/specs/create_organization_saas.spec.ts
+++ b/client/tests/e2e/specs/create_organization_saas.spec.ts
@@ -42,7 +42,7 @@ async function cancelAndResume(page: Page, currentContainer: Locator): Promise<v
   await expect(page.locator('.create-organization-modal')).toBeVisible();
 }
 
-msTest('Go through saas org creation process', async ({ home }) => {
+msTest('Go through saas org creation process', { tag: '@important' }, async ({ home }) => {
   const modal = await openCreateOrganizationModal(home);
 
   const uniqueOrgName = `${home.orgInfo.name}-${randomInt(2 ** 47)}`;

--- a/client/tests/e2e/specs/documents_list.spec.ts
+++ b/client/tests/e2e/specs/documents_list.spec.ts
@@ -25,7 +25,7 @@ const TIME_MATCHER_ARRAY = new Array(9).fill(TIME_MATCHER);
 const SIZE_MATCHER_ARRAY = new Array(1).fill('').concat(new Array(8).fill(SIZE_MATCHER));
 
 for (const displaySize of ['small', 'large']) {
-  msTest(`Documents page default state on ${displaySize} display`, async ({ documents }) => {
+  msTest(`Documents page default state on ${displaySize} display`, { tag: '@important' }, async ({ documents }) => {
     const entries = documents.locator('.folder-container').locator('.file-list-item');
     if (displaySize === DisplaySize.Small) {
       await documents.setDisplaySize(DisplaySize.Small);

--- a/client/tests/e2e/specs/file_import.spec.ts
+++ b/client/tests/e2e/specs/file_import.spec.ts
@@ -31,7 +31,7 @@ async function checkFilesUploaded(page: Page, expectedCount: number): Promise<vo
 }
 
 for (const mode of ['list', 'grid']) {
-  msTest(`Import by drag and drop in ${mode} mode`, async ({ workspaces }, testInfo: TestInfo) => {
+  msTest(`Import by drag and drop in ${mode} mode`, { tag: '@important' }, async ({ workspaces }, testInfo: TestInfo) => {
     // Start with an empty workspace
     await createWorkspace(workspaces, 'New_Workspace');
     await workspaces.locator('.workspaces-container-grid').locator('.workspace-card-item').nth(0).click();

--- a/client/tests/e2e/specs/file_viewers_image.spec.ts
+++ b/client/tests/e2e/specs/file_viewers_image.spec.ts
@@ -2,7 +2,7 @@
 
 import { expect, msTest, openFileType, testFileViewerZoomLevel } from '@tests/e2e/helpers';
 
-msTest('Image viewer', async ({ documents }) => {
+msTest('Image viewer', { tag: '@important' }, async ({ documents }) => {
   await openFileType(documents, 'png');
   await expect(documents).toBeViewerPage();
   await expect(documents.locator('.file-handler').locator('.file-handler-topbar').locator('ion-text')).toHaveText(/^[A-Za-z0-9_-]+\.png$/);

--- a/client/tests/e2e/specs/home_page.spec.ts
+++ b/client/tests/e2e/specs/home_page.spec.ts
@@ -15,7 +15,7 @@ import {
 const USER_NAMES = ['Alicey McAliceFace', 'Boby McBobFace', 'Malloryy McMalloryFace'];
 
 for (const displaySize of [DisplaySize.Small, DisplaySize.Large]) {
-  msTest(`Home default state with devices on ${displaySize} display`, async ({ home }) => {
+  msTest(`Home default state with devices on ${displaySize} display`, { tag: '@important' }, async ({ home }) => {
     if (displaySize === 'small') {
       await home.setDisplaySize(DisplaySize.Small);
     }
@@ -258,7 +258,7 @@ msTest('Warn on Safari', async ({ context }) => {
   await page.release();
 });
 
-msTest('Empty home page default state', async ({ context }) => {
+msTest('Empty home page default state', { tag: '@important' }, async ({ context }) => {
   const page = (await context.newPage()) as MsPage;
   await setupNewPage(page, { libparsecMockFunctions: [{ name: 'listAvailableDevices', result: { ok: true, value: [] } }] });
   const container = page.locator('.no-devices');

--- a/client/tests/e2e/specs/user_greet.spec.ts
+++ b/client/tests/e2e/specs/user_greet.spec.ts
@@ -124,7 +124,7 @@ msTest('Greet user whole process in small display', async ({ usersPage }) => {
   await expect(secondTab).toBeWorkspacePage();
 });
 
-msTest('Greet user whole process in large display', async ({ usersPage }) => {
+msTest('Greet user whole process in large display', { tag: '@important' }, async ({ usersPage }) => {
   // Very slow test since it syncs the greet and join
   msTest.setTimeout(120_000);
 

--- a/client/tests/e2e/specs/users_list.spec.ts
+++ b/client/tests/e2e/specs/users_list.spec.ts
@@ -50,7 +50,7 @@ function getStatusForUser(user: any): string {
 }
 
 for (const displaySize of ['small', 'large']) {
-  msTest(`Check user list items on ${displaySize} display`, async ({ usersPage }) => {
+  msTest(`Check user list items on ${displaySize} display`, { tag: '@important' }, async ({ usersPage }) => {
     if (displaySize === 'small') {
       await usersPage.setDisplaySize(DisplaySize.Small);
     }

--- a/client/tests/e2e/specs/workspace_sharing.spec.ts
+++ b/client/tests/e2e/specs/workspace_sharing.spec.ts
@@ -3,7 +3,7 @@
 import { DisplaySize, expect, fillIonInput, login, MsPage, msTest } from '@tests/e2e/helpers';
 
 for (const displaySize of ['small', 'large']) {
-  msTest(`Workspace sharing modal default state on ${displaySize} display`, async ({ workspaceSharingModal }) => {
+  msTest(`Workspace sharing modal default state on ${displaySize} display`, { tag: '@important' }, async ({ workspaceSharingModal }) => {
     if (displaySize === 'small') {
       await (workspaceSharingModal.page() as MsPage).setDisplaySize(DisplaySize.Small);
     }

--- a/client/tests/e2e/specs/workspaces_list.spec.ts
+++ b/client/tests/e2e/specs/workspaces_list.spec.ts
@@ -27,7 +27,7 @@ msTest('Check workspace card', async ({ workspaces }) => {
 });
 
 for (const gridMode of [false, true]) {
-  msTest.fail(`Empty workspaces in ${gridMode ? 'grid' : 'list'} mode`, async ({ connected }) => {
+  msTest.fail(`Empty workspaces in ${gridMode ? 'grid' : 'list'} mode`, { tag: '@important' }, async ({ connected }) => {
     if (!gridMode) {
       await toggleViewMode(connected);
     }


### PR DESCRIPTION
Adds `npm run test:e2e:important` that only runs the tests marked with '@important'.