### PR TITLE
Remove meta `scws-web_parsec_server` from `index.html`

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -45,6 +45,9 @@
       1. The `scwsapi.js` middleware (as, for copyright reasons, it is not shipped with Parsec).
       2. The web application certificate (as it differs for each application)
 
+      On top of that, the private key corresponding to the web application certificate is
+      expected to be configured on the Parsec server serving this page.
+
       This is done by:
       1. Adding `scwsapi.js` somewhere in the web application resources (typically in `assets/scws/scwsapi-2c8127e9.js`,
          note the hash-based suffix to avoid cache issue whenever this file needs to be updated).
@@ -61,10 +64,6 @@
     />
     <meta
       name="scws-web_application_certificate"
-      content=""
-    />
-    <meta
-      name="scws-web_parsec_server"
       content=""
     />
 

--- a/client/src/parsec/async_enrollment.ts
+++ b/client/src/parsec/async_enrollment.ts
@@ -84,7 +84,8 @@ const _ASYNC_ENROLLMENT_PARSEC_API = {
       // So we do some loading part here, we forward the elements to a proxy inside the worker that wraps "pkiInitForScws"
       // to import the module and set a global state, and finally the real `libparsec.pkiInitForScws` is called.
 
-      const WEB_PARSEC_SERVER = 'scws-web_parsec_server';
+      const parsecServerAddr = window.origin;
+
       const SCWS_LOCATION_NAME = 'scws-scwsapi_js-location';
       const SCWS_APP_CERTIFICATE = 'scws-web_application_certificate';
 
@@ -98,17 +99,12 @@ const _ASYNC_ENROLLMENT_PARSEC_API = {
         console.log(`No meta tag '${SCWS_APP_CERTIFICATE}' present`);
         return { ok: false, error: { tag: PkiSystemInitErrorTag.NotAvailable, error: `No meta tag '${SCWS_APP_CERTIFICATE}' present` } };
       }
-      const parsecServerTag = document.querySelector(`meta[name="${WEB_PARSEC_SERVER}"`) as HTMLMetaElement | null;
-      if (!parsecServerTag?.content) {
-        console.log(`No meta tag '${WEB_PARSEC_SERVER}' present`);
-        return { ok: false, error: { tag: PkiSystemInitErrorTag.NotAvailable, error: `No meta tag '${WEB_PARSEC_SERVER}' present` } };
-      }
 
       // Signature differs between what the proxy expects and what libparsec has defined,
       // so we just cast. Trust me bro.
       return await (libparsec.pkiInitForScws as any)(
         window.getConfigDir(),
-        parsecServerTag.content,
+        parsecServerAddr,
         scwsapiLocationTag.content,
         scwsapiAppCertificateTag.content,
       );


### PR DESCRIPTION
Always use `window.origin` instead for simplicity
