### PR TITLE
Revert "ci: Disable trigger when pushing to master"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
   push:
     branches:
+      - master
       - releases/*
 
 # We set `concurrency` to prevent having this workflow being run on code that is not up-to-date on a PR (a user make multiple push in a quick manner).


### PR DESCRIPTION
This reverts commit 225e7def476a5243cffdb62110090fe75913bf9b.

The reason is with the CI not running on `master` (i.e.: the default branch) and the cache being scoped where only the cache from the default branch is available. The CI is no longer using an effective cache system.

Sees:

- https://github.com/actions/cache#cache-scopes
- https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#cache-key-matching

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
