### PR TITLE
[MS] Fixed various style bugs

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -32,7 +32,7 @@
                 "file-type": "^20.4.1",
                 "fs-extra": "^11.3.0",
                 "luxon": "^3.5.0",
-                "megashark-lib": "git+https://github.com/Scille/megashark-lib.git#568caa6f6b7dc1fbe36be14ad648f22375077fe0",
+                "megashark-lib": "git+https://github.com/Scille/megashark-lib.git#505d62c7f7f6b14c932feea8d2288ddbe4a27ef6",
                 "monaco-editor": "^0.52.2",
                 "native-file-system-adapter": "^3.0.1",
                 "pdfjs-dist": "^5.0.375",
@@ -9025,8 +9025,8 @@
         },
         "node_modules/megashark-lib": {
             "version": "0.0.1",
-            "resolved": "git+ssh://git@github.com/Scille/megashark-lib.git#568caa6f6b7dc1fbe36be14ad648f22375077fe0",
-            "integrity": "sha512-qenogfqmGelWlKQgeaFTT0Po8Dy46aa8JAPhhQyqb3J2V+HyxZrrX6TuB/vfZ9W5tvjPnW+9rcqMi1nx3tyDiQ==",
+            "resolved": "git+ssh://git@github.com/Scille/megashark-lib.git#505d62c7f7f6b14c932feea8d2288ddbe4a27ef6",
+            "integrity": "sha512-XH/PGKLcHCKbBedrCydRQOF6Bi7IoUyWA0uT0mvaQ47GK73N1YRPDbUw4iFCcwdC0Exwr8aNP4HkIHrBV0Okig==",
             "dependencies": {
                 "@ionic/vue": "^8.6.2",
                 "@stripe/stripe-js": "^8.3.0",

--- a/client/package.json
+++ b/client/package.json
@@ -59,7 +59,7 @@
         "file-type": "^20.4.1",
         "fs-extra": "^11.3.0",
         "luxon": "^3.5.0",
-        "megashark-lib": "git+https://github.com/Scille/megashark-lib.git#568caa6f6b7dc1fbe36be14ad648f22375077fe0",
+        "megashark-lib": "git+https://github.com/Scille/megashark-lib.git#505d62c7f7f6b14c932feea8d2288ddbe4a27ef6",
         "monaco-editor": "^0.52.2",
         "native-file-system-adapter": "^3.0.1",
         "pdfjs-dist": "^5.0.375",

--- a/client/src/components/files/explorer/HistoryFileListItem.vue
+++ b/client/src/components/files/explorer/HistoryFileListItem.vue
@@ -100,7 +100,11 @@ onMounted(async () => {
 <style lang="scss" scoped>
 .file-selected {
   flex-shrink: 0;
-  max-width: 2.5rem;
+  width: 2.5rem;
+
+  @include ms.responsive-breakpoint('sm') {
+    flex-basis: 2.5rem;
+  }
 }
 
 .file-name {
@@ -122,6 +126,10 @@ onMounted(async () => {
   .label-name {
     color: var(--parsec-color-light-secondary-text);
     margin-left: 1em;
+
+    @include ms.responsive-breakpoint('sm') {
+      margin-left: 0;
+    }
   }
 }
 </style>

--- a/client/src/components/files/operations/FileMoveItem.vue
+++ b/client/src/components/files/operations/FileMoveItem.vue
@@ -29,12 +29,12 @@
             })
           }}
         </ion-text>
-        <ion-label
+        <ion-text
           class="element-details__workspace body-sm"
           v-if="workspaceName"
         >
           {{ workspaceName }}
-        </ion-label>
+        </ion-text>
         <div
           class="element-details-progress-container"
           v-show="state === FileOperationState.OperationProgress"
@@ -115,7 +115,7 @@
 import { shortenFileName } from '@/common/file';
 import { EntryName, Path, getWorkspaceName } from '@/parsec';
 import { FileOperationState, MoveData, OperationProgressStateData, StateData } from '@/services/fileOperationManager';
-import { IonButton, IonIcon, IonItem, IonLabel, IonText } from '@ionic/vue';
+import { IonButton, IonIcon, IonItem, IonText } from '@ionic/vue';
 import { checkmarkCircle, closeCircle } from 'ionicons/icons';
 import { Move, MsImage, MsInformationTooltip, MsProgress, MsProgressAppearance } from 'megashark-lib';
 import { Ref, onMounted, ref } from 'vue';

--- a/client/src/theme/components/_modals.scss
+++ b/client/src/theme/components/_modals.scss
@@ -391,8 +391,8 @@
   &:has(.created-page.active) {
     .ion-page {
       min-height: 18.75rem;
-      max-height: fit-content;
-      --max-height: fit-content;
+      max-height: 20rem;
+      --max-height: 20rem;
 
       @include ms.responsive-breakpoint('sm') {
         max-height: 90vh;

--- a/client/src/views/files/FileContextMenu.vue
+++ b/client/src/views/files/FileContextMenu.vue
@@ -20,7 +20,7 @@
             class="list-group-item__icon"
             :icon="eye"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('FoldersPage.fileContextMenu.actionPreview') }}
           </ion-text>
         </ion-item>
@@ -34,7 +34,7 @@
             class="list-group-item__icon"
             :icon="create"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('FoldersPage.fileContextMenu.actionEdit') }}
           </ion-text>
         </ion-item>
@@ -48,7 +48,7 @@
             class="list-group-item__icon"
             :image="RenameIcon"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('FoldersPage.fileContextMenu.actionRename') }}
           </ion-text>
         </ion-item>
