### PR TITLE
Improve `libparsec_types::Maybe` type

### DIFF
--- a/libparsec/crates/testbed/src/template/crc_hash.rs
+++ b/libparsec/crates/testbed/src/template/crc_hash.rs
@@ -50,6 +50,18 @@ impl CrcHash for bool {
     }
 }
 
+impl<T: CrcHash> CrcHash for Maybe<T> {
+    fn crc_hash(&self, hasher: &mut crc32fast::Hasher) {
+        match self {
+            Maybe::Absent => hasher.update(b"Absent"),
+            Maybe::Present(x) => {
+                hasher.update(b"Present");
+                x.crc_hash(hasher);
+            }
+        }
+    }
+}
+
 impl<T: CrcHash> CrcHash for Option<T> {
     fn crc_hash(&self, hasher: &mut crc32fast::Hasher) {
         match self {

--- a/libparsec/crates/types/src/ext_types.rs
+++ b/libparsec/crates/types/src/ext_types.rs
@@ -163,6 +163,8 @@ pub enum Maybe<T> {
     Absent,
 }
 
+impl<T: Copy> Copy for Maybe<T> {}
+
 impl<T> Maybe<T> {
     pub fn is_absent(&self) -> bool {
         matches!(self, Self::Absent)


### PR DESCRIPTION
- Add auto-Copy trait
- Support testbed templace CRC hash
