### PR TITLE
Updated Docker image to build docs

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,6 +1,7 @@
 # cspell:words inotify
 
-FROM python:3.12-slim
+# Using bookworm because it provides the same version of gettext (v0.21) used in the CI.
+FROM python:3.12-slim-bookworm
 
 SHELL [ "/bin/bash", "-c" ]
 


### PR DESCRIPTION
The powrap step (wrapping of .po files) give different results between gettext v0.21 and v0.23. So we need to use a Docker image providing the same version used in the CI.

Currently:
- `ci-docs` runs-on `ubuntu-24.04` which provides gettext v0.21
- `python:3.12-slim` is based on Debian Trixie which provides gettext v0.23
- `python:3.12-slim-bookworm` is based on Debian Bookworm which provides gettext v0.21 :heavy_check_mark: 