### PR TITLE
fix(pki): Convert origin into `ParsecAddr` before init

### DIFF
--- a/bindings/electron/src/index.d.ts
+++ b/bindings/electron/src/index.d.ts
@@ -1079,6 +1079,55 @@ export type ActiveUsersLimit =
   | ActiveUsersLimitNoLimit
 
 
+// AddrError
+export interface AddrErrorDuplicateParam {
+    tag: "AddrErrorDuplicateParam"
+    error: string
+    x1: string
+}
+export interface AddrErrorInvalidOrganizationID {
+    tag: "AddrErrorInvalidOrganizationID"
+    error: string
+}
+export interface AddrErrorInvalidParamValue {
+    tag: "AddrErrorInvalidParamValue"
+    error: string
+    param: string
+    help: string
+}
+export interface AddrErrorInvalidUrl {
+    tag: "AddrErrorInvalidUrl"
+    error: string
+}
+export interface AddrErrorInvalidUrlScheme {
+    tag: "AddrErrorInvalidUrlScheme"
+    error: string
+    expected: string
+}
+export interface AddrErrorMissingParam {
+    tag: "AddrErrorMissingParam"
+    error: string
+    x1: string
+}
+export interface AddrErrorNotARedirection {
+    tag: "AddrErrorNotARedirection"
+    error: string
+}
+export interface AddrErrorShouldNotHaveAPath {
+    tag: "AddrErrorShouldNotHaveAPath"
+    error: string
+}
+export type AddrError =
+  | AddrErrorDuplicateParam
+  | AddrErrorInvalidOrganizationID
+  | AddrErrorInvalidParamValue
+  | AddrErrorInvalidUrl
+  | AddrErrorInvalidUrlScheme
+  | AddrErrorMissingParam
+  | AddrErrorNotARedirection
+  | AddrErrorShouldNotHaveAPath
+
+
 // AnyClaimRetrievedInfo
 export interface AnyClaimRetrievedInfoDevice {
     tag: "AnyClaimRetrievedInfoDevice"
@@ -5894,6 +5943,9 @@ export function openbaoListSelfEmails(
     openbao_entity_id: string,
     openbao_auth_token: string
 ): Promise<Result<Array<string>, OpenBaoListSelfEmailsError>>
+export function parseHttpUrl(
+    url: string
+): Promise<Result<string, AddrError>>
 export function parseParsecAddr(
     url: string
 ): Promise<Result<ParsedParsecAddr, ParseParsecAddrError>>

--- a/bindings/electron/src/index.d.ts
+++ b/bindings/electron/src/index.d.ts
@@ -5943,9 +5943,6 @@ export function openbaoListSelfEmails(
     openbao_entity_id: string,
     openbao_auth_token: string
 ): Promise<Result<Array<string>, OpenBaoListSelfEmailsError>>
-export function parseHttpUrl(
-    url: string
-): Promise<Result<string, AddrError>>
 export function parseParsecAddr(
     url: string
 ): Promise<Result<ParsedParsecAddr, ParseParsecAddrError>>
@@ -6049,6 +6046,9 @@ export function totpSetupStatusAnonymous(
     config: ClientConfig,
     addr: string
 ): Promise<Result<TOTPSetupStatus, TotpSetupStatusAnonymousError>>
+export function tryConvertHttpToParsecAddr(
+    http_url: string
+): Promise<Result<string, AddrError>>
 export function updateDeviceChangeAuthentication(
     config_dir: string,
     current_auth: DeviceAccessStrategy,

--- a/bindings/electron/src/meths.rs
+++ b/bindings/electron/src/meths.rs
@@ -27141,47 +27141,6 @@ fn openbao_list_self_emails(mut cx: FunctionContext) -> JsResult<JsPromise> {
     Ok(promise)
 }
 
-// parse_http_url
-fn parse_http_url(mut cx: FunctionContext) -> JsResult<JsPromise> {
-    crate::init_sentry();
-    let url = {
-        let js_val = cx.argument::<JsString>(0)?;
-        js_val.value(&mut cx)
-    };
-    let ret = libparsec::parse_http_url(url);
-    let js_ret = match ret {
-        Ok(ok) => {
-            let js_obj = JsObject::new(&mut cx);
-            let js_tag = JsBoolean::new(&mut cx, true);
-            js_obj.set(&mut cx, "ok", js_tag)?;
-            let js_value = JsString::try_new(&mut cx, {
-                let custom_to_rs_string =
-                    |addr: libparsec::ParsecAddr| -> Result<String, &'static str> {
-                        Ok(addr.to_url().into())
-                    };
-                match custom_to_rs_string(ok) {
-                    Ok(ok) => ok,
-                    Err(err) => return cx.throw_type_error(err.to_string()),
-                }
-            })
-            .or_throw(&mut cx)?;
-            js_obj.set(&mut cx, "value", js_value)?;
-            js_obj
-        }
-        Err(err) => {
-            let js_obj = cx.empty_object();
-            let js_tag = JsBoolean::new(&mut cx, false);
-            js_obj.set(&mut cx, "ok", js_tag)?;
-            let js_err = variant_addr_error_rs_to_js(&mut cx, err)?;
-            js_obj.set(&mut cx, "error", js_err)?;
-            js_obj
-        }
-    };
-    let (deferred, promise) = cx.promise();
-    deferred.resolve(&mut cx, js_ret);
-    Ok(promise)
-}
-
 // parse_parsec_addr
 fn parse_parsec_addr(mut cx: FunctionContext) -> JsResult<JsPromise> {
     crate::init_sentry();
@@ -28709,6 +28668,47 @@ fn totp_setup_status_anonymous(mut cx: FunctionContext) -> JsResult<JsPromise> {
             });
         });
 
