### PR TITLE
feat(editor): add timeout modal for file loading issues and enhance error handling

### DIFF
--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -2512,13 +2512,10 @@
                 "impossibleToOpen": "Cannot edit this file",
                 "genericError": "Failed to open the file",
                 "unsupportedFileType": "File not supported by Parsec",
-                "editionNotAvailable": "Document editing is unavailable",
-                "tooLongToOpen": "The file is taking too long to open"
+                "editionNotAvailable": "Document editing is unavailable"
             },
             "informationEditDownload": "If you want to edit this file, you can download it and open it locally on your device.",
             "informationPreviewDownload": "If you want to preview this file, you can download it and open it locally on your device.",
-            "tooLongToOpenOnWeb": "You can try downloading it and opening with default app (right click on file > 'Download').",
-            "tooLongToOpenOnDesktop": "You can try opening it with default app (right click on file > 'Open with default app').",
             "unknownFileExtension": "This file type extension could not be identified. Please check that it's correctly written (.txt, .pdf, .doc, etc.).",
             "noContentFileType": "Could not open this file in the Parsec editor as its type could not be identified.",
             "noFolderPreview": "Cannot preview folders.",
@@ -2577,9 +2574,12 @@
         "globalTitle": "Cannot open file",
         "errors": {
             "titles": {
-                "networkOffline": "Network connection lost"
+                "networkOffline": "Network connection lost",
+                "tooLongToOpen": "The file seems to be taking too long to open"
             },
             "networkOfflineMessage": "Your network connection has been lost. Please check your internet connection and try again. Any unsaved changes may be lost.",
+            "tooLongToOpenOnWeb": "You can try downloading it and opening with default app (right click on file > 'Download').",
+            "tooLongToOpenOnDesktop": "You can try opening it with default app (right click on file > 'Open with default app').",
             "contentInfoMissing": "The file content information is empty or missing.",
             "fileExtensionMissing": "The file type (extension) is missing or empty.",
             "fileNameMissing": "The file name is empty or missing.",
@@ -2589,12 +2589,15 @@
         "advices": {
             "title": "Some tips to help resolve this issue",
             "advice1": "Check that the file can be opened from an external application.",
-            "advice2": "Re-import the file (check versions).",
-            "advice3": "If the file used to open properly, try restoring a previous version (through file history)"
+            "advice2": "If the file used to open properly, try restoring a previous version (through file history)"
         },
         "actions": {
             "backToFiles": "Back to files",
-            "retry": "Reload page"
+            "retry": "Reload page",
+            "openWithDefaultApp": "Open with default app",
+            "downloadFile": "Download file",
+            "wait": "Wait",
+            "close": "Close"
         },
         "saving": {
             "unsaved": "Changes unsaved",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -2513,13 +2513,10 @@
                 "impossibleToOpen": "Impossible d'éditer ce fichier",
                 "genericError": "Impossible d'ouvrir ce fichier",
                 "unsupportedFileType": "Type de fichier non pris en charge par Parsec",
-                "editionNotAvailable": "L'édition de documents n'est pas disponible",
-                "tooLongToOpen": "Le fichier met trop de temps à s'ouvrir"
+                "editionNotAvailable": "L'édition de documents n'est pas disponible"
             },
             "informationEditDownload": "Si vous souhaitez modifier ce fichier, vous pouvez le télécharger et l'ouvrir localement sur votre appareil.",
             "informationPreviewDownload": "Si vous souhaitez prévisualiser ce fichier, vous pouvez le faire dans Parsec ou le télécharger pour l'ouvrir localement sur votre appareil.",
-            "tooLongToOpenOnWeb": "Vous pouvez essayer de le télécharger et de l'ouvrir avec l'application par défaut (clic droit sur le fichier > 'Télécharger').",
-            "tooLongToOpenOnDesktop": "Vous pouvez essayer de l'ouvrir avec l'application par défaut (clic droit sur le fichier > 'Ouvrir avec l'app par défaut').",
             "unknownFileExtension": "L'extension de ce fichier n'a pas pu être reconnue. Veuillez vérifier qu'elle est correctement écrite (.txt, .pdf, .doc, etc.).",
             "noContentFileType": "Impossible d'ouvrir ce fichier, son type n'ayant pas pu être reconnu dans l'éditeur de Parsec.",
             "noFolderPreview": "Impossible d'afficher l'aperçu d'un dossier.",
@@ -2578,9 +2575,12 @@
         "globalTitle": "Impossible d'ouvrir le fichier",
         "errors": {
             "titles": {
-                "networkOffline": "Connexion réseau perdue"
+                "networkOffline": "Connexion réseau perdue",
+                "tooLongToOpen": "Le fichier semble mettre trop de temps à s'ouvrir"
             },
             "networkOfflineMessage": "Votre connexion réseau a été perdue. Veuillez vérifier votre connexion internet et réessayer. Les modifications non enregistrées peuvent être perdues.",
+            "tooLongToOpenOnWeb": "Vous pouvez essayer de le télécharger et de l'ouvrir avec l'application par défaut (clic droit sur le fichier > 'Télécharger').",
+            "tooLongToOpenOnDesktop": "Vous pouvez essayer de l'ouvrir avec l'application par défaut (clic droit sur le fichier > 'Ouvrir avec l'app par défaut').",
             "contentInfoMissing": "Les informations sur le contenu du fichier sont vides ou manquantes.",
             "fileExtensionMissing": "Le type de fichier (extension) est manquant ou vide.",
             "fileNameMissing": "Le nom du fichier est vide ou manquant.",
@@ -2590,12 +2590,15 @@
         "advices": {
             "title": "Quelques conseils pour résoudre ce problème",
             "advice1": "Vérifier que le fichier s'ouvre correctement depuis un logiciel externe.",
-            "advice2": "Ré-importer le fichier (vérifier les versions).",
-            "advice3": "Si le fichier s'ouvrait avant, essayer de restaurer une version antérieure (via l'historique du fichier)"
+            "advice2": "Si le fichier s'ouvrait avant, essayer de restaurer une version antérieure (via l'historique du fichier)"
         },
         "actions": {
             "backToFiles": "Retour aux fichiers",
-            "retry": "Recharger la page"
+            "retry": "Recharger la page",
+            "openWithDefaultApp": "Ouvrir avec l'app par défaut",
+            "downloadFile": "Télécharger le fichier",
+            "wait": "Attendre",
+            "close": "Fermer"
         },
         "saving": {
             "unsaved": "Modifications non sauvegardées",

--- a/client/src/views/files/handler/editor/EditorIssueModal.vue
+++ b/client/src/views/files/handler/editor/EditorIssueModal.vue
@@ -1,0 +1,174 @@
+<!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
+
+<template>
+  <ms-modal
+    :title="modalConfig.title"
+    :close-button="{ visible: false }"
+    :cancel-button="modalConfig.cancelButton"
+    :confirm-button="modalConfig.confirmButton"
+  >
+    <div class="editor-error">
+      <ms-report-text
+        v-if="modalConfig.message"
+        :theme="modalConfig.theme"
+      >
+        {{ $msTranslate(modalConfig.message) }}
+      </ms-report-text>
+      <div
+        v-if="status === EditorIssueStatus.LoadingTimeout"
+        class="editor-error-advices"
+      >
+        <ion-text class="editor-error-advices__title title-h5">{{ $msTranslate('fileEditors.advices.title') }}</ion-text>
+        <ion-list class="editor-error-advices-list ion-no-padding">
+          <ion-item class="editor-error-advices-list__item ion-no-padding body">
+            <ion-icon
+              class="item-icon"
+              :icon="checkmarkCircle"
+            />
+            {{ $msTranslate('fileEditors.advices.advice1') }}
+          </ion-item>
+          <ion-item class="editor-error-advices-list__item ion-no-padding body">
+            <ion-icon
+              class="item-icon"
+              :icon="checkmarkCircle"
+            />
+            {{ $msTranslate('fileEditors.advices.advice2') }}
+          </ion-item>
+        </ion-list>
+      </div>
+    </div>
+  </ms-modal>
+</template>
+
+<script setup lang="ts">
+import { isWeb } from '@/parsec';
+import { EditorButtonAction, EditorErrorMessage, EditorErrorTitle, EditorIssueStatus } from '@/views/files/handler/editor/types';
+import { IonIcon, IonItem, IonList, IonText, modalController } from '@ionic/vue';
+import { checkmarkCircle } from 'ionicons/icons';
+import { MsModal, MsModalResult, MsReportText, MsReportTheme, Translatable } from 'megashark-lib';
+import { computed, Ref } from 'vue';
+
+const props = defineProps<{
+  status: EditorIssueStatus;
+  fileLoaded?: Ref<boolean>;
+}>();
+
+interface ModalConfig {
+  title: Translatable;
+  message?: Translatable;
+  theme: MsReportTheme;
+  confirmButton: {
+    label: Translatable;
+    disabled: boolean;
+    onClick: () => Promise<boolean>;
+  };
+  cancelButton?: {
+    label: Translatable;
+    disabled: boolean;
+  };
+}
+
+const modalConfig = computed<ModalConfig>(() => {
+  let title: Translatable;
+  let message: Translatable | undefined;
+  let theme: MsReportTheme;
+  let confirmButtonLabel: Translatable;
+  let cancelButton: { label: Translatable; disabled: boolean } | undefined;
+
+  switch (props.status) {
+    case EditorIssueStatus.EditionNotAvailable:
+      title = EditorErrorTitle.EditionNotAvailable;
+      message = EditorErrorMessage.EditableOnlyOnSystem;
+      theme = MsReportTheme.Info;
+      confirmButtonLabel = EditorButtonAction.BackToFiles;
+      break;
+    case EditorIssueStatus.LoadingTimeout:
+      title = EditorErrorTitle.TooLongToOpen;
+      message = isWeb() ? EditorErrorMessage.TooLongToOpenOnWeb : EditorErrorMessage.TooLongToOpenOnDesktop;
+      theme = MsReportTheme.Warning;
+      confirmButtonLabel = props.fileLoaded?.value ? EditorButtonAction.Close : EditorButtonAction.Wait;
+      if (!props.fileLoaded?.value) {
+        cancelButton = {
+          label: EditorButtonAction.BackToFiles,
+          disabled: false,
+        };
+      }
+      break;
+    case EditorIssueStatus.NetworkOffline:
+      title = EditorErrorTitle.NetworkOffline;
+      message = EditorErrorMessage.NetworkOffline;
+      theme = MsReportTheme.Warning;
+      confirmButtonLabel = EditorButtonAction.Close;
+      break;
+    case EditorIssueStatus.UnsupportedFileType:
+      title = EditorErrorTitle.UnsupportedFileType;
+      message = EditorErrorMessage.EditableOnlyOnSystem;
+      theme = MsReportTheme.Info;
+      confirmButtonLabel = EditorButtonAction.BackToFiles;
+      break;
+    default:
+      title = EditorErrorTitle.GenericError;
+      theme = MsReportTheme.Warning;
+      confirmButtonLabel = EditorButtonAction.BackToFiles;
+      break;
+  }
+
+  return {
+    title,
+    message,
+    theme,
+    confirmButton: {
+      label: confirmButtonLabel,
+      disabled: false,
+      onClick: async (): Promise<boolean> => {
+        return modalController.dismiss(true, MsModalResult.Confirm);
+      },
+    },
+    cancelButton,
+  };
+});
+</script>
+
+<style scoped lang="scss">
+.editor-error {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  &-advices {
+    border-top: 1px solid var(--parsec-color-light-secondary-disabled);
+    padding-top: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    &__title {
+      color: var(--parsec-color-light-secondary-text);
+    }
+
+    &-list {
+      padding-left: 0.5rem;
+      list-style-type: circle;
+      background: none;
+
+      &__item {
+        margin-bottom: 0.5rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        color: var(--parsec-color-light-secondary-soft-text);
+        --background: none;
+        font-size: 0.9375rem;
+
+        .item-icon {
+          color: var(--parsec-color-light-secondary-grey);
+          flex-shrink: 0;
+          margin-right: 0.5rem;
+          font-size: 1rem;
+        }
+      }
+    }
+  }
+}
+</style>

--- a/client/src/views/files/handler/editor/FileEditor.vue
+++ b/client/src/views/files/handler/editor/FileEditor.vue
@@ -21,7 +21,7 @@
           class="error-content-buttons__item button-default"
           @click="routerGoBack()"
         >
-          {{ $msTranslate('fileEditors.actions.backToFiles') }}
+          {{ $msTranslate(EditorButtonAction.BackToFiles) }}
         </ion-button>
       </div>
     </div>
@@ -43,13 +43,6 @@
           />
           {{ $msTranslate('fileEditors.advices.advice2') }}
         </ion-item>
-        <ion-item class="error-advices-list__item ion-no-padding body">
-          <ion-icon
-            class="item-icon"
-            :icon="checkmarkCircle"
-          />
-          {{ $msTranslate('fileEditors.advices.advice3') }}
-        </ion-item>
       </ion-list>
     </div>
   </div>
@@ -57,7 +50,7 @@
 
 <script setup lang="ts">
 import { DetectedFileType } from '@/common/fileTypes';
-import { ClientInfo, closeFile, FileDescriptor, isWeb, openFile, writeFile } from '@/parsec';
+import { ClientInfo, closeFile, FileDescriptor, openFile, writeFile } from '@/parsec';
 import { currentRouteIs, getFileHandlerMode, getWorkspaceHandle, routerGoBack, Routes } from '@/router';
 import {
   Cryptpad,
@@ -65,22 +58,21 @@ import {
   CryptpadDocumentType,
   CryptpadError,
   CryptpadErrorCode,
-  CryptpadOpenError,
   getCryptpadDocumentType,
 } from '@/services/cryptpad';
 import { Env } from '@/services/environment';
 import { EventDistributor, EventDistributorKey, Events } from '@/services/eventDistributor';
-import { Information, InformationLevel, InformationManager, InformationManagerKey, PresentationMode } from '@/services/informationManager';
+
 import { longLocaleCodeToShort } from '@/services/translation';
-import { SaveState } from '@/views/files/handler/editor';
+import { EditorButtonAction, EditorErrorMessage, EditorErrorTitle, EditorIssueStatus, SaveState } from '@/views/files/handler/editor';
+import EditorIssueModal from '@/views/files/handler/editor/EditorIssueModal.vue';
 import { FileHandlerMode } from '@/views/files/handler/types';
 import { FileContentInfo } from '@/views/files/handler/viewer/utils';
-import { IonButton, IonIcon, IonItem, IonList, IonText } from '@ionic/vue';
+import { IonButton, IonIcon, IonItem, IonList, IonText, modalController } from '@ionic/vue';
 import { checkmarkCircle } from 'ionicons/icons';
-import { I18n, Translatable } from 'megashark-lib';
-import { inject, onMounted, onUnmounted, ref, useTemplateRef } from 'vue';
+import { I18n, MsModalResult } from 'megashark-lib';
+import { inject, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue';
 
-const informationManager: InformationManager = inject(InformationManagerKey)!;
 const fileEditorRef = useTemplateRef('fileEditor');
 const documentType = ref<CryptpadDocumentType | null>(null);
 const cryptpadInstance = ref<Cryptpad | null>(null);
@@ -88,6 +80,7 @@ const fileUrl = ref<string | null>(null);
 const error = ref('');
 const eventDistributor: EventDistributor = inject(EventDistributorKey)!;
 let eventCbId: null | string = null;
+const fileLoaded = ref(false);
 
 const {
   contentInfo,
@@ -101,19 +94,6 @@ const {
   userInfo?: ClientInfo;
 }>();
 
-enum ErrorTitle {
-  GenericError = 'fileViewers.errors.titles.genericError',
-  UnsupportedFileType = 'fileViewers.errors.titles.unsupportedFileType',
-  EditionNotAvailable = 'fileViewers.errors.titles.editionNotAvailable',
-  CorruptedFile = 'fileViewers.errors.titles.tooLongToOpen',
-}
-
-enum ErrorMessage {
-  EditableOnlyOnSystem = 'fileViewers.errors.informationEditDownload',
-  CorruptedFileOnWeb = 'fileViewers.errors.tooLongToOpenOnWeb',
-  CorruptedFileOnDesktop = 'fileViewers.errors.tooLongToOpenOnDesktop',
-}
-
 const emits = defineEmits<{
   (event: 'fileLoaded'): void;
   (event: 'fileError'): void;
@@ -124,8 +104,8 @@ onMounted(async () => {
   documentType.value = getCryptpadDocumentType(fileInfo.type);
 
   if (documentType.value === CryptpadDocumentType.Unsupported) {
-    error.value = ErrorTitle.UnsupportedFileType;
-    await openRedirectionModal(ErrorTitle.UnsupportedFileType, ErrorMessage.EditableOnlyOnSystem, InformationLevel.Info);
+    error.value = EditorErrorTitle.UnsupportedFileType;
+    await openIssueModal(EditorIssueStatus.UnsupportedFileType);
     return;
   }
   if (!(await loadCryptpad())) {
@@ -142,14 +122,7 @@ onMounted(async () => {
     if (event === Events.Offline) {
       window.electronAPI.log('warn', 'Network connection lost while editing');
       emits('onSaveStateChange', SaveState.Offline);
-      await informationManager.present(
-        new Information({
-          title: 'fileEditors.errors.titles.networkOffline',
-          message: 'fileEditors.errors.networkOfflineMessage',
-          level: InformationLevel.Warning,
-        }),
-        PresentationMode.Modal,
-      );
+      await openIssueModal(EditorIssueStatus.NetworkOffline, false);
     } else if (event === Events.Online) {
       window.electronAPI.log('info', 'Network connection restored');
       emits('onSaveStateChange', SaveState.None);
@@ -187,11 +160,11 @@ async function loadCryptpad(): Promise<boolean> {
     if (e instanceof CryptpadError) {
       switch (e.code) {
         case CryptpadErrorCode.NotEnabled:
-          await openRedirectionModal(ErrorTitle.EditionNotAvailable, ErrorMessage.EditableOnlyOnSystem, InformationLevel.Warning);
+          await openIssueModal(EditorIssueStatus.EditionNotAvailable);
           break;
         case CryptpadErrorCode.ScriptElementCreationFailed:
         case CryptpadErrorCode.InitFailed:
-          error.value = ErrorMessage.EditableOnlyOnSystem;
+          error.value = EditorErrorMessage.EditableOnlyOnSystem;
           break;
       }
     }
@@ -199,23 +172,63 @@ async function loadCryptpad(): Promise<boolean> {
   }
 }
 
-async function openRedirectionModal(title: Translatable, message: Translatable, level: InformationLevel): Promise<void> {
-  await informationManager.present(
-    new Information({
-      title,
-      message,
-      level,
-    }),
-    PresentationMode.Modal,
-  );
-  await routerGoBack();
-  // TODO: find why we have router problems causing routerGoBack to stay on same page
-  // https://github.com/Scille/parsec-cloud/issues/11749
-  // Seems similar to the header back button double click issue
-  // For now, we'll force navigation if page is still the same after modal
-  if (currentRouteIs(Routes.FileHandler) && getFileHandlerMode() === FileHandlerMode.Edit) {
-    await routerGoBack();
+async function openIssueModal(status: EditorIssueStatus, redirectAfterDismiss = true): Promise<MsModalResult> {
+  // Safety check: only show modal if we're still on the file handler/editor route
+  if (!currentRouteIs(Routes.FileHandler) || getFileHandlerMode() !== FileHandlerMode.Edit) {
+    window.electronAPI.log('info', 'Skipping modal - user navigated away from editor');
+    return MsModalResult.Cancel;
   }
+
+  const modal = await modalController.create({
+    component: EditorIssueModal,
+    cssClass: 'editor-issue-modal',
+    componentProps: {
+      status,
+      fileLoaded,
+    },
+    backdropDismiss: false,
+  });
+
+  await modal.present();
+  const { role } = await modal.onWillDismiss();
+
+  // Handle redirection if requested (default is true)
+  if (redirectAfterDismiss) {
+    await routerGoBack();
+    // TODO: find why we have router problems causing routerGoBack to stay on same page
+    // https://github.com/Scille/parsec-cloud/issues/11749
+    // Seems similar to the header back button double click issue
+    // For now, we'll force navigation if page is still the same after modal
+    if (currentRouteIs(Routes.FileHandler) && getFileHandlerMode() === FileHandlerMode.Edit) {
+      await routerGoBack();
+    }
+  }
+
+  return role as MsModalResult;
+}
+
+async function openTimeoutModal(): Promise<'wait' | 'close'> {
+  const role = await openIssueModal(EditorIssueStatus.LoadingTimeout, false);
+
+  // If user clicks primary button (close/dismiss)
+  if (role === MsModalResult.Confirm) {
+    if (fileLoaded.value) {
+      return 'close';
+    } else {
+      return 'wait';
+    }
+  } else if (role === MsModalResult.Cancel) {
+    await routerGoBack();
+    // TODO: find why we have router problems causing routerGoBack to stay on same page
+    // https://github.com/Scille/parsec-cloud/issues/11749
+    if (currentRouteIs(Routes.FileHandler) && getFileHandlerMode() === FileHandlerMode.Edit) {
+      await routerGoBack();
+    }
+    return 'close';
+  }
+
+  // Modal was dismissed (close button) - just close without navigating
+  return 'close';
 }
 
 async function openFileWithCryptpad(): Promise<boolean> {
@@ -225,7 +238,7 @@ async function openFileWithCryptpad(): Promise<boolean> {
   const user = userInfo ? { name: userInfo.humanHandle.label, id: userInfo.userId } : undefined;
 
   if (!workspaceHandle) {
-    error.value = ErrorTitle.GenericError;
+    error.value = EditorErrorTitle.GenericError;
     return false;
   }
   fileUrl.value = URL.createObjectURL(new Blob([contentInfo.data as Uint8Array<ArrayBuffer>], { type: 'application/octet-stream' }));
@@ -250,6 +263,7 @@ async function openFileWithCryptpad(): Promise<boolean> {
     events: {
       onReady: (): void => {
         window.electronAPI.log('info', 'CryptPad editor is ready and document loaded successfully');
+        fileLoaded.value = true;
       },
       onSave: async (file: Blob, callback: () => void): Promise<void> => {
         let hasError = false;
@@ -315,33 +329,76 @@ async function openFileWithCryptpad(): Promise<boolean> {
   };
 
   try {
+    // Start CryptPad (non-blocking)
     await cryptpadApi.open(cryptpadConfig);
-    window.electronAPI.log('info', 'CryptPad editor initialized successfully');
-    return true;
+
+    // Set up timeout for loading files
+    // If the file does not open before timeout, a dialog is displayed
+    // to ask the user if it wants to keep waiting or go back to files.
+    const LOADING_TIMEOUT_MS = 30000;
+    let shouldContinueWaiting = true;
+
+    // TODO: Fix DOCX timeout false positives - OnlyOffice doesn't reliably call onReady for 'doc' type
+    // See: https://github.com/Scille/parsec-cloud/issues/11753
+    // For now, we ignore timeout for DOCX files to avoid false positive "corrupted file" modals
+    const shouldSkipTimeout = documentType.value === CryptpadDocumentType.Doc;
+
+    if (shouldSkipTimeout) {
+      window.electronAPI.log('info', 'Skipping timeout for DOCX file');
+      return true;
+    }
+
+    // Wait for file to load with timeout and restart capability
+    while (!fileLoaded.value && shouldContinueWaiting) {
+      // Wait for timeout or file load
+      const timeoutOccurred = await new Promise<boolean>((resolve) => {
+        const timeoutId = window.setTimeout(() => {
+          resolve(true); // Timeout occurred
+        }, LOADING_TIMEOUT_MS);
+
+        // Watch for file loaded to resolve immediately
+        const stopWatch = watch(fileLoaded, (loaded) => {
+          if (loaded) {
+            window.clearTimeout(timeoutId);
+            stopWatch();
+            resolve(false); // File loaded
+          }
+        });
+      });
+
+      // If file loaded, exit successfully
+      if (!timeoutOccurred) {
+        window.electronAPI.log('info', 'CryptPad editor initialized successfully');
+        return true;
+      }
+
+      // Timeout occurred - show modal
+      window.electronAPI.log('warn', 'CryptPad loading timeout - file appears to be corrupted or too large');
+      const result = await openTimeoutModal();
+
+      // Check if file loaded while modal was open
+      if (fileLoaded.value) {
+        window.electronAPI.log('info', 'File loaded while modal was open');
+        return true;
+      }
+
+      // Continue waiting if user clicked wait, stop if they clicked close
+      shouldContinueWaiting = result === 'wait';
+      if (shouldContinueWaiting) {
+        window.electronAPI.log('info', 'User chose to wait - restarting timeout');
+      }
+    }
+
+    return fileLoaded.value;
   } catch (e: unknown) {
-    // Check if this is a timeout error (corrupted file)
+    // Handle initialization errors
     if (e instanceof CryptpadError) {
       switch (e.code) {
         case CryptpadErrorCode.NotInitialized:
-          error.value = ErrorMessage.EditableOnlyOnSystem;
+          error.value = EditorErrorMessage.EditableOnlyOnSystem;
           break;
         case CryptpadErrorCode.DocumentTypeNotEnabled:
-          await openRedirectionModal(ErrorTitle.EditionNotAvailable, ErrorMessage.EditableOnlyOnSystem, InformationLevel.Info);
-          break;
-        case CryptpadErrorCode.LoadingTimeout:
-          // TODO: Fix DOCX timeout false positives - OnlyOffice doesn't reliably call onReady for 'doc' type
-          // See: https://github.com/Scille/parsec-cloud/issues/11753
-          // For now, we ignore timeout errors for DOCX files to avoid false positive "corrupted file" modals
-          if ((e as CryptpadOpenError).documentType === CryptpadDocumentType.Doc) {
-            window.electronAPI.log('info', 'Ignoring timeout for DOCX file (known OnlyOffice onReady issue)');
-            return true;
-          }
-          window.electronAPI.log('warn', 'CryptPad loading timeout - file appears to be corrupted or too large');
-          await openRedirectionModal(
-            ErrorTitle.CorruptedFile,
-            isWeb() ? ErrorMessage.CorruptedFileOnWeb : ErrorMessage.CorruptedFileOnDesktop,
-            InformationLevel.Warning,
-          );
+          await openIssueModal(EditorIssueStatus.EditionNotAvailable);
           break;
       }
     }

--- a/client/src/views/files/handler/editor/types.ts
+++ b/client/src/views/files/handler/editor/types.ts
@@ -8,3 +8,31 @@ export enum SaveState {
   Error = 'save-error',
   Offline = 'offline',
 }
+
+export enum EditorIssueStatus {
+  UnsupportedFileType = 'unsupported_file_type',
+  NetworkOffline = 'network_offline',
+  EditionNotAvailable = 'edition_not_available',
+  LoadingTimeout = 'loading_timeout',
+}
+
+export enum EditorErrorTitle {
+  GenericError = 'fileViewers.errors.titles.genericError',
+  UnsupportedFileType = 'fileViewers.errors.titles.unsupportedFileType',
+  EditionNotAvailable = 'fileViewers.errors.titles.editionNotAvailable',
+  NetworkOffline = 'fileEditors.errors.titles.networkOffline',
+  TooLongToOpen = 'fileEditors.errors.titles.tooLongToOpen',
+}
+
+export enum EditorErrorMessage {
+  EditableOnlyOnSystem = 'fileViewers.errors.informationEditDownload',
+  NetworkOffline = 'fileEditors.errors.networkOfflineMessage',
+  TooLongToOpenOnWeb = 'fileEditors.errors.tooLongToOpenOnWeb',
+  TooLongToOpenOnDesktop = 'fileEditors.errors.tooLongToOpenOnDesktop',
+}
+
+export enum EditorButtonAction {
+  BackToFiles = 'fileEditors.actions.backToFiles',
+  Close = 'fileEditors.actions.close',
+  Wait = 'fileEditors.actions.wait',
+}


### PR DESCRIPTION
## Testing the Timeout Modal

To test the scenario where the timeout modal appears but the file eventually loads:

**Temporarily make these changes** in `FileEditor.vue`:

1. **Reduce the timeout threshold** (around line 445):
```typescript
const LOADING_TIMEOUT_MS = 3000; // Reduced from 30000 for testing
```

2. **Add a simulated delay** to the `onReady` event (around line 369):
```typescript
onReady: (): void => {
  // Simulate slow file loading to trigger timeout modal
  const SIMULATED_DELAY = 5000; // 5 seconds
  window.setTimeout(() => {
    window.electronAPI.log('info', 'CryptPad editor is ready and document loaded successfully');
    fileLoaded.value = true;
  }, SIMULATED_DELAY);
},
```

**Expected behavior:**
1. Open a CryptPad-supported file (e.g., `.xlsx`, `.md`)
2. After 3 seconds, a timeout modal should appear asking if you want to wait or go back
3. Click "Wait" button
4. After ~2 more seconds, the file should finish loading
5. Click "Close" to dismiss the modal and start editing (it should not redirect you)

This tests that the timeout handling properly continues waiting when the user chooses to wait, correctly detects when the file finally loads, and updates the button accordingly.

**Remember to remove both testing modifications before committing.**
