### PR TITLE
[MS] Forward libparsec exceptions to the GUI

### DIFF
--- a/client/src/plugins/libparsec/web_shared_worker.ts
+++ b/client/src/plugins/libparsec/web_shared_worker.ts
@@ -40,12 +40,18 @@ self.onconnect = async (msg: MessageEvent): Promise<void> => {
       return;
     }
 
-    // Since libparsec bindings never raise exceptions under normal conditions,
-    // we don't need to catch them: any exception here is a bug and we should
-    // just let it bubble up so that Sentry takes care of it.
-    const result = await promise;
-
-    port.postMessage({ id, result, isException: false });
+    try {
+      const result = await promise;
+      port.postMessage({ id, result, isException: false });
+    } catch (err) {
+      // Forward exceptions to the GUI where they are treated as generic errors,
+      // otherwise it may block for all eternity because it doesn't get a return value.
+      // It's also helpful to have the error directly in the console instead of having to inspect
+      // the worker.
+      port.postMessage({ id, result: err, isException: true });
+      // re-throw for Sentry
+      throw err;
+    }
   };
 
   // Notify the client that the worker is ready to process messages.


### PR DESCRIPTION
To test, put something like `await parsec.Path.join('/', '/invalid_entry_name')` somewhere (like in DevLayout) with and without this commit.

With this commit, an error will be printed in the console and the GUI will proceed normally.
Without this commit, no error and the GUI will hang.