### PR TITLE
refactor(pki): Check values of cert info on windows with example

### DIFF
--- a/libparsec/crates/platform_pki/examples/list_user_certificates.rs
+++ b/libparsec/crates/platform_pki/examples/list_user_certificates.rs
@@ -1,8 +1,10 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 #![allow(clippy::unwrap_used)]
+mod utils;
 
 use anyhow::Context;
 use libparsec_platform_pki::{AvailablePkiCertificate, PkiSystem};
+use x509_cert::der::{Decode, Encode};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
@@ -22,8 +24,15 @@ async fn main() -> anyhow::Result<()> {
 
     for (i, cert) in certs.iter().enumerate() {
         match cert {
-            AvailablePkiCertificate::Valid { reference, .. } => {
-                println!("Certificate #{i} fingerprint={}", reference.hash);
+            AvailablePkiCertificate::Valid {
+                reference,
+                friendly_name,
+                ..
+            } => {
+                println!(
+                    "Certificate #{i} (AKA {friendly_name}) fingerprint={}",
+                    reference.hash
+                );
                 let cert = pki
                     .open_certificate(reference)
                     .await
@@ -33,6 +42,38 @@ async fn main() -> anyhow::Result<()> {
                 println!(
                     "  content: {}",
                     data_encoding::BASE64.encode_display(der.as_ref())
+                );
+                println!("  reference: {}", utils::EncodedCertRef(reference.clone()));
+                let (issuer, serial) = cert.get_issuer_and_serial().await;
+                let decoded_cert = x509_cert::der::SliceReader::new(&der)
+                    .and_then(|mut r| x509_cert::Certificate::decode(&mut r))
+                    .expect("Cannot decode certificate DER");
+                let serial = x509_cert::serial_number::SerialNumber::<
+                    x509_cert::certificate::Rfc5280,
+                >::new(&serial)
+                .unwrap();
+                println!(
+                    "  issuer from cert info: {}",
+                    data_encoding::BASE64.encode_display(&issuer)
+                );
+                println!(
+                    "  issuer from cert der : {}",
+                    data_encoding::BASE64.encode_display(
+                        &decoded_cert
+                            .tbs_certificate
+                            .issuer
+                            .to_der()
+                            .unwrap_or_default()
+                    )
+                );
+                println!(
+                    "  serial from cert info: {}",
+                    data_encoding::BASE64.encode_display(serial.as_bytes())
+                );
+                println!(
+                    "  serial from cert der : {}",
+                    data_encoding::BASE64
+                        .encode_display(decoded_cert.tbs_certificate.serial_number.as_bytes())
                 );
             }
 

--- a/libparsec/crates/platform_pki/examples/utils/mod.rs
+++ b/libparsec/crates/platform_pki/examples/utils/mod.rs
@@ -1,6 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use std::path::PathBuf;
+use std::{fmt::Display, path::PathBuf};
 
 use anyhow::Context;
 use bytes::Bytes;
@@ -8,7 +8,7 @@ use clap::{
     builder::{NonEmptyStringValueParser, TypedValueParser},
     error::{Error, ErrorKind},
 };
-use libparsec_types::X509CertificateHash;
+use libparsec_types::{X509CertificateHash, X509CertificateReference};
 
 // Not all examples uses `Base64Parser` so it is not always used.
 #[allow(dead_code)]
@@ -63,6 +63,7 @@ where
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct CertificateSRIHashParser;
 
@@ -107,5 +108,16 @@ impl ContentOpts {
                 .map(Into::into),
             (Some(_), Some(_)) | (None, None) => unreachable!("Handled by clap"),
         }
+    }
+}
+
+#[allow(dead_code)]
+pub struct EncodedCertRef(pub X509CertificateReference);
+
+impl Display for EncodedCertRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let blob = rmp_serde::to_vec(&self.0).expect("Cannot encode cert reference");
+
+        data_encoding::BASE64.encode_display(&blob).fmt(f)
     }
 }

--- a/libparsec/crates/platform_pki/src/pki_certificate.rs
+++ b/libparsec/crates/platform_pki/src/pki_certificate.rs
@@ -131,4 +131,20 @@ impl PkiCertificate {
             self.platform.get_validation_path().await
         }
     }
+
+    pub async fn get_issuer_and_serial(&self) -> (Vec<u8>, Vec<u8>) {
+        #[cfg(feature = "test-with-testbed")]
+        {
+            match &self.platform {
+                crate::testbed::MaybeWithTestbed::WithPlatform(plt) => {
+                    plt.get_issuer_and_serial().await
+                }
+                crate::testbed::MaybeWithTestbed::WithTestbed(_) => {
+                    panic!("Not supported for testbed");
+                }
+            }
+        }
+        #[cfg(not(feature = "test-with-testbed"))]
+        self.platform.get_issuer_and_serial().await
+    }
 }

