### PR TITLE
refactor(editor): upgrade CryptPad to winter version

### DIFF
--- a/client/src/services/cryptpad.ts
+++ b/client/src/services/cryptpad.ts
@@ -14,6 +14,7 @@ namespace CryptpadCommAPI {
     Open = 'editics-open',
     OpenResult = 'editics-open-result',
     Event = 'editics-event',
+    Save = 'editics-save',
   }
 
   export enum Events {
@@ -135,11 +136,16 @@ function cryptpadLog(level: 'debug' | 'warn' | 'error' | 'info', message: string
   window.electronAPI.log(level, `[Cryptpad] ${message}`);
 }
 
+export interface CryptpadSession {
+  controller: AbortController;
+  save: () => void;
+}
+
 export async function openDocument(
   options: OpenDocumentOptions,
   handlers: CryptpadEventHandlers,
   frame: HTMLIFrameElement,
-): Promise<AbortController | undefined> {
+): Promise<CryptpadSession | undefined> {
   const CRYPTPAD_SERVER = Env.getDefaultCryptpadServer();
 
   function sendMessageToFrame(command: CryptpadCommAPI.Commands, data?: any): void {
@@ -260,5 +266,11 @@ export async function openDocument(
   cryptpadLog('debug', 'Initializing the frame');
   sendMessageToFrame(CryptpadCommAPI.Commands.Init);
 
-  return controller;
+  return {
+    controller,
+    save: () => {
+      cryptpadLog('debug', 'Triggering manual save');
+      sendMessageToFrame(CryptpadCommAPI.Commands.Save);
+    },
+  };
 }

--- a/client/tests/e2e/specs/file_editor.spec.ts
+++ b/client/tests/e2e/specs/file_editor.spec.ts
@@ -2,7 +2,6 @@
 
 import { TestInfo } from '@playwright/test';
 import {
-  answerQuestion,
   expect,
   fillInputModal,
   getClipboardText,
@@ -216,6 +215,9 @@ msTest.describe(() => {
           sendToParent({ command: 'editics-event', event: 'save-status', saved: false });
         }, 300);
         setTimeout(() => {
+          sendToParent({ command: 'editics-event', event: 'save-status', saved: false });
+        }, 450);
+        setTimeout(() => {
           sendToParent({ command: 'editics-event', event: 'save', documentContent: new Blob([42, 42, 42, 42, 42, 42, 42], { type: 'application/octet-stream' }) });
         }, 800);
         setTimeout(() => {
@@ -238,11 +240,9 @@ msTest.describe(() => {
     await expect(frame.locator('#editor-container')).toHaveText('document.docx');
     await expect(parsecEditics.locator('.file-editor-error')).toBeHidden();
     const topbar = parsecEditics.locator('.file-handler-topbar');
-    await expect(topbar.locator('.save-info')).toBeVisible();
-    await expect(topbar.locator('.save-info-text')).toBeVisible();
+    await expect(parsecEditics.locator('#unsaved-changes')).toBeVisible();
     await expect(topbar.locator('.save-info-text')).toHaveText('Changes unsaved');
-    await parsecEditics.waitForTimeout(800);
-    await expect(topbar.locator('.save-info-text')).toHaveText('File saved');
+    await waitUntilSaved(parsecEditics);
   });
 
   msTest('Go back with unsaved status', async ({ parsecEditics }, testInfo: TestInfo) => {
@@ -256,6 +256,9 @@ msTest.describe(() => {
         setTimeout(() => {
           sendToParent({ command: 'editics-event', event: 'save-status', saved: false });
         }, 300);
+        setTimeout(() => {
+          sendToParent({ command: 'editics-event', event: 'save-status', saved: false });
+        }, 450);
       `,
     });
     await importDefaultFiles(parsecEditics, testInfo, ImportDocuments.Docx, false);
@@ -277,12 +280,6 @@ msTest.describe(() => {
     await expect(topbar.locator('.save-info-text')).toBeVisible();
     await expect(topbar.locator('.save-info-text')).toHaveText('Changes unsaved');
     await topbar.locator('.back-button').click();
-    await answerQuestion(parsecEditics, true, {
-      expectedNegativeText: 'Stay on page',
-      expectedPositiveText: 'Discard changes',
-      expectedQuestionText: 'Some changes have not been saved yet. Do you want to discard them?',
-      expectedTitleText: 'Discard changes?',
-    });
     await expect(parsecEditics).toBeDocumentPage();
   });
 


### PR DESCRIPTION
Changes:
- Add ManualSave command to CryptPad communication API
- Add CryptpadSession interface (controller + manualSave)
- Auto-save on initial unsaved changes (OO conversion artifacts)
- Save automatically when leaving the editor (modal only on failure)
- Skip save attempt when document never loaded (corrupted files)
- Add ref on dynamic component for parent-to-child save calls
- Remove file-type-specific timeout handling