### PR TITLE
fix(electron): Add missing `tslib` dependency

### DIFF
--- a/client/electron/package-lock.json
+++ b/client/electron/package-lock.json
@@ -18,7 +18,8 @@
                 "electron-unhandled": "~4.0.1",
                 "electron-updater": "6.3.9",
                 "electron-window-state": "~5.0.3",
-                "regedit": "^5.1.4"
+                "regedit": "^5.1.4",
+                "tslib": "^2.8.1"
             },
             "devDependencies": {
                 "@electron/notarize": "^2.5.0",
@@ -6145,7 +6146,8 @@
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
         },
         "node_modules/type-fest": {
             "version": "0.13.1",

--- a/client/electron/package.json
+++ b/client/electron/package.json
@@ -33,7 +33,8 @@
         "electron-unhandled": "~4.0.1",
         "electron-updater": "6.3.9",
         "electron-window-state": "~5.0.3",
-        "regedit": "^5.1.4"
+        "regedit": "^5.1.4",
+        "tslib": "^2.8.1"
     },
     "devDependencies": {
         "@electron/notarize": "^2.5.0",


### PR DESCRIPTION
By manually packaging the application I've had the following issue when running the application:

```
Error: Cannot find module 'tslib'
```

The runtime depends on it because we enable `importHelpers` in `tsconfig.json`. The fix for that error is simple: Make the package depends directly on `tslib` for it to be included in `app.asar`.

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
