### PR TITLE
[MS] Fix breadcrumbs click

### DIFF
--- a/client/src/components/header/HeaderBreadcrumbs.vue
+++ b/client/src/components/header/HeaderBreadcrumbs.vue
@@ -16,16 +16,16 @@
         class="breadcrumb-element breadcrumb-normal"
         :key="path.id"
         ref="breadcrumb"
+        @click="$emit('change', path)"
       >
         <ion-icon
           class="main-icon"
           v-if="path.icon"
           :icon="path.icon"
-          @click="$emit('change', path)"
         />
         <div
           class="breadcrumb-text"
-          @click="$emit('change', path)"
+          v-if="path.display || path.title"
         >
           {{ path.display ? path.display : $msTranslate(path.title) }}
         </div>


### PR DESCRIPTION
Fix the click including the whole breadcrumb, and not showing empty space if no title.

<img width="124" height="48" alt="breadcrumbs" src="https://github.com/user-attachments/assets/018475a0-98c1-468d-ad86-ff357df48eb0" />