@@ -62,7 +62,7 @@
             class="list-group-item__icon"
             :icon="arrowRedo"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('FoldersPage.fileContextMenu.actionMoveTo') }}
           </ion-text>
         </ion-item>
@@ -77,7 +77,7 @@
             class="list-group-item__icon"
             :icon="duplicate"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('FoldersPage.fileContextMenu.actionMakeACopy') }}
           </ion-text>
         </ion-item>
@@ -92,7 +92,7 @@
             class="list-group-item__icon"
             :image="EyeOpenIcon"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('FoldersPage.fileContextMenu.actionOpen') }}
           </ion-text>
         </ion-item>
@@ -107,7 +107,7 @@
             class="list-group-item__icon"
             :icon="open"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('FoldersPage.fileContextMenu.actionSeeInExplorer') }}
           </ion-text>
         </ion-item>
@@ -122,7 +122,7 @@
             class="list-group-item__icon"
             :icon="time"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('FoldersPage.fileContextMenu.actionHistory') }}
           </ion-text>
         </ion-item>
@@ -137,7 +137,7 @@
             class="list-group-item__icon"
             :icon="download"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('FoldersPage.fileContextMenu.actionDownload') }}
           </ion-text>
         </ion-item>
@@ -152,7 +152,7 @@
             class="list-group-item__icon"
             :icon="informationCircle"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('FoldersPage.fileContextMenu.actionDetails') }}
           </ion-text>
         </ion-item>
@@ -167,7 +167,7 @@
             class="list-group-item__icon"
             :icon="trashBin"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('FoldersPage.fileContextMenu.actionDelete') }}
           </ion-text>
         </ion-item>
@@ -191,7 +191,7 @@
             class="list-group-item__icon"
             :icon="link"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('FoldersPage.fileContextMenu.actionCopyLink') }}
           </ion-text>
         </ion-item>

--- a/client/src/views/files/FolderGlobalContextMenu.vue
+++ b/client/src/views/files/FolderGlobalContextMenu.vue
@@ -14,7 +14,7 @@
             class="list-group-item__icon"
             :icon="folderOpen"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('FoldersPage.createFolder') }}
           </ion-text>
         </ion-item>
@@ -28,7 +28,7 @@
             class="list-group-item__icon"
             :icon="cloudUpload"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('FoldersPage.ImportFile.importFilesAction') }}
           </ion-text>
         </ion-item>
