### PR TITLE
fix(pki): Correct wrong endianess for serial number on Windows

### DIFF
--- a/libparsec/crates/platform_pki/examples/list_user_certificates.rs
+++ b/libparsec/crates/platform_pki/examples/list_user_certificates.rs
@@ -1,5 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 #![allow(clippy::unwrap_used)]
+mod utils;
 
 use anyhow::Context;
 use libparsec_platform_pki::{AvailablePkiCertificate, PkiSystem};
@@ -22,8 +23,13 @@ async fn main() -> anyhow::Result<()> {
 
     for (i, cert) in certs.iter().enumerate() {
         match cert {
-            AvailablePkiCertificate::Valid { reference, .. } => {
-                println!("Certificate #{i} fingerprint={}", reference.hash);
+            AvailablePkiCertificate::Valid {
+                reference,
+                friendly_name,
+                ..
+            } => {
+                println!("Certificate #{i} (AKA {friendly_name})");
+                println!("  fingerprint: {}", reference.hash);
                 let cert = pki
                     .open_certificate(reference)
                     .await
@@ -34,6 +40,7 @@ async fn main() -> anyhow::Result<()> {
                     "  content: {}",
                     data_encoding::BASE64.encode_display(der.as_ref())
                 );
+                println!("  reference: {}", utils::EncodedCertRef(reference.clone()));
             }
 
             AvailablePkiCertificate::Invalid {
@@ -44,6 +51,7 @@ async fn main() -> anyhow::Result<()> {
                     "Certificate #{i} fingerprint={} INVALID (reason: {})",
                     reference.hash, invalid_reason
                 );
+                println!("  reference: {}", utils::EncodedCertRef(reference.clone()));
             }
         }
         println!();

--- a/libparsec/crates/platform_pki/examples/utils/mod.rs
+++ b/libparsec/crates/platform_pki/examples/utils/mod.rs
@@ -1,6 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use std::path::PathBuf;
+use std::{fmt::Display, path::PathBuf};
 
 use anyhow::Context;
 use bytes::Bytes;
@@ -8,7 +8,7 @@ use clap::{
     builder::{NonEmptyStringValueParser, TypedValueParser},
     error::{Error, ErrorKind},
 };
-use libparsec_types::X509CertificateHash;
+use libparsec_types::{X509CertificateHash, X509CertificateReference};
 
 // Not all examples uses `Base64Parser` so it is not always used.
 #[allow(dead_code)]
@@ -63,6 +63,7 @@ where
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct CertificateSRIHashParser;
 
@@ -107,5 +108,19 @@ impl ContentOpts {
                 .map(Into::into),
             (Some(_), Some(_)) | (None, None) => unreachable!("Handled by clap"),
         }
+    }
+}
+
+#[allow(dead_code)]
+/// Wrapper used to encode a certificate reference to be displayed.
+///
+/// It encode the reference using the rmp format & base64
+pub struct EncodedCertRef(pub X509CertificateReference);
+
+impl Display for EncodedCertRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let blob = rmp_serde::to_vec(&self.0).expect("Cannot encode cert reference");
+
+        data_encoding::BASE64.encode_display(&blob).fmt(f)
     }
 }

--- a/libparsec/crates/platform_pki/src/windows/mod.rs
+++ b/libparsec/crates/platform_pki/src/windows/mod.rs
@@ -4,7 +4,7 @@ mod find_in_store;
 mod pki_certificate;
 mod pki_private_key;
 mod pki_system;
-mod schannel_utils;
+pub(crate) mod schannel_utils;
 
 pub use pki_certificate::*;
 pub use pki_private_key::*;

--- a/libparsec/crates/platform_pki/src/windows/pki_certificate.rs
+++ b/libparsec/crates/platform_pki/src/windows/pki_certificate.rs
@@ -9,7 +9,7 @@ use crate::{
     X509CertificateDer, X509EndCertificate, X509ValidationPathOwned,
 };
 
-pub struct PlatformPkiCertificate(schannel::cert_context::CertContext);
+pub struct PlatformPkiCertificate(pub(crate) schannel::cert_context::CertContext);
 
 impl std::fmt::Debug for PlatformPkiCertificate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/libparsec/crates/platform_pki/src/windows/pki_system.rs
