### PR TITLE
Fix error on Edge by forcing create:true when listing files

### DIFF
--- a/libparsec/crates/platform_filesystem/src/web/common/internal.rs
+++ b/libparsec/crates/platform_filesystem/src/web/common/internal.rs
@@ -39,7 +39,13 @@ impl Storage {
             "Listing file entries in {} with extension {extension}",
             dir.display()
         );
-        let dir = match self.root_dir.get_directory_from_path(dir, None).await {
+        // Use create:true to work around an Edge quirk in SharedWorker context where
+        // getDirectoryHandle without create:true throws AbortError instead of NotFoundError.
+        let dir = match self
+            .root_dir
+            .get_directory_from_path(dir, Some(OpenOptions::create()))
+            .await
+        {
             Ok(dir) => dir,
             Err(GetDirectoryHandleError::NotFound { .. }) => {
                 log::debug!("Could not find devices dir");


### PR DESCRIPTION
Closes #11736

You may need to exec this code in Edge console to fully clear the data. For some reason, I haven't been able to find any interface option to do that properly. Or test using a private window.

```
const root = await navigator.storage.getDirectory();

for await (const [name, handle] of root.entries()) {
  await root.removeEntry(name, { recursive: true });
}
```