### PR TITLE
Bump taiki-e/install-action to v2.77.6

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -38,7 +38,7 @@ jobs:
             docs
         timeout-minutes: 2
 
-      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # pin v2.75.28
+      - uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # pin v2.77.6
         with:
           tool: ripgrep
 

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -103,7 +103,7 @@ jobs:
         timeout-minutes: 5
 
       # Install cargo nextest command
-      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # pin v2.75.28
+      - uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # pin v2.77.6
         with:
           tool: nextest@0.9.114, wasm-pack@0.13.1, cargo-deny@0.19.0, cargo-udeps@0.1.56
 
@@ -311,7 +311,7 @@ jobs:
         timeout-minutes: 5
 
       # Install cargo nextest command
-      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # pin v2.75.28
+      - uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # pin v2.77.6
         with:
           tool: nextest@0.9.114
 

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -132,7 +132,7 @@ jobs:
         timeout-minutes: 5
 
       # Install wasm-pack command
-      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # pin v2.75.28
+      - uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # pin v2.77.6
         if: steps.cache-libparsec.outputs.cache-hit != 'true'
         with:
           tool: wasm-pack@${{ env.wasm-pack-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
           diff --unified .pre-commit-config.yaml $TEMP_FILE || true
           echo "path=$TEMP_FILE" >> $GITHUB_OUTPUT
 
-      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # pin v2.75.28
+      - uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # pin v2.77.6
         with:
           tool: taplo-cli@0.9.3
 

--- a/.github/workflows/package-desktop.yml
+++ b/.github/workflows/package-desktop.yml
@@ -158,7 +158,7 @@ jobs:
           yq --null-input ".linux-gnu.$ARCH.client.snap = \"$FINAL_ARTIFACT_NAME\"" | tee artifacts.yml
 
       # Install syft
-      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # pin v2.75.28
+      - uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # pin v2.77.6
         with:
           tool: syft@0.84.0
 
@@ -402,7 +402,7 @@ jobs:
         timeout-minutes: 1
 
       # Install syft
-      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # pin v2.75.28
+      - uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # pin v2.77.6
         with:
           tool: syft@0.84.0
 

--- a/.github/workflows/package-server.yml
+++ b/.github/workflows/package-server.yml
@@ -133,7 +133,7 @@ jobs:
           yq --null-input ".${{ matrix.platform }}.$(uname -m).server = \"$(cd dist; ls *.whl | head -n 1)\"" | tee dist/artifacts.yml
 
       # Install syft
-      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # pin v2.75.28
+      - uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # pin v2.77.6
         with:
           tool: syft@0.84.0
 

--- a/.github/workflows/package-webapp.yml
+++ b/.github/workflows/package-webapp.yml
@@ -98,7 +98,7 @@ jobs:
         working-directory: client
 
       # Install syft
-      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # pin v2.75.28
+      - uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # pin v2.77.6
         with:
           tool: syft@0.84.0, wasm-pack@${{ env.wasm-pack-version }}
 


### PR DESCRIPTION
This is required since wasm-pack repo has been moved and older versions of the action don't know about it see: https://github.com/taiki-e/install-action/issues/1810

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