+    Ok(promise)
+}
+
+// try_convert_http_to_parsec_addr
+fn try_convert_http_to_parsec_addr(mut cx: FunctionContext) -> JsResult<JsPromise> {
+    crate::init_sentry();
+    let http_url = {
+        let js_val = cx.argument::<JsString>(0)?;
+        js_val.value(&mut cx)
+    };
+    let ret = libparsec::try_convert_http_to_parsec_addr(&http_url);
+    let js_ret = match ret {
+        Ok(ok) => {
+            let js_obj = JsObject::new(&mut cx);
+            let js_tag = JsBoolean::new(&mut cx, true);
+            js_obj.set(&mut cx, "ok", js_tag)?;
+            let js_value = JsString::try_new(&mut cx, {
+                let custom_to_rs_string =
+                    |addr: libparsec::ParsecAddr| -> Result<String, &'static str> {
+                        Ok(addr.to_url().into())
+                    };
+                match custom_to_rs_string(ok) {
+                    Ok(ok) => ok,
+                    Err(err) => return cx.throw_type_error(err.to_string()),
+                }
+            })
+            .or_throw(&mut cx)?;
+            js_obj.set(&mut cx, "value", js_value)?;
+            js_obj
+        }
+        Err(err) => {
+            let js_obj = cx.empty_object();
+            let js_tag = JsBoolean::new(&mut cx, false);
+            js_obj.set(&mut cx, "ok", js_tag)?;
+            let js_err = variant_addr_error_rs_to_js(&mut cx, err)?;
+            js_obj.set(&mut cx, "error", js_err)?;
+            js_obj
+        }
+    };
+    let (deferred, promise) = cx.promise();
+    deferred.resolve(&mut cx, js_ret);
     Ok(promise)
 }
 
