### PR TITLE
Explicitly specify the build target in `client/vite.config.ts`

### DIFF
--- a/client/electron/package.json
+++ b/client/electron/package.json
@@ -37,6 +37,7 @@
         "regedit": "^5.1.4",
         "tslib": "^2.8.1"
     },
+    "//": "⚠️ Updating Electron requires to also update `build.target` config in `client/vite.config.ts`",
     "devDependencies": {
         "@electron/notarize": "^2.5.0",
         "@sentry/cli": "^2.42.2",

--- a/client/package.json
+++ b/client/package.json
@@ -70,6 +70,7 @@
         "vue-i18n": "^11.3.0",
         "vue-router": "^4.6.4"
     },
+    "//": "⚠️ Updating ViteJS requires to also update `build.target` config in `client/vite.config.ts`",
     "devDependencies": {
         "@capacitor/cli": "^7.4.4",
         "@intlify/eslint-plugin-vue-i18n": "^4.1.0",

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -162,6 +162,20 @@ const config: UserConfigFnObject = (_env: ConfigEnv) => ({
   ],
   build: {
     sourcemap: true,
+    // Without an explicit target, Vite is supposed to pick a good enough default (i.e.
+    // `baseline-widely-available`, see https://v7.vite.dev/config/build-options#build-target).
+    //
+    // However this clashes with `vite-plugin-top-level-await` that overwrites it with its own (too old) default,
+    // that causes issue with `using` declarations (TC39 Explicit Resource Management),
+    // see https://github.com/Menci/vite-plugin-top-level-await/issues/77.
+    //
+    // So we have to be explicit here:
+    // - For native, Electron 41 ships Chrome 146 (see https://www.electronjs.org/blog/electron-41-0).
+    // - For web, we use whatever our current version of Vite considers baseline-widely-available
+    //   (see https://github.com/vitejs/vite/blob/cc383e07b66d4c5a9768fcb570e0af812cb8d999/packages/vite/src/node/constants.ts#L90-L95).
+    //
+    // Also see https://oxc.rs/docs/guide/usage/transformer/lowering#target for allowed target values.
+    target: platform === 'native' ? 'chrome146' : ['chrome107', 'edge107', 'firefox104', 'safari16'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
This is needed to avoid `vite-plugin-top-level-await` incorrectly overwritting the target (see https://github.com/Menci/vite-plugin-top-level-await/issues/77).
