### PR TITLE
[MS] Update create org restrictions for trial

### DIFF
--- a/client/.env.development
+++ b/client/.env.development
@@ -1,7 +1,7 @@
 PARSEC_APP_BMS_API_URL=https://bms-dev.parsec.cloud
 PARSEC_APP_STRIPE_API_KEY=pk_test_P4dfuyoLBQtDHKjTiNDH3JH700TT3mCLbE
 PARSEC_APP_SIGN_URL=https://sign-dev.parsec.cloud
-PARSEC_APP_SAAS_SERVERS="saas-v3.parsec.cloud;saas-demo-v3-mightyfairy.parsec.cloud"
+PARSEC_APP_SAAS_SERVERS="saas-demo-v3-mightyfairy.parsec.cloud;app.parsec.cloud;saas-v3.parsec.cloud"
 PARSEC_APP_TRIAL_SERVERS="trial.parsec.cloud"
 PARSEC_APP_BMS_USE_MOCK="false"
 PARSEC_APP_BMS_MOCKED_FUNCTIONS=""

--- a/client/.env.production
+++ b/client/.env.production
@@ -1,7 +1,7 @@
 PARSEC_APP_BMS_API_URL=https://bms.parsec.cloud
 PARSEC_APP_STRIPE_API_KEY=pk_live_5hF9sn4DLUTYWx9uWPDJv51s00Q8ktUVfI
 PARSEC_APP_SIGN_URL=https://sign.parsec.cloud
-PARSEC_APP_SAAS_SERVERS="saas-v3.parsec.cloud"
+PARSEC_APP_SAAS_SERVERS="app.parsec.cloud;saas-v3.parsec.cloud"
 PARSEC_APP_TRIAL_SERVERS="trial.parsec.cloud"
 PARSEC_APP_ENABLE_CUSTOM_BRANDING=true
 PARSEC_APP_ENABLE_EDITICS=true

--- a/client/.env.release-candidate
+++ b/client/.env.release-candidate
@@ -1,7 +1,7 @@
 PARSEC_APP_BMS_API_URL=https://bms-dev.parsec.cloud
 PARSEC_APP_STRIPE_API_KEY=pk_test_P4dfuyoLBQtDHKjTiNDH3JH700TT3mCLbE
 PARSEC_APP_SIGN_URL=https://sign-dev.parsec.cloud
-PARSEC_APP_SAAS_SERVERS="saas-demo-v3-mightyfairy.parsec.cloud;saas-v3.parsec.cloud"
+PARSEC_APP_SAAS_SERVERS="saas-demo-v3-mightyfairy.parsec.cloud;app.parsec.cloud;saas-v3.parsec.cloud"
 PARSEC_APP_TRIAL_SERVERS="trial.parsec.cloud"
 PARSEC_APP_DEFAULT_LIB_LOG_LEVEL="DEBUG"
 PARSEC_APP_ENABLE_CUSTOM_BRANDING=true

--- a/client/src/services/parsecServers.ts
+++ b/client/src/services/parsecServers.ts
@@ -1,5 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
+import { isWeb } from '@/parsec';
 import { ParsedParsecAddr } from '@/plugins/libparsec';
 import { Env } from '@/services/environment';
 
@@ -38,4 +39,20 @@ export function getTrialServerAddress(): string {
     return '';
   }
   return `parsec3://${server}`;
+}
+
+export function currentLocationIsTrialServer(): boolean {
+  if (!isWeb()) {
+    return false;
+  }
+  const host = window.location.host.toLocaleLowerCase();
+  return Env.getTrialServers().find((server) => server.toLocaleLowerCase() === host) !== undefined;
+}
+
+export function currentLocationIsSaasServer(): boolean {
+  if (!isWeb()) {
+    return false;
+  }
+  const host = window.location.host.toLocaleLowerCase();
+  return Env.getSaasServers().find((server) => server.toLocaleLowerCase() === host) !== undefined;
 }

