### PR TITLE
feat(pki): Make `encrypt_message` platform agnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4052,6 +4052,7 @@ dependencies = [
  "pkcs1",
  "pkcs8 0.9.0",
  "rand_core 0.6.4",
+ "sha2",
  "signature",
  "subtle",
  "zeroize",

--- a/libparsec/crates/platform_device_loader/src/native/mod.rs
+++ b/libparsec/crates/platform_device_loader/src/native/mod.rs
@@ -96,7 +96,10 @@ pub(crate) async fn save_device_pki(
     let secret_key = SecretKey::generate();
 
     // Encrypt the key using the public key related to a certificate from the store
-    let (algorithm, encrypted_key) = encrypt_message(secret_key.as_ref(), certificate_ref)
+    let der = libparsec_platform_pki::get_der_encoded_certificate(certificate_ref)
+        .await
+        .map_err(|e| SaveDeviceError::Internal(e.into()))?;
+    let (algorithm, encrypted_key) = encrypt_message(der.as_ref(), secret_key.as_ref())
         .await
         .map_err(|e| SaveDeviceError::Internal(e.into()))?;
 

--- a/libparsec/crates/platform_pki/Cargo.toml
+++ b/libparsec/crates/platform_pki/Cargo.toml
@@ -19,7 +19,7 @@ bytes = { workspace = true }
 error_set = { workspace = true }
 rustls-webpki = { workspace = true, features = ["std", "ring"] }
 rustls-pki-types = { workspace = true }
-rsa = { workspace = true }
+rsa = { workspace = true, features = ["sha2"] }
 sha2 = { workspace = true }
 libparsec_types = { workspace = true }
 # Use to decode subject & issuer fields of used x509 certificate.

--- a/libparsec/crates/platform_pki/examples/encrypt_message.rs
+++ b/libparsec/crates/platform_pki/examples/encrypt_message.rs
@@ -5,7 +5,7 @@ mod utils;
 
 use anyhow::Context;
 use clap::Parser;
-use libparsec_platform_pki::encrypt_message;
+use libparsec_platform_pki::{encrypt_message, get_der_encoded_certificate};
 use libparsec_types::X509CertificateHash;
 
 #[derive(Debug, Parser)]
@@ -26,7 +26,8 @@ async fn main() -> anyhow::Result<()> {
     let cert_ref = args.certificate_hash.into();
     let data = args.content.into_bytes()?;
 
-    let (algo, ciphered) = encrypt_message(&data, &cert_ref)
+    let der = get_der_encoded_certificate(&cert_ref).await?;
+    let (algo, ciphered) = encrypt_message(der.as_ref(), &data)
         .await
         .context("Failed to encrypt message")?;
 

--- a/libparsec/crates/platform_pki/src/errors.rs
+++ b/libparsec/crates/platform_pki/src/errors.rs
@@ -52,18 +52,6 @@ pub enum VerifySignatureError {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum EncryptMessageError {
-    #[error("Cannot open certificate store: {0}")]
-    CannotOpenStore(std::io::Error),
-    #[error("Cannot find certificate")]
-    NotFound,
-    #[error("Cannot acquire keypair related to certificate: {0}")]
-    CannotAcquireKeypair(std::io::Error),
-    #[error("Cannot encrypt message: {0}")]
-    CannotEncrypt(std::io::Error),
-}
-
-#[derive(Debug, thiserror::Error)]
 pub enum DecryptMessageError {
     #[error("Cannot open certificate store: {0}")]
     CannotOpenStore(std::io::Error),
@@ -98,22 +86,6 @@ pub enum GetRootCertificateInfoFromTrustchainError {
 }
 
 error_set::error_set! {
-    BaseCertStoreError := {
-        #[display("Cannot open certificate store: {0}")]
-        CannotOpenStore(std::io::Error),
-        #[display("Cannot find certificate")]
-        NotFound,
-        #[display("Cannot get certificate info: {0}")]
-        CannotGetCertificateInfo(std::io::Error),
-    }
-    BaseKeyPairError := {
-        #[display("Cannot acquire keypair related to certificate: {0}")]
-        CannotAcquireKeypair(std::io::Error),
-    }
-    CreateLocalPendingError := BaseCertStoreError || BaseKeyPairError || {
-        #[display("Cannot encrypt message: {0}")]
-        CannotEncrypt(std::io::Error),
-    }
     ValidatePayloadError := {
             #[display("Invalid certificate: {0}")]
             InvalidCertificateDer(webpki::Error),

--- a/libparsec/crates/platform_pki/src/lib.rs
+++ b/libparsec/crates/platform_pki/src/lib.rs
@@ -23,7 +23,7 @@ pub(crate) use windows as platform;
 #[cfg(not(target_os = "windows"))]
 mod platform {
     use crate::{
-        errors::ListTrustedRootCertificatesError, DecryptMessageError, EncryptMessageError,
+        errors::ListTrustedRootCertificatesError, DecryptMessageError,
         GetDerEncodedCertificateError, ListIntermediateCertificatesError,
         ShowCertificateSelectionDialogError, SignMessageError,
     };
@@ -53,14 +53,6 @@ mod platform {
     ) -> Result<(PkiSignatureAlgorithm, Bytes), SignMessageError> {
         let _ = message;
         let _ = certificate_ref;
-        unimplemented!("platform not supported")
-    }
-
-    pub async fn encrypt_message(
-        message: &[u8],
-        certificate_ref: &X509CertificateReference,
-    ) -> Result<(PKIEncryptionAlgorithm, Bytes), EncryptMessageError> {
-        let _ = (message, certificate_ref);
         unimplemented!("platform not supported")
     }
 
@@ -104,8 +96,7 @@ pub use platform::sign_message;
 
 pub use shared::{verify_message, Certificate, SignedMessage, X509EndCertificate};
 
-pub use errors::EncryptMessageError;
-pub use platform::encrypt_message;
+pub use shared::{encrypt_message, EncryptMessageError};
 
 pub use errors::DecryptMessageError;
 pub use platform::decrypt_message;

--- a/libparsec/crates/platform_pki/src/shared/mod.rs
+++ b/libparsec/crates/platform_pki/src/shared/mod.rs
@@ -257,3 +257,29 @@ pub fn get_root_certificate_info_from_trustchain<'cert>(
         common_name,
     })
 }
+
+#[derive(Debug, thiserror::Error)]
+pub enum EncryptMessageError {
+    #[error("Cannot acquire public key: {0}")]
+    CannotAcquirePubkey(#[from] crate::x509::GetCertificatePublicKeyError),
+    #[error("Cannot encrypt message: {0}")]
+    CannotEncrypt(#[from] rsa::errors::Error),
+}
+
+pub async fn encrypt_message(
+    certificate: impl AsRef<[u8]>,
+    message: &[u8],
+) -> Result<(PKIEncryptionAlgorithm, Bytes), EncryptMessageError> {
+    let pubkey = crate::x509::get_certificate_public_key(certificate.as_ref())?;
+    match pubkey {
+        crate::x509::PublicKey::Rsa(rsa_public_key) => {
+            use rsa::traits::RandomizedEncryptor;
+
+            let enc_key = rsa::oaep::EncryptingKey::<rsa::sha2::Sha256>::new(rsa_public_key);
+            enc_key
+                .encrypt_with_rng(&mut rsa::rand_core::OsRng, message)
+                .map_err(Into::into)
+                .map(|v| (PKIEncryptionAlgorithm::RsaesOaepSha256, Bytes::from(v)))
+        }
+    }
+}

--- a/libparsec/crates/platform_pki/src/windows/mod.rs
+++ b/libparsec/crates/platform_pki/src/windows/mod.rs
@@ -4,9 +4,8 @@ mod find_in_store;
 mod schannel_utils;
 
 use crate::{
-    DecryptMessageError, EncryptMessageError, GetDerEncodedCertificateError,
-    ListIntermediateCertificatesError, ListTrustedRootCertificatesError,
-    ShowCertificateSelectionDialogError, SignMessageError,
+    DecryptMessageError, GetDerEncodedCertificateError, ListIntermediateCertificatesError,
+    ListTrustedRootCertificatesError, ShowCertificateSelectionDialogError, SignMessageError,
 };
 
 use bytes::Bytes;
@@ -16,8 +15,8 @@ use schannel::{
 };
 use sha2::Digest as _;
 use windows_sys::Win32::Security::Cryptography::{
-    NCryptDecrypt, NCryptEncrypt, NCryptSignHash, BCRYPT_OAEP_PADDING_INFO,
-    BCRYPT_PSS_PADDING_INFO, NCRYPT_PAD_OAEP_FLAG, NCRYPT_PAD_PSS_FLAG, NCRYPT_SHA256_ALGORITHM,
+    NCryptDecrypt, NCryptSignHash, BCRYPT_OAEP_PADDING_INFO, BCRYPT_PSS_PADDING_INFO,
+    NCRYPT_PAD_OAEP_FLAG, NCRYPT_PAD_PSS_FLAG, NCRYPT_SHA256_ALGORITHM,
     UI::CryptUIDlgSelectCertificateFromStore,
 };
 
@@ -278,82 +277,6 @@ fn ncrypt_sign_message_with_rsa(
             flags,
         );
 
-        if res != 0 {
-            return Err(std::io::Error::from_raw_os_error(res));
-        }
-        Ok((ALGO, buff))
-    }
-}
-
-pub async fn encrypt_message(
-    message: &[u8],
-    certificate_ref: &X509CertificateReference,
-) -> Result<(PKIEncryptionAlgorithm, Bytes), EncryptMessageError> {
-    let store = open_store().map_err(EncryptMessageError::CannotOpenStore)?;
-    let cert_context =
-        find_certificate(&store, certificate_ref).ok_or(EncryptMessageError::NotFound)?;
-    let pkey = schannel_utils::acquire_private_key(&cert_context)
-        .map_err(EncryptMessageError::CannotAcquireKeypair)?;
-    let (algo, ciphered) = ncrypt_encrypt_message_with_rsa(message, pkey)
-        .map_err(EncryptMessageError::CannotEncrypt)?;
-
-    Ok((algo, ciphered.into()))
-}
-
-fn ncrypt_encrypt_message_with_rsa(
-    message: &[u8],
-    pkey: schannel_utils::PrivateKey,
-) -> std::io::Result<(PKIEncryptionAlgorithm, Vec<u8>)> {
-    const ALGO: PKIEncryptionAlgorithm = PKIEncryptionAlgorithm::RsaesOaepSha256;
-    let raw_handle = pkey.handle();
-
-    // SAFETY: We follow the windows documentation by correctly passing the correct flags according
-    // to padding_info type, and the other pointer are either coming from allocated buffer or null
-    // pointer with their correct associated sizes.
-    //
-    // Documentation of the below function:
-    // https://learn.microsoft.com/en-us/windows/win32/api/ncrypt/nf-ncrypt-ncryptencrypt
-    // Rust doc:
-    // https://docs.rs/windows-sys/latest/windows_sys/Win32/Security/Cryptography/fn.NCryptEncrypt.html
-    unsafe {
-        // We pad the ciphered data using OAEP.
-        let flags = NCRYPT_PAD_OAEP_FLAG;
-        // https://learn.microsoft.com/en-us/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_oaep_padding_info
-        let padding_info = BCRYPT_OAEP_PADDING_INFO {
-            pszAlgId: NCRYPT_SHA256_ALGORITHM,
-            pbLabel: std::ptr::null_mut(),
-            cbLabel: 0,
-        };
-        let padding_info_ptr = (&raw const padding_info) as *const std::os::raw::c_void;
-        let mut len = 0_u32;
-
-        // 1. Get size of the resulting ciphered data.
-        let res = NCryptEncrypt(
-            raw_handle,
-            message.as_ptr(),
-            message.len() as u32,
-            padding_info_ptr,
-            std::ptr::null_mut(),
-            0,
-            &mut len,
-            flags,
-        );
-        if res != 0 {
-            return Err(std::io::Error::from_raw_os_error(res));
-        }
-
-        // 2. Actually perform the encryption.
-        let mut buff = vec![0_u8; len as usize];
-        let res = NCryptEncrypt(
-            raw_handle,
-            message.as_ptr(),
-            message.len() as u32,
-            padding_info_ptr,
-            buff.as_mut_ptr(),
-            buff.len() as u32,
-            &mut len,
-            flags,
-        );
         if res != 0 {
             return Err(std::io::Error::from_raw_os_error(res));
         }

--- a/libparsec/crates/platform_pki/tests/units/mod.rs
+++ b/libparsec/crates/platform_pki/tests/units/mod.rs
@@ -1,6 +1,5 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-#[cfg(target_os = "windows")] // TODO: libparsec_platform_pki only supports Windows so far
 mod encrypt;
 #[cfg(target_os = "windows")] // TODO: libparsec_platform_pki only supports Windows so far
 mod list;

--- a/libparsec/crates/platform_pki/tests/units/utils.rs
+++ b/libparsec/crates/platform_pki/tests/units/utils.rs
@@ -152,9 +152,11 @@ impl InstalledCertificates {
         payload: &[u8],
     ) -> (PKIEncryptionAlgorithm, Bytes, X509CertificateReference) {
         let certificate_ref = self.alice_cert_ref().await;
-        let (algo, encrypted_message) = crate::encrypt_message(payload, &certificate_ref)
+        let der = crate::get_der_encoded_certificate(&certificate_ref)
             .await
             .unwrap();
+        let (algo, encrypted_message) =
+            crate::encrypt_message(der.as_ref(), payload).await.unwrap();
         (algo, encrypted_message, certificate_ref)
     }
 

--- a/libparsec/src/async_enrollment.rs
+++ b/libparsec/src/async_enrollment.rs
@@ -40,7 +40,6 @@ mod strategy {
     use libparsec_platform_async::{pretend_future_is_send_on_web, PinBoxFutureResult};
     use libparsec_platform_pki::{
         DecryptMessageError as PKIDecryptMessageError,
-        EncryptMessageError as PKIEncryptMessageError,
         GetValidationPathForCertError as PKIGetValidationPathForCertError,
         SignMessageError as PKISignMessageError,
     };
@@ -288,21 +287,28 @@ mod strategy {
                 // 1. Generate a random secret key
                 let key = SecretKey::generate();
 
+                let der = libparsec_platform_pki::get_der_encoded_certificate(&cert_ref)
+                    .await
+                    .map_err(|e| match e {
+                        libparsec_platform_pki::GetDerEncodedCertificateError::CannotOpenStore(
+                            error,
+                        ) => {
+                            SubmitAsyncEnrollmentError::PKICannotOpenCertificateStore(error.into())
+                        }
+                        libparsec_platform_pki::GetDerEncodedCertificateError::NotFound => {
+                            SubmitAsyncEnrollmentError::PKIUnusableX509CertificateReference(
+                                e.into(),
+                            )
+                        }
+                    })?;
                 // 2. Encrypt it with the PKI certificate's public key
                 let (algorithm, encrypted_key) =
-                    libparsec_platform_pki::encrypt_message(key.as_ref(), &cert_ref)
+                    libparsec_platform_pki::encrypt_message(der.as_ref(), key.as_ref())
                         .await
-                        .map_err(|err| match err {
-                            err @ (PKIEncryptMessageError::NotFound
-                            | PKIEncryptMessageError::CannotAcquireKeypair(_)
-                            | PKIEncryptMessageError::CannotEncrypt(_)) => {
-                                SubmitAsyncEnrollmentError::PKIUnusableX509CertificateReference(
-                                    err.into(),
-                                )
-                            }
-                            PKIEncryptMessageError::CannotOpenStore(e) => {
-                                SubmitAsyncEnrollmentError::PKICannotOpenCertificateStore(e.into())
-                            }
+                        .map_err(|err| {
+                            SubmitAsyncEnrollmentError::PKIUnusableX509CertificateReference(
+                                err.into(),
+                            )
                         })?;
 
                 // 3. Create the identity system metadata


### PR DESCRIPTION
Since we only need the public key from the certificate to perform the encryption

Closes #12140

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