--- a/libparsec/crates/platform_pki/src/unix/pki_certificate.rs
+++ b/libparsec/crates/platform_pki/src/unix/pki_certificate.rs
@@ -34,4 +34,8 @@ impl PlatformPkiCertificate {
     ) -> Result<X509ValidationPathOwned, PkiCertificateGetValidationPathError> {
         unimplemented!("platform not supported")
     }
+
+    pub async fn get_issuer_and_serial(&self) -> (Vec<u8>, Vec<u8>) {
+        unimplemented!("platform not supported")
+    }
 }

--- a/libparsec/crates/platform_pki/src/windows/pki_certificate.rs
+++ b/libparsec/crates/platform_pki/src/windows/pki_certificate.rs
@@ -104,6 +104,33 @@ impl PlatformPkiCertificate {
             leaf,
         })
     }
+
+    pub async fn get_issuer_and_serial(&self) -> (Vec<u8>, Vec<u8>) {
+        let raw_context = super::schannel_utils::cert_context_to_raw(&self.0);
+        // SAFETY: The raw pointer come from the inner valid pointer of `cert_context`
+        // that is of type `Cryptography::CERT_CONTEXT`
+        let cert_info = unsafe { *(*raw_context).pCertInfo };
+
+        // SAFETY: Issuer is of type `CRYPT_INTEGER_BLOB` and is obtain from a valid cert_context.
+        let issuer = unsafe {
+            std::slice::from_raw_parts(cert_info.Issuer.pbData, cert_info.Issuer.cbData as usize)
+        }
+        .to_vec();
+        // SAFETY: SerialNumber is of type `CRYPT_INTEGER_BLOB` and is obtain from a valid cert_context.
+        let mut serial_number = unsafe {
+            std::slice::from_raw_parts(
+                cert_info.SerialNumber.pbData,
+                cert_info.SerialNumber.cbData as usize,
+            )
+        }
+        .to_vec();
+
+        // Windows provide the serial_number as little-endian, for consistency, we convert it to
+        // big-endian by reversing bytes order
+        use std::ops::DerefMut;
+        serial_number.deref_mut().reverse();
+        (issuer, serial_number)
+    }
 }
 
 #[cfg(not(feature = "test-with-testbed"))]

--- a/libparsec/crates/platform_pki/src/windows/pki_system.rs
+++ b/libparsec/crates/platform_pki/src/windows/pki_system.rs
@@ -131,8 +131,21 @@ fn open_certificate(
         })
         .and_then(|mut filter| {
             let (issuer, serial) = match &mut filter {
-                Either::Left(pkcs11) => (pkcs11.der_issuer.as_mut(), pkcs11.serial.as_mut()),
-                Either::Right(uri) => (uri.issuer.as_mut(), uri.serial_number.as_mut()),
+                Either::Left(pkcs11) => {
+                    let issuer = pkcs11.der_issuer.as_mut();
+                    let serial = pkcs11.serial.as_mut();
+                    // We need to revers the bytes order of serial as Windows expect the serial to
+                    // be in little-endian as indicated in the description of `SerialNumber` in:
+                    // https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_info
+                    serial.reverse()(issuer, serial)
+                }
+                Either::Right(uri) => (
+                    uri.issuer.as_mut(),
+                    // We do not need to reverse that value as it would have comme from
+                    // `CERT_CONTEXT->pCertInfo->SerialNumber` which would already have the correct
+                    // endian.
+                    uri.serial_number.as_mut(),
+                ),
             };
             log::trace!("Looking for cert with issuer:{issuer:x?} serial:{serial:x?}");
             let filter = find_in_store::CertFilter::cert_id(issuer, serial);

--- a/libparsec/crates/types/src/pki/cert_ref.rs
+++ b/libparsec/crates/types/src/pki/cert_ref.rs
@@ -180,6 +180,8 @@ pub struct X509Pkcs11URI {
     /// Subject of the certificate.
     pub der_subject: Vec<u8>,
     /// Serial number of the certificate.
+    ///
+    /// Should be in big-endian format
     pub serial: Vec<u8>,
 }
 


### PR DESCRIPTION
Use `list_user_certificates` example to compare the value of issuer & serial from different sources:

- `CERT_CONTEXT->pCertInfo`
- Certificate DER

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