@@ -43,7 +43,7 @@
             class="list-group-item__icon"
             :icon="cloudUpload"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('FoldersPage.ImportFile.importFolderAction') }}
           </ion-text>
         </ion-item>
@@ -58,7 +58,7 @@
             class="list-group-item__icon"
             :icon="open"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('FoldersPage.fileContextMenu.actionSeeInExplorer') }}
           </ion-text>
         </ion-item>

--- a/client/src/views/header/ProfileHeaderHomePage.vue
+++ b/client/src/views/header/ProfileHeaderHomePage.vue
@@ -107,6 +107,7 @@ const emit = defineEmits<{
   border: 1px solid transparent;
   transition: all ease-in-out 200ms;
   flex-shrink: 0;
+  max-width: 15rem;
 
   & * {
     pointer-events: none;
@@ -172,6 +173,10 @@ const emit = defineEmits<{
 
     &__text {
       font-size: 0.9375rem;
+      width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
 
       @include ms.responsive-breakpoint('md') {
         display: none;
@@ -181,6 +186,7 @@ const emit = defineEmits<{
     ion-icon {
       transition: transform ease-out 300ms;
       font-size: 1rem;
+      flex-shrink: 0;
 
       &.popover-is-open {
         transform: rotate(180deg);

--- a/client/src/views/header/ProfileHeaderOrganization.vue
+++ b/client/src/views/header/ProfileHeaderOrganization.vue
@@ -188,6 +188,7 @@ async function openOrganizationPopover(event: Event): Promise<void> {
   border: 1px solid transparent;
   transition: all ease-in-out 200ms;
   flex-shrink: 0;
+  max-width: 15rem;
 
   & * {
     pointer-events: none;
@@ -244,6 +245,7 @@ async function openOrganizationPopover(event: Event): Promise<void> {
   display: flex;
   flex-direction: column;
   width: 100%;
+  overflow: hidden;
 
   &-name {
     display: flex;
@@ -253,6 +255,10 @@ async function openOrganizationPopover(event: Event): Promise<void> {
 
     &__text {
       font-size: 0.9375rem;
+      width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
 
       @include ms.responsive-breakpoint('md') {
         display: none;
@@ -262,6 +268,7 @@ async function openOrganizationPopover(event: Event): Promise<void> {
     ion-icon {
       transition: transform ease-out 300ms;
       font-size: 1rem;
+      flex-shrink: 0;
 
       &.popover-is-open {
         transform: rotate(180deg);

--- a/client/src/views/home/HomePageHeader.vue
+++ b/client/src/views/home/HomePageHeader.vue
@@ -452,10 +452,12 @@ const emits = defineEmits<{
 }
 
 #create-organization-button {
+  background: var(--parsec-color-light-secondary-white);
   color: var(--parsec-color-light-secondary-soft-text);
   border-radius: var(--parsec-radius-12);
   transition: all 150ms linear;
   border: 1px solid var(--parsec-color-light-secondary-medium);
+  box-shadow: var(--parsec-shadow-input);
 
   & * {
     pointer-events: none;

--- a/client/src/views/profile/AuthenticationPage.vue
+++ b/client/src/views/profile/AuthenticationPage.vue
@@ -30,9 +30,9 @@
           fill="clear"
           @click="openChangeAuthentication()"
         >
-          <ion-label class="update-auth-button__label">
+          <ion-text class="update-auth-button__label">
             <span>{{ $msTranslate('Authentication.changeAuthenticationButton') }}</span>
-          </ion-label>
+          </ion-text>
         </ion-button>
       </div>
     </template>
@@ -53,7 +53,7 @@ import { AuthenticationCardState } from '@/components/profile/types';
 import { AvailableDevice, AvailableDeviceTypeTag, DeviceSaveStrategyTag, getCurrentAvailableDevice, getServerConfig } from '@/parsec';
 import { Information, InformationLevel, InformationManager, InformationManagerKey, PresentationMode } from '@/services/informationManager';
 import UpdateAuthenticationModal from '@/views/users/UpdateAuthenticationModal.vue';
-import { IonButton, IonIcon, IonLabel, IonText, modalController } from '@ionic/vue';
+import { IonButton, IonIcon, IonText, modalController } from '@ionic/vue';
 import { warning } from 'ionicons/icons';
 import { Answer, askQuestion, MsModalResult } from 'megashark-lib';
 import { inject, onMounted, Ref, ref } from 'vue';

--- a/client/src/views/users/MyProfilePage.vue
+++ b/client/src/views/users/MyProfilePage.vue
@@ -181,9 +181,9 @@
                 :icon="logOut"
                 slot="start"
               />
-              <ion-label class="body logout-text">
+              <ion-text class="body logout-text">
                 {{ $msTranslate('HomePage.topbar.logout') }}
-              </ion-label>
+              </ion-text>
             </div>
           </div>
         </ion-radio-group>
@@ -271,7 +271,7 @@ import AboutView from '@/views/about/AboutView.vue';
 import DevicesPage from '@/views/devices/DevicesPage.vue';
 import AuthenticationPage from '@/views/profile/AuthenticationPage.vue';
 import OrganizationRecoveryPage from '@/views/profile/OrganizationRecoveryPage.vue';
-import { IonContent, IonHeader, IonIcon, IonLabel, IonPage, IonRadio, IonRadioGroup, IonText } from '@ionic/vue';
+import { IonContent, IonHeader, IonIcon, IonPage, IonRadio, IonRadioGroup, IonText } from '@ionic/vue';
 import {
   chatbubbles,
   chevronBack,

--- a/client/src/views/users/UserContextMenu.vue
+++ b/client/src/views/users/UserContextMenu.vue
@@ -22,7 +22,7 @@
             class="list-group-item__icon"
             :icon="personRemove"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate({ key: 'UsersPage.userContextMenu.actionRevoke', count: multipleSelected ? 2 : 1 }) }}
           </ion-text>
         </ion-item>
@@ -46,7 +46,7 @@
             class="list-group-item__icon"
             :icon="repeat"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate({ key: 'UsersPage.userContextMenu.actionUpdateProfile', count: multipleSelected ? 2 : 1 }) }}
           </ion-text>
         </ion-item>
@@ -70,7 +70,7 @@
             class="list-group-item__icon"
             :icon="informationCircle"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('UsersPage.userContextMenu.actionDetails') }}
           </ion-text>
         </ion-item>
@@ -94,7 +94,7 @@
             class="list-group-item__icon"
             :icon="returnUpForward"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('UsersPage.userContextMenu.actionAssignRoles') }}
           </ion-text>
         </ion-item>

--- a/client/src/views/workspaces/WorkspaceContextMenu.vue
+++ b/client/src/views/workspaces/WorkspaceContextMenu.vue
@@ -31,7 +31,7 @@
             class="list-group-item__icon"
             :icon="cloudy"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('WorkspacesPage.workspaceContextMenu.actionOffline') }}
           </ion-text>
         </ion-item>
@@ -57,7 +57,7 @@
             class="list-group-item__icon"
             :image="RenameIcon"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('WorkspacesPage.workspaceContextMenu.actionRename') }}
           </ion-text>
         </ion-item>
@@ -72,7 +72,7 @@
             class="list-group-item__icon"
             :icon="open"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('WorkspacesPage.workspaceContextMenu.actionOpenInExplorer') }}
           </ion-text>
         </ion-item>
@@ -87,7 +87,7 @@
             class="list-group-item__icon"
             :icon="time"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('WorkspacesPage.workspaceContextMenu.actionHistory') }}
           </ion-text>
         </ion-item>
@@ -102,7 +102,7 @@
             class="list-group-item__icon"
             :icon="informationCircle"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('WorkspacesPage.workspaceContextMenu.actionDetails') }}
           </ion-text>
         </ion-item>
@@ -122,7 +122,7 @@
             class="list-group-item__icon"
             :icon="link"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('WorkspacesPage.workspaceContextMenu.actionCopyLink') }}
           </ion-text>
         </ion-item>
