### PR TITLE
chore: disable eslint warning on ignored files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -274,7 +274,7 @@ repos:
             const { spawnSync } = require('child_process');
             const { exit, argv } = require('process');
             let files = argv.slice(1).map(function (x) { return x.replace(/^client\//, '') });
-            let ret = spawnSync('npx', ['eslint', '--max-warnings=0'].concat(files), {cwd: './client', stdio: 'inherit'});
+            let ret = spawnSync('npx', ['eslint', '--no-warn-ignored', '--max-warnings=0'].concat(files), {cwd: './client', stdio: 'inherit'});
             exit(ret.status);
           "
         require_serial: true


### PR DESCRIPTION
ESLint warns when running on files that are explicitly ignored in [`client/eslint.config.ts`](https://github.com/Scille/parsec-cloud/blob/master/client/eslint.config.ts#L13-L30). This makes `pre-commit` to fail when trying to commit a change on one of those files (e.g. `client/electron/src/setup.ts` or `client/electron/src/updater.ts`).

Adding `--no-warn-ignored` suppress those warnings.