### PR TITLE
[MS] Adds polling for the join request list

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -143,6 +143,8 @@ async function parsecEventCallback(handle: ConnectionHandle, event: ClientEvent)
       case ClientEventTag.FrozenSelfUser:
         distributor.dispatchEvent(Events.ClientFrozen, undefined, { delay: 1000 });
         break;
+      case ClientEventTag.AsyncEnrollmentUpdated:
+        distributor.dispatchEvent(Events.AsyncEnrollmentUpdated);
       // Ignore this for now;
       case ClientEventTag.ServerConfigChanged:
         break;

--- a/client/src/services/eventDistributor.ts
+++ b/client/src/services/eventDistributor.ts
@@ -50,6 +50,7 @@ enum Events {
   EntrySyncProgress = 1 << 27,
   WorkspaceMountpointsSync = 1 << 28,
   OpenContextMenu = 1 << 28,
+  AsyncEnrollmentUpdated = 1 << 29,
 }
 
 interface WorkspaceCreatedData {

--- a/client/src/views/invitations/InvitationsPage.vue
+++ b/client/src/views/invitations/InvitationsPage.vue
@@ -266,11 +266,16 @@ const routeWatchCancel = watchRoute(async () => {
 });
 
 onMounted(async (): Promise<void> => {
-  eventCbId = await eventDistributor.value.registerCallback(Events.InvitationUpdated, async (event: Events, data?: EventData) => {
-    if (event === Events.InvitationUpdated && data) {
-      await refreshInvitationList();
-    }
-  });
+  eventCbId = await eventDistributor.value.registerCallback(
+    Events.InvitationUpdated | Events.AsyncEnrollmentUpdated,
+    async (event: Events, data?: EventData) => {
+      if (event === Events.InvitationUpdated && data) {
+        await refreshInvitationList();
+      } else if (event === Events.AsyncEnrollmentUpdated) {
+        await refreshAsyncEnrollmentRequestList();
+      }
+    },
+  );
   pkiAvailable.value = await isSmartcardAvailable();
   const configResult = await getCurrentServerConfig();
   if (configResult.ok) {


### PR DESCRIPTION
How to test:
- with the testbed, don't forget to rebuild
- open two tabs, both should see the same device of the same org (make sure the number is the same)
- [TAB1] log in with Alice > Invitations & Requests > Link requests > Copy link, and nothing else (keep the list of requests opened)
- [TAB2] Alice should appear as logged in, Create or join > Join > paste the link, do the whole process, the request should appear as Pending
- [TAB1] the list of requests should be automatically updated with the new request, validate, the request disapear
- [TAB2] Wait at most 30s, the request should change its state