### PR TITLE
[CLI] check that recipient_shared >= 1 in share recovery creation

### DIFF
--- a/cli/src/commands/shared_recovery/create.rs
+++ b/cli/src/commands/shared_recovery/create.rs
@@ -62,13 +62,15 @@ pub async fn create_shared_recovery(args: Args, client: &StartedClient) -> anyho
             .map(|human| *recipient_info.get(human).expect("human should be here"))
             .collect()
     } else {
-        users
+        let admins: Vec<_> = users
             .iter()
             .filter(|info| {
                 info.current_profile == UserProfile::Admin && info.id != client.user_id()
             })
             .map(|info| info.id)
-            .collect()
+            .collect();
+        anyhow::ensure!(!admins.is_empty(), "No default recipient available");
+        admins
     };
 
     let per_recipient_shares: HashMap<UserID, NonZeroU8> = if let Some(weights) = weights {

--- a/cli/tests/integration/shared_recovery/create.rs
+++ b/cli/tests/integration/shared_recovery/create.rs
@@ -119,3 +119,19 @@ async fn create_shared_recovery_default(tmp_path: TmpPath) {
         .unwrap();
     p.exp_eof().unwrap();
 }
+
+#[rstest::rstest]
+#[tokio::test]
+async fn create_shared_recovery_no_recipient(tmp_path: TmpPath) {
+    let (_, TestOrganization { alice, .. }, _) = bootstrap_cli_test(&tmp_path).await.unwrap();
+
+    // Alice is the only admin
+    crate::assert_cmd_failure!(
+        with_password = DEFAULT_DEVICE_PASSWORD,
+        "shared-recovery",
+        "create",
+        "--device",
+        &alice.device_id.hex()
+    )
+    .stderr(predicates::str::contains("No default recipient available"));
+}

--- a/newsfragments/11522.bugfix.rst
+++ b/newsfragments/11522.bugfix.rst
@@ -1,0 +1,1 @@
+CLI: Check that there is at least one recipient available during shared recovery creation


### PR DESCRIPTION
<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
Fixes #11522

Check added after creating the default recipient list to ensure that it is not empty. If it is, returns an error.