### PR TITLE
refactor(pki): Remove usage of `log::kv`

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,7 +36,7 @@ clap = { workspace = true, features = ["default", "derive", "env"] }
 # `termination` feature enable handling of SIGHUP/SIGTERM on top of SIGINT
 ctrlc = { workspace = true, features = ["termination"] }
 dialoguer = { workspace = true, features = ["fuzzy-select"] }
-env_logger = { workspace = true, features = ["auto-color", "humantime", "regex", "kv"] }
+env_logger = { workspace = true, features = ["auto-color", "humantime", "regex"] }
 log = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 rpassword = { workspace = true }

--- a/libparsec/Cargo.toml
+++ b/libparsec/Cargo.toml
@@ -49,4 +49,4 @@ thiserror = { workspace = true }
 libparsec_platform_mountpoint = { workspace = true }
 libparsec_platform_ipc = { workspace = true }
 
-env_logger = { workspace = true, features = ["auto-color", "humantime", "regex", "kv"] }
+env_logger = { workspace = true, features = ["auto-color", "humantime", "regex"] }

--- a/libparsec/crates/client/src/client/pki_enrollment_finalize.rs
+++ b/libparsec/crates/client/src/client/pki_enrollment_finalize.rs
@@ -97,7 +97,7 @@ pub async fn finalize(
     drop(
         libparsec_platform_device_loader::remove_device(config_dir, &local_pending_path)
             .await
-            .inspect_err(|err| log::warn!(err:%; "Failed to remove pki local pending file")),
+            .inspect_err(|err| log::warn!("Failed to remove pki local pending file: {err}")),
     );
 
     Ok(available_device)

--- a/libparsec/crates/client/src/client/pki_enrollment_list.rs
+++ b/libparsec/crates/client/src/client/pki_enrollment_list.rs
@@ -132,7 +132,7 @@ pub async fn verify_untrusted_items(
                 ) {
                     Ok(payload) => payload,
                     Err(err) => {
-                        log::debug!(err:%; "Cannot validate submit payload");
+                        log::debug!("Cannot validate submit payload: {err}");
                         return PkiEnrollmentListItem::Invalid {
                             human_handle: human_handle.ok(),
                             enrollment_id: req.enrollment_id,

--- a/libparsec/crates/platform_device_loader/src/lib.rs
+++ b/libparsec/crates/platform_device_loader/src/lib.rs
@@ -1033,16 +1033,23 @@ fn load_pending_async_enrollment_frow_raw(
     (),
 > {
     let cooked = AsyncEnrollmentLocalPending::load(raw)
-        .inspect_err(
-            |err| log::warn!(path:% = path.display(), err:%; "Failed to load async enrollment local pending file")
-        )
+        .inspect_err(|err| {
+            log::warn!(
+                "Failed to load async enrollment local pending file {}: {err}",
+                path.display()
+            )
+        })
         .map_err(|_| ())?;
 
-    let cooked_cleartext_content = AsyncEnrollmentLocalPendingCleartextContent::load(&cooked.cleartext_content)
-        .inspect_err(
-            |err| log::warn!(path:% = path.display(), err:%; "Failed to load cleartext part of async enrollment local pending file")
+    let cooked_cleartext_content =
+        AsyncEnrollmentLocalPendingCleartextContent::load(&cooked.cleartext_content)
+            .inspect_err(|err| {
+                log::warn!(
+            "Failed to load cleartext part of async enrollment local pending file {}: {err}",
+            path.display()
         )
-        .map_err(|_| ())?;
+            })
+            .map_err(|_| ())?;
 
     Ok((cooked, cooked_cleartext_content))
 }

--- a/libparsec/crates/platform_device_loader/src/native/mod.rs
+++ b/libparsec/crates/platform_device_loader/src/native/mod.rs
@@ -626,7 +626,7 @@ pub(super) async fn list_pki_local_pending(
 
     // Sort entries so result is deterministic
     files.sort();
-    log::trace!(files:?; "Found pending request files");
+    log::trace!("Found pending request files: {files:?}");
 
     Ok(libparsec_platform_async::stream::iter(files)
         .filter_map(async |path| load_pki_pending_file(&path).await.ok())
@@ -639,7 +639,10 @@ async fn find_local_pending_files(path: &Path) -> Result<Vec<PathBuf>, ListPkiLo
         Ok(v) => v,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(err) => {
-            log::error!(path:% = path.display(), err:%; "Cannot list pending request files");
+            log::error!(
+                "Cannot list pending request files in {}: {err}",
+                path.display()
+            );
             return Err(ListPkiLocalPendingError::StorageNotAvailable);
         }
     };
@@ -666,9 +669,7 @@ async fn load_pki_pending_file(path: &Path) -> Result<PKILocalPendingEnrollment,
         .map_err(Into::into)
         .map_err(LoadFileError::InvalidPath)?;
     PKILocalPendingEnrollment::load(&content)
-        .inspect_err(
-            |err| log::debug!(path:% = path.display(), err:%; "Failed to load pki pending file"),
-        )
+        .inspect_err(|err| log::debug!("Failed to load pki pending file {}: {err}", path.display()))
         .map_err(|_| LoadFileError::InvalidData)
 }
 
@@ -719,7 +720,10 @@ async fn find_pending_async_enrollment_files(
         Ok(v) => v,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(err) => {
-            log::error!(path:% = path.display(), err:%; "Cannot list pending request files");
+            log::error!(
+                "Cannot list pending request files in {}: {err}",
+                path.display()
+            );
             return Err(ListPendingAsyncEnrollmentsError::StorageNotAvailable);
         }
     };

--- a/libparsec/crates/platform_device_loader/src/web/internal.rs
+++ b/libparsec/crates/platform_device_loader/src/web/internal.rs
@@ -63,9 +63,8 @@ impl Storage {
         extension: impl AsRef<OsStr> + std::fmt::Display,
     ) -> Result<Vec<File>, ListFileEntriesError> {
         log::debug!(
-            directory:% = dir.display(),
-            extension:%;
-            "Listing file entries",
+            "Listing file entries in {} with extension {extension}",
+            dir.display()
         );
         let dir = match self.root_dir.get_directory_from_path(&dir, None).await {
             Ok(dir) => dir,
@@ -83,7 +82,7 @@ impl Storage {
             drop(handle);
             res
         } {
-            log::trace!(path:% = dir.path.display(); "Exploring directory");
+            log::trace!("Exploring directory {}", dir.path.display());
             let mut entries_stream = dir.entries();
             while let Some(entry) = entries_stream.next().await {
                 let DirEntry { path, handle } = entry;
@@ -91,14 +90,14 @@ impl Storage {
                     DirOrFileHandle::File(handle)
                         if path.extension() == Some(extension.as_ref()) =>
                     {
-                        log::trace!(path:% = path.display(); "File with correct extension");
+                        log::trace!("File {} with correct extension", path.display());
                         files.push(File { path, handle })
                     }
                     DirOrFileHandle::File(_) => {
-                        log::trace!(path:% = path.display(); "Ignoring file because of bad suffix");
+                        log::trace!("Ignoring file {} because of bad suffix", path.display());
                     }
                     DirOrFileHandle::Dir(handle) => {
-                        log::trace!(path:% = path.display(); "New directory to explore");
+                        log::trace!("New directory to explore: {}", path.display());
                         dirs_to_explore
                             .lock()
                             .await
@@ -373,9 +372,9 @@ async fn load_pki_local_pending(
     PKILocalPendingEnrollment::load(&raw_data)
         .inspect_err(|err| {
             log::warn!(
-                path:% = file.path().display(),
-                err:%;
-                "Failed to decode local pending")
+                "Failed to decode local pending at {}: {err}",
+                file.path().display()
+            )
         })
         .map_err(LoadPkiLocalPendingError::DataError)
 }

--- a/libparsec/crates/platform_device_loader/src/web/mod.rs
+++ b/libparsec/crates/platform_device_loader/src/web/mod.rs
@@ -299,11 +299,19 @@ pub(super) async fn list_pending_async_enrollments(
         return Err(ListPendingAsyncEnrollmentsError::StorageNotAvailable);
     };
 
-    let files = storage.list_file_entries(pending_async_enrollments_dir, crate::PENDING_ASYNC_ENROLLMENT_EXT).await
+    let files = storage
+        .list_file_entries(
+            pending_async_enrollments_dir,
+            crate::PENDING_ASYNC_ENROLLMENT_EXT,
+        )
+        .await
         .or_else(|err| match err {
             ListFileEntriesError::NotFound { .. } => Ok(vec![]),
             _ => {
-                log::error!(path:% = pending_async_enrollments_dir.display(), err:%; "Cannot list pending request files");
+                log::error!(
+                    "Cannot list pending request files in {}: {err}",
+                    pending_async_enrollments_dir.display()
+                );
                 Err(ListPendingAsyncEnrollmentsError::StorageNotAvailable)
             }
         })?;

--- a/libparsec/crates/platform_pki/Cargo.toml
+++ b/libparsec/crates/platform_pki/Cargo.toml
@@ -24,7 +24,7 @@ sha2 = { workspace = true }
 libparsec_types = { workspace = true }
 # Use to decode subject & issuer fields of used x509 certificate.
 x509-cert = { workspace = true, features = ["std"] }
-log = { workspace = true, features = ["kv"] }
+log = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 
@@ -44,7 +44,7 @@ clap = { workspace = true, default-features = true, features = ["env", "derive"]
 # We use some hex encoding in the crate's examples
 data-encoding = { workspace = true, default-features = true }
 anyhow = { workspace = true }
-env_logger = { workspace = true, features = ["kv"] }
+env_logger = { workspace = true }
 hex-literal = { workspace = true }
 libparsec_tests_lite = { workspace = true }
 serde = { workspace = true }

--- a/libparsec/crates/platform_pki/src/windows/mod.rs
+++ b/libparsec/crates/platform_pki/src/windows/mod.rs
@@ -155,10 +155,9 @@ pub fn list_trusted_root_certificate_anchors(
                 .map(|anchor| anchor.to_owned())
                 .inspect_err(|err| {
                     log::warn!(
-                            name:? = ctx.friendly_name().ok(),
-                            fingerprint:? = ctx.fingerprint(HashAlgorithm::sha256()).ok(),
-                            err:%;
-                            "Invalid root certificate"
+                        "Invalid root certificate: name={:?}, fingerprint={:?}, err={err}",
+                        ctx.friendly_name().ok(),
+                        ctx.fingerprint(HashAlgorithm::sha256()).ok()
                     )
                 })
                 .ok()

--- a/libparsec/crates/platform_pki/src/x509/extensions/mod.rs
+++ b/libparsec/crates/platform_pki/src/x509/extensions/mod.rs
@@ -23,27 +23,32 @@ impl TryFrom<Vec<ext::Extension>> for Extensions {
 
     fn try_from(value: Vec<ext::Extension>) -> Result<Self, Self::Error> {
         let mut extensions = Self::default();
-        value.into_iter()
-                .try_for_each(|ext| -> Result<(), DERError> {
-                    log::trace!(id:% = ext.extn_id, value:? =ext.extn_value, critical=ext.critical; "Certificate extensions");
-                    match ext.extn_id {
-                        // Certificate alternative names
-                        // https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
-                        ID_CE_SUBJECT_ALT_NAME => {
-                            extensions.subject_alt_names = parse_san_octet_string(ext.extn_value.as_bytes())?;
-                        },
-                        // Certificate key usage
-                        // https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3
-                        ID_CE_KEY_USAGE => {
-                        }
-                        // Certificate Additional key usage
-                        // https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12
-                        ID_CE_EXT_KEY_USAGE => {
-                        }
-                        _ => {}
+        value
+            .into_iter()
+            .try_for_each(|ext| -> Result<(), DERError> {
+                log::trace!(
+                    "Certificate extensions: id={}, value={:?}, critical={}",
+                    ext.extn_id,
+                    ext.extn_value,
+                    ext.critical
+                );
+                match ext.extn_id {
+                    // Certificate alternative names
+                    // https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
+                    ID_CE_SUBJECT_ALT_NAME => {
+                        extensions.subject_alt_names =
+                            parse_san_octet_string(ext.extn_value.as_bytes())?;
                     }
-                    Ok(())
-                })?;
+                    // Certificate key usage
+                    // https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3
+                    ID_CE_KEY_USAGE => {}
+                    // Certificate Additional key usage
+                    // https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12
+                    ID_CE_EXT_KEY_USAGE => {}
+                    _ => {}
+                }
+                Ok(())
+            })?;
         Ok(extensions)
     }
 }

--- a/libparsec/crates/platform_pki/src/x509/mod.rs
+++ b/libparsec/crates/platform_pki/src/x509/mod.rs
@@ -95,10 +95,10 @@ impl TryFrom<x509_cert::Certificate> for X509CertificateInformation {
 
     fn try_from(value: x509_cert::Certificate) -> Result<Self, Self::Error> {
         let subject = extract_dn_list_from_rnd_seq(value.tbs_certificate.subject);
-        log::trace!(subject:?; "Collected subject");
+        log::trace!("Collected subject: {subject:?}");
 
         let issuer = extract_dn_list_from_rnd_seq(value.tbs_certificate.issuer);
-        log::trace!(issuer:?; "Collected issuer");
+        log::trace!("Collected issuer: {issuer:?}");
 
         // Extensions are only available on V3 certificate
         let extensions: Extensions = if value.tbs_certificate.version == Version::V3 {


### PR DESCRIPTION
The reason is that `console_log` crate does not support `log::kv` feature

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
