### PR TITLE
docs: Fix wrong section levels & add sections for major branches

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,8 +1,11 @@
+=======
 History
 =======
 
-.. towncrier release notes start
+Parsec v3.x
+===========
 
+.. towncrier release notes start
 
 Parsec v3.8.1 (2026-03-17)
 --------------------------
@@ -1071,6 +1074,11 @@ features are still to be ported to v3 (see
 `v3-porting <https://github.com/Scille/parsec-cloud/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Av3-porting>`__
 issues)
 
+
+Parsec v2.x
+===========
+
+
 Parsec v2.17.0 (2024-02-13)
 ---------------------------
 
@@ -2022,7 +2030,7 @@ Parsec v2.2.3 (2021-01-29)
 --------------------------
 
 Features
---------
+~~~~~~~~
 
 * Added MacOS version for release
 
@@ -2043,7 +2051,7 @@ Parsec v2.2.1 (2020-12-15)
 --------------------------
 
 Features
---------
+~~~~~~~~
 
 * Improve backend HTTP welcome page, we no longer use html like it's 1997
   (`#1603 <https://github.com/Scille/parsec-cloud/issues/1603>`__)
@@ -2225,6 +2233,10 @@ Parsec v2.0.0 (2020-09-03)
 --------------------------
 
 No significant changes.
+
+
+Parsec v1.x
+===========
 
 
 Parsec v1.15.2 (2020-09-02)


### PR DESCRIPTION
## Fix wrong section levels

before:
<img width="273" height="219" alt="image" src="https://github.com/user-attachments/assets/2bcd8711-f267-4c09-9f72-0547a8c28b3a" />

after:
<img width="226" height="146" alt="image" src="https://github.com/user-attachments/assets/e568ec55-9cf8-499d-86e5-70a26c6a3cee" />


## Added sections for major branches

before:
<img width="318" height="1164" alt="image" src="https://github.com/user-attachments/assets/5da72536-b34b-4691-9cfc-b944a986fa94" />

after:
<img width="318" height="197" alt="image" src="https://github.com/user-attachments/assets/738a1f7e-d4ea-4546-af10-db47e6a6bf1e" />

