### PR TITLE
ci(releaser): Remove windows latest file in release

### DIFF
--- a/.github/workflows/package-desktop.yml
+++ b/.github/workflows/package-desktop.yml
@@ -454,6 +454,7 @@ jobs:
         working-directory: client/electron/dist
 
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # pin v5.0.0
+        if: matrix.platform != 'windows'
         with:
           name: ${{ matrix.artifact_tag }}${{ matrix.hardened && '-hardened' || '' }}-${{ runner.arch }}-electron
           path: |


### PR DESCRIPTION
Those latest file correspond to the unsigned windows artifacts. We do not include those artifacts in the release.

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
