### PR TITLE
Silence log in `libparsec_platform_filesystem::list_files` complaining about a path not found

### DIFF
--- a/libparsec/crates/platform_filesystem/src/native/list.rs
+++ b/libparsec/crates/platform_filesystem/src/native/list.rs
@@ -32,7 +32,7 @@ pub async fn list_files(
         let mut entries_stream = match tokio::fs::read_dir(&dir).await {
             Ok(v) => v,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                log::info!(
+                log::debug!(
                     "Path {} not found while attempting to list entries",
                     dir.display()
                 );


### PR DESCRIPTION
As this creates useless logs in production when trying to list the async enrollments (since the corresponding folder is most often not present)
