### PR TITLE
fix(parsec-cli): Rework copy file to workspace

### DIFF
--- a/cli/src/commands/workspace/import.rs
+++ b/cli/src/commands/workspace/import.rs
@@ -206,17 +206,18 @@ async fn copy_file_to_fd(
             .read(&mut buffer)
             .await
             .context("Cannot read local file")?;
+        let mut buf = &buffer[..bytes_read];
 
         if bytes_read == 0 {
             break;
         }
 
-        let mut bytes_written = 0_usize;
-        while bytes_written < bytes_read {
-            bytes_written = workspace
-                .fd_write(fd, dst_offset as u64, &buffer[bytes_written..bytes_read])
+        while !buf.is_empty() {
+            let bytes_written = workspace
+                .fd_write(fd, dst_offset as u64, buf)
                 .await
                 .context("Cannot write to workspace")? as usize;
+            buf = &buf[bytes_written..];
             dst_offset += bytes_written;
         }
     }


### PR DESCRIPTION
During the copy of a file during workspace import the logic never offset the buffer correctly:

It reuse the `bytes_written` directly without offsetting with what was already written causing an infinite loop at the worst case (and possibly repeated bytes). This did not happen because the `WorkspaceOps::fd_write` seems to write the full buffer (at least in the test case).

The new logic uses a temp buffer (just a pointer) that will be offset by the amount of written bytes until the end of it.

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
