### PR TITLE
[PKI] Deduplicate certificate storage.

### DIFF
--- a/server/parsec/components/memory/datamodel.py
+++ b/server/parsec/components/memory/datamodel.py
@@ -509,6 +509,9 @@ class MemoryOrganization:
         # in theory it should not have been stored if too long
         return (leaf, sorted_trustchain[1:])
 
+    async def get_cert(self, fingerprint: bytes) -> MemoryPkiCertificate | None:
+        return self.pki_certificates.get(fingerprint)
+
 
 @dataclass(slots=True)
 class MemorySequesterService:
@@ -792,7 +795,8 @@ class MemoryPkiCertificate:
 @dataclass(slots=True)
 class MemoryPkiEnrollment:
     enrollment_id: PKIEnrollmentID
-    submitter_der_x509_certificate: bytes = field(repr=False)
+    # references the cert stored in MemoryPkiCertificate
+    submitter_der_x509_fingerprint: bytes = field(repr=False)
 
     submit_payload_signature: bytes = field(repr=False)
     submit_payload_signature_algorithm: PkiSignatureAlgorithm

--- a/server/parsec/components/pki.py
+++ b/server/parsec/components/pki.py
@@ -334,7 +334,6 @@ class BasePkiEnrollmentComponent:
             current = parse_pki_cert(leaf)
         except ValueError:
             return PkiTrustchainError.ParseError
-
         # Parse intermediate -> HashMap (subject, cert)
         try:
             intermediate = {
@@ -363,9 +362,6 @@ class BasePkiEnrollmentComponent:
                     current = cert
 
         return PkiTrustchainError.TrustchainTooLong
-
-    async def get_cert(self, fingerprint: bytes) -> PkiCertificate | None:
-        raise NotImplementedError
 
     @api
     async def api_pki_enrollment_info(

--- a/server/tests/api_v5/authenticated/test_pki_enrollment_list.py
+++ b/server/tests/api_v5/authenticated/test_pki_enrollment_list.py
@@ -1,5 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
+
 import pytest
 
 from parsec._parsec import (
@@ -15,7 +16,9 @@ from parsec._parsec import (
     UserProfile,
     authenticated_cmds,
 )
-from tests.api_v5.authenticated.test_pki_enrollment_accept import generate_accept_params
+from tests.api_v5.authenticated.test_pki_enrollment_accept import (
+    generate_accept_params,
+)
 from tests.common import (
     Backend,
     CoolorgRpcClients,
@@ -98,7 +101,8 @@ async def test_authenticated_pki_enrollment_list_ok(
                 assert res.payload_signature_algorithm == expected.payload_signature_algorithm
                 assert res.payload == expected.payload
 
-        case _:
+        case e:
+            print(e)
             assert False
 
     # 3) Also ensure `ACCEPTED/CANCELLED/REJECTED` enrollments are ignored
@@ -211,6 +215,3 @@ async def test_authenticated_pki_enrollment_list_http_common_errors(
         await coolorg.alice.pki_enrollment_list()
 
     await authenticated_http_common_errors_tester(do)
-
-
-# TODO test when leaf fingerprint not in db ->  #11871


### PR DESCRIPTION
The certificate was stored in MemoryEnrollment and in MemoryPkiCertificate.
Now MemoryEnrollment contains only the cert's fingerprint.

Fix #11871 