@@ -137,7 +137,7 @@
             class="list-group-item__icon"
             :icon="shareSocial"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{ $msTranslate('WorkspacesPage.workspaceContextMenu.actionShare') }}
           </ion-text>
         </ion-item>
@@ -157,7 +157,7 @@
             class="list-group-item__icon"
             :icon="star"
           />
-          <ion-text class="body list-group-item__label">
+          <ion-text class="button-medium list-group-item__label">
             {{
               $msTranslate(
                 isFavorite

--- a/client/src/views/workspaces/WorkspaceHistoryPage.vue
+++ b/client/src/views/workspaces/WorkspaceHistoryPage.vue
@@ -86,7 +86,7 @@
               ref="topbarRight"
             >
               <ion-button
-                class="select-button body"
+                class="select-button button-medium button-default"
                 @click="entries.selectAll(!allSelected)"
                 v-if="isLargeDisplay && entries.entriesCount() > 0"
               >
@@ -103,6 +103,7 @@
                 id="restore-button"
                 :disabled="!someSelected || querying"
                 @click="onRestoreClicked"
+                class="button-default button-medium"
               >
                 {{ $msTranslate('workspaceHistory.actions.restore') }}
               </ion-button>
@@ -130,7 +131,7 @@
               :show-parent-node="false"
             />
             <ion-button
-              class="select-button body"
+              class="select-button button-medium button-default"
               @click="entries.selectAll(!allSelected)"
             >
               <span v-if="!allSelected">{{ $msTranslate('workspaceHistory.actions.selectAll') }}</span>
@@ -605,14 +606,13 @@ async function onRestoreClicked(): Promise<void> {
 
     @include ms.responsive-breakpoint('sm') {
       order: 1;
-      padding: 0.25rem 1rem;
+      padding: 0.5rem 1rem;
       flex-shrink: 0;
     }
 
     &__text {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+      width: fit-content;
+      max-width: 10rem;
     }
 
     &__icon {


### PR DESCRIPTION
Correction of several elements:
- White background in HomePage
- Contextual menu, update the font size
- History page, add missing space before checkbox
- Add max width for profile name
- Tasks menu - switch `IonLabel` to `IonText` for workspace info
<img width="877" height="142" alt="Screenshot 2025-11-28 at 08 06 54" src="https://github.com/user-attachments/assets/4d70d9fe-a062-47cb-805a-3515da2d2f6b" />

<img width="335" height="376" alt="Screenshot 2025-11-28 at 08 07 22" src="https://github.com/user-attachments/assets/5725523d-fb1e-41b4-8b46-756feef8e0de" />

<img width="784" height="129" alt="Screenshot 2025-11-28 at 08 53 55" src="https://github.com/user-attachments/assets/ba4e6359-d753-4923-a53b-4f157ebf2fe1" />

<img width="509" height="204" alt="Screenshot 2025-11-28 at 08 55 07" src="https://github.com/user-attachments/assets/a51afc36-07ce-4043-9664-b79899141729" />

<img width="353" height="425" alt="Screenshot 2025-11-28 at 08 55 19" src="https://github.com/user-attachments/assets/2c370d73-b352-462b-8a10-3f3398199121" />

<img width="388" height="138" alt="Screenshot 2025-11-28 at 08 56 29" src="https://github.com/user-attachments/assets/1424c002-7cd3-4143-880f-748fa5ad74e4" />

closes [#11770](https://github.com/Scille/parsec-cloud/issues/11770),
closes [#11768](https://github.com/Scille/parsec-cloud/issues/11768),
closes [#11769](https://github.com/Scille/parsec-cloud/issues/11769),
closes [#11781](https://github.com/Scille/parsec-cloud/issues/11781)