### PR TITLE
[MS] Workspace offline details modal

### DIFF
--- a/client/src/components/workspaces/utils.ts
+++ b/client/src/components/workspaces/utils.ts
@@ -21,6 +21,7 @@ import { WorkspaceAttributes } from '@/services/workspaceAttributes';
 import SmallDisplayWorkspaceContextMenu from '@/views/workspaces/SmallDisplayWorkspaceContextMenu.vue';
 import { WorkspaceAction } from '@/views/workspaces/types';
 import WorkspaceContextMenu from '@/views/workspaces/WorkspaceContextMenu.vue';
+import WorkspaceDetailsModal from '@/views/workspaces/WorkspaceDetailsModal.vue';
 import WorkspaceSharingModal from '@/views/workspaces/WorkspaceSharingModal.vue';
 import { modalController, popoverController } from '@ionic/vue';
 import { Clipboard, DisplayState, Translatable, getTextFromUser } from 'megashark-lib';
@@ -184,6 +185,8 @@ export async function openWorkspaceContextMenu(
       case WorkspaceAction.ShowHistory:
         await navigateTo(Routes.History, { query: { documentPath: '/', workspaceHandle: workspace.handle } });
         break;
+      case WorkspaceAction.ShowDetails:
+        await openWorkspaceDetailsModal(workspace);
       default:
         console.warn('No WorkspaceAction match found');
     }
@@ -266,6 +269,19 @@ async function openRenameWorkspaceModal(
   if (newWorkspaceName) {
     await renameWorkspace(workspace, newWorkspaceName, informationManager);
   }
+}
+
+async function openWorkspaceDetailsModal(workspace: WorkspaceInfo): Promise<void> {
+  const modal = await modalController.create({
+    component: WorkspaceDetailsModal,
+    cssClass: 'file-details-modal',
+    componentProps: {
+      workspaceInfo: workspace,
+      progressStateData: undefined,
+    },
+  });
+  await modal.present();
+  await modal.onWillDismiss();
 }
 
 async function copyLinkToClipboard(workspace: WorkspaceInfo, informationManager: InformationManager): Promise<void> {

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -701,6 +701,39 @@
             "roles": "Role"
         }
     },
