### PR TITLE
[CLI] Convert some options as argument

### DIFF
--- a/cli/src/commands/device/import_recovery_device.rs
+++ b/cli/src/commands/device/import_recovery_device.rs
@@ -10,7 +10,6 @@ crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, password_stdin]
     pub struct Args {
         /// Path where encrypted recovery device data is
-        #[arg(short, long)]
         input: PathBuf,
         /// new device label
         #[arg(short, long)]

--- a/cli/src/commands/device/remove.rs
+++ b/cli/src/commands/device/remove.rs
@@ -6,8 +6,11 @@ use libparsec_client::remove_device;
 use crate::utils::*;
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, device]
-    pub struct Args {}
+    #[with = config_dir]
+    pub struct Args {
+        /// Short id of the device to remove
+        device: Option<String>,
+    }
 );
 
 pub async fn main(args: Args) -> anyhow::Result<()> {

--- a/cli/src/commands/organization/stats.rs
+++ b/cli/src/commands/organization/stats.rs
@@ -5,8 +5,10 @@ use serde_json::Value;
 use libparsec::{OrganizationID, ParsecAddr};
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = addr, token, organization]
+    #[with = addr, token]
     pub struct Args {
+        /// Organization ID
+        organization: OrganizationID,
     }
 );
 

--- a/cli/src/commands/organization/status.rs
+++ b/cli/src/commands/organization/status.rs
@@ -5,8 +5,10 @@ use serde_json::Value;
 use libparsec::{OrganizationID, ParsecAddr};
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = addr, token, organization]
+    #[with = addr, token]
     pub struct Args {
+        /// Organization ID
+        organization: OrganizationID,
     }
 );
 

--- a/cli/tests/integration/device/import_recovery_device.rs
+++ b/cli/tests/integration/device/import_recovery_device.rs
@@ -25,7 +25,6 @@ async fn import_recovery_device(tmp_path: TmpPath) {
         with_password = format!("{}\n{DEFAULT_DEVICE_PASSWORD}", *passphrase),
         "device",
         "import-recovery-device",
-        "--input",
         &input.to_string_lossy(),
         "--label",
         "new_device"

--- a/cli/tests/integration/device/remove.rs
+++ b/cli/tests/integration/device/remove.rs
@@ -9,7 +9,7 @@ use crate::{bootstrap_cli_test, testenv_utils::TestOrganization, wait_for};
 async fn remove_device(tmp_path: TmpPath) {
     let (_, TestOrganization { alice, .. }, _) = bootstrap_cli_test(&tmp_path).await.unwrap();
 
-    let mut process = crate::std_cmd!("device", "remove", "--device", &alice.device_id.hex())
+    let mut process = crate::std_cmd!("device", "remove", &alice.device_id.hex())
         .stdin(std::process::Stdio::piped())
         .stderr(std::process::Stdio::inherit())
         .stdout(std::process::Stdio::piped())

--- a/cli/tests/integration/organization/stats.rs
+++ b/cli/tests/integration/organization/stats.rs
@@ -35,7 +35,6 @@ async fn stats_organization(tmp_path: TmpPath) {
     crate::assert_cmd_success!(
         "organization",
         "stats",
-        "--organization",
         org_id.as_ref(),
         "--addr",
         &url.to_string(),

--- a/cli/tests/integration/organization/status.rs
+++ b/cli/tests/integration/organization/status.rs
@@ -22,7 +22,6 @@ async fn status_organization(tmp_path: TmpPath) {
     crate::assert_cmd_success!(
         "organization",
         "status",
-        "--organization",
         org_id.as_ref(),
         "--addr",
         &url.to_string(),

--- a/newsfragments/8556.feature.rst
+++ b/newsfragments/8556.feature.rst
@@ -1,0 +1,1 @@
+CLI: Convert some options as argument in CLI commands: ``device`` in command ``device remove``, ``input`` in command ``device import-recovery-device``, ``organization-id`` in command ``organization stats``, ``organization-id`` in command ``organization status``.


### PR DESCRIPTION
<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->

Closes #8556

Directly pass device id instead of `device` option in `device remove` command.
Directly pass the org-id instead of `organization-id` option in  `organization stats` command.
Directly pass the org-id instead of `organization-id` option in `organization status` command.
Directly pass import path instead of `input` option in `device import-recovery-device` command.

The other options from #8556 seems already converted to arguments.

PR is in draft because, for the `device` option in `device remove` command, the help output is different from the other ones:
```
Remove device

Usage: parsec-cli device remove [OPTIONS] [DEVICE]

Arguments:
  [DEVICE]  Short id of the device to remove

Options: [...]
```
DEVICE is between [ ], and not between < > like the arguments in other commands, and I fail to understand why. Export recovery device help command for reference :
```
Export recovery device

Usage: parsec-cli device export-recovery-device [OPTIONS] <OUTPUT>

Arguments:
  <OUTPUT>  Path where to save recovery device data

Options: [...]
```