### PR TITLE
[MS] Show add button in member tabbar

### DIFF
--- a/client/src/views/menu/TabBarMenu.vue
+++ b/client/src/views/menu/TabBarMenu.vue
@@ -44,10 +44,11 @@
 
     <div
       class="tab-bar-menu fab-button-container"
-      v-show="actions.length > 0"
+      v-show="showFab"
     >
       <ion-fab
         class="fab-content"
+        :class="{ disabled: actions.length === 0 }"
         size="small"
         id="add-menu-fab-button"
         @click="!isMenuOpen ? openMenuModal() : closeMenuModal()"
@@ -103,10 +104,16 @@ import { MenuAction } from '@/views/menu/types';
 import { IonFab, IonFabButton, IonIcon, IonText, modalController } from '@ionic/vue';
 import { business, folder, personCircle, prism } from 'ionicons/icons';
 import { AddIcon, MsImage, MsModalResult } from 'megashark-lib';
-import { onMounted, ref, Ref } from 'vue';
+import { computed, onMounted, ref, Ref } from 'vue';
 
 const isMenuOpen = ref(false);
 const userInfo: Ref<ClientInfo | null> = ref(null);
+
+const showFab = computed((): boolean => {
+  if (!userInfo.value) return false;
+  const isOutsider = userInfo.value.currentProfile === UserProfile.Outsider;
+  return !isOutsider || currentRouteIs(Routes.Documents);
+});
 
 const props = defineProps<{
   actions: Array<Array<MenuAction>>;
@@ -295,6 +302,20 @@ async function openMenuModal(): Promise<void> {
         .fab-icon {
           --fill-color: var(--parsec-color-light-primary-600);
           transform: rotate(45deg);
+        }
+      }
+    }
+
+    .fab-content.disabled {
+      cursor: not-allowed;
+      pointer-events: none;
+
+      .fab-button {
+        --background: var(--parsec-color-light-secondary-text);
+        opacity: 0.4;
+
+        .fab-icon {
+          --fill-color: var(--parsec-color-light-secondary-white);
         }
       }
     }

--- a/client/src/views/users/MyProfilePage.vue
+++ b/client/src/views/users/MyProfilePage.vue
@@ -478,6 +478,7 @@ onUnmounted(async () => {
     background: var(--parsec-color-light-secondary-white);
     box-shadow: var(--parsec-shadow-strong);
     border-radius: var(--parsec-radius-18) var(--parsec-radius-18) 0 0;
+    height: stretch;
   }
 
   .profile-menu {
@@ -706,8 +707,13 @@ onUnmounted(async () => {
   padding: 1rem 0rem;
 
   @include ms.responsive-breakpoint('sm') {
+    border-top: none;
     padding: 0;
     margin-top: 0;
+    padding: 1rem 2rem 2rem;
+  }
+
+  @include ms.responsive-breakpoint('xs') {
     padding: 1rem 1.5rem 2rem;
   }
 
@@ -723,6 +729,9 @@ onUnmounted(async () => {
     color: var(--parsec-color-light-danger-500);
 
     @include ms.responsive-breakpoint('sm') {
+      border: 1px solid var(--parsec-color-light-secondary-medium);
+      box-shadow: var(--parsec-shadow-input);
+      padding: 0.75rem 1rem;
       justify-content: center;
       margin-inline: 0;
     }

--- a/client/tests/e2e/specs/small_display_fab_menu.spec.ts
+++ b/client/tests/e2e/specs/small_display_fab_menu.spec.ts
@@ -75,17 +75,19 @@ msTest('Fab button and menu as standard and reader', async ({ workspacesStandard
 
   // No button in reader workspace
   await workspacesStandard.locator('.workspaces-container-grid').locator('.workspace-card-item').nth(0).click();
-  await expect(fabButton).toBeHidden();
+  await expect(fabButton).toBeVisible();
 
   // No button in organization management
   await tabBarButtons.nth(2).click();
   await expect(workspacesStandard).toBeOrganizationPage();
-  await expect(fabButton).toBeHidden();
+  await expect(fabButton).toBeVisible();
+  await expect(fabButton).toContainClass('disabled');
 
   // No button in profile page
   await tabBarButtons.nth(3).click();
   await expect(workspacesStandard).toBeMyProfilePage();
-  await expect(fabButton).toBeHidden();
+  await expect(fabButton).toBeVisible();
+  await expect(fabButton).toContainClass('disabled');
 });
 
 msTest('Fab button and menu as external', async ({ workspacesExternal }) => {


### PR DESCRIPTION
In order to show fab-button for member even if they cannot add item (files, users, etc.). It is simply disabled.
<img width="444" height="818" alt="Screenshot 2026-05-20 at 15 23 34" src="https://github.com/user-attachments/assets/aed21d8b-5e12-44ee-9519-8cb28d979ecf" />
<img width="441" height="816" alt="Screenshot 2026-05-20 at 15 23 43" src="https://github.com/user-attachments/assets/509e9ee8-8e28-4604-922b-21960ceb20d1" />
