### PR TITLE
Patch hostname address to use "app.parsec.cloud"

### DIFF
--- a/libparsec/crates/types/src/addr.rs
+++ b/libparsec/crates/types/src/addr.rs
@@ -41,6 +41,15 @@ const PARSEC_ACTION_CLAIM_SHAMIR_RECOVERY: &str = "claim_shamir_recovery";
 const PARSEC_ACTION_PKI_ENROLLMENT: &str = "pki_enrollment";
 const PARSEC_ACTION_ASYNC_ENROLLMENT: &str = "async_enrollment";
 const PARSEC_ACTION_TOTP_RESET: &str = "totp_reset";
+// The domain "saas-v3.parsec.cloud" is the name of a specific server. It was chosen
+// before the web app was released but there are still some devices created with it.
+// Since this domain was largely hidden from the end-user, we decided, for security reasons,
+// that each server had to host its own web frontend.
+// The domain "app.parsec.cloud", which is much more user friendly, was chosen for the Parsec
+// SaaS web app.
+// See: https://github.com/Scille/parsec-cloud/issues/12377
+const PARSEC_SAAS_SERVER_HOSTNAME_CURRENT: &str = "app.parsec.cloud";
+const PARSEC_SAAS_SERVER_HOSTNAME_LEGACY: &str = "saas-v3.parsec.cloud";
 
 /// Url has a special way to parse http/https schemes. This is because those kind
 /// of url have special needs (for instance host cannot be empty).
@@ -297,7 +306,14 @@ mod base {
             let port = port.and_then(|p| if p == default_port { None } else { Some(p) });
 
             Self {
-                hostname,
+                // This patch is required because there are still some devices created with the legacy domain
+                // which causes issues on web. See: https://github.com/Scille/parsec-cloud/issues/12377
+                // Also, see comment above (on the lines declaring the LEGACY and CURRENT constants).
+                hostname: if hostname == PARSEC_SAAS_SERVER_HOSTNAME_LEGACY {
+                    PARSEC_SAAS_SERVER_HOSTNAME_CURRENT.to_owned()
+                } else {
+                    hostname
+                },
                 port,
                 use_ssl,
             }

--- a/libparsec/crates/types/tests/unit/addr.rs
+++ b/libparsec/crates/types/tests/unit/addr.rs
@@ -6,7 +6,10 @@ use std::str::FromStr;
 
 use libparsec_tests_lite::prelude::*;
 
-use crate::prelude::*;
+use crate::{
+    addr::{PARSEC_SAAS_SERVER_HOSTNAME_CURRENT, PARSEC_SAAS_SERVER_HOSTNAME_LEGACY},
+    prelude::*,
+};
 
 const ORG: &str = "MyOrg";
 const TOKEN: &str = "a0000000000000000000000000000001";
@@ -239,6 +242,22 @@ fn action_addr(testbed: &dyn TestbedActionAddr) {}
 #[rstest_reuse::apply(all_addr)]
 fn good_addr_base(testbed: &dyn Testbed) {
     testbed.assert_addr_ok(&testbed.url());
+}
+
+// See: https://github.com/Scille/parsec-cloud/issues/12377
+#[rstest_reuse::apply(all_addr)]
+fn patch_addr_saas_legacy(testbed: &dyn Testbed) {
+    let url = testbed
+        .url()
+        .replace(DOMAIN, PARSEC_SAAS_SERVER_HOSTNAME_LEGACY);
+
+    testbed.assert_addr_ok_with_expected(
+        url.as_str(),
+        testbed
+            .url()
+            .replace(DOMAIN, PARSEC_SAAS_SERVER_HOSTNAME_CURRENT)
+            .as_str(),
+    );
 }
 
 #[rstest(value, assert_outcome)]


### PR DESCRIPTION
Alternative to #12563

Some Parsec links provided by libparsec (join request link, file links) depend on the server address stored in the local device.

This posed problems with devices created on the legacy `saas-v3.parsec.cloud` domain that should (now) generate links with the `app.parsec.cloud` domain.

Closes #12377