### PR TITLE
fix(pki): Correct loading SCWS Object

### DIFF
--- a/libparsec/crates/platform_pki/src/web/pki_system.rs
+++ b/libparsec/crates/platform_pki/src/web/pki_system.rs
@@ -217,14 +217,7 @@ fn get_scws_values_from_global_context() -> Result<(scwsapi::Scws, String), PkiS
     if !raw_scws.is_object() || !raw_webapp_cert.is_string() {
         return Err(PkiSystemInitError::NotAvailable);
     }
-    let scws: scwsapi::Scws = raw_scws
-        .dyn_into::<scwsapi_sys::Scws>()
-        .map_err(|e| {
-            PkiSystemInitError::Internal(anyhow::anyhow!(
-                "Cannot cast SCWS object to correct type ({e:?})"
-            ))
-        })
-        .map(Into::into)?;
+    let scws: scwsapi::Scws = scwsapi_sys::Scws::from(raw_scws).into();
     let cert = raw_webapp_cert
         .dyn_into::<js_sys::JsString>()
         .map_err(|e| {


### PR DESCRIPTION
Use `From<JsValue>` instead of `JsCast` interface to be able to load the SCWS JS Object.

`JsCast` if for when the object to cast correspond to the target type. That was not the case because SCWS JS Object is not yet wrapped by `scwsapi_sys::Scws`. Instead we use `From<JsValue>` that is designed for that.

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
