### PR TITLE
[MS] Fix issue show/hide workspaces

### DIFF
--- a/client/src/components/workspaces/WorkspaceCategoriesMenu.vue
+++ b/client/src/components/workspaces/WorkspaceCategoriesMenu.vue
@@ -10,7 +10,6 @@
       @click="$emit('updateMenu', item.key)"
     >
       <ion-icon
-        v-if="isLargeDisplay"
         class="workspace-categories-menu-item__icon"
         :icon="item.icon"
       />
@@ -25,10 +24,10 @@
 import { WorkspaceMenu } from '@/views/workspaces/types';
 import { IonIcon, IonText } from '@ionic/vue';
 import { eyeOff, rocket, star, time } from 'ionicons/icons';
-import { useWindowSize, WindowSizeBreakpoints } from 'megashark-lib';
+import { useWindowSize } from 'megashark-lib';
 import { computed } from 'vue';
 
-const { isLargeDisplay, windowWidth } = useWindowSize();
+const { isSmallDisplay } = useWindowSize();
 
 defineProps<{
   activeMenu: WorkspaceMenu;
@@ -38,29 +37,36 @@ defineEmits<{
   (e: 'updateMenu', value: WorkspaceMenu): void;
 }>();
 
-const workspaceMenuList = computed(() => [
-  {
-    icon: rocket,
-    key: WorkspaceMenu.All,
-    label: windowWidth.value > WindowSizeBreakpoints.MD ? 'WorkspacesPage.categoriesMenu.all' : 'WorkspacesPage.categoriesMenu.allShort',
-  },
-  {
-    icon: time,
-    key: WorkspaceMenu.Recent,
-    label:
-      windowWidth.value > WindowSizeBreakpoints.MD ? 'WorkspacesPage.categoriesMenu.recent' : 'WorkspacesPage.categoriesMenu.recentShort',
-  },
-  {
-    icon: star,
-    key: WorkspaceMenu.Favorites,
-    label: 'WorkspacesPage.categoriesMenu.favorites',
-  },
-  {
-    icon: eyeOff,
-    key: WorkspaceMenu.Hidden,
-    label: 'WorkspacesPage.categoriesMenu.hidden',
-  },
-]);
+const workspaceMenuList = computed(() => {
+  const allMenus = [
+    {
+      icon: rocket,
+      key: WorkspaceMenu.All,
+      label: 'WorkspacesPage.categoriesMenu.myWorkspaces',
+    },
+    {
+      icon: time,
+      key: WorkspaceMenu.Recent,
+      label: 'WorkspacesPage.categoriesMenu.recent',
+    },
+    {
+      icon: star,
+      key: WorkspaceMenu.Favorites,
+      label: 'WorkspacesPage.categoriesMenu.favorites',
+    },
+    {
+      icon: eyeOff,
+      key: WorkspaceMenu.Hidden,
+      label: 'WorkspacesPage.categoriesMenu.hidden',
+    },
+  ];
+
+  if (isSmallDisplay.value) {
+    return allMenus.filter((menu) => [WorkspaceMenu.Recent, WorkspaceMenu.Favorites, WorkspaceMenu.Hidden].includes(menu.key));
+  }
+
+  return allMenus;
+});
 </script>
 
 <style scoped lang="scss">
@@ -78,6 +84,12 @@ const workspaceMenuList = computed(() => [
     width: 100%;
     margin: 0 1rem;
     gap: 0;
+  }
+
+  @include ms.responsive-breakpoint('sm') {
+    background: none;
+    gap: 1rem;
+    overflow: auto;
   }
 
   &::after {
@@ -98,6 +110,10 @@ const workspaceMenuList = computed(() => [
     @include ms.responsive-breakpoint('lg') {
       width: calc(100% / 4 - 0.25rem);
     }
+
+    @include ms.responsive-breakpoint('sm') {
+      display: none;
+    }
   }
 
   &-item {
@@ -110,11 +126,17 @@ const workspaceMenuList = computed(() => [
     min-width: 12rem;
     padding: 0.5rem 1rem;
     color: var(--parsec-color-light-secondary-soft-text);
-    box-shadow: var(--parsec-shadow-filter);
     position: relative;
     border-radius: var(--parsec-radius-8);
+    overflow: visible;
     z-index: 3;
     transition: background-color 0.2s ease-in-out;
+
+    &:not(.active) {
+      @include ms.responsive-breakpoint('sm') {
+        outline: 1px solid var(--parsec-color-light-secondary-disabled);
+      }
+    }
 
     &:not(:last-child)::after {
       content: '';
@@ -125,6 +147,10 @@ const workspaceMenuList = computed(() => [
       width: 1px;
       height: 100%;
       background-color: var(--parsec-color-light-secondary-disabled);
+
+      @include ms.responsive-breakpoint('sm') {
+        display: none;
+      }
     }
 
     @include ms.responsive-breakpoint('lg') {
@@ -133,6 +159,11 @@ const workspaceMenuList = computed(() => [
       width: calc(100% / 4 - 1rem);
       text-align: center;
       padding: 0.375rem 0.5rem;
+    }
+
+    @include ms.responsive-breakpoint('sm') {
+      padding: 0.5rem 1rem;
+      min-width: fit-content;
     }
 
     &__text {
@@ -151,6 +182,12 @@ const workspaceMenuList = computed(() => [
     }
 
     &.active {
+      @include ms.responsive-breakpoint('sm') {
+        background-color: var(--parsec-color-light-secondary-background);
+        outline: 1px solid var(--parsec-color-light-primary-400);
+        box-shadow: var(--parsec-shadow-input);
+      }
+
       .workspace-categories-menu-item__text {
         background: var(--parsec-color-light-gradient-background);
         background-clip: text;

--- a/client/src/components/workspaces/utils.ts
+++ b/client/src/components/workspaces/utils.ts
@@ -333,9 +333,10 @@ async function seeInExplorer(
       },
     );
 
-    if (answer === Answer.Yes) {
-      await showWorkspace(workspace, workspaceAttributes, informationManager, eventDistributor);
+    if (answer === Answer.No) {
+      return;
     }
+    await showWorkspace(workspace, workspaceAttributes, informationManager, eventDistributor);
   }
 
   const result = await getSystemPath(workspace.handle, '/');

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -698,8 +698,8 @@
             "actionHide": "Hide this workspace",
             "actionShow": "Show this workspace",
             "actionCopyLink": "Copy link",
-            "actionAddFavorite": "Add to favorites",
-            "actionRemoveFavorite": "Remove from favorites"
+            "actionAddFavorite": "Add as starred",
+            "actionRemoveFavorite": "Remove as starred"
         },
         "CreateWorkspaceModal": {
             "pageTitle": "Create a new workspace",
@@ -751,14 +751,12 @@
             "reset": "Reset"
         },
         "categoriesMenu": {
-            "all": "All workspaces",
-            "allShort": "All",
-            "recent": "Recently viewed",
-            "recentShort": "Recent",
-            "favorites": "Favorites",
+            "myWorkspaces": "My workspaces",
+            "recent": "Recent",
+            "favorites": "Starred",
             "hidden": "Hidden",
             "noRecentWorkspaces": "You have not consulted any workspaces yet. Recently consulted workspaces will be listed here.",
-            "noFavoriteWorkspaces": "You have not set any workspaces as favorite. Favorite a workspace to have it be listed here.",
+            "noFavoriteWorkspaces": "You have not set starred any workspaces yet. Starred workspaces will be listed here.",
             "noHiddenWorkspaces": "You have not hidden any workspaces yet. Hidden workspaces will be listed here.",
             "showHiddenWorkspaces": "Show hidden workspaces"
         },
@@ -789,11 +787,11 @@
         },
         "openInExplorerModal": {
             "file": {
-                "title": "Failed to open the file in your explorer",
+                "title": "Workspace is hidden",
                 "description": "You must make this workspace visible in order to view your file in your explorer."
             },
             "workspace": {
-                "title": "Failed to open the workspace in your explorer",
+                "title": "Workspace is hidden",
                 "description": "You must make this workspace visible in order to view it from your file explorer."
             },
             "actionConfirm": "Make this workspace visible",
@@ -1123,9 +1121,9 @@
     },
     "SideMenu": {
         "organization": "Organization",
-        "workspaces": "My workspaces",
-        "recentWorkspaces": "Recently viewed",
-        "favorites": "Favorites",
+        "workspaces": "Workspaces",
+        "recent": "Recent",
+        "favorites": "Starred",
         "hidden": "Hidden",
         "noWorkspace": "No workspaces",
         "users": "Users",
@@ -1133,7 +1131,7 @@
         "storage": "Storage",
         "information": "Information",
         "goToHome": "My workspaces",
-        "allWorkspaces": "All workspaces",
+        "myWorkspaces": "My workspaces",
         "recentDocuments": "Recent documents",
         "noRecentDocuments": "No recent documents",
         "back": "Back",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -750,10 +750,8 @@
             "reset": "Réinitialiser"
         },
         "categoriesMenu": {
-            "all": "Tous les espaces",
-            "allShort": "Tous",
-            "recent": "Vus récemment",
-            "recentShort": "Récents",
+            "myWorkspaces": "Mes espaces",
+            "recent": "Récents",
             "favorites": "Favoris",
             "hidden": "Masqués",
             "noRecentWorkspaces": "Vous n'avez encore consulté aucun espace de travail. Les espaces consultés récemment apparaîtront ici.",
@@ -788,11 +786,11 @@
         },
         "openInExplorerModal": {
             "file": {
-                "title": "Impossible d'ouvrir le fichier",
+                "title": "Espace de travail masqué",
                 "description": "Vous devez rendre visible cet espace de travail pour pouvoir le consulter depuis votre explorateur de fichiers."
             },
             "workspace": {
-                "title": "Impossible d'ouvrir l'espace de travail",
+                "title": "Espace de travail masqué",
                 "description": "Vous devez rendre visible cet espace de travail pour pouvoir le consulter depuis votre explorateur de fichiers."
             },
             "actionConfirm": "Rendre cet espace de travail visible",
@@ -1123,8 +1121,8 @@
     },
     "SideMenu": {
         "organization": "Organisation",
-        "workspaces": "Mes espaces de travail",
-        "recentWorkspaces": "Vus récemment",
+        "workspaces": "Espaces de travail",
+        "recent": "Récents",
         "favorites": "Favoris",
         "hidden": "Masqués",
         "noWorkspace": "Aucun espace de travail",
@@ -1133,7 +1131,7 @@
         "storage": "Stockage",
         "information": "Informations",
         "goToHome": "Mes espaces",
-        "allWorkspaces": "Tous les espaces",
+        "myWorkspaces": "Mes espaces",
         "recentDocuments": "Documents récents",
         "noRecentDocuments": "Aucun document récent",
         "back": "Retour",

--- a/client/src/views/menu/MainMenu.vue
+++ b/client/src/views/menu/MainMenu.vue
@@ -202,7 +202,7 @@
                 :icon="rocket"
               />
               <span class="sidebar-content-organization-button__text">
-                {{ $msTranslate('SideMenu.allWorkspaces') }}
+                {{ $msTranslate('SideMenu.myWorkspaces') }}
               </span>
             </ion-text>
 
@@ -219,7 +219,7 @@
                 :icon="time"
               />
               <span class="sidebar-content-organization-button__text">
-                {{ $msTranslate('SideMenu.recentWorkspaces') }}
+                {{ $msTranslate('SideMenu.recent') }}
               </span>
             </ion-text>
 

--- a/client/src/views/workspaces/WorkspaceHiddenModal.vue
+++ b/client/src/views/workspaces/WorkspaceHiddenModal.vue
@@ -26,9 +26,6 @@
             </template>
           </i18n-t>
         </ion-text>
-        <ms-report-text :theme="MsReportTheme.Info">
-          {{ $msTranslate('WorkspacesPage.workspaceHiddenModal.info') }}
-        </ms-report-text>
       </div>
       <ms-checkbox
         label-placement="end"
@@ -46,7 +43,7 @@
 <script setup lang="ts">
 import { WorkspaceName } from '@/parsec';
 import { IonPage, IonText, modalController } from '@ionic/vue';
-import { MsCheckbox, MsModal, MsModalResult, MsReportText, MsReportTheme } from 'megashark-lib';
+import { MsCheckbox, MsModal, MsModalResult } from 'megashark-lib';
 import { ref } from 'vue';
 
 defineProps<{
@@ -77,7 +74,8 @@ async function confirmHidden(): Promise<boolean> {
 
   &__checkbox {
     position: absolute;
-    bottom: 2.25rem;
+    z-index: 30;
+    bottom: 1.625rem;
     color: var(--parsec-color-light-secondary-soft-text);
     padding: 0.25rem 0.25rem;
     border-radius: var(--parsec-radius-8);

--- a/client/src/views/workspaces/WorkspacesPage.vue
+++ b/client/src/views/workspaces/WorkspacesPage.vue
@@ -53,7 +53,7 @@
       >
         <workspace-categories-menu
           :active-menu="workspaceMenuState"
-          @update-menu="workspaceMenuState = $event"
+          @update-menu="onMenuUpdate"
         />
       </div>
 
@@ -80,7 +80,7 @@
           </div>
           <workspace-categories-menu
             :active-menu="workspaceMenuState"
-            @update-menu="workspaceMenuState = $event"
+            @update-menu="onMenuUpdate"
           />
           <ms-search-input
             v-model="searchFilterContent"
@@ -751,6 +751,18 @@ function isWorkspaceFiltered(role: WorkspaceRole): boolean {
 
 async function onFilterUpdate(): Promise<void> {
   await refreshWorkspacesList();
+}
+
+function onMenuUpdate(menu: WorkspaceMenu): void {
+  if (isSmallDisplay.value) {
+    if (workspaceMenuState.value === menu) {
+      workspaceMenuState.value = WorkspaceMenu.All;
+    } else {
+      workspaceMenuState.value = menu;
+    }
+  } else {
+    workspaceMenuState.value = menu;
+  }
 }
 </script>
 

--- a/client/tests/e2e/specs/sidebar.spec.ts
+++ b/client/tests/e2e/specs/sidebar.spec.ts
@@ -26,7 +26,7 @@ msTest('Sidebar in organization management', async ({ organizationPage }) => {
   const sidebar = organizationPage.locator('.sidebar');
 
   const mainButtons = sidebar.locator('.list-sidebar-header-text');
-  await expect(mainButtons).toHaveText(['Organization', 'My workspaces', 'Recent documents']);
+  await expect(mainButtons).toHaveText(['Organization', 'Workspaces', 'Recent documents']);
 
   const items = sidebar.locator('#sidebar-organization').locator('.sidebar-content-organization-button__text');
   await expect(items).toHaveText(['Users', 'Invitations & Requests', 'Information']);
@@ -38,11 +38,11 @@ msTest('Sidebar in workspaces page', async ({ workspaces }) => {
   await workspaces.locator('.workspaces-container-grid').locator('.workspace-card-item').nth(0).click();
 
   const mainButtons = sidebar.locator('.list-sidebar-header-text');
-  await expect(mainButtons).toHaveText(['Organization', 'My workspaces', 'Recent documents']);
+  await expect(mainButtons).toHaveText(['Organization', 'Workspaces', 'Recent documents']);
 
   const currentWorkspace = sidebar.locator('#sidebar-workspaces').locator('.current-workspace').locator('.sidebar-item');
   await expect(currentWorkspace).toBeVisible();
-  await expect(sidebar.locator('#sidebar-all-workspaces')).toHaveText('All workspaces');
+  await expect(sidebar.locator('#sidebar-all-workspaces')).toHaveText('My workspaces');
   await sidebar.locator('.sidebar-content-organization-button').nth(0).click();
   await expect(currentWorkspace).toBeHidden();
 });
@@ -51,7 +51,7 @@ msTest('Sidebar in connected page', async ({ workspaces }) => {
   const sidebar = workspaces.locator('.sidebar');
 
   const mainButtons = sidebar.locator('.list-sidebar-header-text');
-  await expect(mainButtons).toHaveText(['Organization', 'My workspaces', 'Recent documents']);
+  await expect(mainButtons).toHaveText(['Organization', 'Workspaces', 'Recent documents']);
 
   const organizationContent = sidebar.locator('#sidebar-organization');
   const workspacesContent = sidebar.locator('#sidebar-workspaces');
@@ -67,7 +67,7 @@ msTest('Sidebar in connected page', async ({ workspaces }) => {
   }
 
   await checkSidebarToggleVisibility(organizationContent, 'Organization');
-  await checkSidebarToggleVisibility(workspacesContent, 'My workspaces');
+  await checkSidebarToggleVisibility(workspacesContent, 'Workspaces');
   await checkSidebarToggleVisibility(filesContent, 'Recent documents');
 
   await workspaces.locator('.workspaces-container-grid').locator('.workspace-card-item').nth(0).click();
@@ -417,16 +417,9 @@ msTest.describe(() => {
     const workspaceCategoriesSidebarItem = workspaceCategoriesSidebar.locator('.sidebar-content-organization-button');
 
     await expect(workspaceCategoriesMenu.locator('.workspace-categories-menu-item__text')).toHaveText([
-      'All workspaces',
-      'Recently viewed',
-      'Favorites',
-      'Hidden',
-    ]);
-
-    await expect(workspaceCategoriesSidebar.locator('.sidebar-content-organization-button__text')).toHaveText([
-      'All workspaces',
-      'Recently viewed',
-      'Favorites',
+      'My workspaces',
+      'Recent',
+      'Starred',
       'Hidden',
     ]);
 
@@ -463,7 +456,7 @@ msTest('Trying to navigate through the workspace content, profile, invitations, 
   await expect(connected).toBeInvitationPage();
 
   const allWorkspacesButton = connected.locator('#sidebar-all-workspaces');
-  await expect(allWorkspacesButton).toHaveText('All workspaces');
+  await expect(allWorkspacesButton).toHaveText('My workspaces');
   await allWorkspacesButton.click();
   await expect(connected).toBeWorkspacePage();
 });

--- a/client/tests/e2e/specs/workspaces_actions.spec.ts
+++ b/client/tests/e2e/specs/workspaces_actions.spec.ts
@@ -62,7 +62,7 @@ const MENU = [
   },
   {
     title: 'Miscellaneous',
-    actions: ['Add to favorites'],
+    actions: ['Add as starred'],
   },
 ];
 
@@ -175,7 +175,7 @@ for (const mode of ['grid', 'list', 'sidebar']) {
     }
     await expect(wk.locator('.workspace-favorite-icon')).toHaveTheClass('workspace-favorite-icon__on');
     await expect(favorites).toBeVisible();
-    await expect(favorites.locator('.sidebar-content-organization-button__text')).toHaveText('Favorites');
+    await expect(favorites.locator('.sidebar-content-organization-button__text')).toHaveText('Starred');
   });
 
   msTest(`Open workspace sharing ${mode}`, async ({ workspaces }) => {

--- a/client/tests/e2e/specs/workspaces_list.spec.ts
+++ b/client/tests/e2e/specs/workspaces_list.spec.ts
@@ -193,27 +193,27 @@ for (const displaySize of [DisplaySize.Small, DisplaySize.Large]) {
       'The Copper Coronet',
     ]);
     const workspaceCategoriesMenu = workspaces.locator('.workspace-categories-menu');
-    const allWorkspacesButton = workspaceCategoriesMenu.locator('.workspace-categories-menu-item').nth(0);
-    const favoriteWorkspacesButton = workspaceCategoriesMenu.locator('.workspace-categories-menu-item').nth(2);
+    const allWorkspacesButton = workspaceCategoriesMenu.locator('.workspace-categories-menu-item').getByText('My workspaces');
+    const starredWorkspacesButton = workspaceCategoriesMenu.locator('.workspace-categories-menu-item').getByText('Starred');
     if (displaySize === DisplaySize.Small) {
-      await expect(workspaceCategoriesMenu.locator('.workspace-categories-menu-item__text')).toHaveText([
-        'All',
-        'Recent',
-        'Favorites',
-        'Hidden',
-      ]);
+      await expect(workspaceCategoriesMenu.locator('.workspace-categories-menu-item__text')).toHaveText(['Recent', 'Starred', 'Hidden']);
     } else {
       await expect(workspaceCategoriesMenu.locator('.workspace-categories-menu-item__text')).toHaveText([
-        'All workspaces',
-        'Recently viewed',
-        'Favorites',
+        'My workspaces',
+        'Recent',
+        'Starred',
         'Hidden',
       ]);
     }
     await expect(workspaceCategoriesMenu).toBeVisible();
-    await expect(favoriteWorkspacesButton).toBeVisible();
-    await favoriteWorkspacesButton.click({ force: true });
-    await allWorkspacesButton.click({ force: true });
+    await expect(starredWorkspacesButton).toBeVisible();
+    await starredWorkspacesButton.click({ force: true });
+    if (displaySize === DisplaySize.Large) {
+      await allWorkspacesButton.click({ force: true });
+    } else {
+      // In small display, we toggle the current category to show/hide starred workspaces
+      await starredWorkspacesButton.click({ force: true });
+    }
     await expect(workspaces.locator('.workspace-card-item').locator('.workspace-card-content__title')).toHaveText([
       'wksp1',
       'The Copper Coronet',
@@ -247,38 +247,50 @@ for (const displaySize of [DisplaySize.Small, DisplaySize.Large]) {
 
     await expect(workspaceCategoriesMenu).toBeVisible();
     if (displaySize === DisplaySize.Small) {
-      await expect(workspaceCategoriesMenu.locator('.workspace-categories-menu-item__text')).toHaveText([
-        'All',
-        'Recent',
-        'Favorites',
-        'Hidden',
-      ]);
+      await expect(workspaceCategoriesMenu.locator('.workspace-categories-menu-item__text')).toHaveText(['Recent', 'Starred', 'Hidden']);
     } else {
       await expect(workspaceCategoriesMenu.locator('.workspace-categories-menu-item__text')).toHaveText([
-        'All workspaces',
-        'Recently viewed',
-        'Favorites',
+        'My workspaces',
+        'Recent',
+        'Starred',
         'Hidden',
       ]);
     }
-    const allWorkspacesButton = workspaceCategoriesMenu.locator('.workspace-categories-menu-item').nth(0);
-    const recentWorkspacesButton = workspaceCategoriesMenu.locator('.workspace-categories-menu-item').nth(1);
-    const favoriteWorkspacesButton = workspaceCategoriesMenu.locator('.workspace-categories-menu-item').nth(2);
-    const hiddenWorkspacesButton = workspaceCategoriesMenu.locator('.workspace-categories-menu-item').nth(3);
+    const allWorkspacesButton = workspaceCategoriesMenu.locator('.workspace-categories-menu-item').getByText('My workspaces');
+    const recentWorkspacesButton = workspaceCategoriesMenu.locator('.workspace-categories-menu-item').getByText('Recent');
+    const starredWorkspacesButton = workspaceCategoriesMenu.locator('.workspace-categories-menu-item').getByText('Starred');
+    const hiddenWorkspacesButton = workspaceCategoriesMenu.locator('.workspace-categories-menu-item').getByText('Hidden');
 
-    await verifyActiveCategory(workspaces, 0);
+    if (displaySize === DisplaySize.Large) {
+      await verifyActiveCategory(workspaces, 0);
+    }
 
     await recentWorkspacesButton.click({ force: true });
-    await verifyActiveCategory(workspaces, 1);
 
-    await allWorkspacesButton.click({ force: true });
-    await verifyActiveCategory(workspaces, 0);
+    if (displaySize === DisplaySize.Large) {
+      await verifyActiveCategory(workspaces, 1);
+    } else {
+      await verifyActiveCategory(workspaces, 0);
+    }
 
-    await favoriteWorkspacesButton.click({ force: true });
-    await verifyActiveCategory(workspaces, 2);
+    if (displaySize === DisplaySize.Large) {
+      await allWorkspacesButton.click({ force: true });
+      await verifyActiveCategory(workspaces, 0);
+    }
+
+    await starredWorkspacesButton.click({ force: true });
+    if (displaySize === DisplaySize.Large) {
+      await verifyActiveCategory(workspaces, 2);
+    } else {
+      await verifyActiveCategory(workspaces, 1);
+    }
 
     await hiddenWorkspacesButton.click({ force: true });
-    await verifyActiveCategory(workspaces, 3);
+    if (displaySize === DisplaySize.Large) {
+      await verifyActiveCategory(workspaces, 3);
+    } else {
+      await verifyActiveCategory(workspaces, 2);
+    }
   });
 
   msTest(`Show/hide workspace ${displaySize} display`, async ({ workspaces }) => {
@@ -307,7 +319,7 @@ for (const displaySize of [DisplaySize.Small, DisplaySize.Large]) {
         'Copy link',
         'Sharing and roles',
         'Miscellaneous',
-        'Add to favorites',
+        'Add as starred',
       ]);
       await popover.getByRole('listitem').nth(3).click();
     } else {
@@ -319,7 +331,7 @@ for (const displaySize of [DisplaySize.Small, DisplaySize.Large]) {
         'Hide this workspace',
         'Copy link',
         'Sharing and roles',
-        'Add to favorites',
+        'Add as starred',
       ]);
       await popover.getByRole('listitem').nth(2).click();
     }
@@ -341,7 +353,7 @@ for (const displaySize of [DisplaySize.Small, DisplaySize.Large]) {
     await expect(workspaceCard.nth(0)).toBeHidden();
     await expect(workspaceCard.nth(1)).toBeHidden();
 
-    await workspaces.locator('.workspace-categories-menu-item').nth(3).click();
+    await workspaces.locator('.workspace-categories-menu-item').getByText('Hidden').click();
     await expect(workspaceCard.nth(0).locator('.workspace-hidden')).toHaveText('Hidden');
     await expect(workspaceCard.nth(0)).toBeVisible();
     await expect(workspaceCard.nth(1).locator('.workspace-hidden')).toHaveText('Hidden');
@@ -362,7 +374,7 @@ for (const displaySize of [DisplaySize.Small, DisplaySize.Large]) {
         'Copy link',
         'Sharing and roles',
         'Miscellaneous',
-        'Add to favorites',
+        'Add as starred',
       ]);
       await popover.getByRole('listitem').nth(3).click();
     } else {
@@ -374,7 +386,7 @@ for (const displaySize of [DisplaySize.Small, DisplaySize.Large]) {
         'Show this workspace',
         'Copy link',
         'Sharing and roles',
-        'Add to favorites',
+        'Add as starred',
       ]);
       await popover.getByRole('listitem').nth(2).click();
     }
@@ -542,6 +554,6 @@ msTest('Check no favorite or recent workspaces', async ({ connected }) => {
   await favoriteWorkspacesButton.click({ force: true });
   await expect(connected.locator('.workspaces-container').locator('.no-favorite-workspaces')).toBeVisible();
   await expect(connected.locator('.workspaces-container').locator('.no-favorite-workspaces').locator('ion-text')).toHaveText(
-    'You have not set any workspaces as favorite. Favorite a workspace to have it be listed here.',
+    'You have not set starred any workspaces yet. Starred workspaces will be listed here.',
   );
 });


### PR DESCRIPTION
## What's updated?
- While hiding a workspace, we cannot see the "Reminder my choice" checkbox
- In small display, we can toggle workspaces categories (Recent, Hidden or Starred)
- Update the locales:
  - `All workspaces` to `My workspaces` to avoid confusing because this tab doesn't include hidden workspaces.
  - Harmonize `Recents` (for the recent workspaces), in French and English.
  - `Favorites` to `Starred` (only in English).
  - The modal `Failed to open the file in your explorer` will be updated with positive sentence `Workspace hidden`
