### PR TITLE
ci: Add read perm for pull-request obj

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ concurrency:
 permissions:
   contents: read
   packages: read
+  pull-requests: read # Needed by `dorny/paths-filter` action
 
 jobs:
   dispatch:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,7 @@ concurrency:
 permissions:
   contents: read
   security-events: write
+  pull-requests: read # Needed by `dorny/paths-filter` action
 
 jobs:
   python-analyze:


### PR DESCRIPTION
Try to fix issue where `dorny/paths-filter` action does not work on private fork

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
