### PR TITLE
refactor(server): Change when we build trustchain in `pki_submit`

### DIFF
--- a/server/parsec/components/postgresql/pki.py
+++ b/server/parsec/components/postgresql/pki.py
@@ -17,6 +17,7 @@ from parsec._parsec import (
 from parsec.ballpark import RequireGreaterTimestamp, TimestampOutOfBallpark
 from parsec.components.pki import (
     BasePkiEnrollmentComponent,
+    PkiCertificate,
     PkiEnrollmentAcceptStoreBadOutcome,
     PkiEnrollmentAcceptValidateBadOutcome,
     PkiEnrollmentInfo,
@@ -50,8 +51,7 @@ class PGPkiEnrollmentComponent(BasePkiEnrollmentComponent):
         enrollment_id: PKIEnrollmentID,
         force: bool,
         submitter_human_handle: HumanHandle,
-        submitter_der_x509_certificate: bytes,
-        intermediate_certificates: list[bytes],
+        submitter_trustchain: list[PkiCertificate],
         submit_payload_signature: bytes,
         submit_payload_signature_algorithm: PkiSignatureAlgorithm,
         submit_payload: bytes,
@@ -63,7 +63,7 @@ class PGPkiEnrollmentComponent(BasePkiEnrollmentComponent):
             enrollment_id,
             force,
             submitter_human_handle,
-            submitter_der_x509_certificate,
+            submitter_trustchain,
             submit_payload_signature,
             submit_payload_signature_algorithm,
             submit_payload,

--- a/server/tests/api_v5/anonymous/test_pki_enrollment_info.py
+++ b/server/tests/api_v5/anonymous/test_pki_enrollment_info.py
@@ -15,6 +15,7 @@ from parsec._parsec import (
     UserProfile,
     anonymous_cmds,
 )
+from parsec.components.pki import parse_pki_cert
 from tests.api_v5.authenticated.test_user_create import (
     NEW_MIKE_DEVICE_ID,
     NEW_MIKE_DEVICE_LABEL,
@@ -47,8 +48,7 @@ async def test_anonymous_pki_enrollment_info_ok(
         enrollment_id=enrollment_id,
         force=False,
         submitter_human_handle=NEW_MIKE_HUMAN_HANDLE,
-        submitter_der_x509_certificate=test_pki.cert["bob"].der_certificate,
-        intermediate_certificates=[],
+        submitter_trustchain=[parse_pki_cert(test_pki.cert["bob"].der_certificate)],
         submit_payload_signature=b"<mike submit payload signature>",
         submit_payload_signature_algorithm=PkiSignatureAlgorithm.RSASSA_PSS_SHA256,
         submit_payload=submit_payload,
@@ -128,8 +128,7 @@ async def test_anonymous_pki_enrollment_info_ok(
                 enrollment_id=new_enrollment_id,
                 force=True,
                 submitter_human_handle=NEW_MIKE_HUMAN_HANDLE,
-                submitter_der_x509_certificate=test_pki.cert["bob"].der_certificate,
-                intermediate_certificates=[],
+                submitter_trustchain=[parse_pki_cert(test_pki.cert["bob"].der_certificate)],
                 submit_payload_signature=b"<mike submit payload signature>",
                 submit_payload_signature_algorithm=PkiSignatureAlgorithm.RSASSA_PSS_SHA256,
                 submit_payload=submit_payload,
@@ -197,8 +196,7 @@ async def test_anonymous_pki_enrollment_info_http_common_errors(
         enrollment_id=enrollment_id,
         force=False,
         submitter_human_handle=NEW_MIKE_HUMAN_HANDLE,
-        submitter_der_x509_certificate=test_pki.cert["bob"].der_certificate,
-        intermediate_certificates=[],
+        submitter_trustchain=[parse_pki_cert(test_pki.cert["bob"].der_certificate)],
         submit_payload_signature=b"<mike submit payload signature>",
         submit_payload_signature_algorithm=PkiSignatureAlgorithm.RSASSA_PSS_SHA256,
         submit_payload=submit_payload,

--- a/server/tests/api_v5/authenticated/test_pki_enrollment_accept.py
+++ b/server/tests/api_v5/authenticated/test_pki_enrollment_accept.py
@@ -21,6 +21,7 @@ from parsec._parsec import (
     UserProfile,
     authenticated_cmds,
 )
+from parsec.components.pki import parse_pki_cert
 from parsec.events import EventPkiEnrollment
 from tests.api_v5.authenticated.test_user_create import (
     NEW_MIKE_DEVICE_ID,
@@ -56,8 +57,7 @@ async def enrollment_id(
         enrollment_id=enrollment_id,
         force=False,
         submitter_human_handle=NEW_MIKE_HUMAN_HANDLE,
-        submitter_der_x509_certificate=test_pki.cert["bob"].der_certificate,
-        intermediate_certificates=[],
+        submitter_trustchain=[parse_pki_cert(test_pki.cert["bob"].der_certificate)],
         submit_payload_signature=b"<philip submit payload signature>",
         submit_payload_signature_algorithm=PkiSignatureAlgorithm.RSASSA_PSS_SHA256,
         submit_payload=submit_payload,

--- a/server/tests/api_v5/authenticated/test_pki_enrollment_list.py
+++ b/server/tests/api_v5/authenticated/test_pki_enrollment_list.py
@@ -88,14 +88,17 @@ async def test_authenticated_pki_enrollment_list_ok(
                 payload=submit_payload,
             )
         )
+        trustchain = await backend.pki.build_trustchain(
+            expected_enrollment_item.der_x509_certificate, (x.der_certificate for x in every_cert)
+        )
+        assert isinstance(trustchain, list)
         outcome = await backend.pki.submit(
             now=submitted_on,
             organization_id=coolorg.organization_id,
             enrollment_id=enrollment_id,
             force=False,
             submitter_human_handle=human_handle,
-            submitter_der_x509_certificate=expected_enrollment_item.der_x509_certificate,
-            intermediate_certificates=[x.der_certificate for x in every_cert],
+            submitter_trustchain=trustchain,
             submit_payload_signature=expected_enrollment_item.payload_signature,
             submit_payload_signature_algorithm=expected_enrollment_item.payload_signature_algorithm,
             submit_payload=expected_enrollment_item.payload,
@@ -162,14 +165,18 @@ async def test_authenticated_pki_enrollment_list_ok(
             payload=canceller_submit_payload,
         )
     )
+    trustchain = await backend.pki.build_trustchain(
+        canceller_expected_enrollment_item.der_x509_certificate,
+        canceller_expected_enrollment_item.intermediate_der_x509_certificates,
+    )
+    assert isinstance(trustchain, list)
     outcome = await backend.pki.submit(
         now=canceller_submitted_on,
         organization_id=coolorg.organization_id,
         enrollment_id=canceller_enrollment_id,
         force=True,
         submitter_human_handle=human_handle,
-        submitter_der_x509_certificate=canceller_expected_enrollment_item.der_x509_certificate,
-        intermediate_certificates=canceller_expected_enrollment_item.intermediate_der_x509_certificates,
+        submitter_trustchain=trustchain,
         submit_payload_signature=canceller_expected_enrollment_item.payload_signature,
         submit_payload_signature_algorithm=canceller_expected_enrollment_item.payload_signature_algorithm,
         submit_payload=canceller_expected_enrollment_item.payload,

--- a/server/tests/api_v5/authenticated/test_pki_enrollment_reject.py
+++ b/server/tests/api_v5/authenticated/test_pki_enrollment_reject.py
@@ -15,6 +15,7 @@ from parsec._parsec import (
     UserProfile,
     authenticated_cmds,
 )
+from parsec.components.pki import parse_pki_cert
 from parsec.events import EventPkiEnrollment
 from tests.common import (
     Backend,
@@ -43,8 +44,7 @@ async def enrollment_id(
         enrollment_id=enrollment_id,
         force=False,
         submitter_human_handle=human_handle,
-        submitter_der_x509_certificate=test_pki.cert["bob"].der_certificate,
-        intermediate_certificates=[],
+        submitter_trustchain=[parse_pki_cert(test_pki.cert["bob"].der_certificate)],
         submit_payload_signature=b"<philip submit payload signature>",
         submit_payload_signature_algorithm=PkiSignatureAlgorithm.RSASSA_PSS_SHA256,
         submit_payload=submit_payload,


### PR DESCRIPTION
So each implementation does not have to build is how trustchain (it simplify PG implementation as we do not have to pass `PGPkiEnrollmentComponent`)

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