+++ b/libparsec/crates/platform_pki/src/windows/pki_system.rs
@@ -134,8 +134,14 @@ fn open_certificate(
         })
         .and_then(|mut filter| {
             let (issuer, serial) = match &mut filter {
-                URIFlavor::Pkcs11(pkcs11) => (pkcs11.der_issuer.as_mut(), pkcs11.serial.as_mut()),
-                URIFlavor::WindowsCng(uri) => (uri.issuer.as_mut(), uri.serial_number.as_mut()),
+                URIFlavor::Pkcs11(pkcs11) => get_issuer_serial_from_pkcs11_uri(pkcs11),
+                URIFlavor::WindowsCng(uri) => (
+                    uri.issuer.as_mut(),
+                    // We do not need to reverse that value as it would have comme from
+                    // `CERT_CONTEXT->pCertInfo->SerialNumber` which would already have the correct
+                    // endian.
+                    uri.serial_number.as_mut(),
+                ),
             };
             log::trace!("Looking for cert with issuer:{issuer:x?} serial:{serial:x?}");
             let filter = find_in_store::CertFilter::cert_id(issuer, serial);
@@ -154,6 +160,20 @@ fn open_certificate(
                 }
             })
         })
+}
+
+// Use a function to be able to test the obtained issuer and serial to be similar to the one
+// obtained in CERT_INFO for a given certificate.
+pub(crate) fn get_issuer_serial_from_pkcs11_uri(
+    pkcs11: &mut X509Pkcs11URI,
+) -> (&mut [u8], &mut [u8]) {
+    let issuer = pkcs11.der_issuer.as_mut();
+    let serial: &mut [u8] = pkcs11.serial.as_mut();
+    // We need to revers the bytes order of serial as Windows expect the serial to
+    // be in little-endian as indicated in the description of `SerialNumber` in:
+    // https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_info
+    serial.reverse();
+    (issuer, serial)
 }
 
 pub(super) fn get_certificate_uri(cert_context: &CertContext) -> X509WindowsCngURI {

--- a/libparsec/crates/platform_pki/src/windows/schannel_utils.rs
+++ b/libparsec/crates/platform_pki/src/windows/schannel_utils.rs
@@ -16,7 +16,7 @@ pub(super) unsafe fn cert_context_from_raw(
     RawPointer::from_ptr(raw_context as *mut std::os::raw::c_void)
 }
 
-pub(super) fn cert_context_to_raw(cert_context: &CertContext) -> *const Cryptography::CERT_CONTEXT {
+pub(crate) fn cert_context_to_raw(cert_context: &CertContext) -> *const Cryptography::CERT_CONTEXT {
     // SAFETY: Ideally we would use `schannel::Inner::as_inner` to get the already typed type, but it's a
     // private trait.
     // Instead, the following that require to cast to the correct type.

--- a/libparsec/crates/platform_pki/tests/units/mod.rs
+++ b/libparsec/crates/platform_pki/tests/units/mod.rs
@@ -7,5 +7,7 @@ mod shared;
 mod sign;
 #[cfg(feature = "test-with-testbed")]
 mod testbed;
+#[cfg(windows)] // TODO: libparsec_platform_pki only supports Windows so far
+mod uri;
 mod utils;
 mod x509;

--- a/libparsec/crates/platform_pki/tests/units/uri.rs
+++ b/libparsec/crates/platform_pki/tests/units/uri.rs
@@ -1,0 +1,89 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+use libparsec_tests_lite::parsec_test;
+use libparsec_types::X509Pkcs11URI;
+use x509_cert::der::Decode;
+
+use crate::test::utils::{certificates, initialize_pki_system, InstalledCertificates};
+
+/// Check that serial number contained in the certificate reference is similar to the serial number in
+/// the certificate DER.
+///
+/// This test was notably made to check if we correctly handle the serial endian on Windows platform
+/// as `CERT_INFO` would provide that value in little-endian over the standard big-endian.
+#[parsec_test]
+async fn ensure_corresponding_serial_number(certificates: &InstalledCertificates) {
+    let pki = initialize_pki_system().await;
+
+    let certs = pki.list_user_certificates().await.unwrap();
+    let alice_reference = certificates.alice_cert_ref();
+
+    let got_ref = certs
+        .iter()
+        .find_map(|c| match c {
+            crate::AvailablePkiCertificate::Valid { reference, .. }
+                if reference.hash == alice_reference.hash =>
+            {
+                Some(reference)
+            }
+            _ => None,
+        })
+        .unwrap();
+
+    let got_uri = got_ref
+        .get_uri::<X509Pkcs11URI>()
+        .expect("No pkcs11 uri for reference");
+
+    let alice_der = certificates.alice_der_cert();
+    let alice_parsed_cert = x509_cert::der::SliceReader::new(&alice_der)
+        .and_then(|mut r| x509_cert::Certificate::decode(&mut r))
+        .expect("Cannot parse alice cert");
+
+    assert_eq!(
+        got_uri.serial,
+        alice_parsed_cert.tbs_certificate.serial_number.as_bytes(),
+        "Serial in URI should be the same in the certificate"
+    );
+
+    let got_cert = pki
+        .open_certificate(got_ref)
+        .await
+        .expect("Cannot open certificate");
+    let crate::testbed::MaybeWithTestbed::WithPlatform(got_cert) = got_cert.platform else {
+        panic!("Used fake testbed pki, nulling the whole test");
+    };
+    #[cfg(not(windows))]
+    drop(got_cert);
+    #[cfg(windows)]
+    {
+        let raw_cert_context = crate::platform::schannel_utils::cert_context_to_raw(&got_cert.0);
+        // SAFETY: The raw pointer come from the inner valid pointer of `cert_context`
+        // that is of type `Cryptography::CERT_CONTEXT`
+        let cert_info = unsafe { *(*raw_cert_context).pCertInfo };
+        // SAFETY: Issuer is of type `CRYPT_INTEGER_BLOB` and is obtain from a valid cert_context.
+        let cert_info_issuer = unsafe {
+            std::slice::from_raw_parts(cert_info.Issuer.pbData, cert_info.Issuer.cbData as usize)
+        };
+        // SAFETY: SerialNumber is of type `CRYPT_INTEGER_BLOB` and is obtain from a valid cert_context.
+        let cert_info_serial = unsafe {
+            std::slice::from_raw_parts(
+                cert_info.SerialNumber.pbData,
+                cert_info.SerialNumber.cbData as usize,
+            )
+        };
+
+        let mut got_uri = got_uri.clone();
+        assert_eq!(
+            cert_info_issuer, got_uri.der_issuer,
+            "issuer is in DER format for both side"
+        );
+        assert_ne!(
+            cert_info_serial, got_uri.serial,
+            "Should not match as cert_info_serial is in little-endian"
+        );
+
+        let (issuer, serial) = crate::platform::get_issuer_serial_from_pkcs11_uri(&mut got_uri);
+        assert_eq!(cert_info_issuer, issuer);
+        assert_eq!(cert_info_serial, serial, "get_issuer_serial_from_pkcs11_uri transform the serial to be similar to the one obtain from cert info");
+    }
+}

--- a/libparsec/crates/types/src/pki/cert_ref.rs
+++ b/libparsec/crates/types/src/pki/cert_ref.rs
@@ -180,6 +180,13 @@ pub struct X509Pkcs11URI {
     /// Subject of the certificate.
     pub der_subject: Vec<u8>,
     /// Serial number of the certificate.
+    ///
+    /// It is a positive integer assigned by the CA (cf. https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.2).
+    /// It is stored here as an unsigned integer in big-endian, as it is the format used in X509 certificate format
+    /// (i.e. ASN.1 DER's INTEGER type, cf. https://datatracker.ietf.org/doc/html/rfc5280#section-4.1 and https://en.wikipedia.org/wiki/X.690)
+    ///
+    /// Be aware that Windows provide you the serial number in little-endian if the value is coming
+    /// from [`CERT_INFO`](https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_info)
     pub serial: Vec<u8>,
 }
 


### PR DESCRIPTION
Windows expect the serial number to be provided in little endian (LE) as indicated by the field description of `SerialNumber` in: https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_info

Since we extract the serial number from the certificate DER we de not have to convert the serial from LE to Big Endian (BE), but we still need to convert it during `open_certificate` from BE to LE.

We do the conversion by simply reversing the bytes order using `slice.reverse()`

I've also updated the `list_user_certificates` example to show the friendly name + certificate reference in full (rmp + base64).

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
