### PR TITLE
feat(pki): Use own trusted anchor to validate accept payload

### DIFF
--- a/libparsec/crates/client/src/client/pki_enrollment_accept.rs
+++ b/libparsec/crates/client/src/client/pki_enrollment_accept.rs
@@ -56,7 +56,7 @@ pub async fn accept(
                 .context("Missing human handle from submitter certificate")
         })?;
     let accepter_intermediate_certs =
-        libparsec_platform_pki::get_intermediate_certs_for_cert(accepter_cert_ref, DateTime::now())
+        libparsec_platform_pki::get_validation_path_for_cert(accepter_cert_ref, DateTime::now())
             .map_err(anyhow::Error::from)
             .context("Failed to get intermediate certificates for itself")
             .map_err(PkiEnrollmentAcceptError::PkiOperationError)?;
@@ -69,7 +69,7 @@ pub async fn accept(
             Accepter {
                 cert_ref: accepter_cert_ref,
                 der_cert: &accepter_der_x509_certificate,
-                intermediate_der_certs: &accepter_intermediate_certs,
+                intermediate_der_certs: &accepter_intermediate_certs.intermediate_certs,
             },
             Submitter {
                 payload: submit_payload.clone(),

--- a/libparsec/crates/client/src/client/pki_enrollment_submit.rs
+++ b/libparsec/crates/client/src/client/pki_enrollment_submit.rs
@@ -60,7 +60,7 @@ pub async fn pki_enrollment_submit(
         .map_err(PkiEnrollmentSubmitError::PkiOperationError)?;
 
     let intermediate_certificates =
-        libparsec_platform_pki::get_intermediate_certs_for_cert(&x509_cert_ref, DateTime::now())
+        libparsec_platform_pki::get_validation_path_for_cert(&x509_cert_ref, DateTime::now())
             .map_err(anyhow::Error::from)
             .context("Failed to get intermediate certificates for itself")
             .map_err(PkiEnrollmentSubmitError::PkiOperationError)?;
@@ -68,7 +68,7 @@ pub async fn pki_enrollment_submit(
     let submitted_on = match cmds
         .send(Req {
             der_x509_certificate: der_x509_certificate.der_content,
-            intermediate_der_x509_certificates: intermediate_certificates,
+            intermediate_der_x509_certificates: intermediate_certificates.intermediate_certs,
             enrollment_id,
             force,
             payload: raw_payload.into(),

--- a/libparsec/crates/platform_pki/src/errors.rs
+++ b/libparsec/crates/platform_pki/src/errors.rs
@@ -62,7 +62,7 @@ error_set::error_set! {
     LoadAnswerPayloadError := ValidatePayloadError
         || DataError
         || ListTrustedRootCertificatesError
-    GetIntermediatesCertsForCertError := ListTrustedRootCertificatesError
+    GetValidationPathForCertError := ListTrustedRootCertificatesError
         || ListIntermediateCertificatesError
         || InvalidCertificateDer
         || VerifyCertificateError

--- a/libparsec/crates/platform_pki/src/lib.rs
+++ b/libparsec/crates/platform_pki/src/lib.rs
@@ -170,5 +170,5 @@ pub use shared::load_submit_payload;
 pub use errors::LoadAnswerPayloadError;
 pub use shared::load_answer_payload;
 
-pub use errors::GetIntermediatesCertsForCertError;
-pub use shared::get_intermediate_certs_for_cert;
+pub use errors::GetValidationPathForCertError;
+pub use shared::{get_validation_path_for_cert, ValidationPathOwned};

--- a/server/src/data/pki.rs
+++ b/server/src/data/pki.rs
@@ -294,10 +294,10 @@ pub(crate) fn load_submit_payload<'py>(
 ) -> PyResult<PkiEnrollmentSubmitPayload> {
     let trusted_roots = trusted_roots.into_iter().map(|v| v.0).collect::<Vec<_>>();
     libparsec_platform_pki::load_submit_payload(
-        der_certificate,
         &signed_message.0,
-        &trusted_roots,
+        der_certificate,
         intermediate_certs.iter().map(|v| v.as_bytes()),
+        &trusted_roots,
         now.0,
     )
     .map_err(|e| {


### PR DESCRIPTION
Refactor:

- Order param in load_pki_submit
- Rename `get_intermediate_certs_for_cert` to `get_validation_path_for_cert`
- `get_validation_path_for_cert` now include the trusted root
- Simplify `verify_untrusted_items` retrieval of trusted root using `get_validation_path_for_cert`

Closes #11757

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
