### PR TITLE
[MS] Responsive header redesign

### DIFF
--- a/client/src/components/files/explorer/FolderSelectionModal.vue
+++ b/client/src/components/files/explorer/FolderSelectionModal.vue
@@ -20,11 +20,11 @@
       class="navigation"
       ref="navigation"
     >
-      <div ref="buttons">
-        <div
-          class="navigation-buttons"
-          v-if="isLargeDisplay"
-        >
+      <div
+        v-if="isLargeDisplay"
+        ref="buttons"
+      >
+        <div class="navigation-buttons">
           <ion-button
             fill="clear"
             @click="back()"
@@ -46,12 +46,14 @@
         </div>
       </div>
       <header-breadcrumbs
+        v-if="workspaceInfo"
         :path-nodes="headerPath"
         @change="onPathChange"
         class="navigation-breadcrumb"
         :items-before-collapse="1"
         :items-after-collapse="2"
         :available-width="breadcrumbsWidth"
+        :workspace-name="workspaceInfo.currentName"
       />
     </div>
     <ion-list class="folder-list">

--- a/client/src/components/files/explorer/HistoryFileListItem.vue
+++ b/client/src/components/files/explorer/HistoryFileListItem.vue
@@ -100,6 +100,7 @@ onMounted(async () => {
 <style lang="scss" scoped>
 .file-selected {
   flex-shrink: 0;
+  overflow: visible;
   width: 2.5rem;
 
   @include ms.responsive-breakpoint('sm') {

--- a/client/src/components/header/HeaderBackButton.vue
+++ b/client/src/components/header/HeaderBackButton.vue
@@ -55,19 +55,19 @@ async function goBack(): Promise<void> {
   flex-shrink: 0;
 
   @include ms.responsive-breakpoint('sm') {
-    background: var(--parsec-color-light-secondary-premiere);
-    border-radius: var(--parsec-radius-8);
+    background: var(--parsec-color-light-secondary-white);
+    border-radius: var(--parsec-radius-circle);
+    --border-radius: var(--parsec-radius-circle);
+    box-shadow: var(--parsec-shadow-soft);
   }
 
   &::part(native) {
     padding: 0.5rem;
-
-    @include ms.responsive-breakpoint('sm') {
-      padding: 0.375rem;
-    }
   }
 
   &__icon {
+    font-size: 1.375rem;
+
     @include ms.responsive-breakpoint('sm') {
       color: var(--parsec-color-light-secondary-hard-grey);
     }
@@ -75,6 +75,13 @@ async function goBack(): Promise<void> {
 
   &__label {
     margin-left: 0.625rem;
+  }
+
+  &:hover {
+    @include ms.responsive-breakpoint('sm') {
+      --background-hover: var(--parsec-color-light-secondary-medium);
+      background: var(--parsec-color-light-secondary-medium);
+    }
   }
 }
 

--- a/client/src/components/header/HeaderBreadcrumbPopover.vue
+++ b/client/src/components/header/HeaderBreadcrumbPopover.vue
@@ -4,16 +4,16 @@
   <ion-content class="popover">
     <ion-list>
       <ion-item
-        class="popover-item ion-no-padding"
         v-for="(breadcrumb, index) in filteredBreadcrumbs"
+        class="breadcrumb-item ion-no-padding"
         :key="index"
         @click="onClick(breadcrumb)"
       >
         <ion-icon
           :icon="breadcrumb.popoverIcon ? breadcrumb.popoverIcon : returnDownForward"
-          class="popover-item__icon"
+          class="breadcrumb-item__icon"
         />
-        <ion-text class="button-medium">{{ breadcrumb.display }}</ion-text>
+        <ion-text class="breadcrumb-item__text button-medium">{{ breadcrumb.display }}</ion-text>
       </ion-item>
     </ion-list>
   </ion-content>
@@ -36,7 +36,7 @@ async function onClick(breadcrumb: RouterPathNode): Promise<void> {
 </script>
 
 <style scoped lang="scss">
-.popover {
+.breadcrumb {
   &-item {
     color: var(--parsec-color-light-secondary-soft-text);
     --background: none;
@@ -50,7 +50,7 @@ async function onClick(breadcrumb: RouterPathNode): Promise<void> {
       background: var(--parsec-color-light-secondary-background);
     }
 
-    ion-text {
+    &__text {
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: nowrap;
@@ -60,6 +60,16 @@ async function onClick(breadcrumb: RouterPathNode): Promise<void> {
       font-size: 1rem;
       color: var(--parsec-color-light-secondary-grey);
       margin-right: 0.625rem;
+    }
+
+    &--disabled {
+      pointer-events: none;
+      color: var(--parsec-color-light-secondary-text);
+      opacity: 0.5;
+
+      & .breadcrumb-item__icon {
+        color: var(--parsec-color-light-secondary-text);
+      }
     }
   }
 }

--- a/client/src/components/header/InvitationsButton.vue
+++ b/client/src/components/header/InvitationsButton.vue
@@ -7,16 +7,10 @@
     id="invitations-button"
     class="button-medium"
     :class="{
-      unread: invitations,
+      unread: invitations.length > 0,
       'gradient-button': isGradientButton,
     }"
   >
-    <span
-      v-if="isLargeDisplay"
-      class="button-text"
-    >
-      {{ $msTranslate({ key: 'HeaderPage.invitations.title', data: { count: invitations.length }, count: invitations.length }) }}
-    </span>
     <ion-text
       v-if="isGradientButton"
       :class="{ 'gradient-button-text': isGradientButton }"
@@ -29,13 +23,14 @@
     <span
       class="unread-count"
       :class="{ 'unread-count--more': invitations.length > 99 }"
-      v-if="invitations.length > 0 && !isGradientButton && windowWidth < WindowSizeBreakpoints.LG"
+      v-if="invitations.length > 0 && !isGradientButton"
     >
       {{ invitations.length > 99 ? '99+' : invitations.length }}
     </span>
     <ion-icon
       v-if="!isGradientButton"
       :icon="mail"
+      class="invitation-button-icon"
     />
     <ion-icon
       v-else
@@ -56,14 +51,14 @@ import { Information, InformationLevel, InformationManager, InformationManagerKe
 import GreetUserModal from '@/views/users/GreetUserModal.vue';
 import { IonButton, IonIcon, IonText, modalController, popoverController } from '@ionic/vue';
 import { mail, mailUnread } from 'ionicons/icons';
-import { Answer, MsModalResult, WindowSizeBreakpoints, askQuestion, useWindowSize } from 'megashark-lib';
+import { Answer, MsModalResult, askQuestion, useWindowSize } from 'megashark-lib';
 import { Ref, inject, onMounted, onUnmounted, ref } from 'vue';
 
 const informationManager: InformationManager = inject(InformationManagerKey)!;
 const eventDistributor: EventDistributor = inject(EventDistributorKey)!;
 let eventCbId: string | null = null;
 const invitations: Ref<UserInvitation[]> = ref([]);
-const { isLargeDisplay, windowWidth } = useWindowSize();
+const { isLargeDisplay } = useWindowSize();
 
 defineProps<{
   isGradientButton?: boolean;
@@ -227,13 +222,8 @@ async function greetUser(invitation: UserInvitation): Promise<void> {
     }
   }
 
-  ion-icon {
+  .invitation-button-icon {
     font-size: 1.375rem;
-    margin-left: 0.5rem;
-
-    @include ms.responsive-breakpoint('lg') {
-      margin-left: 0;
-    }
   }
 
   .button-text {
@@ -245,26 +235,9 @@ async function greetUser(invitation: UserInvitation): Promise<void> {
   &.unread {
     position: relative;
 
-    &::after {
-      content: '';
-      position: absolute;
-      right: 6px;
-      top: 5px;
-      width: 0.625rem;
-      height: 0.625rem;
-      background: var(--parsec-color-light-danger-500);
-      border: 2px solid var(--parsec-color-light-primary-50);
-      border-radius: var(--parsec-radius-12);
-    }
-
-    @include ms.responsive-breakpoint('lg') {
-      &::after {
-        content: none;
-      }
-    }
-
     .unread-count {
       position: absolute;
+      z-index: 3;
       right: -8px;
       top: -8px;
       padding-inline: 2px;
@@ -280,12 +253,28 @@ async function greetUser(invitation: UserInvitation): Promise<void> {
       background: var(--parsec-color-light-danger-500);
       border: 2px solid var(--parsec-color-light-primary-50);
       border-radius: var(--parsec-radius-12);
-      z-index: 2;
+
+      @include ms.responsive-breakpoint('sm') {
+        left: 12px;
+        right: auto;
+        border-color: var(--parsec-color-light-secondary-white);
+      }
 
       &--more {
         font-size: 10px;
         right: -10px;
+        justify-content: end;
       }
+    }
+  }
+
+  @include ms.responsive-breakpoint('sm') {
+    &::part(native) {
+      padding: 0.5rem;
+      border-radius: var(--parsec-radius-circle);
+      --background: var(--parsec-color-light-secondary-white);
+      box-shadow: var(--parsec-shadow-soft);
+      overflow: visible;
     }
   }
 }

--- a/client/src/components/header/SmallDisplaySelectionHeader.vue
+++ b/client/src/components/header/SmallDisplaySelectionHeader.vue
@@ -1,58 +1,40 @@
 <!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
 
 <template>
-  <div
-    class="small-display-header-title"
-    :class="selectionEnabled ? 'small-display-header-title--selection' : ''"
-  >
-    <div v-if="selectionEnabled">
-      <ion-text
-        v-if="someSelected"
-        class="button-medium title__button title__button-left"
-        @click="$emit('unselect', $event)"
-      >
-        {{ $msTranslate('FoldersPage.actions.unselect') }}
-      </ion-text>
-      <ion-text
-        v-else
-        class="button-medium title__button title__button-left"
-        @click="$emit('select', $event)"
-      >
-        {{ $msTranslate('FoldersPage.actions.select') }}
-      </ion-text>
-    </div>
+  <div class="small-display-selection-header">
     <ion-text
-      v-if="title"
-      class="title__text title-h2"
-      :class="selectionEnabled ? 'title__text--selection' : ''"
+      v-if="someSelected"
+      class="button-medium title__button title__button-left"
+      @click="$emit('unselect', $event)"
     >
+      {{ $msTranslate('FoldersPage.actions.unselect') }}
+    </ion-text>
+    <ion-text
+      v-else
+      class="button-medium title__button title__button-left"
+      @click="$emit('select', $event)"
+    >
+      {{ $msTranslate('FoldersPage.actions.select') }}
+    </ion-text>
+    <ion-text class="title__text title-h3">
       <span class="title__text--content">{{ $msTranslate(props.title) }}</span>
     </ion-text>
     <slot />
     <ion-text
-      v-if="selectionEnabled"
       class="button-medium title__button title__button-right"
       @click="$emit('cancelSelection', $event)"
     >
       {{ $msTranslate('FoldersPage.actions.cancel') }}
     </ion-text>
-    <ion-icon
-      v-if="!selectionEnabled && !optionsDisabled"
-      class="title__icon"
-      :icon="ellipsisHorizontal"
-      @click="$emit('openContextualModal', $event)"
-    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { IonIcon, IonText } from '@ionic/vue';
-import { ellipsisHorizontal } from 'ionicons/icons';
+import { IonText } from '@ionic/vue';
 import { Translatable } from 'megashark-lib';
 
 const props = defineProps<{
   title: Translatable;
-  selectionEnabled?: boolean;
   someSelected?: boolean;
   optionsDisabled?: boolean;
 }>();
@@ -66,18 +48,13 @@ defineEmits<{
 </script>
 
 <style scoped lang="scss">
-.small-display-header-title {
+.small-display-selection-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.125rem 2rem 1rem;
-  min-height: 3.75rem;
   gap: 0.5rem;
   background: var(--parsec-color-light-secondary-background);
-
-  &--selection {
-    padding: 0.125rem 0.25rem 1rem;
-  }
+  padding: 1.5rem 1rem;
 }
 
 .title__text {
@@ -87,15 +64,12 @@ defineEmits<{
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  justify-content: center;
 
   &--content {
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
-  }
-
-  &--selection {
-    justify-content: center;
   }
 }
 
@@ -116,8 +90,12 @@ defineEmits<{
 }
 
 .title__button {
-  padding: 0.8rem;
+  padding: 0.625rem 0.825rem;
   flex-shrink: 0;
+  background: var(--parsec-color-light-secondary-white);
+  border: 1px solid var(--parsec-color-light-secondary-medium);
+  border-radius: var(--parsec-radius-12);
+  box-shadow: var(--parsec-shadow-soft);
 
   &:hover {
     cursor: pointer;

--- a/client/src/components/misc/RecommendationChecklistPopoverModal.vue
+++ b/client/src/components/misc/RecommendationChecklistPopoverModal.vue
@@ -9,7 +9,7 @@
     <div class="checklist-list">
       <div
         class="checklist-list-item subtitles-sm"
-        v-show="securityWarnings.isWorkspaceOwner"
+        v-show="securityWarnings.needsSecondOwner"
         :class="{ done: securityWarnings.soloOwnerWorkspaces.length === 0, clickable: workspaceWarningClickable }"
         @click="workspaceWarningClickable && onClick(RecommendationAction.AddWorkspaceOwner)"
       >

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -1094,7 +1094,7 @@
         "noRecentDocuments": "No recent documents",
         "back": "Back",
         "checklist": {
-            "title": "Security checklist",
+            "title": "Security recommendations",
             "description": "To reduce the risk of data loss, we strongly recommend that you take the following actions.",
             "remaining": "1 remaining task | {count} remaining tasks",
             "open": "Open",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -1094,7 +1094,7 @@
         "noRecentDocuments": "Aucun document récent",
         "back": "Retour",
         "checklist": {
-            "title": "Actions recommandées",
+            "title": "Recommandations de sécurité",
             "description": "Pour réduire le risque de perte de données, nous vous recommandons d'effectuer les tâches suivantes.",
             "remaining": "1 tâche restante | {count} tâches restantes",
             "open": "Ouvrir",

--- a/client/src/services/eventDistributor.ts
+++ b/client/src/services/eventDistributor.ts
@@ -49,6 +49,7 @@ enum Events {
   EntryDeleted = 1 << 26,
   EntrySyncProgress = 1 << 27,
   WorkspaceMountpointsSync = 1 << 28,
+  OpenContextMenu = 1 << 28,
 }
 
 interface WorkspaceCreatedData {
@@ -130,6 +131,10 @@ interface WorkspaceMountpointInfo {
   isMounted: boolean;
 }
 
+interface OpenContextualMenuData {
+  event: Event;
+}
+
 type EventData =
   | WorkspaceCreatedData
   | InvitationUpdatedData
@@ -145,7 +150,8 @@ type EventData =
   | WorkspaceRoleUpdateData
   | EntryRenamedData
   | EntryDeletedData
-  | WorkspaceMountpointInfo;
+  | WorkspaceMountpointInfo
+  | OpenContextualMenuData;
 
 interface Callback {
   id: string;
@@ -235,6 +241,7 @@ export {
   IncompatibleServerData,
   InvitationUpdatedData,
   MenuActionData,
+  OpenContextualMenuData,
   UpdateAvailabilityData,
   WorkspaceCreatedData,
   WorkspaceMountpointInfo,

--- a/client/src/theme/components/_modals.scss
+++ b/client/src/theme/components/_modals.scss
@@ -662,6 +662,10 @@
 
   @include ms.responsive-breakpoint('sm') {
     padding: 1rem 0 0;
+
+    &::part(content) {
+      --height: 100%;
+    }
   }
 
   .navigation {

--- a/client/src/views/files/FileOperationMenu.vue
+++ b/client/src/views/files/FileOperationMenu.vue
@@ -299,6 +299,7 @@ function scrollToTop(): void {
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  z-index: 20;
 
   @include ms.responsive-breakpoint('sm') {
     right: 0;
@@ -418,6 +419,10 @@ function scrollToTop(): void {
     max-height: 28rem;
     transition: all 250ms ease-in-out;
     background: var(--parsec-color-light-secondary-white);
+
+    @media screen and (max-height: 1000px) {
+      height: 40vh;
+    }
 
     &__empty {
       overflow: hidden;

--- a/client/src/views/workspaces/WorkspaceHistoryPage.vue
+++ b/client/src/views/workspaces/WorkspaceHistoryPage.vue
@@ -71,7 +71,8 @@
                 </ion-button>
               </div>
               <header-breadcrumbs
-                v-if="isLargeDisplay"
+                v-if="workspaceInfo && isLargeDisplay"
+                :workspace-name="workspaceInfo.currentName"
                 :path-nodes="headerPath"
                 @change="onPathChange"
                 class="navigation-breadcrumb"
@@ -110,24 +111,21 @@
             </div>
           </div>
           <div
-            class="current-folder button-medium"
-            v-if="headerPath.length > 0 && isSmallDisplay"
+            class="current-folder button-large"
+            v-if="isSmallDisplay"
           >
             <ms-image
               v-show="pathLength > 1"
               :image="Folder"
               class="current-folder__icon"
             />
-            <ion-text class="current-folder__text">{{ `${headerPath[headerPath.length - 1].display}` }}</ion-text>
             <header-breadcrumbs
-              v-if="pathLength > 1"
+              v-if="workspaceInfo"
+              :workspace-name="workspaceInfo.currentName"
               :path-nodes="headerPath"
               @change="onPathChange"
               class="navigation-breadcrumb"
-              :items-before-collapse="0"
-              :items-after-collapse="0"
-              :max-shown="0"
-              :available-width="breadcrumbsWidth"
+              :from-header-page="false"
               :show-parent-node="false"
             />
             <ion-button
@@ -597,44 +595,74 @@ async function onRestoreClicked(): Promise<void> {
   }
 
   .current-folder {
-    color: var(--parsec-color-light-secondary-grey);
+    color: var(--parsec-color-light-secondary-hard-grey);
     background: var(--parsec-color-light-secondary-white);
     border-bottom: 1px solid var(--parsec-color-light-secondary-medium);
     padding: 0.5rem 1.75rem;
     display: flex;
     align-items: center;
-    gap: 0.5rem;
     overflow: hidden;
 
     @include ms.responsive-breakpoint('sm') {
       order: 1;
-      padding: 0.5rem 1rem;
+      padding: 0.75rem 1rem;
       flex-shrink: 0;
     }
 
     &__text {
       width: fit-content;
       max-width: 10rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+
+      .chevron-icon {
+        font-size: 1rem;
+        color: var(--parsec-color-light-secondary-text);
+        font-size: 0.75rem;
+        padding: 0.125rem;
+        flex-shrink: 0;
+        border-radius: var(--parsec-radius-circle);
+        background: var(--parsec-color-light-secondary-medium);
+      }
     }
 
     &__icon {
       flex-shrink: 0;
-      width: 1.25rem;
-      height: 1.25rem;
+      width: 1.375rem;
+      height: 1.375rem;
     }
   }
 
   .select-button {
+    padding: 0.75rem 1rem;
+    margin-left: 0.75rem;
+    flex-shrink: 0;
+    background: var(--parsec-color-light-secondary-white);
     color: var(--parsec-color-light-primary-500);
+    border: 1px solid var(--parsec-color-light-secondary-medium);
+    border-radius: var(--parsec-radius-8);
+    box-shadow: var(--parsec-shadow-input);
     cursor: pointer;
-    margin-left: auto;
-    font-size: 0.875rem;
-    --background: transparent;
-    --background-hover: var(--parsec-color-light-primary-50);
+
+    &::part(native) {
+      padding: 0;
+      background: transparent;
+      --background-hover: transparent;
+      --border-radius: none;
+    }
+
+    &:hover {
+      background: var(--parsec-color-light-secondary-medium);
+    }
 
     @include ms.responsive-breakpoint('sm') {
+      padding: 0.625rem 0.825rem;
+      border-radius: var(--parsec-radius-8);
+      box-shadow: var(--parsec-shadow-soft);
+
       &::part(native) {
-        padding: 0.25rem 0.5rem;
+        padding: 0;
       }
     }
   }

--- a/client/src/views/workspaces/WorkspaceSharingModal.vue
+++ b/client/src/views/workspaces/WorkspaceSharingModal.vue
@@ -3,7 +3,7 @@
 <template>
   <ion-page class="modal">
     <ms-modal
-      :title="$msTranslate('WorkspaceSharing.title')"
+      title="WorkspaceSharing.title"
       :close-button="{ visible: true }"
     >
       <ion-text class="sharing-modal__title body">{{ workspaceName }}</ion-text>
@@ -11,7 +11,7 @@
         <ms-search-input
           class="modal-head-content__search"
           v-model="search"
-          :placeholder="'WorkspaceSharing.searchPlaceholder'"
+          placeholder="WorkspaceSharing.searchPlaceholder"
         />
         <div class="modal-head-content-right">
           <ion-text

--- a/client/tests/component/specs/testHeaderBreadcrumbs.spec.ts
+++ b/client/tests/component/specs/testHeaderBreadcrumbs.spec.ts
@@ -41,6 +41,7 @@ describe('Header breadcrumbs', () => {
     ];
     const wrapper = mount(HeaderBreadcrumbs, {
       props: {
+        workspaceName: 'My Workspace',
         pathNodes: NODES,
       },
       global: {

--- a/client/tests/e2e/helpers/utils.ts
+++ b/client/tests/e2e/helpers/utils.ts
@@ -179,7 +179,7 @@ export async function openFileType(
   for (const entry of await entries.all()) {
     const entryName = (await entry.locator('.file-name').locator('.label-name').textContent()) ?? '';
     if (entryName.endsWith(`.${type}`)) {
-      await entry.dblclick();
+      await entry.locator('.label-name').click();
       await expect(documentsPage).toBeFileHandlerPage();
       return;
     }

--- a/client/tests/e2e/specs/document_context_menu.spec.ts
+++ b/client/tests/e2e/specs/document_context_menu.spec.ts
@@ -41,6 +41,7 @@ async function openPopover(page: MsPage, index: number): Promise<Locator> {
     await entry.locator('.card-option').click();
   } else {
     const entry = page.locator('.folder-container').locator('.file-list-item').nth(index);
+    await expect(entry).toBeVisible();
     await entry.hover();
     await entry.locator('.options-button').click();
   }
@@ -637,7 +638,7 @@ msTest.describe(() => {
         if (gridMode) {
           await toggleViewMode(documents);
         }
-        await documents.locator('.folder-content').locator('.small-display-header-title .title__icon').click();
+        await documents.locator('.topbar-right-buttons').locator('.topbar-right-buttons__item').nth(0).click();
         await expect(documents.locator('.file-context-sheet-modal')).toBeVisible();
         const modal = documents.locator('.file-context-sheet-modal');
         await expandSheetModal(documents, modal);
@@ -647,7 +648,7 @@ msTest.describe(() => {
         await expect(modal.locator('.list-group-item').nth(0)).toHaveText('Select all');
         await modal.locator('.list-group-item').click();
 
-        const headerElements = documents.locator('.small-display-header-title').locator('ion-text');
+        const headerElements = documents.locator('.small-display-selection-header').locator('ion-text');
         await expect(headerElements).toHaveCount(3);
         await expect(headerElements.nth(0)).toHaveText('Unselect');
         await expect(headerElements.nth(1)).toHaveText('2 selected items');
@@ -657,8 +658,7 @@ msTest.describe(() => {
         await expect(headerElements.nth(0)).toBeVisible();
         await expect(headerElements.nth(2)).toBeVisible();
         await headerElements.nth(2).click();
-        await expect(headerElements).toHaveCount(1);
-        await expect(headerElements.nth(0)).toHaveText('wksp1');
+        await expect(headerElements).toBeHidden();
       },
     );
 
@@ -676,14 +676,12 @@ msTest.describe(() => {
           await toggleViewMode(documents);
           entries = documents.locator('.folder-container').locator('.file-card-item');
         }
-        await documents.locator('.folder-content').locator('.small-display-header-title .title__icon').click();
+        await documents.locator('.topbar-right-buttons').locator('.topbar-right-buttons__item').nth(0).click();
         await expandSheetModal(documents, documents.locator('.file-context-sheet-modal'));
 
         await documents.locator('.file-context-sheet-modal').locator('.list-group-item').nth(0).click();
 
-        await expect(documents.locator('.folder-content').locator('.small-display-header-title .title__text--content')).toHaveText(
-          '3 selected items',
-        );
+        await expect(documents.locator('.folder-content').locator('.title__text')).toContainText('3 selected items');
 
         await expect(entries.nth(0).locator('.ms-checkbox')).toBeChecked();
         await expect(entries.nth(1).locator('.ms-checkbox')).toBeChecked();
@@ -715,7 +713,7 @@ msTest.describe(() => {
           await toggleViewMode(documents);
           entries = documents.locator('.folder-container').locator('.file-card-item');
         }
-        await documents.locator('.folder-content').locator('.small-display-header-title .title__icon').click();
+        await documents.locator('.topbar-right-buttons').locator('.topbar-right-buttons__item').nth(0).click();
         await expandSheetModal(documents, documents.locator('.file-context-sheet-modal'));
         await documents.locator('.file-context-sheet-modal').locator('.list-group-item').nth(0).click();
         await expect(entries.nth(0).locator('.ms-checkbox')).toBeChecked();

--- a/client/tests/e2e/specs/documents_list.spec.ts
+++ b/client/tests/e2e/specs/documents_list.spec.ts
@@ -273,7 +273,7 @@ msTest.describe(() => {
 
     msTest(`Header breadcrumbs ${displaySize} display`, async ({ documents }, testInfo: TestInfo) => {
       async function navigateDown(): Promise<void> {
-        await documents.locator('.folder-container').getByRole('listitem').nth(0).dblclick();
+        await documents.locator('.folder-container').getByRole('listitem').nth(0).locator('.label-name').click();
       }
 
       async function clickOnBreadcrumb(i: number): Promise<void> {
@@ -284,38 +284,26 @@ msTest.describe(() => {
 
       if (displaySize === DisplaySize.Small) {
         await documents.setDisplaySize(DisplaySize.Small);
-        const smallBreadcrumbs = documents.locator('#connected-header').locator('.topbar-left').locator('.breadcrumb-small-container');
+        const smallBreadcrumbsPopover = documents.locator('.breadcrumbs-popover');
 
-        await expect(documents.locator('#connected-header').locator('.topbar-left').locator('ion-breadcrumbs')).not.toBeVisible();
-        await expect(smallBreadcrumbs).not.toBeVisible();
+        await expect(documents.locator('#connected-header').locator('.topbar-left').locator('ion-breadcrumbs')).toBeHidden();
+        await expect(smallBreadcrumbsPopover).toBeHidden();
         await navigateDown();
-        await expect(smallBreadcrumbs).toBeVisible();
-        await expect(smallBreadcrumbs.locator('ion-text')).toHaveCount(2);
-        await expect(smallBreadcrumbs.locator('ion-text').nth(0)).toHaveText('wksp1');
-        await expect(smallBreadcrumbs.locator('ion-text').nth(1)).toHaveText('/');
-        await expect(smallBreadcrumbs.locator('.breadcrumb-popover-button')).toBeVisible();
+        await documents.locator('.topbar').locator('.breadcrumb-file-mobile').click();
+        await expect(smallBreadcrumbsPopover).toBeVisible();
+        await expect(smallBreadcrumbsPopover.locator('ion-text')).toHaveCount(1);
+        await expect(smallBreadcrumbsPopover.locator('ion-text').nth(0)).toHaveText('wksp1');
+        await smallBreadcrumbsPopover.locator('.breadcrumb-item').nth(0).click();
+        await navigateDown();
+        await expect(smallBreadcrumbsPopover).toBeHidden();
         await createFolder(documents, 'Subdir');
         await navigateDown();
-        await expect(smallBreadcrumbs.locator('ion-text')).toHaveCount(4);
-        await expect(smallBreadcrumbs.locator('ion-text').nth(0)).toHaveText('...');
-        await expect(smallBreadcrumbs.locator('ion-text').nth(1)).toHaveText('/');
-        await expect(smallBreadcrumbs.locator('ion-text').nth(2)).toHaveText('Dir_Folder');
-        await expect(smallBreadcrumbs.locator('ion-text').nth(3)).toHaveText('/');
-        await smallBreadcrumbs.locator('.breadcrumb-popover-button').click();
-
-        const popoverItems = documents.locator('ion-popover').locator('.popover-item');
-        await expect(popoverItems).toHaveCount(2);
-        await expect(popoverItems.nth(0)).toHaveText('wksp1');
-        await expect(popoverItems.nth(1)).toHaveText('Dir_Folder');
-        await popoverItems.nth(1).click();
-        await expect(smallBreadcrumbs.locator('ion-text')).toHaveCount(2);
-        await expect(smallBreadcrumbs.locator('ion-text').nth(0)).toHaveText('wksp1');
-        await expect(smallBreadcrumbs.locator('ion-text').nth(1)).toHaveText('/');
-        await smallBreadcrumbs.locator('.breadcrumb-popover-button').click();
-        await expect(popoverItems).toHaveCount(1);
-        await expect(popoverItems).toHaveText('wksp1');
-        await popoverItems.click();
-        await expect(smallBreadcrumbs).not.toBeVisible();
+        await documents.locator('.topbar').locator('.breadcrumb-file-mobile').click();
+        await expect(smallBreadcrumbsPopover.locator('ion-text')).toHaveCount(2);
+        await expect(smallBreadcrumbsPopover.locator('ion-text').nth(0)).toHaveText('wksp1');
+        await expect(smallBreadcrumbsPopover.locator('ion-text').nth(1)).toHaveText('Dir_Folder');
+        await smallBreadcrumbsPopover.locator('.breadcrumb-item').nth(1).click();
+        await expect(smallBreadcrumbsPopover).toBeHidden();
       } else {
         await expect(documents).toHaveHeader(['wksp1'], true, true);
         await navigateDown();
@@ -330,7 +318,7 @@ msTest.describe(() => {
         await navigateDown();
         await expect(documents).toHaveHeader(['wksp1', '', '', '', 'Subdir 3'], true, true);
         await clickOnBreadcrumb(2);
-        const popoverItems = documents.locator('ion-popover').locator('.popover-item');
+        const popoverItems = documents.locator('ion-popover').locator('.breadcrumb-item');
         await expect(popoverItems).toHaveCount(3);
         await popoverItems.nth(2).click();
         await expect(documents).toHaveHeader(['wksp1', '', '', 'Subdir 2'], true, true);

--- a/client/tests/e2e/specs/file_copy.spec.ts
+++ b/client/tests/e2e/specs/file_copy.spec.ts
@@ -111,9 +111,12 @@ msTest.describe(() => {
         await expect(entries.nth(1).locator('.label-name')).toHaveText('image.png');
       }
       // And also in the folder
-      await entries.nth(0).dblclick();
+      await expect(entries.nth(0).locator(gridMode ? '.file-card__title' : '.label-name')).toHaveText('Dir_Folder');
+      await entries
+        .nth(0)
+        .locator(gridMode ? '.file-card__title' : '.label-name')
+        .click();
 
-      await expect(documents).toHaveHeader(['wksp1', 'Dir_Folder'], true, true);
       await expect(entries).toHaveCount(1);
 
       if (gridMode) {

--- a/client/tests/e2e/specs/file_import.spec.ts
+++ b/client/tests/e2e/specs/file_import.spec.ts
@@ -147,7 +147,11 @@ for (const displaySize of [DisplaySize.Small, DisplaySize.Large]) {
     // Start with an empty workspace
     await createWorkspace(workspaces, 'New_Workspace');
     await workspaces.locator('.workspaces-container-grid').locator('.workspace-card-item').nth(0).click();
-    await expect(workspaces).toHaveHeader(['New_Workspace'], true, true);
+    if (displaySize === DisplaySize.Large) {
+      await expect(workspaces).toHaveHeader(['New_Workspace'], true, true);
+    } else {
+      await expect(workspaces.locator('.breadcrumb-file-mobile__title')).toHaveText('New_Workspace');
+    }
     const documents = workspaces;
 
     if (displaySize === DisplaySize.Small) {
@@ -174,8 +178,10 @@ for (const displaySize of [DisplaySize.Small, DisplaySize.Large]) {
     await checkFilesUploaded(documents, 1, 11);
     await documents.locator('.upload-menu').locator('.menu-header-icons').locator('ion-icon').nth(1).click();
     await expect(documents.locator('.upload-menu')).toBeHidden();
-    await documents.locator('.folder-container').locator('.file-list-item').nth(0).dblclick();
-    await expect(workspaces).toHaveHeader(['New_Workspace', 'imports'], true, true);
+    await documents.locator('.folder-container').locator('.file-list-item').locator('.label-name').nth(0).click();
+    if (displaySize === DisplaySize.Large) {
+      await expect(workspaces).toHaveHeader(['New_Workspace', 'imports'], true, true);
+    }
     await expect(documents.locator('.folder-container').locator('.file-list-item')).toHaveCount(fs.readdirSync(importPath).length);
   });
 }
@@ -189,7 +195,9 @@ for (const displaySize of [DisplaySize.Small, DisplaySize.Large]) {
     // Start with an empty workspace
     await createWorkspace(workspaces, 'New_Workspace');
     await workspaces.locator('.workspaces-container-grid').locator('.workspace-card-item').nth(0).click();
-    await expect(workspaces).toHaveHeader(['New_Workspace'], true, true);
+    if (displaySize === DisplaySize.Large) {
+      await expect(workspaces).toHaveHeader(['New_Workspace'], true, true);
+    }
     const documents = workspaces;
 
     if (displaySize === DisplaySize.Small) {

--- a/client/tests/e2e/specs/file_move.spec.ts
+++ b/client/tests/e2e/specs/file_move.spec.ts
@@ -110,14 +110,14 @@ msTest.describe(() => {
       if (gridMode) {
         await expect(entries).toHaveCount(1);
         await expect(entries.nth(0).locator('.file-card__title')).toHaveText('Dir_Folder');
+        await entries.nth(0).locator('.file-card__title').click();
       } else {
         await expect(entries).toHaveCount(1);
         await expect(entries.nth(0).locator('.label-name')).toHaveText('Dir_Folder');
+        await entries.nth(0).locator('.label-name').click();
       }
       // But in the folder
-      await entries.nth(0).dblclick();
 
-      await expect(documents).toHaveHeader(['wksp1', 'Dir_Folder'], true, true);
       await expect(entries).toHaveCount(1);
 
       if (gridMode) {

--- a/client/tests/e2e/specs/file_viewers.spec.ts
+++ b/client/tests/e2e/specs/file_viewers.spec.ts
@@ -625,7 +625,7 @@ msTest.describe(() => {
     await documents.setDisplaySize(DisplaySize.Small);
 
     const entries = documents.locator('.folder-container').locator('.file-list-item');
-    await entries.nth(0).dblclick();
+    await entries.nth(0).locator('.label-name').click();
     await expect(documents).toBeViewerPage();
 
     await expect(documents.locator('.sidebar')).toBeHidden();

--- a/client/tests/e2e/specs/invitations_popover.spec.ts
+++ b/client/tests/e2e/specs/invitations_popover.spec.ts
@@ -3,7 +3,7 @@
 import { answerQuestion, expect, getClipboardText, inviteUsers, msTest, setWriteClipboardPermission } from '@tests/e2e/helpers';
 
 msTest('Profile popover default state', async ({ connected }) => {
-  await expect(connected.locator('.topbar').locator('#invitations-button')).toHaveText('One invitation');
+  await expect(connected.locator('.topbar').locator('#invitations-button').locator('.unread-count')).toHaveText('1');
 
   await expect(connected.locator('.invitations-list-popover')).toBeHidden();
   await connected.locator('.topbar').locator('#invitations-button').click();
@@ -87,7 +87,7 @@ msTest('Invite new user', async ({ connected }) => {
   await expect(connected).toShowToast('An invitation to join the organization has been sent to zana@wraeclast.', 'Success');
   await connected.locator('.topbar .back-button').click();
   await expect(connected).toBeWorkspacePage();
-  await expect(connected.locator('.topbar').locator('#invitations-button')).toHaveText('2 invitations');
+  await expect(connected.locator('.topbar').locator('#invitations-button').locator('.unread-count')).toHaveText('2');
 
   await expect(connected.locator('.invitations-list-popover')).toBeHidden();
   await connected.locator('.topbar').locator('#invitations-button').click();

--- a/client/tests/e2e/specs/options_tab_menu.spec.ts
+++ b/client/tests/e2e/specs/options_tab_menu.spec.ts
@@ -252,7 +252,7 @@ msTest('Test files options tab menu', async ({ documents, context }) => {
   await expect(optionsTabModal).toBeVisible();
   await expect(documents).toBeWorkspaceHistoryPage();
   await expect(documents.locator('.history-container')).toBeVisible();
-  await expect(documents.locator('.history-container').locator('.current-folder__text')).toHaveText('wksp1');
+  await expect(documents.locator('.history-container').locator('.breadcrumb-file-mobile__title')).toHaveText('wksp1');
   await documents.locator('#connected-header').locator('.topbar-left').locator('.back-button-container').click();
   await expect(documents).toBeDocumentPage();
 

--- a/client/tests/e2e/specs/sidebar.spec.ts
+++ b/client/tests/e2e/specs/sidebar.spec.ts
@@ -94,7 +94,7 @@ msTest('Sidebar recommendations checklist in large display', async ({ workspaces
 
   await expect(checklistPopover).toBeHidden();
   await expect(checklist).toBeVisible();
-  await expect(checklist.locator('.checklist-text__title')).toHaveText('Security checklist');
+  await expect(checklist.locator('.checklist-text__title')).toHaveText('Security recommendations');
   await expect(checklist.locator('.checklist-text__description')).toHaveText('2 remaining tasks');
   await checklist.click();
   await expect(checklistPopover).toBeVisible();
@@ -116,7 +116,7 @@ msTest('Sidebar recommendations checklist in large display', async ({ workspaces
   workspaces.locator('.dropdown-popover').getByRole('listitem').nth(0).click();
   await workspaceSharingModal.locator('.closeBtn').click();
 
-  await expect(checklist.locator('.checklist-text__title')).toHaveText('Security checklist');
+  await expect(checklist.locator('.checklist-text__title')).toHaveText('Security recommendations');
   await expect(checklist.locator('.checklist-text__description')).toHaveText('1 remaining task');
   await checklist.click();
   await expect(checklistPopover).toBeVisible();
@@ -198,8 +198,6 @@ msTest('Sidebar recommendations checklist in small display', async ({ workspaces
   await expect(users.nth(1).locator('#dropdown-popover-button').locator('.input-text')).toHaveText('Owner');
   await workspaces.locator('.toast-container').locator('.toast-button').click();
   await workspaceSharingModal.locator('.closeBtn').click();
-
-  await expect(checklistButton).toHaveTheClass('unread');
 
   await checklistButton.click();
   await expect(checklistModal).toBeVisible();

--- a/client/tests/e2e/specs/users_list.spec.ts
+++ b/client/tests/e2e/specs/users_list.spec.ts
@@ -675,10 +675,12 @@ msTest('Update multiple profiles', async ({ usersPage }) => {
 msTest('Small display selection', async ({ usersPage }) => {
   await usersPage.setDisplaySize(DisplaySize.Small);
 
-  const headerTexts = usersPage.locator('.small-display-header-title').locator('ion-text');
-  const headerOption = usersPage.locator('.small-display-header-title').locator('ion-icon');
-  await expect(headerTexts).toHaveCount(1);
-  await expect(headerTexts.nth(0)).toHaveText('Users');
+  const topbar = usersPage.locator('.topbar');
+  const topbarTitle = topbar.locator('.topbar-left-text__title');
+  const headerSelection = usersPage.locator('.small-display-selection-header');
+  const headerOption = usersPage.locator('.topbar-right-buttons').locator('ion-button').nth(1);
+
+  await expect(topbarTitle).toHaveText('Users');
   const user1 = usersPage.locator('#users-page-user-list').getByRole('listitem').nth(1);
   const user2 = usersPage.locator('#users-page-user-list').getByRole('listitem').nth(2);
   await expect(user1.locator('.ms-checkbox')).not.toBeVisible();
@@ -692,27 +694,27 @@ msTest('Small display selection', async ({ usersPage }) => {
   // Selection
   await modal.locator('.button-right').click();
   await expect(modal).not.toBeVisible();
-  await expect(headerTexts).toHaveCount(3);
-  await expect(headerTexts.nth(0)).toHaveText('Unselect');
-  await expect(headerTexts.nth(1)).toHaveText('2 users selected');
-  await expect(headerTexts.nth(2)).toHaveText('Cancel');
+  await expect(headerSelection).toBeVisible();
+  await expect(headerSelection.locator('.title__text')).toContainText('2 users selected');
+  await expect(headerSelection.locator('.title__button').nth(0)).toHaveText('Unselect');
+  await expect(headerSelection.locator('.title__button').nth(1)).toHaveText('Cancel');
   await expect(user1.locator('.ms-checkbox')).toBeVisible();
   await expect(user2.locator('.ms-checkbox')).toBeVisible();
   await expect(user1.locator('.ms-checkbox')).toBeChecked();
   await expect(user2.locator('.ms-checkbox')).toBeChecked();
   await user1.locator('.ms-checkbox').uncheck();
   await expect(user1.locator('.ms-checkbox')).not.toBeChecked();
-  await expect(headerTexts.nth(1)).toHaveText('One user selected');
+  await expect(headerSelection.locator('.title__text')).toContainText('One user selected');
   await user1.locator('.ms-checkbox').check();
-  await expect(headerTexts.nth(1)).toHaveText('2 users selected');
-  await headerTexts.nth(0).click();
-  await expect(headerTexts.nth(1)).toHaveText('Users');
+  await expect(headerSelection.locator('.title__text')).toContainText('2 users selected');
+  await headerSelection.locator('.title__button').nth(0).click();
+
+  await expect(headerSelection.locator('.title__text')).toHaveText('No user selected');
   await expect(user1.locator('.ms-checkbox')).not.toBeChecked();
   await expect(user2.locator('.ms-checkbox')).not.toBeChecked();
-  await headerTexts.nth(2).click();
+  await headerSelection.locator('.title__button').nth(1).click();
   await expect(user1.locator('.ms-checkbox')).not.toBeVisible();
   await expect(user2.locator('.ms-checkbox')).not.toBeVisible();
-  await expect(headerTexts).toHaveCount(1);
 });
 
 msTest('Small display member context menu', async ({ usersPage }) => {
@@ -740,12 +742,13 @@ msTest('Small display external context menu', async ({ usersPage }) => {
 msTest('Small display multiple users context menu', async ({ usersPage }) => {
   await usersPage.setDisplaySize(DisplaySize.Small);
   const user1 = usersPage.locator('#users-page-user-list').getByRole('listitem').nth(1);
-  const headerOption = usersPage.locator('.small-display-header-title').locator('ion-icon');
   const modal = usersPage.locator('.user-context-sheet-modal');
-  await headerOption.click();
 
-  await expect(modal).toBeVisible();
-  await modal.locator('.button-right').click();
+  await user1.hover();
+  await user1.locator('.ms-checkbox').click();
+  const headerOption = usersPage.locator('.small-display-selection-header').locator('.button-medium');
+  await headerOption.nth(0).click();
+  await headerOption.nth(0).click();
 
   await user1.locator('.user-options').click();
   await expect(modal.getByRole('group')).toHaveCount(1);

--- a/client/tests/e2e/specs/workspace_history.spec.ts
+++ b/client/tests/e2e/specs/workspace_history.spec.ts
@@ -141,7 +141,7 @@ msTest.describe(() => {
     await documents.locator('.sidebar').locator('#sidebar-workspaces').locator('#sidebar-all-workspaces').click();
     await expect(documents).toBeWorkspacePage();
     await expect(documents.locator('.workspace-card-item')).toHaveCount(1);
-    await documents.locator('.workspace-card-item').nth(0).locator('.icon-option-container').nth(0).click();
+    await documents.locator('.workspace-card-item').locator('.icon-option-container').click();
     const contextMenu = documents.locator('.workspace-context-menu');
     await expect(contextMenu).toBeVisible();
     await contextMenu.locator('.menu-list').locator('ion-item-group').nth(1).locator('ion-item').nth(3).click();
@@ -156,7 +156,7 @@ msTest.describe(() => {
     await navigateDown();
     await headerContentMatch(['wksp1', '', '', '', 'Subdir 3']);
 
-    const popoverItems = documents.locator('.breadcrumbs-popover').locator('.popover-item');
+    const popoverItems = documents.locator('.breadcrumbs-popover').locator('.breadcrumb-item');
     await clickOnBreadcrumb(1);
     await expect(popoverItems).toHaveCount(3);
     await popoverItems.nth(2).click();
@@ -165,15 +165,11 @@ msTest.describe(() => {
     await headerContentMatch(['wksp1']);
 
     await documents.setDisplaySize(DisplaySize.Small);
-    const smallBreadcrumbsButton = documents
-      .locator('.history-container')
-      .locator('.breadcrumb-small-container')
-      .locator('.breadcrumb-popover-button');
+    const smallBreadcrumbsButton = documents.locator('.history-container').locator('.breadcrumb-file-mobile');
 
     await expect(documents.locator('.history-container').locator('.navigation-breadcrumb').locator('ion-breadcrumbs')).not.toBeVisible();
-    await expect(smallBreadcrumbsButton).toBeHidden();
     await expect(documents.locator('.topbar-left-text__workspace')).toHaveText('wksp1');
-    const currentFolder = documents.locator('.history-container').locator('.current-folder__text');
+    const currentFolder = documents.locator('.history-container').locator('.breadcrumb-file-mobile__title');
     await navigateDown();
     await expect(currentFolder).toHaveText('Dir_Folder');
     await expect(currentFolder).toBeVisible();
@@ -198,7 +194,6 @@ msTest.describe(() => {
     await expect(popoverItems).toHaveCount(1);
     await expect(popoverItems).toHaveText('wksp1');
     await popoverItems.click();
-    await expect(smallBreadcrumbsButton).toBeHidden();
   });
 
   msTest('Workspace history select all', async ({ documents }, testInfo: TestInfo) => {


### PR DESCRIPTION
### What's changed?

[ONLY on Small Display]
- The header has been redesign to gather all buttons (back, select and notifications) and the breadcrumb has been removed replaced by the current folder/workspace name. If the user wants to navigate through the folders, he can click on the folder name to open a popover.

### Preview

https://github.com/user-attachments/assets/8fa22349-1fc0-4323-ae34-4ad233bf081b




closes #11321 