@@ -32730,7 +32730,6 @@ pub fn register_meths(cx: &mut ModuleContext) -> NeonResult<()> {
     cx.export_function("mountpointUnmount", mountpoint_unmount)?;
     cx.export_function("newCanceller", new_canceller)?;
     cx.export_function("openbaoListSelfEmails", openbao_list_self_emails)?;
-    cx.export_function("parseHttpUrl", parse_http_url)?;
     cx.export_function("parseParsecAddr", parse_parsec_addr)?;
     cx.export_function("pathFilename", path_filename)?;
     cx.export_function("pathJoin", path_join)?;
@@ -32782,6 +32781,10 @@ pub fn register_meths(cx: &mut ModuleContext) -> NeonResult<()> {
     cx.export_function("totpFetchOpaqueKey", totp_fetch_opaque_key)?;
     cx.export_function("totpSetupConfirmAnonymous", totp_setup_confirm_anonymous)?;
     cx.export_function("totpSetupStatusAnonymous", totp_setup_status_anonymous)?;
+    cx.export_function(
+        "tryConvertHttpToParsecAddr",
+        try_convert_http_to_parsec_addr,
+    )?;
     cx.export_function(
         "updateDeviceChangeAuthentication",
         update_device_change_authentication,

--- a/bindings/electron/src/meths.rs
+++ b/bindings/electron/src/meths.rs
@@ -6745,6 +6745,63 @@ fn variant_active_users_limit_rs_to_js<'a>(
     Ok(js_obj)
 }
 
+// AddrError
+
+#[allow(dead_code)]
+fn variant_addr_error_rs_to_js<'a>(
+    cx: &mut impl Context<'a>,
+    rs_obj: libparsec::AddrError,
+) -> NeonResult<Handle<'a, JsObject>> {
+    let js_obj = cx.empty_object();
+    let js_display = JsString::try_new(cx, &rs_obj.to_string()).or_throw(cx)?;
+    js_obj.set(cx, "error", js_display)?;
+    match rs_obj {
+        libparsec::AddrError::DuplicateParam(x0, ..) => {
+            let js_tag = JsString::try_new(cx, "AddrErrorDuplicateParam").or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+            let js_x0 = JsString::try_new(cx, x0).or_throw(cx)?;
+            js_obj.set(cx, "x0", js_x0)?;
+        }
+        libparsec::AddrError::InvalidOrganizationID { .. } => {
+            let js_tag = JsString::try_new(cx, "AddrErrorInvalidOrganizationID").or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::AddrError::InvalidParamValue { param, help, .. } => {
+            let js_tag = JsString::try_new(cx, "AddrErrorInvalidParamValue").or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+            let js_param = JsString::try_new(cx, param).or_throw(cx)?;
+            js_obj.set(cx, "param", js_param)?;
+            let js_help = JsString::try_new(cx, help).or_throw(cx)?;
+            js_obj.set(cx, "help", js_help)?;
+        }
+        libparsec::AddrError::InvalidUrl { .. } => {
+            let js_tag = JsString::try_new(cx, "AddrErrorInvalidUrl").or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::AddrError::InvalidUrlScheme { expected, .. } => {
+            let js_tag = JsString::try_new(cx, "AddrErrorInvalidUrlScheme").or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+            let js_expected = JsString::try_new(cx, expected).or_throw(cx)?;
+            js_obj.set(cx, "expected", js_expected)?;
+        }
+        libparsec::AddrError::MissingParam(x0, ..) => {
+            let js_tag = JsString::try_new(cx, "AddrErrorMissingParam").or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+            let js_x0 = JsString::try_new(cx, x0).or_throw(cx)?;
+            js_obj.set(cx, "x0", js_x0)?;
+        }
+        libparsec::AddrError::NotARedirection { .. } => {
+            let js_tag = JsString::try_new(cx, "AddrErrorNotARedirection").or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+        libparsec::AddrError::ShouldNotHaveAPath { .. } => {
+            let js_tag = JsString::try_new(cx, "AddrErrorShouldNotHaveAPath").or_throw(cx)?;
+            js_obj.set(cx, "tag", js_tag)?;
+        }
+    }
+    Ok(js_obj)
+}
+
 // AnyClaimRetrievedInfo
 
 #[allow(dead_code)]
@@ -27084,6 +27141,47 @@ fn openbao_list_self_emails(mut cx: FunctionContext) -> JsResult<JsPromise> {
     Ok(promise)
 }
 
+// parse_http_url
+fn parse_http_url(mut cx: FunctionContext) -> JsResult<JsPromise> {
+    crate::init_sentry();
+    let url = {
+        let js_val = cx.argument::<JsString>(0)?;
+        js_val.value(&mut cx)
+    };
+    let ret = libparsec::parse_http_url(url);
+    let js_ret = match ret {
+        Ok(ok) => {
+            let js_obj = JsObject::new(&mut cx);
+            let js_tag = JsBoolean::new(&mut cx, true);
+            js_obj.set(&mut cx, "ok", js_tag)?;
+            let js_value = JsString::try_new(&mut cx, {
+                let custom_to_rs_string =
+                    |addr: libparsec::ParsecAddr| -> Result<String, &'static str> {
+                        Ok(addr.to_url().into())
+                    };
+                match custom_to_rs_string(ok) {
+                    Ok(ok) => ok,
+                    Err(err) => return cx.throw_type_error(err.to_string()),
+                }
+            })
+            .or_throw(&mut cx)?;
+            js_obj.set(&mut cx, "value", js_value)?;
+            js_obj
+        }
+        Err(err) => {
+            let js_obj = cx.empty_object();
+            let js_tag = JsBoolean::new(&mut cx, false);
+            js_obj.set(&mut cx, "ok", js_tag)?;
+            let js_err = variant_addr_error_rs_to_js(&mut cx, err)?;
+            js_obj.set(&mut cx, "error", js_err)?;
+            js_obj
+        }
+    };
+    let (deferred, promise) = cx.promise();
+    deferred.resolve(&mut cx, js_ret);
+    Ok(promise)
+}
+
 // parse_parsec_addr
 fn parse_parsec_addr(mut cx: FunctionContext) -> JsResult<JsPromise> {
     crate::init_sentry();
@@ -32632,6 +32730,7 @@ pub fn register_meths(cx: &mut ModuleContext) -> NeonResult<()> {
     cx.export_function("mountpointUnmount", mountpoint_unmount)?;
     cx.export_function("newCanceller", new_canceller)?;
     cx.export_function("openbaoListSelfEmails", openbao_list_self_emails)?;
+    cx.export_function("parseHttpUrl", parse_http_url)?;
     cx.export_function("parseParsecAddr", parse_parsec_addr)?;
     cx.export_function("pathFilename", path_filename)?;
     cx.export_function("pathJoin", path_join)?;

--- a/bindings/generator/api/addr.py
+++ b/bindings/generator/api/addr.py
@@ -12,6 +12,7 @@ from .common import (
     StrBasedType,
     UserID,
     Variant,
+    VariantItemTuple,
     VlobID,
 )
 
@@ -232,4 +233,28 @@ def build_parsec_addr(
     port: U16 | None,
     use_ssl: bool,
 ) -> ParsecAddr:
+    raise NotImplementedError
+
+
+class AddrError(ErrorVariant):
+    class InvalidUrl: ...
+
+    class NotARedirection: ...
+
+    class InvalidUrlScheme:
+        expected: str
+
+    class InvalidParamValue:
+        param: str
+        help: str
+
+    DuplicateParam = VariantItemTuple(str)
+    MissingParam = VariantItemTuple(str)
+
+    class ShouldNotHaveAPath: ...
+
+    class InvalidOrganizationID: ...
+
+
+def parse_http_url(url: str) -> Result[ParsecAddr, AddrError]:
     raise NotImplementedError

--- a/bindings/generator/api/addr.py
+++ b/bindings/generator/api/addr.py
@@ -256,5 +256,5 @@ class AddrError(ErrorVariant):
     class InvalidOrganizationID: ...
 
 
-def parse_http_url(url: str) -> Result[ParsecAddr, AddrError]:
+def try_convert_http_to_parsec_addr(http_url: Ref[str]) -> Result[ParsecAddr, AddrError]:
     raise NotImplementedError

--- a/bindings/web/src/meths.rs
+++ b/bindings/web/src/meths.rs
@@ -27663,42 +27663,6 @@ pub fn openbaoListSelfEmails(
     }))
 }
 
-// parse_http_url
-#[allow(non_snake_case)]
-#[wasm_bindgen]
-pub fn parseHttpUrl(url: String) -> Promise {
-    future_to_promise(libparsec::WithTaskIDFuture::from(async move {
-        let ret = libparsec::parse_http_url(url);
-        Ok(match ret {
-            Ok(value) => {
-                let js_obj = Object::new().into();
-                Reflect::set(&js_obj, &"ok".into(), &true.into())?;
-                let js_value = JsValue::from_str({
-                    let custom_to_rs_string =
-                        |addr: libparsec::ParsecAddr| -> Result<String, &'static str> {
-                            Ok(addr.to_url().into())
-                        };
-                    match custom_to_rs_string(value) {
-                        Ok(ok) => ok,
-                        #[allow(clippy::unnecessary_to_owned)]
-                        Err(err) => return Err(JsValue::from(TypeError::new(&err.to_string()))),
-                    }
-                    .as_ref()
-                });
-                Reflect::set(&js_obj, &"value".into(), &js_value)?;
-                js_obj
-            }
-            Err(err) => {
-                let js_obj = Object::new().into();
-                Reflect::set(&js_obj, &"ok".into(), &false.into())?;
-                let js_err = variant_addr_error_rs_to_js(err)?;
-                Reflect::set(&js_obj, &"error".into(), &js_err)?;
-                js_obj
-            }
-        })
-    }))
-}
-
 // parse_parsec_addr
 #[allow(non_snake_case)]
 #[wasm_bindgen]
