### PR TITLE
ci: Use `wget` over `curl` to dl `pre-commit`

### DIFF
--- a/.github/actions/use-pre-commit/action.yml
+++ b/.github/actions/use-pre-commit/action.yml
@@ -52,9 +52,19 @@ runs:
       shell: bash -eux {0}
       run: |
         mkdir -p ${{ inputs.install-dir }}
-        curl --proto '=https' --tlsv1.2 -sSL \
+        MAX_TRIES=5
+        tries=0
+        until wget \
           https://github.com/pre-commit/pre-commit/releases/download/v${{ inputs.version }}/pre-commit-${{ inputs.version }}.pyz \
-          > ${{ inputs.install-dir }}/pre-commit.pyz
+          -O ${{ inputs.install-dir }}/pre-commit.pyz; do
+          tries=$((tries + 1))
+          if [ $tries -gt $MAX_TRIES ]; then
+            echo "Too many retries"
+            exit 1
+          fi
+          echo "Download failed, retrying in 5sec"
+          sleep 5
+        done
 
     - name: Debug installed python package
       run: |


### PR DESCRIPTION
`curl` was not failing when download of `pre-commit` failed, `wget` should handle that.

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
