### PR TITLE
[MS] 3.8 style issues fixes

### DIFF
--- a/client/src/components/devices/ConnectSso.vue
+++ b/client/src/components/devices/ConnectSso.vue
@@ -5,17 +5,20 @@
     class="provider-card"
     v-if="serverConfig.openbao"
   >
-    <sso-provider-card
-      v-for="auth in serverConfig.openbao.auths.filter((auth) => isSSOProviderHandled(auth.tag))"
-      :key="auth.tag"
-      :provider="auth.tag"
-      :is-connected="openBaoClient !== undefined && openBaoClient.getConnectionInfo().provider === auth.tag"
-      @sso-selected="onSSOLoginClicked"
-    />
-    <ms-spinner
-      v-if="querying"
-      class="provider-card-spinner"
-    />
+    <div class="provider-card-content">
+      <sso-provider-card
+        v-for="auth in serverConfig.openbao.auths.filter((auth) => isSSOProviderHandled(auth.tag))"
+        :key="auth.tag"
+        :provider="auth.tag"
+        :is-connected="openBaoClient !== undefined && openBaoClient.getConnectionInfo().provider === auth.tag"
+        @sso-selected="onSSOLoginClicked"
+        :class="{ disabled: querying }"
+      />
+      <ms-spinner
+        v-if="querying"
+        class="provider-card-spinner"
+      />
+    </div>
     <ms-report-text
       v-if="error"
       :theme="MsReportTheme.Error"
@@ -99,12 +102,27 @@ async function onSSOLoginClicked(provider: OpenBaoAuthConfigTag): Promise<void> 
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  position: relative;
+
+  &-content {
+    display: flex;
+    gap: 1rem;
+    position: relative;
+    align-items: center;
+
+    .disabled {
+      pointer-events: none;
+      opacity: 0.2;
+    }
+  }
 
   &-spinner {
     position: absolute;
-    top: 1.125rem;
-    right: 2rem;
+    top: 1.75rem;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: var(--parsec-color-light-secondary-white);
+    border-radius: 50%;
+    padding: 0.125rem;
   }
 }
 </style>

