### PR TITLE
feat(pki): Add binding to `load_answer_payload`

### DIFF
--- a/libparsec/crates/platform_pki/src/errors.rs
+++ b/libparsec/crates/platform_pki/src/errors.rs
@@ -59,9 +59,7 @@ error_set::error_set! {
         DataError(libparsec_types::DataError)
     }
     LoadSubmitPayloadError := ValidatePayloadError || DataError
-    LoadAnswerPayloadError := ValidatePayloadError
-        || DataError
-        || ListTrustedRootCertificatesError
+    LoadAnswerPayloadError := ValidatePayloadError || DataError
     GetValidationPathForCertError := ListTrustedRootCertificatesError
         || ListIntermediateCertificatesError
         || InvalidCertificateDer

--- a/server/parsec/_parsec.pyi
+++ b/server/parsec/_parsec.pyi
@@ -106,6 +106,7 @@ from parsec._parsec_pyi.pki import (
     TrustAnchor,
     X509Certificate,
     X509CertificateInformation,
+    load_accept_payload,
     load_submit_payload,
 )
 from parsec._parsec_pyi.protocol import (
@@ -223,6 +224,7 @@ __all__ = [
     "X509Certificate",
     "TrustAnchor",
     "load_submit_payload",
+    "load_accept_payload",
     "PkiUntrusted",
     "PkiInvalidCertificateDER",
     "PkiInvalidSignature",

--- a/server/parsec/_parsec_pyi/pki.pyi
+++ b/server/parsec/_parsec_pyi/pki.pyi
@@ -89,9 +89,16 @@ class SignedMessage:
     def __init__(self, algo: PkiSignatureAlgorithm, signature: bytes, message: bytes) -> None: ...
 
 def load_submit_payload(
+    signed_message: SignedMessage,
     der_certificate: bytes,
     intermediate_certs: list[bytes],
     trusted_roots: list[TrustAnchor],
     now: DateTime,
-    signed_message: SignedMessage,
 ) -> PkiEnrollmentSubmitPayload: ...
+def load_accept_payload(
+    signed_message: SignedMessage,
+    der_certificate: bytes,
+    intermediate_certs: list[bytes],
+    trusted_roots: list[TrustAnchor],
+    now: DateTime,
+) -> PkiEnrollmentAnswerPayload: ...

--- a/server/parsec/components/memory/pki.py
+++ b/server/parsec/components/memory/pki.py
@@ -89,13 +89,13 @@ class MemoryPkiEnrollmentComponent(BasePkiEnrollmentComponent):
 
         try:
             load_submit_payload(
+                SignedMessage(
+                    submit_payload_signature_algorithm, submit_payload_signature, submit_payload
+                ),
                 submitter_trustchain[0].content,
                 list(map(lambda v: v.content, submitter_trustchain[1:])),
                 self._config.x509_trust_anchor,
                 now,
-                SignedMessage(
-                    submit_payload_signature_algorithm, submit_payload_signature, submit_payload
-                ),
             )
         except PkiUntrusted:
             return PkiEnrollmentSubmitBadOutcome.INVALID_X509_TRUSTCHAIN

--- a/server/parsec/components/postgresql/pki_submit.py
+++ b/server/parsec/components/postgresql/pki_submit.py
@@ -188,13 +188,13 @@ async def pki_submit(
 
     try:
         load_submit_payload(
+            SignedMessage(
+                submit_payload_signature_algorithm, submit_payload_signature, submit_payload
+            ),
             submitter_trustchain[0].content,
             list(map(lambda v: v.content, submitter_trustchain[1:])),
             config.x509_trust_anchor,
             now,
-            SignedMessage(
-                submit_payload_signature_algorithm, submit_payload_signature, submit_payload
-            ),
         )
     except PkiUntrusted:
         return PkiEnrollmentSubmitBadOutcome.INVALID_X509_TRUSTCHAIN

--- a/server/src/data/mod.rs
+++ b/server/src/data/mod.rs
@@ -55,6 +55,7 @@ pub(crate) fn add_mod(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<TrustAnchor>()?;
     m.add_class::<SignedMessage>()?;
     m.add_function(wrap_pyfunction!(load_submit_payload, m)?)?;
+    m.add_function(wrap_pyfunction!(load_accept_payload, m)?)?;
     crate::binding_utils::export_exception!(m, py, PkiInvalidSignature);
     crate::binding_utils::export_exception!(m, py, PkiInvalidCertificateDER);
     crate::binding_utils::export_exception!(m, py, PkiUntrusted);


### PR DESCRIPTION
Re-order param of `load_submit_payload` that was binding to be similar to `libparsec_platform_pki` and binded `load_accept_payload`

Closes #11938

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
