### PR TITLE
refactor(electron): Set feature flags in publish configuration

### DIFF
--- a/bindings/electron/scripts/build.js
+++ b/bindings/electron/scripts/build.js
@@ -80,7 +80,7 @@ function fetch_cargo_flags() {
 }
 
 async function build_electron_bindings(cargo_flags) {
-  const CARGO_ARGS = ['cargo', 'build', '--locked', '--verbose', '--message-format=json-render-diagnostics', '--package', 'libparsec_bindings_electron', ...cargo_flags];
+  const CARGO_ARGS = ['cargo', 'build', '--locked', '--message-format=json-render-diagnostics', '--package', 'libparsec_bindings_electron', ...cargo_flags];
   const log = await new Promise((resolve) => {
     const stream = fs.createWriteStream(BUILD_LOG);
     stream.on('ready', () => resolve(stream));
@@ -98,7 +98,7 @@ function process_rust_lib() {
   const NEON_ARGS = [];
   // On Windows only .exe/.bat can be directly executed, `npx.cmd` is the bat version of `npx`
   on_windows() ? NEON_ARGS.push("npx.cmd") : NEON_ARGS.push("npx"),
-  NEON_ARGS.push(...['cargo-cp-artifact', '--npm', 'cdylib', OUTPUT_DIR + '/libparsec.node', '--']);
+    NEON_ARGS.push(...['cargo-cp-artifact', '--npm', 'cdylib', OUTPUT_DIR + '/libparsec.node', '--']);
   if (on_windows()) {
     // `cat` does not exist by default on Windows
     NEON_ARGS.push(...['type', path.win32.normalize(BUILD_LOG)]);

--- a/client/electron/assets/publishConfig.d.ts
+++ b/client/electron/assets/publishConfig.d.ts
@@ -5,6 +5,7 @@ export interface CustomPublishOptions {
   /** The machine arch the electron-builder is running on */
   readonly buildMachineArch: string;
   nightlyBuild: boolean;
+  features: ParsecFeatures;
   /**
    * The repository name.
    */
@@ -31,4 +32,9 @@ export interface CustomPublishOptions {
    * @default draft
    */
   releaseType?: 'draft' | 'prerelease' | 'release' | null;
+}
+
+export interface ParsecFeatures {
+  hardened: boolean;
+  [k: string]: any;
 }

--- a/client/electron/package.js
+++ b/client/electron/package.js
@@ -77,6 +77,9 @@ const publishConfig = {
   repo: 'parsec-cloud',
   buildMachineArch: process.env.BUILD_MACHINE_ARCH,
   nightlyBuild: OPTS.nightly,
+  features: {
+    hardened: OPTS.hardened,
+  },
 };
 
 const fs = require('node:fs');

--- a/client/electron/src/envVariables.ts
+++ b/client/electron/src/envVariables.ts
@@ -1,10 +1,7 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-const HARDENED = process.env.PARSEC_APP_HARDENED === 'true';
+import { FEATURE_FLAGS } from './features';
 
 export const Env = {
-  HARDENED,
-  DISABLE_SENTRY: HARDENED,
-  DISABLE_UPDATES: HARDENED,
-  ENABLE_CUSTOM_BRANDING: !HARDENED && process.env.PARSEC_APP_ENABLE_CUSTOM_BRANDING === 'true',
+  ENABLE_CUSTOM_BRANDING: !FEATURE_FLAGS.hardened() && process.env.PARSEC_APP_ENABLE_CUSTOM_BRANDING === 'true',
 };

--- a/client/electron/src/features.ts
+++ b/client/electron/src/features.ts
@@ -1,0 +1,35 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { CustomPublishOptions, ParsecFeatures } from '../assets/publishConfig';
+
+const DEFAULT_FEATURES: ParsecFeatures = {
+  hardened: false,
+};
+
+export default class FeaturesFlag {
+  private data: ParsecFeatures;
+
+  constructor() {
+    let data: CustomPublishOptions | undefined = undefined;
+    try {
+      data = require('../assets/publishConfig.json');
+    } catch {}
+    this.data = data ? data.features : DEFAULT_FEATURES;
+
+    console.debug('Configured features:', this.data);
+  }
+
+  sentryEnabled(): boolean {
+    return !this.hardened();
+  }
+
+  updatesEnabled(): boolean {
+    return !this.hardened();
+  }
+
+  hardened(): boolean {
+    return this.data.hardened;
+  }
+}
+
+export const FEATURE_FLAGS = new FeaturesFlag();

--- a/client/electron/src/index.ts
+++ b/client/electron/src/index.ts
@@ -12,7 +12,7 @@ import { electronIsDev } from './utils';
 import fs from 'fs';
 import path from 'path';
 import { PageToWindowChannel, WindowToPageChannel } from './communicationChannels';
-import { Env } from './envVariables';
+import { FEATURE_FLAGS } from './features';
 import { ElectronCapacitorApp, setupContentSecurityPolicy, setupReloadWatcher } from './setup';
 
 const PARSEC_CONFIG_DIR_NAME = 'parsec3';
@@ -36,16 +36,16 @@ function initSentry(): void {
   if (!sentry_dsn && !electronIsDev) {
     sentry_dsn = SENTRY_DSN_GUI_ELECTRON_DEFAULT;
   }
-  if (sentry_dsn && !Env.DISABLE_SENTRY) {
+  if (sentry_dsn && FEATURE_FLAGS.sentryEnabled()) {
     Sentry.init({
       dsn: sentry_dsn,
       integrations: [Sentry.captureConsoleIntegration({ levels: ['warn', 'error', 'assert'] })],
     });
   } else {
-    if (Env.DISABLE_SENTRY) {
-      console.info('Sentry is disabled');
-    } else {
+    if (FEATURE_FLAGS.sentryEnabled()) {
       console.info('Sentry not configured ("SENTRY_DSN_GUI_ELECTRON" env variable was not set).');
+    } else {
+      console.info('Sentry is disabled');
     }
   }
 }

--- a/client/electron/src/setup.ts
+++ b/client/electron/src/setup.ts
@@ -12,6 +12,7 @@ import fs from 'fs';
 import { join } from 'path';
 import { WindowToPageChannel } from './communicationChannels';
 import { Env } from './envVariables';
+import { FEATURE_FLAGS } from './features';
 import { SplashScreen } from './splashscreen';
 import AppUpdater, { UpdaterState, createAppUpdater } from './updater';
 import { electronIsDev } from './utils';
@@ -122,11 +123,11 @@ export class ElectronCapacitorApp {
       scheme: this.customScheme,
     });
 
-    if (Env.DISABLE_UPDATES) {
-      this.log('info', 'Disabled application updates');
-    } else {
+    if (FEATURE_FLAGS.updatesEnabled()) {
       this.log('info', 'Setting up application updates');
       this.updater = createAppUpdater();
+    } else {
+      this.log('info', 'Disabled application updates');
     }
 
     if (this.updater) {

--- a/client/electron/src/updater.ts
+++ b/client/electron/src/updater.ts
@@ -10,7 +10,7 @@ import { parseUpdateInfo, type ProviderRuntimeOptions } from 'electron-updater/o
 import { getChannelFilename, newUrlFromBase } from 'electron-updater/out/util';
 import * as semver from 'semver';
 import type { CustomPublishOptions as CustomGitHubOptions } from '../assets/publishConfig';
-import { Env } from './envVariables';
+import { FEATURE_FLAGS } from './features';
 
 // Greatly inspired by (it isn't exported by `electron-updater`)
 // https://github.com/electron-userland/electron-builder/blob/77f977435c99247d5db395895618b150f5006e8f/packages/electron-updater/src/providers/GitHubProvider.ts#L11-L13
@@ -104,7 +104,7 @@ class CustomGithubProvider extends GitHubProvider {
       case 'win32':
         platform = 'win';
     }
-    const base = Env.HARDENED ? '-hardened' : '';
+    const base = FEATURE_FLAGS.hardened() ? '-hardened' : '';
     return `${base}-${platform}-${arch}`;
   }
 


### PR DESCRIPTION
Previously we read the `process.env.HARDENED` to try to know is the build was hardened, but that value is not fixed on build but at runtime.

To fix that we needed to have a file with hard-coded values. Initially I though of using a JSON file in `src` but `electron-builder` does not provided a simple way to overwrite it. Instead, I've extended the generated `publishConfig` JSON to include a `features` section. That JSON is read upon startup (with a fallback to default values if missing (e.g: during dev)) and wrapped by a class.

Other:

- Invert the meaning of feature flags `DISABLE_UPDATES` to `enableUpdates()` and `DISABLE_SENTRY` to `enableSentry()`:

  It's simpler to work of additive features

- Remove `--verbose` flag in `cargo build` command

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
