### PR TITLE
[MS] Show update modal automatically

### DIFF
--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -210,6 +210,7 @@
             "changelog": "What's new?",
             "currentVersion": "Current version: ",
             "updateAvailable": "Update available",
+            "recommended": "Recommended for compatibility",
             "newVersionAvailable": "New update available",
             "downloadParsec": "Download desktop app"
         },

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -209,6 +209,7 @@
             "changelog": "Voir les nouveautés",
             "currentVersion": "Votre version actuelle : ",
             "updateAvailable": "Mise à jour disponible",
+            "recommended": "Recommandé pour la compatibilité",
             "newVersionAvailable": "Nouvelle version disponible",
             "downloadParsec": "Télécharger l'application de bureau"
         },

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -480,8 +480,8 @@ function setupWebElectronAPI(injectionProvider: InjectionProvider): void {
     sendMountpointFolder: (_path: string): void => {
       console.log('SetMountpointFolder: Not available.');
     },
-    getUpdateAvailability: (): void => {
-      if (window.usesTestbed()) {
+    getUpdateAvailability: (force?: boolean): void => {
+      if ((window as any).TESTING_ENABLE_UPDATE_EVENT === true || force) {
         injectionProvider.distributeEventToAll(Events.UpdateAvailability, { updateAvailable: true, version: '13.37' });
         injectionProvider.notifyAll(
           new Information({
@@ -584,7 +584,7 @@ declare global {
       receive: (channel: string, f: (...args: any[]) => Promise<void>) => void;
       openFile: (path: string) => void;
       sendMountpointFolder: (path: string) => void;
-      getUpdateAvailability: () => void;
+      getUpdateAvailability: (force?: boolean) => void;
       updateApp: () => void;
       prepareUpdate: () => void;
       log: (level: LogLevel, message: string) => void;

--- a/client/src/services/updateManager.ts
+++ b/client/src/services/updateManager.ts
@@ -1,0 +1,20 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { ref, Ref } from 'vue';
+
+const updatePromptSuppressed: Ref<boolean> = ref(false);
+
+export function useUpdateManager() {
+  function isUpdatePromptAllowed(): boolean {
+    return !updatePromptSuppressed.value;
+  }
+
+  function suppressUpdatePrompt(): void {
+    updatePromptSuppressed.value = true;
+  }
+
+  return {
+    isUpdatePromptAllowed,
+    suppressUpdatePrompt,
+  };
+}

--- a/client/src/theme/components/_modals.scss
+++ b/client/src/theme/components/_modals.scss
@@ -784,11 +784,18 @@
 
 .update-app-modal {
   &::part(content) {
-    max-width: var(--parsec-modal-width-sm);
+    max-width: 25rem;
   }
 
   .ms-modal {
-    padding-top: 1.5rem;
+    padding: 1.5rem;
+  }
+
+  .ms-modal-content {
+    @include ms.responsive-breakpoint('sm') {
+      margin-top: 0;
+      padding: 0;
+    }
   }
 }
 

--- a/client/src/views/about/UpdateAppModal.vue
+++ b/client/src/views/about/UpdateAppModal.vue
@@ -15,22 +15,20 @@
       </ion-text>
       <div class="update-main">
         <div class="update-version">
-          <ion-text class="title-h3 update-version__item">
+          <ion-text
+            class="title-h3 update-version__item"
+            @click="openChangelog"
+            :title="$msTranslate('HomePage.topbar.changelog')"
+          >
             {{ targetVersion }}
           </ion-text>
-          <ion-button
-            class="update-version__button"
-            @click="openChangelog"
-            fill="clear"
-          >
-            {{ $msTranslate('HomePage.topbar.changelog') }}
-          </ion-button>
         </div>
-        <div class="update-message body">
-          <ion-text class="update-message__curent-version">
-            {{ $msTranslate('HomePage.topbar.currentVersion') }}<span class="subtitles-sm">{{ currentVersion ?? APP_VERSION }}</span>
+        <div class="update-message">
+          <span class="update-message__badge button-medium">{{ $msTranslate('HomePage.topbar.recommended') }}</span>
+          <ion-text class="update-message__curent-version body-lg">
+            {{ $msTranslate('HomePage.topbar.currentVersion') }}<span class="subtitles-normal">{{ currentVersion ?? APP_VERSION }}</span>
           </ion-text>
-          <ion-text>
+          <ion-text class="body-lg">
             {{ $msTranslate('HomePage.topbar.updateConfirmQuestion') }}
           </ion-text>
         </div>
@@ -38,13 +36,13 @@
       <div class="update-footer">
         <ion-button
           @click="dismiss(MsModalResult.Confirm)"
-          class="update-footer__button"
+          class="update-footer__button button-default button-large"
         >
           {{ $msTranslate('HomePage.topbar.updateYes') }}
         </ion-button>
         <ion-button
           @click="dismiss(MsModalResult.Cancel)"
-          class="update-footer__button"
+          class="update-footer__button button-default button-large"
         >
           {{ $msTranslate('HomePage.topbar.updateNo') }}
         </ion-button>
@@ -81,7 +79,7 @@ async function dismiss(role: MsModalResult): Promise<void> {
 .update-content {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.5rem;
 
   .update__title {
     text-align: center;
@@ -110,16 +108,14 @@ async function dismiss(role: MsModalResult): Promise<void> {
         border-radius: var(--parsec-radius-8);
         color: var(--parsec-color-light-secondary-text);
         padding: 0.5rem 1.25rem;
-      }
-
-      &__button {
-        --color: var(--parsec-color-light-secondary-text);
-        --background-hover: transparent;
-        --padding-end: 0.5rem;
-        --padding-start: 0.5rem;
+        transition: outline 100ms ease-in-out;
+        border: 1px solid var(--parsec-color-light-secondary-medium);
 
         &:hover {
-          text-decoration: underline;
+          cursor: pointer;
+          outline: 1px solid var(--parsec-color-light-primary-500);
+          outline-offset: 2px;
+          color: var(--parsec-color-light-primary-500);
         }
       }
     }
@@ -129,6 +125,15 @@ async function dismiss(role: MsModalResult): Promise<void> {
       display: flex;
       flex-direction: column;
 
+      &__badge {
+        background: var(--parsec-color-light-primary-50);
+        width: fit-content;
+        color: var(--parsec-color-light-primary-700);
+        padding: 0.25rem 0.75rem;
+        border-radius: var(--parsec-radius-8);
+        margin-bottom: 0.5rem;
+      }
+
       &__curent-version span {
         color: var(--parsec-color-light-secondary-text);
       }
@@ -137,13 +142,13 @@ async function dismiss(role: MsModalResult): Promise<void> {
 
   .update-footer {
     display: flex;
+    flex-direction: column;
     justify-content: center;
     gap: 0.5rem;
-    margin-top: 0.5rem;
 
     &__button {
       margin: auto;
-      width: fit-content;
+      width: 100%;
 
       &:nth-child(1) {
         --background: var(--parsec-color-light-gradient-background);
@@ -154,8 +159,6 @@ async function dismiss(role: MsModalResult): Promise<void> {
       }
 
       &:nth-child(2) {
-        position: absolute;
-        right: 2.5rem;
         --background: transparent;
         --background-hover: var(--parsec-color-light-secondary-premiere);
         --color: var(--parsec-color-light-secondary-text);

--- a/client/src/views/home/HomePageHeader.vue
+++ b/client/src/views/home/HomePageHeader.vue
@@ -135,6 +135,7 @@ import { APP_VERSION, Env } from '@/services/environment';
 import { EventData, Events, UpdateAvailabilityData } from '@/services/eventDistributor';
 import { HotkeyGroup, HotkeyManager, HotkeyManagerKey, Modifiers, Platforms } from '@/services/hotkeyManager';
 import { InjectionProvider, InjectionProviderKey } from '@/services/injectionProvider';
+import { useUpdateManager } from '@/services/updateManager';
 import { openAboutModal } from '@/views/about';
 import UpdateAppModal from '@/views/about/UpdateAppModal.vue';
 import { AccountSettingsTabs } from '@/views/account/types';
@@ -146,10 +147,11 @@ import { MsModalResult, Translatable, useWindowSize, WindowSizeBreakpoints } fro
 import { inject, onMounted, onUnmounted, ref, Ref } from 'vue';
 
 const { isSmallDisplay, isLargeDisplay, windowWidth } = useWindowSize();
+const { isUpdatePromptAllowed, suppressUpdatePrompt } = useUpdateManager();
 const injectionProvider: InjectionProvider = inject(InjectionProviderKey)!;
 const eventDistributor = injectionProvider.getDefault().eventDistributor;
-let eventCbId: string | null = null;
 const updateAvailability: Ref<UpdateAvailabilityData | null> = ref(null);
+let eventCbId: string | null = null;
 const hotkeyManager: HotkeyManager = inject(HotkeyManagerKey)!;
 
 let hotkeys: HotkeyGroup | null = null;
@@ -182,6 +184,9 @@ onMounted(async () => {
   eventCbId = await eventDistributor.registerCallback(Events.UpdateAvailability, async (event: Events, data?: EventData) => {
     if (event === Events.UpdateAvailability) {
       updateAvailability.value = data as UpdateAvailabilityData;
+      if (isUpdatePromptAllowed()) {
+        await update();
+      }
     }
   });
   accountLoggedIn.value = ParsecAccount.isLoggedIn();
@@ -202,10 +207,16 @@ onUnmounted(async () => {
   if (hotkeys) {
     hotkeyManager.unregister(hotkeys);
   }
+
   routeWatchCancel();
 });
 
 async function update(): Promise<void> {
+  const existingModal = await modalController.getTop();
+  if (existingModal) {
+    window.electronAPI.log('debug', 'An existing modal is opened, skipping update prompt');
+    return;
+  }
   if (!updateAvailability.value) {
     window.electronAPI.log('error', 'Missing update data when trying to update');
     return;
@@ -232,6 +243,7 @@ async function update(): Promise<void> {
   if (role === MsModalResult.Confirm) {
     window.electronAPI.prepareUpdate();
   }
+  suppressUpdatePrompt();
 }
 
 async function goToParsecAccountLogin(): Promise<void> {
@@ -243,7 +255,7 @@ async function goToParsecAccountLogin(): Promise<void> {
 
 async function openSettings(): Promise<void> {
   if (!Env.isAccountEnabled()) {
-    return openSettingsModal();
+    await openSettingsModal();
   } else {
     emits('settingsClick');
   }

--- a/client/tests/e2e/helpers/fixtures.ts
+++ b/client/tests/e2e/helpers/fixtures.ts
@@ -65,6 +65,10 @@ export async function setupNewPage(page: MsPage, opts: SetupOptions = {}): Promi
 
       (window as any).TESTING = true;
       (window as any).TESTING_DISABLE_STRIPE = !options.enableStripe;
+      if (options.enableUpdateEvent) {
+        (window as any).TESTING_ENABLE_UPDATE_EVENT = options.enableUpdateEvent;
+      }
+
       if (options.parsecAccountAutoLogin) {
         options.withParsecAccount = true;
         (window as any).TESTING_ACCOUNT_AUTO_LOGIN = true;
@@ -198,8 +202,6 @@ export async function setupNewPage(page: MsPage, opts: SetupOptions = {}): Promi
     return page.displaySize;
   };
   await page.setDisplaySize(opts.displaySize ?? DisplaySize.Large);
-
-  await expect(page.locator('#app')).toHaveAttribute('app-state', 'ready');
 }
 
 const debugTest = base.extend({

--- a/client/tests/e2e/helpers/types.ts
+++ b/client/tests/e2e/helpers/types.ts
@@ -27,6 +27,7 @@ export interface SetupOptions {
   expectTimeout?: number;
   libparsecMockFunctions?: Array<LibParsecFunction>;
   enableStripe?: boolean;
+  enableUpdateEvent?: boolean;
 }
 
 export interface MsPage extends Page {

--- a/client/tests/e2e/helpers/utils.ts
+++ b/client/tests/e2e/helpers/utils.ts
@@ -404,3 +404,9 @@ export async function resizePage(page: Page, width: number, height?: number): Pr
   await page.setViewportSize({ width, height: height ?? 900 });
   await page.waitForTimeout(100);
 }
+
+export async function sendUpdateEvent(page: MsPage): Promise<void> {
+  await page.evaluate(() => {
+    window.electronAPI.getUpdateAvailability(true);
+  });
+}

--- a/client/tests/e2e/specs/app_update.spec.ts
+++ b/client/tests/e2e/specs/app_update.spec.ts
@@ -1,33 +1,91 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 import { Page } from '@playwright/test';
-import { DisplaySize, expect, msTest } from '@tests/e2e/helpers';
+import { DisplaySize, expect, msTest, sendUpdateEvent } from '@tests/e2e/helpers';
 
 async function checkAppUpdateModal(page: Page): Promise<void> {
   const modal = page.locator('.update-app-modal');
   await expect(modal).toBeVisible();
   await expect(modal.locator('.update-version').locator('.update-version__item')).toHaveText('13.37');
-  await expect(modal.locator('.update-version').locator('.update-version__button')).toHaveText("What's new?");
   await expect(modal.locator('.update-footer').locator('ion-button').nth(0)).toHaveText('Update Parsec');
   await expect(modal.locator('.update-footer').locator('ion-button').nth(1)).toHaveText('Later');
 
   const newTabPromise = page.waitForEvent('popup');
-  await modal.locator('.update-version').locator('.update-version__button').click();
+  await modal.locator('.update-version').locator('.update-version__item').click();
   const newTab = await newTabPromise;
   await newTab.waitForLoadState();
   await expect(newTab).toHaveURL(new RegExp('^https://docs\\.parsec\\.cloud/.+'));
   await newTab.close();
 }
 
-msTest('Opens app update modal on home page', async ({ home }) => {
+msTest('Opens app update modal automatically on home page', async ({ home }) => {
+  await sendUpdateEvent(home);
   const updateContainer = home.locator('.update-container');
   await expect(updateContainer.locator('.update-text')).toHaveText('A new version is available');
-  await updateContainer.click();
+
   await checkAppUpdateModal(home);
+});
+
+msTest('Prevent to open app update modal automatically if a modal is already opened on home page', async ({ home }) => {
+  await expect(home.locator('.settings-modal')).toBeHidden();
+  await home.locator('.menu-secondary').locator('#trigger-settings-button').click();
+  await sendUpdateEvent(home);
+  await expect(home.locator('.settings-modal')).toBeVisible();
+
+  const modal = home.locator('.update-app-modal');
+  await expect(modal).toBeHidden();
+});
+
+msTest('Opens app update modal automatically after being connected', async ({ connected }) => {
+  await sendUpdateEvent(connected);
+  await checkAppUpdateModal(connected);
+});
+
+msTest('Prevent to open app update modal automatically if a modal is already opened on connected page', async ({ workspaces }) => {
+  await expect(workspaces.locator('.workspace-sharing-modal')).toBeHidden();
+  await workspaces.locator('.workspaces-container-grid').locator('.workspace-card-item').nth(0).hover();
+  await workspaces.locator('.workspaces-container-grid').locator('.workspace-card-item').nth(0).locator('.icon-share-container').click();
+  await expect(workspaces.locator('.workspace-sharing-modal')).toBeVisible();
+  await sendUpdateEvent(workspaces);
+
+  const modal = workspaces.locator('.update-app-modal');
+  await expect(modal).toBeHidden();
+});
+
+msTest("Dismiss update on home page and update modal shouldn't be appear again", async ({ home }) => {
+  await sendUpdateEvent(home);
+  const modal = home.locator('.update-app-modal');
+  await checkAppUpdateModal(home);
+  await expect(modal).toBeVisible();
+  await expect(modal.locator('.update-footer').locator('ion-button').nth(1)).toHaveText('Later');
+  await modal.locator('.update-footer').locator('ion-button').nth(1).click();
+  await expect(modal).toBeHidden();
+
+  await home.locator('.organization-card').first().click();
+  await expect(home.locator('#password-input')).toBeVisible();
+  await sendUpdateEvent(home);
+  await expect(modal).toBeHidden();
+});
+
+msTest("Dismiss update on connected page and update modal shouldn't be appear again", async ({ workspaces }) => {
+  await sendUpdateEvent(workspaces);
+  const modal = workspaces.locator('.update-app-modal');
+  await checkAppUpdateModal(workspaces);
+  await expect(modal).toBeVisible();
+  await expect(modal.locator('.update-footer').locator('ion-button').nth(1)).toHaveText('Later');
+  await modal.locator('.update-footer').locator('ion-button').nth(1).click();
+  await expect(modal).toBeHidden();
+
+  await sendUpdateEvent(workspaces);
+
+  await expect(modal).toBeHidden();
 });
 
 for (const displaySize of [DisplaySize.Small, DisplaySize.Large]) {
   msTest(`Opens app update modal with notification on ${displaySize}`, async ({ connected }) => {
+    await sendUpdateEvent(connected);
+    const modal = connected.locator('.update-app-modal');
+    await modal.locator('.update-footer').locator('ion-button').nth(1).click();
     const header = connected.locator('#connected-header');
     const notifButton = header.locator('#trigger-notifications-button');
     await expect(notifButton).toHaveTheClass('unread');
@@ -54,6 +112,10 @@ for (const displaySize of [DisplaySize.Small, DisplaySize.Large]) {
 }
 
 msTest('Opens app update modal with profile popover', async ({ connected }) => {
+  await sendUpdateEvent(connected);
+  const modal = connected.locator('.update-app-modal');
+  await modal.locator('.update-footer').locator('ion-button').nth(1).click();
+
   const header = connected.locator('#connected-header');
   await expect(header.locator('#profile-button').locator('.text-content-update')).toBeVisible();
   await expect(header.locator('#profile-button').locator('.text-content-update')).toHaveText('Update available');

--- a/newsfragments/11740.feature.rst
+++ b/newsfragments/11740.feature.rst
@@ -1,0 +1,1 @@
+Application update modal appears automatically when an update is available.


### PR DESCRIPTION
## Decription
The user will receive a notification (modal) asking them to update the application each time they reopen it.
If the user decides to do so later, the application will not ask them to update it again until the next time they open it.


https://github.com/user-attachments/assets/8d372d25-31b2-470a-b8a3-3388310c0d4a



<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->

closes #11740