--- a/client/src/services/resourcesManager.ts
+++ b/client/src/services/resourcesManager.ts
@@ -116,7 +116,7 @@ class WebResourcesProvider implements IResourcesProvider {
     }
     // Returns index.html if resource does not exist
     // Note content-type header may contain charset (e.g. `text/html; charset=utf-8`)
-    if (resp.headers['content-type'].startsWith('text/html')) {
+    if (resp.headers['content-type'] && resp.headers['content-type'].startsWith('text/html')) {
       throw new Error('Resource not found');
     }
     const convertF = ResourceConverters.get(res);

--- a/client/src/views/organizations/creation/CreateOrganizationModal.vue
+++ b/client/src/views/organizations/creation/CreateOrganizationModal.vue
@@ -40,12 +40,19 @@ import {
   AvailableDevice,
   constructAccessStrategy,
   DeviceSaveStrategy,
+  isWeb,
   OrganizationID,
   ParsedParsecAddrTag,
   parseParsecAddr,
 } from '@/parsec';
+import { Env } from '@/services/environment';
 import { InformationManager } from '@/services/informationManager';
-import { getServerTypeFromParsedParsecAddr, ServerType } from '@/services/parsecServers';
+import {
+  currentLocationIsSaasServer,
+  currentLocationIsTrialServer,
+  getServerTypeFromParsedParsecAddr,
+  ServerType,
+} from '@/services/parsecServers';
 import CreateOrganizationCustomServer from '@/views/organizations/creation/CreateOrganizationCustomServer.vue';
 import CreateOrganizationSaas from '@/views/organizations/creation/CreateOrganizationSaas.vue';
 import CreateOrganizationTrial from '@/views/organizations/creation/CreateOrganizationTrial.vue';
@@ -68,11 +75,31 @@ onMounted(async () => {
     if (result.ok && result.value.tag === ParsedParsecAddrTag.OrganizationBootstrap) {
       serverType.value = getServerTypeFromParsedParsecAddr(result.value);
     }
+  } else if ((window as any).TESTING === true || window.isDev()) {
+    // On Playwright, everything's available
+    serverType.value = undefined;
+  } else if (currentLocationIsSaasServer()) {
+    // We're on the Saas server, letting the user chose
+    serverType.value = undefined;
+  } else if (currentLocationIsTrialServer()) {
+    // We're on the trial server, using trial by default
+    serverType.value = ServerType.Trial;
+  } else if (isWeb()) {
+    // We're on web but not on trial nor saas, use custom by default
+    serverType.value = ServerType.Custom;
+  } else {
+    serverType.value = undefined;
   }
 });
 
 async function onServerChosen(chosenServerType: ServerType): Promise<void> {
-  serverType.value = chosenServerType;
+  if (chosenServerType === ServerType.Trial && isWeb() && !currentLocationIsTrialServer() && !(window as any).TESTING === true) {
+    await Env.Links.openUrl(`https://${Env.getTrialServers()[0]}/client/home?createOrg=trial`);
+  } else if (chosenServerType === ServerType.Saas && isWeb() && !currentLocationIsSaasServer() && !(window as any).TESTING === true) {
+    await Env.Links.openUrl(`https://${Env.getSaasServers()[0]}/client/home?createOrg=saas`);
+  } else {
+    serverType.value = chosenServerType;
+  }
 }
 
 async function onCloseRequested(force = false): Promise<void> {


### PR DESCRIPTION
To test locally, use your `.env.development.local`:

To make the GUI act as it was hosted on the saas:
`PARSEC_APP_SAAS_SERVERS="localhost:8080;app.parsec.cloud;saas-v3.parsec.cloud"`

To make it act as if it was hosted on trial:
`PARSEC_APP_TRIAL_SERVERS="localhost:8080;trial.parsec.cloud"`

Nothing should change on Electron.