@@ -28844,6 +28808,42 @@ pub fn totpSetupStatusAnonymous(config: Object, addr: String) -> Promise {
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
                 let js_err = variant_totp_setup_status_anonymous_error_rs_to_js(err)?;
+                Reflect::set(&js_obj, &"error".into(), &js_err)?;
+                js_obj
+            }
+        })
+    }))
+}
+
+// try_convert_http_to_parsec_addr
+#[allow(non_snake_case)]
+#[wasm_bindgen]
+pub fn tryConvertHttpToParsecAddr(http_url: String) -> Promise {
+    future_to_promise(libparsec::WithTaskIDFuture::from(async move {
+        let ret = libparsec::try_convert_http_to_parsec_addr(&http_url);
+        Ok(match ret {
+            Ok(value) => {
+                let js_obj = Object::new().into();
+                Reflect::set(&js_obj, &"ok".into(), &true.into())?;
+                let js_value = JsValue::from_str({
+                    let custom_to_rs_string =
+                        |addr: libparsec::ParsecAddr| -> Result<String, &'static str> {
+                            Ok(addr.to_url().into())
+                        };
+                    match custom_to_rs_string(value) {
+                        Ok(ok) => ok,
+                        #[allow(clippy::unnecessary_to_owned)]
+                        Err(err) => return Err(JsValue::from(TypeError::new(&err.to_string()))),
+                    }
+                    .as_ref()
+                });
+                Reflect::set(&js_obj, &"value".into(), &js_value)?;
+                js_obj
+            }
+            Err(err) => {
+                let js_obj = Object::new().into();
+                Reflect::set(&js_obj, &"ok".into(), &false.into())?;
+                let js_err = variant_addr_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }

--- a/bindings/web/src/meths.rs
+++ b/bindings/web/src/meths.rs
@@ -7474,6 +7474,91 @@ fn variant_active_users_limit_rs_to_js(
     Ok(js_obj)
 }
 
+// AddrError
+
+#[allow(dead_code)]
+fn variant_addr_error_rs_to_js(rs_obj: libparsec::AddrError) -> Result<JsValue, JsValue> {
+    let js_obj = Object::new().into();
+    let js_display = &rs_obj.to_string();
+    Reflect::set(&js_obj, &"error".into(), &js_display.into())?;
+    match rs_obj {
+        libparsec::AddrError::DuplicateParam(x1, ..) => {
+            Reflect::set(&js_obj, &"tag".into(), &"AddrErrorDuplicateParam".into())?;
+            let js_x1 = {
+                #[allow(clippy::useless_asref)]
+                JsValue::from_str(x1.as_ref())
+            };
+            Reflect::set(
+                &js_obj,
+                &"x1".into(),
+                #[expect(clippy::useless_conversion)]
+                &js_x1.into(),
+            )?;
+        }
+        #[allow(clippy::unneeded_struct_pattern)]
+        libparsec::AddrError::InvalidOrganizationID { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"AddrErrorInvalidOrganizationID".into(),
+            )?;
+        }
+        #[allow(clippy::unneeded_struct_pattern)]
+        libparsec::AddrError::InvalidParamValue { param, help, .. } => {
+            Reflect::set(&js_obj, &"tag".into(), &"AddrErrorInvalidParamValue".into())?;
+            let js_param = {
+                #[allow(clippy::useless_asref)]
+                JsValue::from_str(param.as_ref())
+            };
+            Reflect::set(&js_obj, &"param".into(), &js_param)?;
+            let js_help = {
+                #[allow(clippy::useless_asref)]
+                JsValue::from_str(help.as_ref())
+            };
+            Reflect::set(&js_obj, &"help".into(), &js_help)?;
+        }
+        #[allow(clippy::unneeded_struct_pattern)]
+        libparsec::AddrError::InvalidUrl { .. } => {
+            Reflect::set(&js_obj, &"tag".into(), &"AddrErrorInvalidUrl".into())?;
+        }
+        #[allow(clippy::unneeded_struct_pattern)]
+        libparsec::AddrError::InvalidUrlScheme { expected, .. } => {
+            Reflect::set(&js_obj, &"tag".into(), &"AddrErrorInvalidUrlScheme".into())?;
+            let js_expected = {
+                #[allow(clippy::useless_asref)]
+                JsValue::from_str(expected.as_ref())
+            };
+            Reflect::set(&js_obj, &"expected".into(), &js_expected)?;
+        }
+        libparsec::AddrError::MissingParam(x1, ..) => {
+            Reflect::set(&js_obj, &"tag".into(), &"AddrErrorMissingParam".into())?;
+            let js_x1 = {
+                #[allow(clippy::useless_asref)]
+                JsValue::from_str(x1.as_ref())
+            };
+            Reflect::set(
+                &js_obj,
+                &"x1".into(),
+                #[expect(clippy::useless_conversion)]
+                &js_x1.into(),
+            )?;
+        }
+        #[allow(clippy::unneeded_struct_pattern)]
+        libparsec::AddrError::NotARedirection { .. } => {
+            Reflect::set(&js_obj, &"tag".into(), &"AddrErrorNotARedirection".into())?;
+        }
+        #[allow(clippy::unneeded_struct_pattern)]
+        libparsec::AddrError::ShouldNotHaveAPath { .. } => {
+            Reflect::set(
+                &js_obj,
+                &"tag".into(),
+                &"AddrErrorShouldNotHaveAPath".into(),
+            )?;
+        }
+    }
+    Ok(js_obj)
+}
+
 // AnyClaimRetrievedInfo
 
 #[allow(dead_code)]
@@ -27571,6 +27656,42 @@ pub fn openbaoListSelfEmails(
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &false.into())?;
                 let js_err = variant_open_bao_list_self_emails_error_rs_to_js(err)?;
+                Reflect::set(&js_obj, &"error".into(), &js_err)?;
+                js_obj
+            }
+        })
+    }))
+}
+
+// parse_http_url
+#[allow(non_snake_case)]
+#[wasm_bindgen]
+pub fn parseHttpUrl(url: String) -> Promise {
+    future_to_promise(libparsec::WithTaskIDFuture::from(async move {
+        let ret = libparsec::parse_http_url(url);
+        Ok(match ret {
+            Ok(value) => {
+                let js_obj = Object::new().into();
+                Reflect::set(&js_obj, &"ok".into(), &true.into())?;
+                let js_value = JsValue::from_str({
+                    let custom_to_rs_string =
+                        |addr: libparsec::ParsecAddr| -> Result<String, &'static str> {
+                            Ok(addr.to_url().into())
+                        };
+                    match custom_to_rs_string(value) {
+                        Ok(ok) => ok,
+                        #[allow(clippy::unnecessary_to_owned)]
+                        Err(err) => return Err(JsValue::from(TypeError::new(&err.to_string()))),
+                    }
+                    .as_ref()
+                });
+                Reflect::set(&js_obj, &"value".into(), &js_value)?;
+                js_obj
+            }
+            Err(err) => {
+                let js_obj = Object::new().into();
+                Reflect::set(&js_obj, &"ok".into(), &false.into())?;
+                let js_err = variant_addr_error_rs_to_js(err)?;
                 Reflect::set(&js_obj, &"error".into(), &js_err)?;
                 js_obj
             }

--- a/client/src/parsec/async_enrollment.ts
+++ b/client/src/parsec/async_enrollment.ts
@@ -83,19 +83,23 @@ const _ASYNC_ENROLLMENT_PARSEC_API = {
       // So we do some loading part here, we forward the elements to a proxy inside the worker that wraps "pkiInitForScws"
       // to import the module and set a global state, and finally the real `libparsec.pkiInitForScws` is called.
 
-      const parsecServerAddr = window.origin;
+      const parsedRes = await libparsec.parseHttpUrl(window.origin)
+      if (!parsedRes.ok) {
+        console.warn(`PKI: Failed to parse ${window.origin} into a parsec addr`);
+        return { ok: false, error: { tag: PkiSystemInitErrorTag.NotAvailable, error: `Cannot parse origin: ${parsedRes.error.tag}: ${parsedRes.error.error}` } };
+      }
 
       const SCWS_LOCATION_NAME = 'scws-scwsapi_js-location';
       const SCWS_APP_CERTIFICATE = 'scws-web_application_certificate';
 
       const scwsapiLocationTag = document.querySelector(`meta[name="${SCWS_LOCATION_NAME}"`) as HTMLMetaElement | null;
       if (!scwsapiLocationTag?.content) {
-        console.log(`No meta tag '${SCWS_LOCATION_NAME}' present`);
+        console.log(`PKI: No meta tag '${SCWS_LOCATION_NAME}' present`);
         return { ok: false, error: { tag: PkiSystemInitErrorTag.NotAvailable, error: `No meta tag '${SCWS_LOCATION_NAME}' present` } };
       }
       const scwsapiAppCertificateTag = document.querySelector(`meta[name="${SCWS_APP_CERTIFICATE}"`) as HTMLMetaElement | null;
       if (!scwsapiAppCertificateTag?.content) {
-        console.log(`No meta tag '${SCWS_APP_CERTIFICATE}' present`);
+        console.log(`PKI: No meta tag '${SCWS_APP_CERTIFICATE}' present`);
         return { ok: false, error: { tag: PkiSystemInitErrorTag.NotAvailable, error: `No meta tag '${SCWS_APP_CERTIFICATE}' present` } };
       }
 
@@ -103,7 +107,7 @@ const _ASYNC_ENROLLMENT_PARSEC_API = {
       // so we just cast. Trust me bro.
       return await (libparsec.pkiInitForScws as any)(
         window.getConfigDir(),
-        parsecServerAddr,
+        parsedRes.value,
         scwsapiLocationTag.content,
         scwsapiAppCertificateTag.content,
       );

--- a/client/src/parsec/async_enrollment.ts
+++ b/client/src/parsec/async_enrollment.ts
@@ -83,10 +83,16 @@ const _ASYNC_ENROLLMENT_PARSEC_API = {
       // So we do some loading part here, we forward the elements to a proxy inside the worker that wraps "pkiInitForScws"
       // to import the module and set a global state, and finally the real `libparsec.pkiInitForScws` is called.
 
-      const parsedRes = await libparsec.tryConvertHttpToParsecAddr(window.origin)
+      const parsedRes = await libparsec.tryConvertHttpToParsecAddr(window.origin);
       if (!parsedRes.ok) {
         console.warn(`PKI: Failed to parse ${window.origin} into a parsec addr`);
-        return { ok: false, error: { tag: PkiSystemInitErrorTag.NotAvailable, error: `Cannot parse origin: ${parsedRes.error.tag}: ${parsedRes.error.error}` } };
+        return {
+          ok: false,
+          error: {
+            tag: PkiSystemInitErrorTag.NotAvailable,
+            error: `Cannot parse origin: ${parsedRes.error.tag}: ${parsedRes.error.error}`,
+          },
+        };
       }
 
       const SCWS_LOCATION_NAME = 'scws-scwsapi_js-location';

--- a/client/src/parsec/async_enrollment.ts
+++ b/client/src/parsec/async_enrollment.ts
@@ -83,7 +83,7 @@ const _ASYNC_ENROLLMENT_PARSEC_API = {
       // So we do some loading part here, we forward the elements to a proxy inside the worker that wraps "pkiInitForScws"
       // to import the module and set a global state, and finally the real `libparsec.pkiInitForScws` is called.
 
-      const parsedRes = await libparsec.parseHttpUrl(window.origin)
+      const parsedRes = await libparsec.tryConvertHttpToParsecAddr(window.origin)
       if (!parsedRes.ok) {
         console.warn(`PKI: Failed to parse ${window.origin} into a parsec addr`);
         return { ok: false, error: { tag: PkiSystemInitErrorTag.NotAvailable, error: `Cannot parse origin: ${parsedRes.error.tag}: ${parsedRes.error.error}` } };

--- a/client/src/plugins/libparsec/definitions.ts
+++ b/client/src/plugins/libparsec/definitions.ts
@@ -1227,6 +1227,65 @@ export type ActiveUsersLimit =
   | ActiveUsersLimitLimitedTo
   | ActiveUsersLimitNoLimit
 
+// AddrError
+export enum AddrErrorTag {
+    DuplicateParam = 'AddrErrorDuplicateParam',
+    InvalidOrganizationID = 'AddrErrorInvalidOrganizationID',
+    InvalidParamValue = 'AddrErrorInvalidParamValue',
+    InvalidUrl = 'AddrErrorInvalidUrl',
+    InvalidUrlScheme = 'AddrErrorInvalidUrlScheme',
+    MissingParam = 'AddrErrorMissingParam',
+    NotARedirection = 'AddrErrorNotARedirection',
+    ShouldNotHaveAPath = 'AddrErrorShouldNotHaveAPath',
+}
+
+export interface AddrErrorDuplicateParam {
+    tag: AddrErrorTag.DuplicateParam
+    error: string
+    x1: string
+}
+export interface AddrErrorInvalidOrganizationID {
+    tag: AddrErrorTag.InvalidOrganizationID
+    error: string
+}
+export interface AddrErrorInvalidParamValue {
+    tag: AddrErrorTag.InvalidParamValue
+    error: string
+    param: string
+    help: string
+}
+export interface AddrErrorInvalidUrl {
+    tag: AddrErrorTag.InvalidUrl
+    error: string
+}
+export interface AddrErrorInvalidUrlScheme {
+    tag: AddrErrorTag.InvalidUrlScheme
+    error: string
+    expected: string
+}
+export interface AddrErrorMissingParam {
+    tag: AddrErrorTag.MissingParam
+    error: string
+    x1: string
+}
+export interface AddrErrorNotARedirection {
+    tag: AddrErrorTag.NotARedirection
+    error: string
+}
+export interface AddrErrorShouldNotHaveAPath {
+    tag: AddrErrorTag.ShouldNotHaveAPath
+    error: string
+}
+export type AddrError =
+  | AddrErrorDuplicateParam
+  | AddrErrorInvalidOrganizationID
+  | AddrErrorInvalidParamValue
+  | AddrErrorInvalidUrl
+  | AddrErrorInvalidUrlScheme
+  | AddrErrorMissingParam
+  | AddrErrorNotARedirection
+  | AddrErrorShouldNotHaveAPath
+
 // AnyClaimRetrievedInfo
 export enum AnyClaimRetrievedInfoTag {
     Device = 'AnyClaimRetrievedInfoDevice',
@@ -7036,6 +7095,9 @@ export interface LibParsecPlugin {
         openbao_entity_id: string,
         openbao_auth_token: string
     ): Promise<Result<Array<string>, OpenBaoListSelfEmailsError>>
+    parseHttpUrl(
+        url: string
+    ): Promise<Result<ParsecAddr, AddrError>>
     parseParsecAddr(
         url: string
     ): Promise<Result<ParsedParsecAddr, ParseParsecAddrError>>

--- a/client/src/plugins/libparsec/definitions.ts
+++ b/client/src/plugins/libparsec/definitions.ts
@@ -7095,9 +7095,6 @@ export interface LibParsecPlugin {
         openbao_entity_id: string,
         openbao_auth_token: string
     ): Promise<Result<Array<string>, OpenBaoListSelfEmailsError>>
-    parseHttpUrl(
-        url: string
-    ): Promise<Result<ParsecAddr, AddrError>>
     parseParsecAddr(
         url: string
     ): Promise<Result<ParsedParsecAddr, ParseParsecAddrError>>
@@ -7201,6 +7198,9 @@ export interface LibParsecPlugin {
         config: ClientConfig,
         addr: ParsecTOTPResetAddr
     ): Promise<Result<TOTPSetupStatus, TotpSetupStatusAnonymousError>>
+    tryConvertHttpToParsecAddr(
+        http_url: string
+    ): Promise<Result<ParsecAddr, AddrError>>
     updateDeviceChangeAuthentication(
         config_dir: Path,
         current_auth: DeviceAccessStrategy,

--- a/libparsec/src/addr.rs
+++ b/libparsec/src/addr.rs
@@ -200,6 +200,6 @@ pub fn build_parsec_addr(hostname: String, port: Option<u16>, use_ssl: bool) -> 
     ParsecAddr::new(hostname, port, use_ssl)
 }
 
-pub fn parse_http_url(url: String) -> Result<ParsecAddr, AddrError> {
-    ParsecAddr::from_http_url(&url)
+pub fn try_convert_http_to_parsec_addr(http_url: &str) -> Result<ParsecAddr, AddrError> {
+    ParsecAddr::from_http_url(http_url)
 }

--- a/libparsec/src/addr.rs
+++ b/libparsec/src/addr.rs
@@ -199,3 +199,7 @@ pub fn build_parsec_organization_bootstrap_addr(
 pub fn build_parsec_addr(hostname: String, port: Option<u16>, use_ssl: bool) -> ParsecAddr {
     ParsecAddr::new(hostname, port, use_ssl)
 }
+
+pub fn parse_http_url(url: String) -> Result<ParsecAddr, AddrError> {
+    ParsecAddr::from_http_url(&url)
+}


### PR DESCRIPTION
Convert `window.origin` into `ParsecAddr` before calling `libparsec.pkiInitForScws` as it expect a `ParsecAddr` in the bindings.

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
