### PR TITLE
feat(pki): Impl `PkiSystem::open_certificate` for web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4296,8 +4296,8 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scwsapi"
-version = "0.7.1"
-source = "git+https://github.com/Scille/scwsapi-rs.git?rev=0c20f95a195c7c23f5aae82dc29c6f8a2513918b#0c20f95a195c7c23f5aae82dc29c6f8a2513918b"
+version = "0.8.0"
+source = "git+https://github.com/Scille/scwsapi-rs.git?rev=aba3bb209f437edb5ed5eedf2561b4e5bc7d1a97#aba3bb209f437edb5ed5eedf2561b4e5bc7d1a97"
 dependencies = [
  "futures",
  "hex",
@@ -4314,7 +4314,7 @@ dependencies = [
 [[package]]
 name = "scwsapi-sys"
 version = "0.4.0"
-source = "git+https://github.com/Scille/scwsapi-rs.git?rev=0c20f95a195c7c23f5aae82dc29c6f8a2513918b#0c20f95a195c7c23f5aae82dc29c6f8a2513918b"
+source = "git+https://github.com/Scille/scwsapi-rs.git?rev=aba3bb209f437edb5ed5eedf2561b4e5bc7d1a97#aba3bb209f437edb5ed5eedf2561b4e5bc7d1a97"
 dependencies = [
  "js-sys",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,8 +196,8 @@ rustls-webpki = { version = "0.103.10", default-features = false }
 ruzstd = { version = "0.8.2", default-features = true }
 # Crate to interact with windows credential store, it's used notably in `native-tls` crate.
 schannel = { version = "0.1.29", default-features = false }
-scwsapi = { git = "https://github.com/Scille/scwsapi-rs.git", rev = "0c20f95a195c7c23f5aae82dc29c6f8a2513918b", default-features = false }
-scwsapi-sys = { git = "https://github.com/Scille/scwsapi-rs.git", rev = "0c20f95a195c7c23f5aae82dc29c6f8a2513918b", default-features = false }
+scwsapi = { git = "https://github.com/Scille/scwsapi-rs.git", rev = "aba3bb209f437edb5ed5eedf2561b4e5bc7d1a97", default-features = false }
+scwsapi-sys = { git = "https://github.com/Scille/scwsapi-rs.git", rev = "aba3bb209f437edb5ed5eedf2561b4e5bc7d1a97", default-features = false }
 sentry = { version = "0.47.0", default-features = false }
 sentry-log = { version = "0.47.0", default-features = false }
 serde = { version = "1.0.228", default-features = false }

--- a/bindings/electron/src/index.d.ts
+++ b/bindings/electron/src/index.d.ts
@@ -568,6 +568,11 @@ export interface X509CertificateReference {
 
 
 export interface X509Pkcs11URI {
+    id: Uint8Array | null
+    label: Uint8Array | null
+    issuer: Uint8Array
+    subject: Uint8Array
+    serial: Uint8Array
 }
 
 

--- a/bindings/electron/src/meths.rs
+++ b/bindings/electron/src/meths.rs
@@ -5570,6 +5570,153 @@ fn struct_x509_certificate_reference_rs_to_js<'a>(
     Ok(js_obj)
 }
 
+// X509Pkcs11URI
+
+#[allow(dead_code)]
+fn struct_x509_pkcs11_uri_js_to_rs<'a>(
+    cx: &mut impl Context<'a>,
+    obj: Handle<'a, JsObject>,
+) -> NeonResult<libparsec::X509Pkcs11URI> {
+    let id = {
+        let js_val: Handle<JsValue> = obj.get(cx, "id")?;
+        {
+            if js_val.is_a::<JsNull, _>(cx) {
+                None
+            } else {
+                let js_val = js_val.downcast_or_throw::<JsTypedArray<u8>, _>(cx)?;
+                Some({
+                    let custom_from_rs_bytes =
+                        |v: &[u8]| -> Result<libparsec::Bytes, String> { Ok(v.to_vec().into()) };
+                    #[allow(clippy::unnecessary_mut_passed)]
+                    match custom_from_rs_bytes(js_val.as_slice(cx)) {
+                        Ok(val) => val,
+                        // err can't infer type in some case, because of the previous `try_into`
+                        #[allow(clippy::useless_format)]
+                        Err(err) => return cx.throw_type_error(format!("{}", err)),
+                    }
+                })
+            }
+        }
+    };
+    let label = {
+        let js_val: Handle<JsValue> = obj.get(cx, "label")?;
+        {
+            if js_val.is_a::<JsNull, _>(cx) {
+                None
+            } else {
+                let js_val = js_val.downcast_or_throw::<JsTypedArray<u8>, _>(cx)?;
+                Some({
+                    let custom_from_rs_bytes =
+                        |v: &[u8]| -> Result<libparsec::Bytes, String> { Ok(v.to_vec().into()) };
+                    #[allow(clippy::unnecessary_mut_passed)]
+                    match custom_from_rs_bytes(js_val.as_slice(cx)) {
+                        Ok(val) => val,
+                        // err can't infer type in some case, because of the previous `try_into`
+                        #[allow(clippy::useless_format)]
+                        Err(err) => return cx.throw_type_error(format!("{}", err)),
+                    }
+                })
+            }
+        }
+    };
+    let issuer = {
+        let js_val: Handle<JsTypedArray<u8>> = obj.get(cx, "issuer")?;
+        {
+            let custom_from_rs_bytes =
+                |v: &[u8]| -> Result<libparsec::Bytes, String> { Ok(v.to_vec().into()) };
+            #[allow(clippy::unnecessary_mut_passed)]
+            match custom_from_rs_bytes(js_val.as_slice(cx)) {
+                Ok(val) => val,
+                // err can't infer type in some case, because of the previous `try_into`
+                #[allow(clippy::useless_format)]
+                Err(err) => return cx.throw_type_error(format!("{}", err)),
+            }
+        }
+    };
+    let subject = {
+        let js_val: Handle<JsTypedArray<u8>> = obj.get(cx, "subject")?;
+        {
+            let custom_from_rs_bytes =
+                |v: &[u8]| -> Result<libparsec::Bytes, String> { Ok(v.to_vec().into()) };
+            #[allow(clippy::unnecessary_mut_passed)]
+            match custom_from_rs_bytes(js_val.as_slice(cx)) {
+                Ok(val) => val,
+                // err can't infer type in some case, because of the previous `try_into`
+                #[allow(clippy::useless_format)]
+                Err(err) => return cx.throw_type_error(format!("{}", err)),
+            }
+        }
+    };
+    let serial = {
+        let js_val: Handle<JsTypedArray<u8>> = obj.get(cx, "serial")?;
+        {
+            let custom_from_rs_bytes =
+                |v: &[u8]| -> Result<libparsec::Bytes, String> { Ok(v.to_vec().into()) };
+            #[allow(clippy::unnecessary_mut_passed)]
+            match custom_from_rs_bytes(js_val.as_slice(cx)) {
+                Ok(val) => val,
+                // err can't infer type in some case, because of the previous `try_into`
+                #[allow(clippy::useless_format)]
+                Err(err) => return cx.throw_type_error(format!("{}", err)),
+            }
+        }
+    };
+    Ok(libparsec::X509Pkcs11URI {
+        id,
+        label,
+        issuer,
+        subject,
+        serial,
+    })
+}
+
+#[allow(dead_code)]
+fn struct_x509_pkcs11_uri_rs_to_js<'a>(
+    cx: &mut impl Context<'a>,
+    rs_obj: libparsec::X509Pkcs11URI,
+) -> NeonResult<Handle<'a, JsObject>> {
+    let js_obj = cx.empty_object();
+    let js_id = match rs_obj.id {
+        Some(elem) => {
+            let rs_buff = { elem };
+            let js_buff = JsTypedArray::from_slice(cx, rs_buff.as_ref())?;
+            js_buff
+        }
+        .as_value(cx),
+        None => JsNull::new(cx).as_value(cx),
+    };
+    js_obj.set(cx, "id", js_id)?;
+    let js_label = match rs_obj.label {
+        Some(elem) => {
+            let rs_buff = { elem };
+            let js_buff = JsTypedArray::from_slice(cx, rs_buff.as_ref())?;
+            js_buff
+        }
+        .as_value(cx),
+        None => JsNull::new(cx).as_value(cx),
+    };
+    js_obj.set(cx, "label", js_label)?;
+    let js_issuer = {
+        let rs_buff = { rs_obj.issuer };
+        let js_buff = JsTypedArray::from_slice(cx, rs_buff.as_ref())?;
+        js_buff
+    };
+    js_obj.set(cx, "issuer", js_issuer)?;
+    let js_subject = {
+        let rs_buff = { rs_obj.subject };
+        let js_buff = JsTypedArray::from_slice(cx, rs_buff.as_ref())?;
+        js_buff
+    };
+    js_obj.set(cx, "subject", js_subject)?;
+    let js_serial = {
+        let rs_buff = { rs_obj.serial };
+        let js_buff = JsTypedArray::from_slice(cx, rs_buff.as_ref())?;
+        js_buff
+    };
+    js_obj.set(cx, "serial", js_serial)?;
+    Ok(js_obj)
+}
+
 // X509WindowsCngURI
 
 #[allow(dead_code)]
