### PR TITLE
[CLI] Invite claim and bootstrap accept any url.

### DIFF
--- a/cli/src/commands/invite/claim.rs
+++ b/cli/src/commands/invite/claim.rs
@@ -15,7 +15,7 @@ use libparsec::{
         UserClaimInProgress1Ctx, UserClaimInProgress2Ctx, UserClaimInProgress3Ctx,
         UserClaimInitialCtx, UserClaimListAdministratorsCtx,
     },
-    ClientConfig, ParsecInvitationAddr,
+    ClientConfig, ParsecInvitationAddr, Url,
 };
 use libparsec_client::{DeviceSaveStrategy, ShamirRecoveryClaimFinalizeCtx};
 
@@ -26,8 +26,9 @@ crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, data_dir, password_stdin]
     pub struct Args {
         // cspell:disable-next-line
-        /// Server invitation address (e.g.: parsec3://127.0.0.1:41997/Org?no_ssl=true&a=claim_shamir_recovery&p=xBA2FaaizwKy4qG5cGDFlXaL`)
-        addr: ParsecInvitationAddr,
+        /// Server invitation address (e.g.: parsec3://127.0.0.1:41997/Org?no_ssl=true&a=claim_shamir_recovery&p=xBA2FaaizwKy4qG5cGDFlXaL`
+        /// or http://127.0.0.1:41997/Org?no_ssl=true&a=claim_shamir_recovery&p=xBA2FaaizwKy4qG5cGDFlXaL`)
+        addr: Url,
         /// Use keyring to store the password for the device.
         #[arg(long, default_value_t, conflicts_with = "password_stdin")]
         use_keyring: bool,
@@ -47,6 +48,7 @@ pub async fn main(args: Args) -> anyhow::Result<()> {
         password_stdin,
         use_keyring,
     } = args;
+    let addr = ParsecInvitationAddr::from_any(addr.as_str())?;
     log::trace!("Claiming invitation (addr={addr})");
     let save_mode = if use_keyring {
         SaveMode::Keyring

--- a/cli/src/commands/organization/bootstrap.rs
+++ b/cli/src/commands/organization/bootstrap.rs
@@ -4,7 +4,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use libparsec::{
     AvailableDevice, ClientConfig, DeviceLabel, DevicePrimaryProtectionStrategy,
-    DeviceSaveStrategy, EmailAddress, HumanHandle, ParsecOrganizationBootstrapAddr, Password,
+    DeviceSaveStrategy, EmailAddress, HumanHandle, ParsecOrganizationBootstrapAddr, Password, Url,
 };
 
 use crate::utils::*;
@@ -12,9 +12,10 @@ use crate::utils::*;
 #[derive(clap::Parser)]
 pub struct Args {
     /// Bootstrap address
-    /// (e.g: parsec3://127.0.0.1:6770/Org?no_ssl=true&action=bootstrap_organization&token=59961ba6dcc9b018d2fdc9da1c0c762b716a27cff30594562dc813e4b765871a)
+    /// (e.g: parsec3://127.0.0.1:6770/Org?no_ssl=true&action=bootstrap_organization&token=59961ba6dcc9b018d2fdc9da1c0c762b716a27cff30594562dc813e4b765871a
+    /// or http://127.0.0.1:6770/Org?no_ssl=true&action=bootstrap_organization&token=59961ba6dcc9b018d2fdc9da1c0c762b716a27cff30594562dc813e4b765871a)
     #[arg(short, long)]
-    addr: ParsecOrganizationBootstrapAddr,
+    addr: Url,
     /// Device label
     #[arg(short, long)]
     device_label: DeviceLabel,
@@ -71,6 +72,8 @@ pub async fn main(args: Args) -> anyhow::Result<()> {
         password_stdin,
         sequester_key,
     } = args;
+    let addr = ParsecOrganizationBootstrapAddr::from_any(addr.as_str())?;
+
     log::trace!("Bootstrapping organization (addr={addr})");
 
     let human_handle = HumanHandle::new(email, &label)

--- a/cli/tests/integration/invitations/device.rs
+++ b/cli/tests/integration/invitations/device.rs
@@ -31,7 +31,9 @@ async fn invite_device(tmp_path: TmpPath) {
 #[cfg(target_family = "unix")] // rexpect doesn't support Windows
 #[rstest::rstest]
 #[tokio::test]
-async fn invite_device_dance(tmp_path: TmpPath) {
+#[case("http")]
+#[case("parsec3")]
+async fn invite_device_dance(tmp_path: TmpPath, #[case] scheme: &str) {
     let (_, TestOrganization { alice, .. }, _) = bootstrap_cli_test(&tmp_path).await.unwrap();
 
     let cmds = AuthenticatedCmds::new(
@@ -76,7 +78,13 @@ async fn invite_device_dance(tmp_path: TmpPath) {
 
     // spawn claimer thread
 
-    let program_claimer = std_cmd!("invite", "claim", invitation_addr.to_url().as_ref());
+    let addr = match scheme {
+        "parsec3" => invitation_addr.to_url().to_string(),
+        "http" => invitation_addr.to_http_redirection_url().to_string(),
+        _ => unimplemented!(),
+    };
+
+    let program_claimer = std_cmd!("invite", "claim", &addr);
 
     let p_claimer = Arc::new(Mutex::new(
         crate::spawn_interactive_command(dbg!(program_claimer), Some(10_000)).unwrap(),

--- a/cli/tests/integration/invitations/shared_recovery.rs
+++ b/cli/tests/integration/invitations/shared_recovery.rs
@@ -34,7 +34,9 @@ async fn invite_shared_recovery(tmp_path: TmpPath) {
 #[cfg(target_family = "unix")] // rexpect doesn't support Windows
 #[rstest::rstest]
 #[tokio::test]
-async fn invite_shared_recovery_dance(tmp_path: TmpPath) {
+#[case("http")]
+#[case("parsec3")]
+async fn invite_shared_recovery_dance(tmp_path: TmpPath, #[case] scheme: &str) {
     let (_, TestOrganization { alice, bob, .. }, _) = bootstrap_cli_test(&tmp_path).await.unwrap();
 
     crate::shared_recovery_create(&alice, &bob, None);
@@ -84,7 +86,13 @@ async fn invite_shared_recovery_dance(tmp_path: TmpPath) {
 
     // spawn claimer thread
 
-    let program_claimer = crate::std_cmd!("invite", "claim", invitation_addr.to_url().as_ref());
+    let addr = match scheme {
+        "parsec3" => invitation_addr.to_url().to_string(),
+        "http" => invitation_addr.to_http_redirection_url().to_string(),
+        _ => unimplemented!(),
+    };
+
+    let program_claimer = crate::std_cmd!("invite", "claim", &addr);
 
     let p_claimer = Arc::new(Mutex::new(
         crate::spawn_interactive_command(dbg!(program_claimer), Some(10_000)).unwrap(),

--- a/cli/tests/integration/invitations/user.rs
+++ b/cli/tests/integration/invitations/user.rs
@@ -38,7 +38,9 @@ async fn invite_user(tmp_path: TmpPath) {
 #[cfg(target_family = "unix")] // rexpect doesn't support Windows
 #[rstest::rstest]
 #[tokio::test]
-async fn invite_user_dance(tmp_path: TmpPath) {
+#[case("http")]
+#[case("parsec3")]
+async fn invite_user_dance(tmp_path: TmpPath, #[case] scheme: &str) {
     let (_, TestOrganization { alice, .. }, _) = bootstrap_cli_test(&tmp_path).await.unwrap();
 
     let cmds = AuthenticatedCmds::new(
@@ -85,8 +87,13 @@ async fn invite_user_dance(tmp_path: TmpPath) {
     ));
 
     // spawn claimer thread
+    let addr = match scheme {
+        "parsec3" => invitation_addr.to_url().to_string(),
+        "http" => invitation_addr.to_http_redirection_url().to_string(),
+        _ => unimplemented!(),
+    };
 
-    let program_claimer = crate::std_cmd!("invite", "claim", invitation_addr.to_url().as_ref());
+    let program_claimer = crate::std_cmd!("invite", "claim", &addr);
 
     let p_claimer = Arc::new(Mutex::new(
         crate::spawn_interactive_command(dbg!(program_claimer), Some(10_000)).unwrap(),

--- a/cli/tests/integration/organization/bootstrap.rs
+++ b/cli/tests/integration/organization/bootstrap.rs
@@ -9,7 +9,9 @@ use parsec_cli::commands::organization::create::create_organization_req;
 
 #[rstest::rstest]
 #[tokio::test]
-async fn bootstrap_organization(tmp_path: TmpPath) {
+#[case("http")]
+#[case("parsec3")]
+async fn bootstrap_organization(tmp_path: TmpPath, #[case] scheme: &str) {
     bootstrap_cli_test(&tmp_path).await.unwrap();
 
     let organization_id = unique_org_id();
@@ -21,13 +23,18 @@ async fn bootstrap_organization(tmp_path: TmpPath) {
             .await
             .unwrap();
 
+    let addr = match scheme {
+        "parsec3" => organization_addr.to_string(),
+        "http" => organization_addr.to_http_redirection_url().to_string(),
+        _ => unimplemented!(),
+    };
     log::debug!("Bootstrapping organization {organization_id}");
     crate::assert_cmd_success!(
         with_password = DEFAULT_DEVICE_PASSWORD,
         "organization",
         "bootstrap",
         "--addr",
-        &organization_addr.to_string(),
+        &addr,
         "--device-label",
         "pc",
         "--label",

--- a/newsfragments/12629.bugfix.rst
+++ b/newsfragments/12629.bugfix.rst
@@ -1,0 +1,1 @@
+[CLI] Organization bootstrap and invite claim now accept urls with http scheme.


### PR DESCRIPTION
Provided it can be converted to the expected type.

Fix #12629