+    "WorkspaceDetails": {
+        "title": "Workspace details",
+        "labelName": "Name",
+        "stats": {
+            "generalInfo": "General information",
+            "rights": "Access rights",
+            "joinedOn": "Joined on",
+            "created": "Created"
+        },
+        "rightsInfos": {
+            "owner": "As an {role}, you have full control over this workspace, including managing sharing settings and permissions.",
+            "manager": "As a {role}, you can manage sharing settings and permissions for this workspace.",
+            "contributor": "As a {role}, you can add, modify, and delete files within this workspace.",
+            "reader": "As a {role}, you can only view and download files but cannot make any changes."
+        },
+        "offlineAvailability": {
+            "notAvailable": "Not available offline",
+            "inProgress": "Synchronising...",
+            "available": "Available offline",
+            "title": "Offline availability",
+            "storage": "Required storage",
+            "remainingToDownload": "{size} remaining to download",
+            "availableOfflineInfo": "This workspace is available offline. You can access its files even without an internet connection.",
+            "stopSynchronisation": "Stop offline availability",
+            "makeAvailableOffline": "Make available offline",
+            "cancel": "Cancel",
+            "close": "Close",
+            "error": {
+                "enableFailed": "Failed to enable offline availability for this workspace.",
+                "disableFailed": "Failed to disable offline availability for this workspace."
+            }
+        }
+    },
     "FoldersPage": {
         "createFolder": "New folder",
         "copyHere": "Copy here",

--- a/client/src/parsec/types.ts
+++ b/client/src/parsec/types.ts
@@ -372,9 +372,17 @@ interface WorkspaceInfo extends ParsecWorkspaceInfo {
   size: number;
   lastUpdated: DateTime;
   created?: DateTime;
+  joinedOn?: DateTime;
   availableOffline: boolean;
   handle: WorkspaceHandle;
+  downloadState: WorkspaceDownloadState;
   mountpoints: [MountpointHandle, SystemPath][];
+}
+
+enum WorkspaceDownloadState {
+  NotAvailable,
+  InProgress,
+  Available,
 }
 
 interface StartedWorkspaceInfo extends ParsecStartedWorkspaceInfo {
@@ -461,6 +469,7 @@ export {
   UserID,
   UserInfo,
   UserTuple,
+  WorkspaceDownloadState,
   WorkspaceHandle,
   WorkspaceHistoryEntryStat,
   WorkspaceHistoryEntryStatFile,

--- a/client/src/views/workspaces/SmallDisplayWorkspaceContextMenu.vue
+++ b/client/src/views/workspaces/SmallDisplayWorkspaceContextMenu.vue
@@ -6,25 +6,6 @@
       <ion-list class="menu-list menu-list-small">
         <ion-item-group
           class="list-group"
-          v-show="false"
-        >
-          <ion-item
-            button
-            @click="onClick(WorkspaceAction.MakeAvailableOffline)"
-            class="ion-no-padding list-group-item"
-          >
-            <ion-icon
-              class="list-group-item__icon"
-              :icon="cloudy"
-            />
-            <ion-text class="button-large list-group-item__label-small">
-              {{ $msTranslate('WorkspacesPage.workspaceContextMenu.actionOffline') }}
-            </ion-text>
-          </ion-item>
-        </ion-item-group>
-
-        <ion-item-group
-          class="list-group"
           v-show="isDesktop() || clientRole === WorkspaceRole.Owner"
         >
           <ion-item
@@ -71,7 +52,20 @@
 
           <ion-item
             button
-            v-show="clientProfile !== UserProfile.Outsider && false"
+            @click="onClick(WorkspaceAction.MakeAvailableOffline)"
+            class="ion-no-padding list-group-item"
+          >
+            <ion-icon
+              class="list-group-item__icon"
+              :icon="cloudy"
+            />
+            <ion-text class="button-large list-group-item__label-small">
+              {{ $msTranslate('WorkspacesPage.workspaceContextMenu.actionOffline') }}
+            </ion-text>
+          </ion-item>
+
+          <ion-item
+            button
             @click="onClick(WorkspaceAction.ShowDetails)"
             class="ion-no-padding list-group-item"
           >

--- a/client/src/views/workspaces/WorkspaceContextMenu.vue
+++ b/client/src/views/workspaces/WorkspaceContextMenu.vue
@@ -15,30 +15,6 @@
     <ion-list class="menu-list">
       <ion-item-group
         class="list-group"
-        v-show="false"
-      >
-        <ion-item class="list-group-title button-small">
-          <ion-text class="list-group-title__label">
-            {{ $msTranslate('WorkspacesPage.workspaceContextMenu.titleOffline') }}
-          </ion-text>
-        </ion-item>
-        <ion-item
-          button
-          @click="onClick(WorkspaceAction.MakeAvailableOffline)"
-          class="ion-no-padding list-group-item"
-        >
-          <ion-icon
-            class="list-group-item__icon"
-            :icon="cloudy"
-          />
-          <ion-text class="button-medium list-group-item__label">
-            {{ $msTranslate('WorkspacesPage.workspaceContextMenu.actionOffline') }}
-          </ion-text>
-        </ion-item>
-      </ion-item-group>
-
-      <ion-item-group
-        class="list-group"
         v-show="isDesktop() || clientRole === WorkspaceRole.Owner"
       >
         <ion-item class="list-group-title button-small">
@@ -94,7 +70,20 @@
 
         <ion-item
           button
-          v-show="clientProfile !== UserProfile.Outsider && false"
+          @click="onClick(WorkspaceAction.MakeAvailableOffline)"
+          class="ion-no-padding list-group-item"
+        >
+          <ion-icon
+            class="list-group-item__icon"
+            :icon="cloudy"
+          />
+          <ion-text class="button-medium list-group-item__label">
+            {{ $msTranslate('WorkspacesPage.workspaceContextMenu.actionOffline') }}
+          </ion-text>
+        </ion-item>
+
+        <ion-item
+          button
           @click="onClick(WorkspaceAction.ShowDetails)"
           class="ion-no-padding list-group-item"
         >

--- a/client/src/views/workspaces/WorkspaceDetailsModal.vue
+++ b/client/src/views/workspaces/WorkspaceDetailsModal.vue
@@ -1,0 +1,351 @@
+<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+
+<template>
+  <ion-page class="modal">
+    <ms-modal
+      title="WorkspaceDetails.title"
+      :close-button="{ visible: true }"
+    >
+      <div class="workspace-info-container">
+        <div class="workspace-header">
+          <ion-icon
+            class="workspace-header__icon"
+            :icon="business"
+          />
+          <div class="workspace-header-text">
+            <ion-text class="workspace-header-text__name title-h4">
+              {{ workspaceInfo.currentName }}
+            </ion-text>
+            <ion-text class="workspace-header-text__subtitle subtitles-sm">
+              {{ $msTranslate('WorkspaceDetails.offlineAvailability.notAvailable') }}
+            </ion-text>
+          </div>
+        </div>
+
+        <div class="workspace-infos">
+          <ion-text class="workspace-infos__title subtitles-normal">
+            {{ $msTranslate('WorkspaceDetails.stats.generalInfo') }}
+          </ion-text>
+          <div class="workspace-infos-content">
+            <div class="workspace-infos-item">
+              <ion-label class="workspace-infos-item__title subtitles-sm">
+                {{ $msTranslate('WorkspaceDetails.stats.rights') }}
+              </ion-label>
+              <workspace-role-tag
+                :role="workspaceInfo.currentSelfRole"
+                class="workspace-role-tag"
+              />
+            </div>
+
+            <div
+              class="workspace-infos-item"
+              v-if="workspaceInfo.joinedOn"
+            >
+              <ion-label class="workspace-infos-item__title subtitles-sm">
+                {{ $msTranslate('WorkspaceDetails.stats.joinedOn') }}
+              </ion-label>
+              <span class="workspace-infos-item__value body">
+                {{ $msTranslate(I18n.formatDate(workspaceInfo.joinedOn, 'short')) }}
+              </span>
+            </div>
+
+            <div
+              class="workspace-infos-item"
+              v-if="workspaceInfo.created"
+            >
+              <ion-label class="workspace-infos-item__title subtitles-sm">
+                {{ $msTranslate('WorkspaceDetails.stats.joinedOn') }}
+              </ion-label>
+              <span class="workspace-infos-item__value body">
+                {{ $msTranslate(I18n.formatDate(workspaceInfo.created, 'short')) }}
+              </span>
+            </div>
+          </div>
+          <ion-text class="workspace-infos__role body">
+            <i18n-t
+              :keypath="getRoleInfo(workspaceInfo.currentSelfRole)"
+              scope="global"
+            >
+              <template #role>
+                <strong>
+                  {{ $msTranslate(getWorkspaceRoleTranslationKey(workspaceInfo.currentSelfRole).label) }}
+                </strong>
+              </template>
+            </i18n-t>
+          </ion-text>
+        </div>
+
+        <div class="workspace-infos">
+          <ion-text class="workspace-infos__title subtitles-normal">
+            {{ $msTranslate('WorkspaceDetails.offlineAvailability.title') }}
+          </ion-text>
+          <div class="workspace-infos-content">
+            <div class="workspace-infos-item">
+              <ion-label class="workspace-infos-item__title subtitles-sm">
+                {{ $msTranslate('WorkspaceDetails.offlineAvailability.storage') }}
+              </ion-label>
+              <ion-text class="workspace-infos-item__value body-lg">
+                {{
+                  $msTranslate({
+                    key: 'WorkspaceDetails.offlineAvailability.remainingToDownload',
+                    data: { size: formatFileSize(workspaceInfo.size) },
+                  })
+                }}
+              </ion-text>
+              <template v-if="workspaceInfo.downloadState">
+                <ion-button
+                  id="available-offline-btn"
+                  class="button-medium"
+                  :class="{
+                    'stop-sync': workspaceInfo.downloadState === WorkspaceDownloadState.Available,
+                    'enable-sync': workspaceInfo.downloadState === WorkspaceDownloadState.NotAvailable,
+                  }"
+                  @click="offlineAvailability"
+                  v-if="workspaceInfo.downloadState !== WorkspaceDownloadState.InProgress"
+                >
+                  <span v-if="workspaceInfo.downloadState === WorkspaceDownloadState.NotAvailable">
+                    {{ $msTranslate('WorkspaceDetails.offlineAvailability.makeAvailableOffline') }}
+                  </span>
+                  <span v-if="workspaceInfo.downloadState === WorkspaceDownloadState.Available">
+                    {{ $msTranslate('WorkspaceDetails.offlineAvailability.stopSynchronisation') }}
+                  </span>
+                </ion-button>
+
+                <div
+                  class="download"
+                  v-if="workspaceInfo.downloadState === WorkspaceDownloadState.InProgress"
+                >
+                  <ms-progress
+                    class="download__progress-bar"
+                    :progress="getProgress()"
+                    :appearance="MsProgressAppearance.Bar"
+                  />
+                  <ion-button
+                    class="download__cancel button-medium"
+                    @click="stopOfflineAvailability"
+                  >
+                    {{ $msTranslate('WorkspaceDetails.offlineAvailability.cancel') }}
+                  </ion-button>
+                </div>
+              </template>
+              <div v-if="error">
+                <ion-text class="body-lg button-medium error">
+                  {{ $msTranslate('WorkspaceDetails.offlineAvailability.error.enableFailed') }}
+                </ion-text>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </ms-modal>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { formatFileSize } from '@/common/file';
+import { WorkspaceRoleTag } from '@/components/workspaces';
+import { WorkspaceDownloadState, WorkspaceInfo, WorkspaceRole } from '@/parsec';
+import { getWorkspaceRoleTranslationKey } from '@/services/translation';
+import { IonIcon, IonLabel, IonPage, IonText } from '@ionic/vue';
+import { business } from 'ionicons/icons';
+import { I18n, MsModal, MsProgress, MsProgressAppearance } from 'megashark-lib';
+import { ref } from 'vue';
+
+const error = ref(true);
+
+const props = defineProps<{
+  workspaceInfo: WorkspaceInfo;
+  progress: number;
+}>();
+
+const getRoleInfo = (role: WorkspaceRole) => {
+  switch (role) {
+    case WorkspaceRole.Owner:
+      return 'WorkspaceDetails.rightsInfos.owner';
+    case WorkspaceRole.Manager:
+      return 'WorkspaceDetails.rightsInfos.administrator';
+    case WorkspaceRole.Contributor:
+      return 'WorkspaceDetails.rightsInfos.contributor';
+    case WorkspaceRole.Reader:
+      return 'WorkspaceDetails.rightsInfos.reader';
+    default:
+      return 'Unknown';
+  }
+};
+
+async function offlineAvailability() {
+  if (props.workspaceInfo.downloadState === WorkspaceDownloadState.NotAvailable) {
+    await props.workspaceInfo.makeAvailableOffline();
+  } else {
+    await props.workspaceInfo.stopOfflineAvailability();
+  }
+}
+
+function getProgress(): number {
+  if (props.workspaceInfo.downloadState === WorkspaceDownloadState.NotAvailable) {
+    return 100;
+  } else if (props.workspaceInfo.downloadState === WorkspaceDownloadState.InProgress) {
+    return props.progress;
+  }
+  return 0;
+}
+</script>
+
+<style scoped lang="scss">
+.workspace-info-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  --background-color: var(--parsec-color-light-secondary-premiere);
+  --color: var(--parsec-color-light-primary-600);
+  margin-top: 0.5rem;
+
+  @include ms.responsive-breakpoint('sm') {
+    margin-bottom: 2rem;
+  }
+}
+
+.workspace-header {
+  display: flex;
+  gap: 1rem;
+  position: relative;
+  align-items: center;
+
+  &__icon {
+    display: flex;
+    align-items: center;
+    font-size: 1.5rem;
+    background: var(--parsec-color-light-primary-50);
+    padding: 0.5rem;
+    border-radius: var(--parsec-radius-8);
+    color: var(--parsec-color-light-primary-800);
+  }
+
+  &-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+
+    &__name {
+      color: var(--parsec-color-light-secondary-text);
+    }
+
+    &__subtitle {
+      color: var(--parsec-color-light-secondary-grey);
+    }
+  }
+}
+
+.workspace-infos {
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--parsec-radius-6);
+  gap: 0.75rem;
+
+  &__title {
+    color: var(--parsec-color-light-secondary-text);
+  }
+
+  &-content {
+    background: var(--parsec-color-light-secondary-background);
+    border-radius: var(--parsec-radius-8);
+    box-shadow: var(--parsec-shadow-input);
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  &-item {
+    display: flex;
+    flex-direction: column;
+    padding: 0.625rem 1rem;
+    gap: 0.5rem;
+    width: 100%;
+
+    &:not(:last-child) {
+      border-right: 1px solid var(--parsec-color-light-secondary-disabled);
+    }
+
+    .workspace-role-tag {
+      border: 1px solid var(--parsec-color-light-secondary-medium);
+      border-radius: var(--parsec-radius-18);
+      background: var(--parsec-color-light-secondary-white);
+      width: fit-content;
+    }
+
+    &__title {
+      color: var(--parsec-color-light-secondary-grey);
+    }
+
+    &__value {
+      color: var(--parsec-color-light-secondary-text);
+    }
+  }
+
+  &__role {
+    color: var(--parsec-color-light-secondary-hard-grey);
+  }
+}
+
+#available-offline-btn {
+  --background: transparent;
+  --background-hover: transparent;
+  width: fit-content;
+  margin: 0;
+  border-bottom: 1px solid transparent;
+
+  &.enable-sync {
+    color: var(--parsec-color-light-primary-500);
+  }
+
+  &.stop-sync {
+    color: var(--parsec-color-light-danger-500);
+  }
+
+  &::part(native) {
+    padding: 0.375rem 0;
+    border-radius: var(--parsec-radius-6);
+  }
+
+  &:hover {
+    &.enable-sync {
+      color: var(--parsec-color-light-primary-600);
+      border-bottom: 1px solid var(--parsec-color-light-primary-600);
+    }
+
+    &.stop-sync {
+      color: var(--parsec-color-light-danger-500);
+      border-bottom: 1px solid var(--parsec-color-light-danger-500);
+    }
+  }
+}
+
+.download {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+
+  &__progress-bar {
+    flex-grow: 1;
+  }
+
+  &__cancel {
+    color: var(--parsec-color-light-primary-500);
+    border-bottom: 1px solid transparent;
+
+    &::part(native) {
+      --background: transparent;
+      --background-hover: var(--parsec-color-light-primary-50);
+
+      padding: 0.5rem 0.75rem;
+    }
+
+    &:hover {
+      color: var(--parsec-color-light-primary-600);
+    }
+  }
+}
+
+.error {
+  color: var(--parsec-color-light-danger-500);
+}
+</style>


### PR DESCRIPTION
### Missing backend information:
- Download state (downloaded, in progress, available, error)
- Progress information
- Date of joining the workspace

### Should be changed:
`utils.ts`: `openWorkspaceDetailsModal` function
`WorkspaceDetailsModal.ts`: Managed error cases
`types.ts`: Check if you have the download state here and the joining date + make sure we have an enum for the downloading state here.
```
interface WorkspaceInfo extends ParsecWorkspaceInfo {
  sharing: Array<[UserTuple, WorkspaceRole | null]>;
  size: number;
  lastUpdated: DateTime;
  created?: DateTime;
  joinedOn?: DateTime;
  availableOffline: boolean;
  handle: WorkspaceHandle;
  downloadState: WorkspaceDownloadState;
  mountpoints: [MountpointHandle, SystemPath][];
}

enum WorkspaceDownloadState {
  NotAvailable,
  InProgress,
  Available,
}
```