@@ -19152,10 +19299,7 @@ fn variant_x509_uri_flavor_value_js_to_rs<'a>(
         "X509URIFlavorValuePKCS11" => {
             let x0 = {
                 let js_val: Handle<JsObject> = obj.get(cx, "x0")?;
-                {
-                    let _ = js_val;
-                    libparsec::X509Pkcs11URI
-                }
+                struct_x509_pkcs11_uri_js_to_rs(cx, js_val)?
             };
             Ok(libparsec::X509URIFlavorValue::PKCS11(x0))
         }
@@ -19180,10 +19324,7 @@ fn variant_x509_uri_flavor_value_rs_to_js<'a>(
         libparsec::X509URIFlavorValue::PKCS11(x0, ..) => {
             let js_tag = JsString::try_new(cx, "X509URIFlavorValuePKCS11").or_throw(cx)?;
             js_obj.set(cx, "tag", js_tag)?;
-            let js_x0 = {
-                let _ = x0;
-                cx.undefined()
-            };
+            let js_x0 = struct_x509_pkcs11_uri_rs_to_js(cx, x0)?;
             js_obj.set(cx, "x0", js_x0)?;
         }
         libparsec::X509URIFlavorValue::WindowsCNG(x0, ..) => {

--- a/bindings/generator/api/common.py
+++ b/bindings/generator/api/common.py
@@ -385,8 +385,12 @@ class X509WindowsCngURI(Structure):
     serial_number: BytesVec
 
 
-class X509Pkcs11URI(UnitStructure):
-    pass
+class X509Pkcs11URI(Structure):
+    id: Bytes | None
+    label: Bytes | None
+    issuer: Bytes
+    subject: Bytes
+    serial: Bytes
 
 
 class X509URIFlavorValue(Variant):

--- a/bindings/web/src/meths.rs
+++ b/bindings/web/src/meths.rs
@@ -6135,6 +6135,115 @@ fn struct_x509_certificate_reference_rs_to_js(
     Ok(js_obj)
 }
 
+// X509Pkcs11URI
+
+#[allow(dead_code)]
+fn struct_x509_pkcs11_uri_js_to_rs(obj: JsValue) -> Result<libparsec::X509Pkcs11URI, JsValue> {
+    let id = {
+        let js_val = Reflect::get(&obj, &"id".into())?;
+        if js_val.is_null() {
+            None
+        } else {
+            Some(
+                js_val
+                    .dyn_into::<Uint8Array>()
+                    .map(|x| x.to_vec())
+                    .map_err(|_| TypeError::new("Not a Uint8Array"))
+                    .and_then(|x| {
+                        let custom_from_rs_bytes = |v: &[u8]| -> Result<libparsec::Bytes, String> {
+                            Ok(v.to_vec().into())
+                        };
+                        custom_from_rs_bytes(&x).map_err(|e| TypeError::new(e.as_ref()))
+                    })?,
+            )
+        }
+    };
+    let label = {
+        let js_val = Reflect::get(&obj, &"label".into())?;
+        if js_val.is_null() {
+            None
+        } else {
+            Some(
+                js_val
+                    .dyn_into::<Uint8Array>()
+                    .map(|x| x.to_vec())
+                    .map_err(|_| TypeError::new("Not a Uint8Array"))
+                    .and_then(|x| {
+                        let custom_from_rs_bytes = |v: &[u8]| -> Result<libparsec::Bytes, String> {
+                            Ok(v.to_vec().into())
+                        };
+                        custom_from_rs_bytes(&x).map_err(|e| TypeError::new(e.as_ref()))
+                    })?,
+            )
+        }
+    };
+    let issuer = {
+        let js_val = Reflect::get(&obj, &"issuer".into())?;
+        js_val
+            .dyn_into::<Uint8Array>()
+            .map(|x| x.to_vec())
+            .map_err(|_| TypeError::new("Not a Uint8Array"))
+            .and_then(|x| {
+                let custom_from_rs_bytes =
+                    |v: &[u8]| -> Result<libparsec::Bytes, String> { Ok(v.to_vec().into()) };
+                custom_from_rs_bytes(&x).map_err(|e| TypeError::new(e.as_ref()))
+            })?
+    };
+    let subject = {
+        let js_val = Reflect::get(&obj, &"subject".into())?;
+        js_val
+            .dyn_into::<Uint8Array>()
+            .map(|x| x.to_vec())
+            .map_err(|_| TypeError::new("Not a Uint8Array"))
+            .and_then(|x| {
+                let custom_from_rs_bytes =
+                    |v: &[u8]| -> Result<libparsec::Bytes, String> { Ok(v.to_vec().into()) };
+                custom_from_rs_bytes(&x).map_err(|e| TypeError::new(e.as_ref()))
+            })?
+    };
+    let serial = {
+        let js_val = Reflect::get(&obj, &"serial".into())?;
+        js_val
+            .dyn_into::<Uint8Array>()
+            .map(|x| x.to_vec())
+            .map_err(|_| TypeError::new("Not a Uint8Array"))
+            .and_then(|x| {
+                let custom_from_rs_bytes =
+                    |v: &[u8]| -> Result<libparsec::Bytes, String> { Ok(v.to_vec().into()) };
+                custom_from_rs_bytes(&x).map_err(|e| TypeError::new(e.as_ref()))
+            })?
+    };
+    Ok(libparsec::X509Pkcs11URI {
+        id,
+        label,
+        issuer,
+        subject,
+        serial,
+    })
+}
+
+#[allow(dead_code)]
+fn struct_x509_pkcs11_uri_rs_to_js(rs_obj: libparsec::X509Pkcs11URI) -> Result<JsValue, JsValue> {
+    let js_obj = Object::new().into();
+    let js_id = match rs_obj.id {
+        Some(val) => JsValue::from(Uint8Array::from(val.as_ref())),
+        None => JsValue::NULL,
+    };
+    Reflect::set(&js_obj, &"id".into(), &js_id)?;
+    let js_label = match rs_obj.label {
+        Some(val) => JsValue::from(Uint8Array::from(val.as_ref())),
+        None => JsValue::NULL,
+    };
+    Reflect::set(&js_obj, &"label".into(), &js_label)?;
+    let js_issuer = JsValue::from(Uint8Array::from(rs_obj.issuer.as_ref()));
+    Reflect::set(&js_obj, &"issuer".into(), &js_issuer)?;
+    let js_subject = JsValue::from(Uint8Array::from(rs_obj.subject.as_ref()));
+    Reflect::set(&js_obj, &"subject".into(), &js_subject)?;
+    let js_serial = JsValue::from(Uint8Array::from(rs_obj.serial.as_ref()));
+    Reflect::set(&js_obj, &"serial".into(), &js_serial)?;
+    Ok(js_obj)
+}
+
 // X509WindowsCngURI
 
 #[allow(dead_code)]
@@ -22942,10 +23051,7 @@ fn variant_x509_uri_flavor_value_js_to_rs(
         "X509URIFlavorValuePKCS11" => {
             let x1 = {
                 let js_val = Reflect::get(&obj, &"x1".into())?;
-                {
-                    let _ = js_val;
-                    libparsec::X509Pkcs11URI
-                }
+                struct_x509_pkcs11_uri_js_to_rs(js_val)?
             };
             Ok(libparsec::X509URIFlavorValue::PKCS11(x1))
         }
@@ -22970,10 +23076,7 @@ fn variant_x509_uri_flavor_value_rs_to_js(
     match rs_obj {
         libparsec::X509URIFlavorValue::PKCS11(x1, ..) => {
             Reflect::set(&js_obj, &"tag".into(), &"X509URIFlavorValuePKCS11".into())?;
-            let js_x1 = {
-                let _ = x1;
-                JsValue::UNDEFINED
-            };
+            let js_x1 = struct_x509_pkcs11_uri_rs_to_js(x1)?;
             Reflect::set(
                 &js_obj,
                 &"x1".into(),

--- a/client/src/plugins/libparsec/definitions.ts
+++ b/client/src/plugins/libparsec/definitions.ts
@@ -591,6 +591,11 @@ export interface X509CertificateReference {
 }
 
 export interface X509Pkcs11URI {
+    id: Bytes | null
+    label: Bytes | null
+    issuer: Bytes
+    subject: Bytes
+    serial: Bytes
 }
 
 export interface X509WindowsCngURI {

--- a/libparsec/crates/platform_pki/src/web/pki_system.rs
+++ b/libparsec/crates/platform_pki/src/web/pki_system.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use futures::{StreamExt, TryStreamExt};
 use libparsec_types::prelude::*;
+use sha2::Digest;
 use wasm_bindgen::JsCast;
 
 pub struct PlatformPkiSystem {
@@ -57,9 +58,91 @@ impl PlatformPkiSystem {
 
     pub async fn open_certificate(
         &self,
-        _cert_ref: &X509CertificateReference,
+        cert_ref: &X509CertificateReference,
     ) -> Result<PkiCertificate, PkiSystemOpenCertificateError> {
-        unimplemented!("platform not supported")
+        let expected_cert_hash = &cert_ref.hash;
+        let uri = cert_ref.get_uri::<X509Pkcs11URI>();
+        log::debug!("Looking for certificate matching the reference: {cert_ref:?}");
+        let cert = self
+            .scws
+            .iter_working_reader()
+            .filter_map(|token| async move {
+                let cert_it = token
+                    .iter_objects()
+                    .await
+                    .filter_map(|obj| {
+                        if let scwsapi::Object::Certificate(cert) = obj {
+                            Some(cert)
+                        } else {
+                            None
+                        }
+                    })
+                    .inspect(|cert| {
+                        log::trace!(
+                            r#"Found certificate with id:{:?} and label:"{}""#,
+                            cert.ck_id(),
+                            cert.ck_label()
+                        )
+                    })
+                    // Apply some pre-filter on the certificate using the URI
+                    .filter(|cert| {
+                        if let Some(uri) = uri {
+                            if let Some(expected_label) = &uri.label {
+                                if expected_label != cert.ck_label().as_bytes() {
+                                    return false;
+                                }
+                            }
+                            if let Some(expected_id) = &uri.id {
+                                let Ok(id) = cert.ck_id() else {
+                                    return false;
+                                };
+                                return *id == *expected_id;
+                            }
+                        }
+                        true
+                    })
+                    .map(super::PlatformPkiCertificate::from);
+                futures::stream::iter(cert_it)
+                    .filter_map(|cert| async move {
+                        let der = match cert.get_der().await.map_err(|e| {
+                            PkiSystemOpenCertificateError::Internal(anyhow::anyhow!(
+                                "Cannot obtain DER for certificate {name}: {e}",
+                                name = cert.0.ck_label()
+                            ))
+                        }) {
+                            Ok(v) => v,
+                            // Abort if we cannot get the DER of a given certificate.
+                            Err(e) => return Some(Err(e)),
+                        };
+
+                        // Test for the fingerprint of the certificate
+                        match expected_cert_hash {
+                            X509CertificateHash::SHA256(expected_hash) => {
+                                let cert_hash = sha2::Sha256::digest(&der);
+                                if cert_hash.as_slice() == expected_hash.as_ref() {
+                                    Some(Ok(cert))
+                                } else {
+                                    None
+                                }
+                            }
+                        }
+                    })
+                    .map_ok(|cert| PkiCertificate {
+                        #[cfg(not(feature = "test-with-testbed"))]
+                        platform: cert,
+                        #[cfg(feature = "test-with-testbed")]
+                        platform: crate::testbed::MaybeWithTestbed::WithPlatform(cert),
+                    })
+                    .boxed_local()
+                    .try_next()
+                    .await
+                    .transpose()
+            })
+            .boxed_local()
+            .try_next()
+            .await
+            .and_then(|maybe_cert| maybe_cert.ok_or(PkiSystemOpenCertificateError::NotFound));
+        cert
     }
 
     pub async fn list_user_certificates(

--- a/libparsec/crates/types/src/pki/cert_ref.rs
+++ b/libparsec/crates/types/src/pki/cert_ref.rs
@@ -2,6 +2,7 @@
 
 use std::{fmt::Display, str::FromStr};
 
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
 use crate::DataError;
@@ -165,10 +166,23 @@ impl From<X509WindowsCngURI> for X509URIFlavorValue {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
-// TODO: See if we store raw pkcs11 attribute in a list
-// Or a string representing a valid pkcs11-URI (following RFC-7512)
-// Or something else
-pub struct X509Pkcs11URI;
+pub struct X509Pkcs11URI {
+    /// Key identifier for key.
+    ///
+    /// Used to link together a certificate & private key.
+    /// That information is provided/configured by the smartcard so it may not be present.
+    pub id: Option<Bytes>,
+    /// Label of the object.
+    ///
+    /// That information is provided/configured by the smartcard so it may not be present.
+    pub label: Option<Bytes>,
+    /// Issuer of the certificate.
+    pub issuer: Bytes,
+    /// Subject of the certificate.
+    pub subject: Bytes,
+    /// Serial number of the certificate.
+    pub serial: Bytes,
+}
 
 impl X509URIFlavor for X509Pkcs11URI {
     const HEADER: &'static str = "pkcs11";


### PR DESCRIPTION
- Had to update `scwsapi-rs` to make `Certificate::ck_id` return bytes of hex string.
- Define `X509Pkcs11URI` to store some well know field obtain from the smartcard and certificate.

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
