### PR TITLE
fix(pki): Return correct IO Error for windows API errors

### DIFF
--- a/libparsec/crates/platform_pki/src/windows/mod.rs
+++ b/libparsec/crates/platform_pki/src/windows/mod.rs
@@ -277,7 +277,7 @@ fn ncrypt_sign_message_with_rsa(
         );
 
         if res != 0 {
-            return Err(std::io::Error::last_os_error());
+            return Err(std::io::Error::from_raw_os_error(res));
         }
 
         // 2. Fill the actual signature in a buffer
@@ -294,7 +294,7 @@ fn ncrypt_sign_message_with_rsa(
         );
 
         if res != 0 {
-            return Err(std::io::Error::last_os_error());
+            return Err(std::io::Error::from_raw_os_error(res));
         }
         Ok((ALGO, buff))
     }
@@ -360,7 +360,7 @@ fn ncrypt_encrypt_message_with_rsa(
             flags,
         );
         if res != 0 {
-            return Err(std::io::Error::last_os_error());
+            return Err(std::io::Error::from_raw_os_error(res));
         }
 
         // 2. Actually perform the encryption.
@@ -376,7 +376,7 @@ fn ncrypt_encrypt_message_with_rsa(
             flags,
         );
         if res != 0 {
-            return Err(std::io::Error::last_os_error());
+            return Err(std::io::Error::from_raw_os_error(res));
         }
         Ok((ALGO, buff))
     }
@@ -447,7 +447,7 @@ fn ncrypt_decrypt_message_with_rsa(
             flags,
         );
         if res != 0 {
-            return Err(std::io::Error::last_os_error());
+            return Err(std::io::Error::from_raw_os_error(res));
         }
 
         // 2. Actually perform the decryption.
@@ -463,7 +463,7 @@ fn ncrypt_decrypt_message_with_rsa(
             flags,
         );
         if res != 0 {
-            return Err(std::io::Error::last_os_error());
+            return Err(std::io::Error::from_raw_os_error(res));
         }
         Ok(buff)
     }


### PR DESCRIPTION
We can obtain the IO Error directly from the returned value of `NCryptSignHash` & `NcryptEncrypt`

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
