### PR TITLE
feat(cli): merge recipients and weights in creation of shared-recovery

### DIFF
--- a/cli/src/commands/shared_recovery/create.rs
+++ b/cli/src/commands/shared_recovery/create.rs
@@ -9,21 +9,53 @@ use crate::utils::{
     GREEN_CHECKMARK,
 };
 
-// TODO: should provide the recipients and their share count as a single parameter
-//       e.g. `--recipients=foo@example.com=2,bar@example.com=3`
+const ONE: NonZeroU8 = NonZeroU8::new(1).expect("always valid");
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct WeightedEmail {
+    pub email: EmailAddress,
+    pub weight: NonZeroU8,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum WeightedEmailParseError {
+    #[error("Invalid email address")]
+    InvalidEmail,
+    #[error("Invalid weight")]
+    InvalidWeight,
+}
+
+impl std::str::FromStr for WeightedEmail {
+    type Err = WeightedEmailParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (email, weight) = match s.split_once(':') {
+            Some((email, weight)) => (
+                email,
+                weight
+                    .parse::<NonZeroU8>()
+                    .map_err(|_| WeightedEmailParseError::InvalidWeight)?,
+            ),
+            None => (s, ONE), // default weight is 1
+        };
+
+        let email = email
+            .parse::<EmailAddress>()
+            .map_err(|_| WeightedEmailParseError::InvalidEmail)?;
+
+        Ok(WeightedEmail { email, weight })
+    }
+}
+
 crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, device, password_stdin]
     pub struct Args {
-        /// Share recipients, if missing organization's admins will be used instead
+        /// Share recipients, with their weight.
+        /// If missing organization's admins will be used instead.
         /// Author must not be included as recipient.
-        /// User email is expected.
-        #[arg(short, long, num_args = 1..=255)]
-        recipients: Option<Vec<EmailAddress>>,
-        /// Share weights. Requires Share recipient list.
-        /// Must have the same length as recipients.
-        /// Defaults to one per recipient.
-        #[arg(short, long, requires = "recipients", num_args = 1..=255)]
-        weights: Option<Vec<NonZeroU8>>,
+        /// email or email:weight format is expected (weight defaults to one if not provided).
+        #[arg(long, num_args = 1..=255)]
+        recipients: Option<Vec<WeightedEmail>>,
         /// Threshold number of shares required to proceed with recovery.
         #[arg(short, long, requires = "recipients")]
         threshold: Option<NonZeroU8>,
@@ -38,7 +70,6 @@ crate::build_main_with_client!(main, create_shared_recovery);
 pub async fn create_shared_recovery(args: Args, client: &StartedClient) -> anyhow::Result<()> {
     let Args {
         recipients,
-        weights,
         threshold,
         no_confirmation,
         ..
@@ -48,50 +79,43 @@ pub async fn create_shared_recovery(args: Args, client: &StartedClient) -> anyho
 
     let mut handle = start_spinner("Creating shared recovery setup".into());
     let users = client.list_users(true, None, None).await?;
-    let recipients_ids: Vec<_> = if let Some(recipients) = recipients {
-        let recipient_info: HashMap<_, _> = users
+
+    let per_recipient_shares: HashMap<UserID, NonZeroU8> = if let Some(recipients) = recipients {
+        let users_ids: HashMap<_, _> = users
             .iter()
-            .filter(|info| recipients.contains(info.human_handle.email()))
             .map(|info| (info.human_handle.email().to_owned(), info.id))
             .collect();
-        if recipient_info.len() != recipients.len() {
-            return Err(anyhow::anyhow!("A user is missing"));
-        }
+
         recipients
             .iter()
-            .map(|human| *recipient_info.get(human).expect("human should be here"))
-            .collect()
+            .map(|recipient| {
+                users_ids
+                    .get(&recipient.email)
+                    .copied()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("A user with email {} not found", recipient.email)
+                    })
+                    .map(|id| (id, recipient.weight))
+            })
+            .collect::<Result<HashMap<_, _>, _>>()?
     } else {
-        let admins: Vec<_> = users
+        let admins: HashMap<_, _> = users
             .iter()
             .filter(|info| {
                 info.current_profile == UserProfile::Admin && info.id != client.user_id()
             })
-            .map(|info| info.id)
+            .map(|info| (info.id, ONE))
             .collect();
         anyhow::ensure!(!admins.is_empty(), "No default recipient available");
         admins
     };
 
-    let per_recipient_shares: HashMap<UserID, NonZeroU8> = if let Some(weights) = weights {
-        if recipients_ids.len() != weights.len() {
-            return Err(anyhow::anyhow!("incoherent weights count"));
-        }
-
-        recipients_ids.into_iter().zip(weights).collect()
-    } else {
-        let weight = NonZeroU8::new(1).expect("always valid");
-        recipients_ids
-            .into_iter()
-            .map(|user_id| (user_id, weight))
-            .collect()
-    };
     // we must stop the handle here to avoid messing up with the threshold choice
     handle.stop_with_symbol("..."); // not green check mark because it's not finished
     let threshold = if let Some(t) = threshold {
         t
     } else {
-        println!("The threshold is the minimum number of recipients that one must gather to recover the account");
+        println!("The threshold is the minimum number of shares that one must gather to recover the account");
         // note that this is a blocking call
         Input::<NonZeroU8>::new()
             .with_prompt(format!(
@@ -114,6 +138,7 @@ pub async fn create_shared_recovery(args: Args, client: &StartedClient) -> anyho
                 format!("{BULLET_CHAR} User {user} will have {share} share{}", maybe_plural(&share.get()))
             })
             .join("\n"));
+
     if !no_confirmation
         && !Confirm::new()
             .with_prompt("Do you want to proceed?")

--- a/cli/tests/integration/mod.rs
+++ b/cli/tests/integration/mod.rs
@@ -188,9 +188,6 @@ fn shared_recovery_create(
             "--recipients",
             &bob.human_handle.email().to_string(),
             &toto.human_handle.email().to_string(),
-            "--weights",
-            "1",
-            "1",
             "--threshold",
             "1",
             "--no-confirmation"
@@ -207,8 +204,6 @@ fn shared_recovery_create(
             &alice.device_id.hex(),
             "--recipients",
             &bob.human_handle.email().to_string(),
-            "--weights",
-            "1",
             "--threshold",
             "1",
             "--no-confirmation"

--- a/cli/tests/integration/shared_recovery/create.rs
+++ b/cli/tests/integration/shared_recovery/create.rs
@@ -1,9 +1,46 @@
+use std::{num::NonZeroU8, str::FromStr};
+
 use libparsec::{tmp_path, TmpPath};
+use predicates::prelude::PredicateBooleanExt;
 
 use crate::{
     bootstrap_cli_test,
     testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
 };
+
+use parsec_cli::commands::shared_recovery::create::WeightedEmail;
+use parsec_cli::commands::shared_recovery::create::WeightedEmailParseError;
+
+#[rstest::rstest]
+#[tokio::test]
+async fn weighted_email_from_str() {
+    let expected = Ok(WeightedEmail {
+        email: "alice@example.com".parse().unwrap(),
+        weight: NonZeroU8::new(1).expect("always valid"),
+    });
+    // Explicit call
+    assert_eq!(WeightedEmail::from_str("alice@example.com:1"), expected);
+    assert_eq!(WeightedEmail::from_str("alice@example.com"), expected);
+    // Implicit calls, through parse
+    assert_eq!("alice@example.com:1".parse(), expected);
+    assert_eq!("alice@example.com".parse(), expected);
+    assert_eq!("alice@example.com:1".parse::<WeightedEmail>(), expected);
+    assert_eq!("alice@example.com".parse::<WeightedEmail>(), expected);
+    // Invalid input string
+    assert_eq!(
+        // cspell: disable-next-line
+        WeightedEmail::from_str("aliceexample.com:1"),
+        Err(WeightedEmailParseError::InvalidEmail)
+    );
+    assert_eq!(
+        WeightedEmail::from_str("alice@example.com:a"),
+        Err(WeightedEmailParseError::InvalidWeight)
+    );
+    assert_eq!(
+        WeightedEmail::from_str("alice@example.com:"),
+        Err(WeightedEmailParseError::InvalidWeight)
+    );
+}
 
 #[rstest::rstest]
 #[tokio::test]
@@ -25,9 +62,6 @@ async fn create_shared_recovery_ok(tmp_path: TmpPath) {
         "--recipients",
         &bob.human_handle.email().to_string(),
         &toto.human_handle.email().to_string(),
-        "--weights",
-        "1",
-        "1",
         "--threshold",
         "1",
         "--no-confirmation"
@@ -39,7 +73,7 @@ async fn create_shared_recovery_ok(tmp_path: TmpPath) {
 
 #[rstest::rstest]
 #[tokio::test]
-async fn create_shared_recovery_incoherent_weights(tmp_path: TmpPath) {
+async fn create_shared_recovery_with_weights(tmp_path: TmpPath) {
     let (
         _,
         TestOrganization {
@@ -48,22 +82,30 @@ async fn create_shared_recovery_incoherent_weights(tmp_path: TmpPath) {
         _,
     ) = bootstrap_cli_test(&tmp_path).await.unwrap();
 
-    crate::assert_cmd_failure!(
+    crate::assert_cmd_success!(
         with_password = DEFAULT_DEVICE_PASSWORD,
         "shared-recovery",
         "create",
         "--device",
         &alice.device_id.hex(),
         "--recipients",
-        &bob.human_handle.email().to_string(),
-        &toto.human_handle.email().to_string(),
-        "--weights",
-        "1",
+        &format!("{}:{}", &bob.human_handle.email(), "2"),
+        &format!("{}:{}", &toto.human_handle.email(), "3"),
         "--threshold",
-        "1",
+        "2",
         "--no-confirmation"
     )
-    .stderr(predicates::str::contains("incoherent weights count"));
+    .stdout(
+        predicates::str::contains("Shared recovery setup has been created")
+            .and(predicates::str::contains(format!(
+                "• User {} will have 2 shares",
+                &bob.human_handle
+            )))
+            .and(predicates::str::contains(format!(
+                "• User {} will have 3 shares",
+                &toto.human_handle
+            ))),
+    );
 }
 
 #[rstest::rstest]
@@ -80,13 +122,13 @@ async fn create_shared_recovery_inexistent_email(tmp_path: TmpPath) {
         &alice.device_id.hex(),
         "--recipients",
         "not-here@example.com",
-        "--weights",
-        "1",
         "--threshold",
         "1",
         "--no-confirmation"
     )
-    .stderr(predicates::str::contains("A user is missing"));
+    .stderr(predicates::str::contains(
+        "A user with email not-here@example.com not found",
+    ));
 }
 
 #[cfg(target_family = "unix")] // rexpect doesn't support Windows
@@ -110,7 +152,7 @@ async fn create_shared_recovery_default(tmp_path: TmpPath) {
     p.exp_regex(".*Poll server for new certificates.*").unwrap();
     p.exp_regex(".*Creating shared recovery setup.*").unwrap();
 
-    p.exp_regex(".*The threshold is the minimum number of recipients that one must gather to recover the account.*").unwrap();
+    p.exp_regex(".*The threshold is the minimum number of shares that one must gather to recover the account.*").unwrap();
     p.send_line("1").unwrap();
     p.exp_string("The following shared recovery setup will be created")
         .unwrap();

--- a/cli/tests/integration/shared_recovery/info.rs
+++ b/cli/tests/integration/shared_recovery/info.rs
@@ -37,9 +37,6 @@ async fn info_shared_recovery_ok(tmp_path: TmpPath) {
         "--recipients",
         &bob.human_handle.email().to_string(),
         &toto.human_handle.email().to_string(),
-        "--weights",
-        "1",
-        "1",
         "--threshold",
         "1",
         "--no-confirmation"

--- a/newsfragments/9131.feature.rst
+++ b/newsfragments/9131.feature.rst
@@ -1,0 +1,1 @@
+[CLI] Merge options ``--recipients`` and ``--weights`` of the command ``shared-recovery create`` into ``--recipients``.


### PR DESCRIPTION
Fixes #9131

Options ``recipients`` and ``weights`` of the command ``shared-recovery create`` are merged into one option ``recipients``, which have the following format:
- either -r email:weight.
- or -r email, then weight is set to 1.

The test using inconsistent recipient and weights values is removed and replaced by a test using explicit weights.