### PR TITLE
refactor(pki): Make `get_certificate_der` async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2515,6 +2515,7 @@ dependencies = [
  "serde",
  "sha2",
  "thiserror 2.0.18",
+ "tokio",
  "windows-sys 0.61.2",
  "x509-cert",
 ]

--- a/libparsec/crates/client/src/client/pki_enrollment_accept.rs
+++ b/libparsec/crates/client/src/client/pki_enrollment_accept.rs
@@ -52,6 +52,7 @@ pub async fn accept(
         })?;
     let accepter_intermediate_certs =
         libparsec_platform_pki::get_validation_path_for_cert(accepter_cert_ref, DateTime::now())
+            .await
             .map_err(anyhow::Error::from)
             .context("Failed to get intermediate certificates for itself")
             .map_err(PkiEnrollmentAcceptError::PkiOperationError)?;

--- a/libparsec/crates/client/src/client/pki_enrollment_finalize.rs
+++ b/libparsec/crates/client/src/client/pki_enrollment_finalize.rs
@@ -39,6 +39,7 @@ pub async fn finalize(
             .context("Cannot decrypt key")
             .and_then(|raw| SecretKey::try_from(raw.as_ref()).context("Invalid key"))?;
     let human_handle = libparsec_platform_pki::get_der_encoded_certificate(&cert_ref)
+        .await
         .context("Cannot get certificate content")
         .and_then(|der| {
             X509CertificateInformation::load_der(&der)

--- a/libparsec/crates/client/src/client/pki_enrollment_info.rs
+++ b/libparsec/crates/client/src/client/pki_enrollment_info.rs
@@ -100,6 +100,7 @@ pub async fn info(
             // Get root anchor to use to verify the response
             let path =
                 libparsec_platform_pki::get_validation_path_for_cert(&x509_cert_ref, accepted_on)
+                    .await
                     .context("Cannot validate own certificate")
                     .map_err(PkiEnrollmentInfoError::Internal)?;
 

--- a/libparsec/crates/client/src/client/pki_enrollment_list.rs
+++ b/libparsec/crates/client/src/client/pki_enrollment_list.rs
@@ -85,6 +85,7 @@ pub async fn verify_untrusted_items(
     libparsec_platform_async::spawn(async move {
         // Obtain the root cert used by the PKI
         let path = libparsec_platform_pki::get_validation_path_for_cert(&cert_ref, now)
+            .await
             .context("Failed to validate own certificate")
             .map_err(PkiEnrollmentListError::Internal)?;
 

--- a/libparsec/crates/client/src/client/pki_enrollment_submit.rs
+++ b/libparsec/crates/client/src/client/pki_enrollment_submit.rs
@@ -58,6 +58,7 @@ pub async fn pki_enrollment_submit(
 
     let intermediate_certificates =
         libparsec_platform_pki::get_validation_path_for_cert(&x509_cert_ref, DateTime::now())
+            .await
             .map_err(anyhow::Error::from)
             .context("Failed to get intermediate certificates for itself")
             .map_err(PkiEnrollmentSubmitError::PkiOperationError)?;

--- a/libparsec/crates/platform_pki/Cargo.toml
+++ b/libparsec/crates/platform_pki/Cargo.toml
@@ -46,6 +46,9 @@ data-encoding = { workspace = true, default-features = true }
 anyhow = { workspace = true }
 env_logger = { workspace = true }
 hex-literal = { workspace = true }
-libparsec_tests_lite = { workspace = true }
+libparsec_tests_lite = { workspace = true, features = ["parsec_test_macro"] }
 serde = { workspace = true }
 rmp-serde = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { workspace = true, features = ["macros"] }

--- a/libparsec/crates/platform_pki/examples/decode_cert_subject.rs
+++ b/libparsec/crates/platform_pki/examples/decode_cert_subject.rs
@@ -13,7 +13,8 @@ struct Args {
     cert: utils::CertificateOrRef,
 }
 
-fn main() -> anyhow::Result<()> {
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let args = Args::parse();
     log::debug!("args={args:?}");
@@ -21,6 +22,7 @@ fn main() -> anyhow::Result<()> {
     let raw_cert = args
         .cert
         .get_certificate()
+        .await
         .context("Invalid cert arguments")?;
     let cert =
         libparsec_platform_pki::x509::X509CertificateInformation::load_der(raw_cert.as_ref())

--- a/libparsec/crates/platform_pki/examples/get_certificate_der.rs
+++ b/libparsec/crates/platform_pki/examples/get_certificate_der.rs
@@ -20,7 +20,8 @@ struct Args {
     certificate_uri: Option<X509URIFlavorValue>,
 }
 
-fn main() -> anyhow::Result<()> {
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let args = Args::parse();
     log::debug!("args={args:x?}");
@@ -51,7 +52,9 @@ fn main() -> anyhow::Result<()> {
         println!("original uri: {uri}");
     }
     println!("original fingerprint: {}", cert_ref.hash);
-    let certificate = get_der_encoded_certificate(&cert_ref).context("Get certificate")?;
+    let certificate = get_der_encoded_certificate(&cert_ref)
+        .await
+        .context("Get certificate")?;
 
     let uri = cert_ref.uris().next().unwrap();
     println!("uri: {uri}");

--- a/libparsec/crates/platform_pki/examples/utils/mod.rs
+++ b/libparsec/crates/platform_pki/examples/utils/mod.rs
@@ -129,10 +129,11 @@ pub struct CertificateOrRef {
 impl CertificateOrRef {
     // Not all examples uses `CertificateOrRef` so `get_certificate` is not always used.
     #[allow(dead_code)]
-    pub fn get_certificate(&self) -> anyhow::Result<Certificate<'static>> {
+    pub async fn get_certificate(&self) -> anyhow::Result<Certificate<'static>> {
         let cert = if let Some(hash) = self.certificate_hash.clone() {
             let cert_ref: libparsec_types::X509CertificateReference = hash.into();
-            let certificate = libparsec_platform_pki::get_der_encoded_certificate(&cert_ref)?;
+            let certificate =
+                libparsec_platform_pki::get_der_encoded_certificate(&cert_ref).await?;
             Certificate::from_der_owned(certificate.into())
         } else if let Some(der_file) = &self.der_file {
             let raw = std::fs::read(der_file).context("Failed to read file")?;

--- a/libparsec/crates/platform_pki/examples/verify_certificate.rs
+++ b/libparsec/crates/platform_pki/examples/verify_certificate.rs
@@ -13,7 +13,8 @@ struct Args {
     cert: utils::CertificateOrRef,
 }
 
-pub fn main() -> anyhow::Result<()> {
+#[tokio::main(flavor = "current_thread")]
+pub async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let args = Args::parse();
     log::debug!("args={args:?}");
@@ -32,6 +33,7 @@ pub fn main() -> anyhow::Result<()> {
     let untrusted_certificate = args
         .cert
         .get_certificate()
+        .await
         .context("Cannot get certificate")?;
 
     let end_cert = untrusted_certificate

--- a/libparsec/crates/platform_pki/examples/verify_message.rs
+++ b/libparsec/crates/platform_pki/examples/verify_message.rs
@@ -21,14 +21,15 @@ struct Args {
     signature: Bytes,
 }
 
-fn main() -> anyhow::Result<()> {
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let args = Args::parse();
     log::debug!("args={args:?}");
 
     let data = args.content.into_bytes()?;
 
-    let cert = args.cert.get_certificate()?;
+    let cert = args.cert.get_certificate().await?;
 
     {
         let fingerprint =

--- a/libparsec/crates/platform_pki/src/lib.rs
+++ b/libparsec/crates/platform_pki/src/lib.rs
@@ -29,7 +29,7 @@ mod platform {
     };
     use libparsec_types::prelude::*;
 
-    pub fn get_der_encoded_certificate(
+    pub async fn get_der_encoded_certificate(
         certificate_ref: &X509CertificateReference,
     ) -> Result<Bytes, GetDerEncodedCertificateError> {
         let _ = certificate_ref;

--- a/libparsec/crates/platform_pki/src/shared/mod.rs
+++ b/libparsec/crates/platform_pki/src/shared/mod.rs
@@ -246,7 +246,7 @@ pub struct ValidationPathOwned {
     pub root: TrustAnchor<'static>,
 }
 
-pub fn get_validation_path_for_cert(
+pub async fn get_validation_path_for_cert(
     cert_ref: &X509CertificateReference,
     now: DateTime,
 ) -> Result<ValidationPathOwned, GetValidationPathForCertError> {
@@ -261,12 +261,14 @@ pub fn get_validation_path_for_cert(
             GetValidationPathForCertError::CannotOpenStore(err)
         }
     })?;
-    let leaf = get_der_encoded_certificate(cert_ref).map_err(|err| match err {
-        GetDerEncodedCertificateError::CannotOpenStore(err) => {
-            GetValidationPathForCertError::CannotOpenStore(err)
-        }
-        GetDerEncodedCertificateError::NotFound => GetValidationPathForCertError::NotFound,
-    })?;
+    let leaf = get_der_encoded_certificate(cert_ref)
+        .await
+        .map_err(|err| match err {
+            GetDerEncodedCertificateError::CannotOpenStore(err) => {
+                GetValidationPathForCertError::CannotOpenStore(err)
+            }
+            GetDerEncodedCertificateError::NotFound => GetValidationPathForCertError::NotFound,
+        })?;
 
     let leaf_cert_der = CertificateDer::from_slice(&leaf);
     let leaf_end_cert = X509EndCertificate::try_from(&leaf_cert_der)

--- a/libparsec/crates/platform_pki/src/windows/mod.rs
+++ b/libparsec/crates/platform_pki/src/windows/mod.rs
@@ -102,7 +102,7 @@ fn get_certificate_uri(cert_context: &CertContext) -> X509WindowsCngURI {
     }
 }
 
-pub fn get_der_encoded_certificate(
+pub async fn get_der_encoded_certificate(
     certificate_ref: &X509CertificateReference,
 ) -> Result<Bytes, GetDerEncodedCertificateError> {
     let store = open_store().map_err(GetDerEncodedCertificateError::CannotOpenStore)?;

--- a/libparsec/src/async_enrollment.rs
+++ b/libparsec/src/async_enrollment.rs
@@ -71,7 +71,7 @@ mod strategy {
     }
 
     impl SubmitAsyncEnrollmentIdentityStrategy {
-        pub(super) fn convert(
+        pub(super) async fn convert(
             self,
         ) -> anyhow::Result<Box<dyn libparsec_client::SubmitAsyncEnrollmentIdentityStrategy>>
         {
@@ -110,6 +110,7 @@ mod strategy {
                     // Get certificate DER
                     let cert_der =
                         libparsec_platform_pki::get_der_encoded_certificate(&certificate_reference)
+                            .await
                             .map_err(|e| anyhow::anyhow!("Cannot get certificate: {}", e))?;
 
                     // Parse certificate and extract human handle
@@ -249,6 +250,7 @@ mod strategy {
                 // 2. Get leaf & intermediate certificates
                 let validation_path: libparsec_platform_pki::ValidationPathOwned =
                     libparsec_platform_pki::get_validation_path_for_cert(&cert_ref, DateTime::now())
+                    .await
                         .map_err(|err| match err {
                             err @ (
                                 PKIGetValidationPathForCertError::NotFound
@@ -598,6 +600,7 @@ mod strategy {
 
                 let validation_path: libparsec_platform_pki::ValidationPathOwned =
                     libparsec_platform_pki::get_validation_path_for_cert(&cert_ref, DateTime::now())
+                        .await
                         .map_err(|err| match err {
                             err @ (
                                 PKIGetValidationPathForCertError::NotFound
@@ -696,6 +699,7 @@ mod strategy {
                 // 2. Get leaf & intermediate certificates
                 let validation_path: libparsec_platform_pki::ValidationPathOwned =
                     libparsec_platform_pki::get_validation_path_for_cert(&cert_ref, DateTime::now())
+                        .await
                         .map_err(|err| match err {
                             err @ (
                                 PKIGetValidationPathForCertError::NotFound
@@ -749,6 +753,7 @@ mod strategy {
 
                 let validation_path: libparsec_platform_pki::ValidationPathOwned =
                     libparsec_platform_pki::get_validation_path_for_cert(&cert_ref, DateTime::now())
+                        .await
                         .map_err(|err| match err {
                             err @ (
                                 PKIGetValidationPathForCertError::NotFound
@@ -904,7 +909,7 @@ pub async fn submit_async_enrollment(
     identity_strategy: SubmitAsyncEnrollmentIdentityStrategy,
 ) -> Result<AvailablePendingAsyncEnrollment, SubmitAsyncEnrollmentError> {
     let config: Arc<libparsec_client::ClientConfig> = config.into();
-    let identity_strategy = identity_strategy.convert()?;
+    let identity_strategy = identity_strategy.convert().await?;
 
     libparsec_client::submit_async_enrollment(
         config,


### PR DESCRIPTION
Need the API to be async to be compatible with future integration with PkiWeb

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