--- a/client/src/components/files/explorer/FolderSelectionModal.vue
+++ b/client/src/components/files/explorer/FolderSelectionModal.vue
@@ -514,7 +514,6 @@ async function cancel(): Promise<boolean> {
   --background: var(--parsec-color-light-secondary-white);
   cursor: pointer;
   position: relative;
-  overflow: visible;
 
   &::part(native) {
     --padding-start: 0px;
@@ -538,6 +537,9 @@ async function cancel(): Promise<boolean> {
   &__name {
     color: var(--parsec-color-light-secondary-text);
     margin-left: 1rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
   }
 
   &-image {

--- a/client/src/components/invitations/InviteModal.vue
+++ b/client/src/components/invitations/InviteModal.vue
@@ -3,7 +3,6 @@
 <template>
   <ms-modal
     title="UsersPage.CreateUserInvitationModal.pageTitle"
-    subtitle="UsersPage.CreateUserInvitationModal.subtitle"
     :close-button="{ visible: true }"
     :cancel-button="{
       disabled: false,
@@ -17,13 +16,18 @@
     }"
     :class="emails.length > 5 ? 'has-multiple-emails' : ''"
   >
-    <ms-input
-      @change="onInputChange"
-      v-model="textModel"
-      placeholder="UsersPage.CreateUserInvitationModal.placeholder"
-      label="UsersPage.CreateUserInvitationModal.label"
-      id="email-input"
-    />
+    <div class="email-input-container">
+      <ms-report-text :theme="MsReportTheme.Info">
+        <ion-text>{{ $msTranslate('UsersPage.CreateUserInvitationModal.subtitle') }}</ion-text>
+      </ms-report-text>
+      <ms-input
+        @change="onInputChange"
+        v-model="textModel"
+        placeholder="UsersPage.CreateUserInvitationModal.placeholder"
+        label="UsersPage.CreateUserInvitationModal.label"
+        id="email-input"
+      />
+    </div>
     <div
       class="email-list-container"
       v-if="emails.length > 1"
@@ -47,7 +51,7 @@
 <script setup lang="ts">
 import { emailValidator } from '@/common/validators';
 import { IonText, modalController } from '@ionic/vue';
-import { MsInput, MsModal, MsModalResult, MsReportTheme, Validity } from 'megashark-lib';
+import { MsInput, MsModal, MsModalResult, MsReportText, MsReportTheme, Validity } from 'megashark-lib';
 import { ref } from 'vue';
 
 const textModel = ref('');
@@ -80,6 +84,12 @@ async function onConfirmClicked(): Promise<boolean> {
   @include ms.responsive-breakpoint('sm') {
     margin-top: 1rem;
   }
+}
+
+.email-input-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .email-list-container {

--- a/client/src/components/organizations/OrganizationJoinRequest.vue
+++ b/client/src/components/organizations/OrganizationJoinRequest.vue
@@ -134,6 +134,7 @@ const statusText = computed(() => {
     flex-direction: column;
     gap: 0.25rem;
     width: 100%;
+    overflow: hidden;
 
     .organization-request-organization {
       color: var(--parsec-color-light-secondary-text);

--- a/client/src/components/organizations/OrganizationSwitchPopover.vue
+++ b/client/src/components/organizations/OrganizationSwitchPopover.vue
@@ -193,6 +193,9 @@ async function goToLogin(): Promise<void> {
 }
 
 .connected-organization {
+  max-height: 20%;
+  max-height: 30vh;
+  overflow-y: auto;
   gap: 0.5rem;
 
   &-title {
@@ -284,6 +287,9 @@ async function goToLogin(): Promise<void> {
       }
 
       &__email {
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
         color: var(--parsec-color-light-secondary-grey);
       }
     }

--- a/client/src/components/settings/SettingsList.vue
+++ b/client/src/components/settings/SettingsList.vue
@@ -140,7 +140,6 @@
         </settings-option>
         <!-- skip file viewers -->
         <settings-option
-          v-if="isDesktop()"
           class="settings-list__item"
           title="SettingsModal.skipViewers.label"
           description="SettingsModal.skipViewers.description"

--- a/client/src/components/users/UserAvatarName.vue
+++ b/client/src/components/users/UserAvatarName.vue
@@ -9,7 +9,7 @@
       {{ userAvatar.substring(0, 2) }}
     </ion-avatar>
     <ion-text
-      class="person-name button-sm"
+      class="person-name cell"
       v-if="userName"
       :title="userName"
     >

--- a/client/src/components/users/UserCard.vue
+++ b/client/src/components/users/UserCard.vue
@@ -210,6 +210,12 @@ async function onCopyEmailClicked(email: string): Promise<void> {
       display: flex;
       gap: 0.5rem;
 
+      span {
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+      }
+
       .name-you {
         color: var(--parsec-color-light-secondary-text);
         font-weight: 700;

--- a/client/src/components/workspaces/WorkspaceUserRole.vue
+++ b/client/src/components/workspaces/WorkspaceUserRole.vue
@@ -101,6 +101,10 @@ function onRoleChanged(user: UserTuple, newRoleOption: MsOption, oldRoleOption?:
   }
 }
 
+.dropdown {
+  flex-shrink: 0;
+}
+
 .content-user {
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -652,8 +652,8 @@
             "open": "Open in explorer"
         },
         "skipViewers": {
-            "label": "Do not use file preview",
-            "description": "Always open files in your system's default application"
+            "label": "Use system's applications to open files",
+            "description": "When enabled, files will be opened with the system's default applications instead of Parsec's built-in viewers and editors"
         },
         "language": {
             "label": "Language",
@@ -1041,7 +1041,8 @@
         }
     },
     "FileDetails": {
-        "title": "Details on {name}",
+        "fileTitle": "Details on the file",
+        "folderTitle": "Details on the folder",
         "stats": {
             "generalInfo": "General information",
             "lastUpdate": "Last updated",
@@ -1580,7 +1581,7 @@
         "emptyList": "No user to display.",
         "noMatch": "No users matching your filters.",
         "listUsersFailed": "Failed to retrieve users for this organization. Please make sure you are online.",
-        "userSelectedCount": "No user selected | One user selected | {count} users selected",
+        "userSelectedCount": "No user selected | 1 user selected | {count} users selected",
         "userContextMenu": {
             "titleRemove": "Deletion",
             "titleDetails": "User details",
@@ -2841,7 +2842,7 @@
             "tooltipUnsaved": "Changes haven't been saved yet.",
             "tooltipError": "Failed to save the changes.",
             "tooltipOffline": "You are offline, changes cannot be saved.",
-            "readOnly": "Read only document",
+            "readOnly": "Read only",
             "notSavedTitle": "Discard changes?",
             "notSavedQuestion": "Some changes have not been saved yet. Do you want to discard them?",
             "notSavedDiscard": "Discard changes",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -651,8 +651,8 @@
             "open": "Ouvrir dans l'explorateur"
         },
         "skipViewers": {
-            "label": "Ne pas utiliser l'aperçu des fichiers",
-            "description": "Toujours ouvrir les fichiers dans l'application par défaut de votre système"
+            "label": "Utiliser les applications du système pour ouvrir les fichiers",
+            "description": "Lorsque cette option est activée, les fichiers seront ouverts avec les applications par défaut du système plutôt qu'avec l'aperçu et l'éditeur intégrés à Parsec."
         },
         "language": {
             "label": "Langue",
@@ -1041,7 +1041,8 @@
         }
     },
     "FileDetails": {
-        "title": "Détails de {name}",
+        "fileTitle": "Détails du fichier",
+        "folderTitle": "Détails du dossier",
         "stats": {
             "generalInfo": "Informations générales",
             "lastUpdate": "Dernière modification",
@@ -1580,7 +1581,7 @@
         "emptyList": "Aucun utilisateur à afficher.",
         "noMatch": "Aucun utilisateur ne correspond à vos filtres.",
         "listUsersFailed": "Impossible d'obtenir les utilisateurs de l'organisation. Veuillez vérifier votre connexion internet.",
-        "userSelectedCount": "Aucun utilisateur sélectionné | Un utilisateur sélectionné | {count} utilisateurs sélectionnés",
+        "userSelectedCount": "Aucun utilisateur sélectionné | 1 utilisateur sélectionné | {count} utilisateurs sélectionnés",
         "userContextMenu": {
             "titleRemove": "Suppression",
             "titleDetails": "Détails de l'utilisateur",
@@ -2840,7 +2841,7 @@
             "tooltipUnsaved": "Les modifications ne sont pas encore sauvegardées.",
             "tooltipError": "Les modifications n'ont pas été sauvegardées.",
             "tooltipOffline": "Vous êtes hors-ligne, les changements ne peuvent pas être sauvegardés.",
-            "readOnly": "Document en lecture seule",
+            "readOnly": "Lecture seule",
             "notSavedTitle": "Abandonner les modifications ?",
             "notSavedQuestion": "Certaines modifications n'ont pas encore été enregistrées. Voulez-vous abandonner les modifications ?",
             "notSavedDiscard": "Abandonner les modifications",

--- a/client/src/theme/components/_file-operation.scss
+++ b/client/src/theme/components/_file-operation.scss
@@ -12,6 +12,9 @@
 
   strong {
     font-weight: 700;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .element {

--- a/client/src/views/files/FileDetailsModal.vue
+++ b/client/src/views/files/FileDetailsModal.vue
@@ -3,7 +3,7 @@
 <template>
   <ion-page class="modal">
     <ms-modal
-      :title="{ key: 'FileDetails.title', data: { name: entry.name } }"
+      :title="entry.isFile() ? 'FileDetails.fileTitle' : 'FileDetails.folderTitle'"
       :close-button="{ visible: true }"
     >
       <div class="file-info-container">
@@ -236,10 +236,15 @@ async function copyPath(): Promise<void> {
     display: flex;
     width: 3rem;
     height: 3rem;
+    flex-shrink: 0;
   }
 
   &__name {
     color: var(--parsec-color-light-secondary-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-height: 1.5rem;
   }
 
   &-details {

--- a/client/src/views/files/handler/FileHandler.vue
+++ b/client/src/views/files/handler/FileHandler.vue
@@ -51,8 +51,12 @@
             </div>
             <div
               v-if="isComponentEditor() && readOnly"
-              class="save-info"
+              class="save-info read-only subtitles-sm"
             >
+              <ion-icon
+                :icon="eye"
+                class="read-only-icon"
+              />
               {{ $msTranslate('fileEditors.saving.readOnly') }}
             </div>
             <div
@@ -259,7 +263,19 @@ import SmallDisplayViewerActionMenu from '@/views/files/handler/SmallDisplayView
 import { FileViewer } from '@/views/files/handler/viewer';
 import { FileContentInfo } from '@/views/files/handler/viewer/utils';
 import { IonButton, IonContent, IonIcon, IonPage, IonText, modalController } from '@ionic/vue';
-import { alert, chevronDown, chevronUp, create, ellipsisHorizontal, informationCircle, link, open, save, warning } from 'ionicons/icons';
+import {
+  alert,
+  chevronDown,
+  chevronUp,
+  create,
+  ellipsisHorizontal,
+  eye,
+  informationCircle,
+  link,
+  open,
+  save,
+  warning,
+} from 'ionicons/icons';
 import { DateTime } from 'luxon';
 import {
   Answer,
@@ -1019,6 +1035,20 @@ async function openSmallDisplayActionMenu(): Promise<void> {
           width: 1.125rem;
           font-size: 1.125rem;
           margin-right: 0;
+        }
+
+        &.read-only {
+          background: var(--parsec-color-light-secondary-medium);
+          color: var(--parsec-color-light-secondary-text);
+          padding: 0.25rem 0.75rem;
+          border-radius: var(--parsec-radius-12);
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+
+          &-icon {
+            font-size: 1rem;
+          }
         }
 
         &-text {

--- a/client/src/views/users/UserDetailsModal.vue
+++ b/client/src/views/users/UserDetailsModal.vue
@@ -157,12 +157,16 @@ onMounted(async () => {
       display: flex;
       flex-direction: column;
       gap: 0.5rem;
+      overflow: hidden;
 
       &__title {
         color: var(--parsec-color-light-secondary-text);
       }
 
       &__text {
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
         color: var(--parsec-color-light-primary-800);
       }
     }

--- a/client/src/views/workspaces/WorkspaceSharingModal.vue
+++ b/client/src/views/workspaces/WorkspaceSharingModal.vue
@@ -664,6 +664,7 @@ async function onBatchRoleChange(newRoleOption: MsOption): Promise<void> {
     .dropdown {
       border: 1px solid var(--parsec-color-light-secondary-medium);
       border-radius: var(--parsec-radius-8);
+      flex-shrink: 0;
     }
 
     #batch-activate-button {

--- a/client/tests/e2e/specs/async_enrollment.spec.ts
+++ b/client/tests/e2e/specs/async_enrollment.spec.ts
@@ -96,7 +96,7 @@ for (const identitySystem of ['pki', 'openbao']) {
 
     await expect(sidebar.locator('#sidebar-invitations').locator('.request-notification')).toBeVisible();
 
-    await expect(page).toHavePageTitle('Invitations & Requests');
+    await expect(page).toHavePageTitle('Invitations & Join Requests');
 
     await expect(page.locator('.toggle-view-container').locator('.pki-button').locator('.toggle-view-button__label')).toHaveText(
       'Join requests (PKI/SSO)',

--- a/client/tests/e2e/specs/file_details.spec.ts
+++ b/client/tests/e2e/specs/file_details.spec.ts
@@ -32,7 +32,11 @@ msTest.describe(() => {
       }
       await expect(documents.locator('.file-details-modal')).toBeVisible();
       const modal = documents.locator('.file-details-modal');
-      await expect(modal.locator('.ms-modal-header__title ')).toHaveText(new RegExp(`^Details on ${nameMatcher}$`));
+      if (isFile) {
+        await expect(modal.locator('.ms-modal-header__title ')).toHaveText('Details on the file');
+      } else {
+        await expect(modal.locator('.ms-modal-header__title ')).toHaveText('Details on the folder');
+      }
 
       const generalDetails = modal.locator('.file-info-details-content').nth(0);
       const generalDetailsItem = generalDetails.locator('.file-info-details-item');
@@ -91,6 +95,6 @@ msTest.describe(() => {
     await documents.locator('.file-context-menu').getByRole('listitem').nth(7).click();
     await expect(documents.locator('.file-details-modal')).toBeVisible();
     const modal = documents.locator('.file-details-modal');
-    await expect(modal.locator('.ms-modal-header__title ')).toHaveText(/^Details on [a-z0-9._]+$/);
+    await expect(modal.locator('.ms-modal-header__title ')).toHaveText('Details on the file');
   });
 });

--- a/client/tests/e2e/specs/file_editor.spec.ts
+++ b/client/tests/e2e/specs/file_editor.spec.ts
@@ -66,7 +66,7 @@ msTest.describe(() => {
         await expect(topbarButtons).toHaveText(['Details', 'Copy link', 'Download', 'Show menu']);
       } else {
         await expect(topbar.locator('.save-info')).toBeVisible();
-        await expect(topbar.locator('.save-info')).toHaveText('Read only document');
+        await expect(topbar.locator('.save-info')).toHaveText('Read only');
         await expect(topbarButtons).toHaveCount(5);
         await expect(topbarButtons).toHaveText(['Details', 'Copy link', 'Edit', 'Download', 'Show menu']);
       }
@@ -96,7 +96,7 @@ msTest.describe(() => {
       const topbarButtons = topbar.locator('.file-handler-topbar-buttons').locator('.file-handler-topbar-buttons__item:visible');
       await expect(topbarButtons).toHaveText(['Details', 'Copy link', 'Edit', 'Download', 'Show menu']);
       await expect(topbar.locator('.save-info')).toBeVisible();
-      await expect(topbar.locator('.save-info')).toHaveText('Read only document');
+      await expect(topbar.locator('.save-info')).toHaveText('Read only');
 
       if (action === 'details') {
         const modal = parsecEditics.locator('.file-details-modal');

--- a/client/tests/e2e/specs/users_list.spec.ts
+++ b/client/tests/e2e/specs/users_list.spec.ts
@@ -197,7 +197,7 @@ msTest('Selection in grid mode', async ({ usersPage }) => {
   await expect(actionBar.getByText('Revoke this user')).toBeVisible();
   await expect(actionBar.getByText('Revoke this user')).toHaveText('Revoke this user');
   await expect(actionBar.getByText('Details')).toBeVisible();
-  await expect(actionBar.locator('.counter')).toHaveText('One user selected', { useInnerText: true });
+  await expect(actionBar.locator('.counter')).toHaveText('1 user selected', { useInnerText: true });
 });
 
 msTest('Test users selection in list mode', async ({ usersPage }) => {
@@ -212,7 +212,7 @@ msTest('Test users selection in list mode', async ({ usersPage }) => {
   await expect(actionBar.getByText('Revoke this user')).toBeVisible();
   await expect(actionBar.getByText('Revoke this user')).toHaveText('Revoke this user');
   await expect(actionBar.getByText('Details')).toBeVisible();
-  await expect(actionBar.locator('.counter')).toHaveText('One user selected', { useInnerText: true });
+  await expect(actionBar.locator('.counter')).toHaveText('1 user selected', { useInnerText: true });
 
   const headerCheckbox = usersPage.locator('.user-list-header').locator('.ms-checkbox');
   // Header checkbox should be indeterminate since not all users are selected
@@ -294,7 +294,7 @@ msTest('Maintain selection between modes', async ({ usersPage }) => {
   }
   // Uncheck one
   await usersPage.locator('.users-container-grid').locator('.user-card-item').nth(2).locator('.ms-checkbox').uncheck();
-  await expect(actionBar.locator('.counter')).toHaveText('One user selected', { useInnerText: true });
+  await expect(actionBar.locator('.counter')).toHaveText('1 user selected', { useInnerText: true });
   for (const [index, user] of USERS.entries()) {
     if (user.active && !user.currentUser) {
       const item = usersPage.locator('.users-container-grid').locator('.user-card-item').nth(index);
@@ -393,7 +393,7 @@ msTest('Remove selection on filtering', async ({ usersPage }) => {
   const item = usersPage.locator('#users-page-user-list').getByRole('listitem').nth(1);
   await item.hover();
   await item.locator('.ms-checkbox').check();
-  await expect(actionBar.locator('.counter')).toHaveText('One user selected', { useInnerText: true });
+  await expect(actionBar.locator('.counter')).toHaveText('1 user selected', { useInnerText: true });
   await toggleFilter(usersPage, 'Member');
   await expect(actionBar.locator('.counter')).toHaveText('2 users', { useInnerText: true });
 });
@@ -490,9 +490,9 @@ msTest('Search user list', async ({ usersPage }) => {
   await usersPage.locator('.user-list-header').locator('.ms-checkbox').check();
   await expect(actionBar.locator('.counter')).toHaveText('2 users selected', { useInnerText: true });
   await fillIonInput(searchInput, 'Bob');
-  await expect(actionBar.locator('.counter')).toHaveText('One user selected', { useInnerText: true });
+  await expect(actionBar.locator('.counter')).toHaveText('1 user selected', { useInnerText: true });
   await fillIonInput(searchInput, '');
-  await expect(actionBar.locator('.counter')).toHaveText('One user selected', { useInnerText: true });
+  await expect(actionBar.locator('.counter')).toHaveText('1 user selected', { useInnerText: true });
   await expect(items).toHaveCount(3);
   await expect(items.nth(1).locator('.user-name')).toContainText('Boby McBobFace');
   await expect(items.nth(1).locator('.ms-checkbox')).toBeChecked();
@@ -556,9 +556,9 @@ msTest('Search user grid', async ({ usersPage }) => {
   await items.nth(2).locator('.ms-checkbox').check();
   await expect(actionBar.locator('.counter')).toHaveText('2 users selected', { useInnerText: true });
   await fillIonInput(searchInput, 'Bob');
-  await expect(actionBar.locator('.counter')).toHaveText('One user selected', { useInnerText: true });
+  await expect(actionBar.locator('.counter')).toHaveText('1 user selected', { useInnerText: true });
   await fillIonInput(searchInput, '');
-  await expect(actionBar.locator('.counter')).toHaveText('One user selected', { useInnerText: true });
+  await expect(actionBar.locator('.counter')).toHaveText('1 user selected', { useInnerText: true });
 
   await expect(items.nth(1).locator('.user-card-info__name')).toContainText('Boby McBobFace');
   await expect(items.nth(1).locator('.ms-checkbox')).toBeChecked();
@@ -704,7 +704,7 @@ msTest('Small display selection', async ({ usersPage }) => {
   await expect(user2.locator('.ms-checkbox')).toBeChecked();
   await user1.locator('.ms-checkbox').uncheck();
   await expect(user1.locator('.ms-checkbox')).not.toBeChecked();
-  await expect(headerSelection.locator('.title__text')).toContainText('One user selected');
+  await expect(headerSelection.locator('.title__text')).toContainText('1 user selected');
   await user1.locator('.ms-checkbox').check();
   await expect(headerSelection.locator('.title__text')).toContainText('2 users selected');
   await headerSelection.locator('.title__button').nth(0).click();


### PR DESCRIPTION
## Bug list to check:

### UserPage
- The information on the invitation modal should be on 1 line.
- The user name on detail user modal / User card / Organization switch popover should be with ellipsis if there are too long

### WorkspacePage
- Sharing workspace modal : the dropdown shouldn't shrinked

### Settings
- Update settings locales for skipping viewers option

### FoldersPage
- On Selection modal, the folder name should be with ellipsis if there are too long
- On details modal, the name of the modal should be `Details of the file/folder`

closes #12292 