### PR TITLE
Restore happy-dom, required for unit tests on web

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -73,6 +73,7 @@
                 "eslint-plugin-vue": "^10.5.1",
                 "eslint-plugin-vue-scoped-css": "^2.5.1",
                 "globals": "^16.4.0",
+                "happy-dom": "^20.8.9",
                 "jiti": "^2.6.1",
                 "otplib": "^13.3.0",
                 "prettier": "3.6.2",
@@ -3887,9 +3888,17 @@
             "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
             "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "dev": true,
             "license": "MIT",
-            "optional": true,
-            "peer": true
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.46.2",
@@ -7934,42 +7943,22 @@
             }
         },
         "node_modules/happy-dom": {
-            "version": "20.0.8",
-            "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.0.8.tgz",
-            "integrity": "sha512-TlYaNQNtzsZ97rNMBAm8U+e2cUQXNithgfCizkDgc11lgmN4j9CKMhO3FPGKWQYPwwkFcPpoXYF/CqEPLgzfOg==",
+            "version": "20.8.9",
+            "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.9.tgz",
+            "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
-            "peer": true,
             "dependencies": {
-                "@types/node": "^20.0.0",
+                "@types/node": ">=20.0.0",
                 "@types/whatwg-mimetype": "^3.0.2",
-                "whatwg-mimetype": "^3.0.0"
+                "@types/ws": "^8.18.1",
+                "entities": "^7.0.1",
+                "whatwg-mimetype": "^3.0.0",
+                "ws": "^8.18.3"
             },
             "engines": {
                 "node": ">=20.0.0"
             }
-        },
-        "node_modules/happy-dom/node_modules/@types/node": {
-            "version": "20.19.23",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.23.tgz",
-            "integrity": "sha512-yIdlVVVHXpmqRhtyovZAcSy0MiPcYWGkoO4CGe/+jpP0hmNuihm4XhHbADpK++MsiLHP5MVlv+bcgdF99kSiFQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "undici-types": "~6.21.0"
-            }
-        },
-        "node_modules/happy-dom/node_modules/undici-types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/has-bigints": {
             "version": "1.1.0",
@@ -13751,8 +13740,6 @@
             "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14025,6 +14012,28 @@
                 "is-typedarray": "^1.0.0",
                 "signal-exit": "^3.0.2",
                 "typedarray-to-buffer": "^3.1.5"
+            }
+        },
+        "node_modules/ws": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/xml-name-validator": {

--- a/client/package.json
+++ b/client/package.json
@@ -100,6 +100,7 @@
         "eslint-plugin-vue": "^10.5.1",
         "eslint-plugin-vue-scoped-css": "^2.5.1",
         "globals": "^16.4.0",
+        "happy-dom": "^20.8.9",
         "jiti": "^2.6.1",
         "otplib": "^13.3.0",
         "prettier": "3.6.2",


### PR DESCRIPTION
`happy-dom` is required when running:

```shell
npm run test:unit   # runs: vitest run --dom
```

Was removed by mistake in #12484