### PR TITLE
Fix server openapi.json generation

### DIFF
--- a/server/parsec/types.py
+++ b/server/parsec/types.py
@@ -245,11 +245,8 @@ VlobIDField = Annotated[
 ]
 DateTimeField = Annotated[
     DateTime,
-    get_pydantic_schema(
-        DateTime,
-        lambda v: DateTime.from_rfc3339(v),
-        lambda v: v.to_rfc3339() if isinstance(v, DateTime) else v,
-    ),
+    PlainValidator(lambda v: v if isinstance(v, DateTime) else DateTime.from_rfc3339(str(v))),
+    PlainSerializer(lambda v: v.to_rfc3339() if isinstance(v, DateTime) else v, return_type=str),
 ]
 
 UserProfileField = Annotated[

--- a/server/tests/test_docs.py
+++ b/server/tests/test_docs.py
@@ -1,0 +1,10 @@
+# Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.parametrize("which_docs", ("docs", "redoc", "openapi.json"))
+async def test_get_docs(which_docs: str, client: AsyncClient):
+    rep = await client.get(f"http://parsec.invalid/{which_docs}")
+    assert rep.status_code == 200


### PR DESCRIPTION
Pydantic was not being able to generate a JsonSchema for DateTimeField since DateTime.to_rfc3339 was being called (instead of passing the function). Passing the function did not work either, probably because it is not declared as a property in libparsec bindings. Anyway, switching back to PlainValidator.

Also, added minimal test for docs/redoc/openapi.json routes.

Closes #12820