### PR TITLE
[CLI] add spinner after sas code from the claimer in invitation greet

### DIFF
--- a/cli/src/commands/invite/greet.rs
+++ b/cli/src/commands/invite/greet.rs
@@ -201,12 +201,24 @@ async fn step3_shamir(
 
 /// Step 4: get claim requests
 async fn step4_user(ctx: UserGreetInProgress3Ctx) -> anyhow::Result<UserGreetInProgress4Ctx> {
-    Ok(ctx.do_get_claim_requests().await?)
+    let mut handle = start_spinner("Waiting for claimer information".into());
+
+    let ctx = ctx.do_get_claim_requests().await?;
+
+    handle.stop_with_symbol(GREEN_CHECKMARK);
+
+    Ok(ctx)
 }
 
 /// Step 4: get claim requests
 async fn step4_device(ctx: DeviceGreetInProgress3Ctx) -> anyhow::Result<DeviceGreetInProgress4Ctx> {
-    Ok(ctx.do_get_claim_requests().await?)
+    let mut handle = start_spinner("Waiting for claimer information".into());
+
+    let ctx = ctx.do_get_claim_requests().await?;
+
+    handle.stop_with_symbol(GREEN_CHECKMARK);
+
+    Ok(ctx)
 }
 
 /// Step 4: send shares

--- a/cli/tests/integration/invitations/device.rs
+++ b/cli/tests/integration/invitations/device.rs
@@ -148,6 +148,9 @@ async fn invite_device_dance(tmp_path: TmpPath) {
         locked
             .exp_string(&format!("Select code provided by claimer: {sas_code}"))
             .unwrap();
+        locked
+            .exp_string("Waiting for claimer information")
+            .unwrap();
     }
 
     // device creation

--- a/cli/tests/integration/invitations/user.rs
+++ b/cli/tests/integration/invitations/user.rs
@@ -161,6 +161,9 @@ async fn invite_user_dance(tmp_path: TmpPath) {
         locked
             .exp_string(&format!("Select code provided by claimer: {sas_code}"))
             .unwrap();
+        locked
+            .exp_string("Waiting for claimer information")
+            .unwrap();
     }
 
     // device creation

--- a/newsfragments/9633.feature.rst
+++ b/newsfragments/9633.feature.rst
@@ -1,0 +1,1 @@
+CLI: Add spinner for greeter after code exchange in invitations, to indicate we wait for claimer information


### PR DESCRIPTION
<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->

Fixes #9633

Spinners added at step 4 of device and user invitation. No changes for recovery invitation, as step 4 is the last one and there is nothing on the greeter side after code exchange.