### PR TITLE
ci(pkg-desktop): Fix skip upload windows unsigned artifact on release

### DIFF
--- a/.github/workflows/package-desktop.yml
+++ b/.github/workflows/package-desktop.yml
@@ -456,9 +456,8 @@ jobs:
         working-directory: client/electron/dist
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pin v7.0.1
-        # Skip uploading unsigned windows artifact when called by releaser script
-        # Will upload them otherwise considering it's for testing something (manual run, PR that change something, ...)
-        if: matrix.platform != 'windows' || github.event_name != 'workflow_call'
+        # Only uploading unsigned windows artifact on pull request or manual call
+        if: matrix.platform != 'windows' || contains(fromJSON('["pull_request", "workflow_dispatch"]'), github.event_name)
         with:
           name: ${{ matrix.artifact_tag }}${{ matrix.hardened && '-hardened' || '' }}-${{ runner.arch }}-electron
           path: |


### PR DESCRIPTION
During release the unsigned artifact was uploaded to the workflow generated artifact because the `event_name` is set to `push` (because we push a git tag and not the expected `workflow_call`).

I've decided to change the run strategy to an allow list when we decide if we should upload the windows artifact.