### PR TITLE
Added AllowOther mount option in MacOS

### DIFF
--- a/libparsec/crates/platform_mountpoint/src/unix/mount.rs
+++ b/libparsec/crates/platform_mountpoint/src/unix/mount.rs
@@ -89,6 +89,8 @@ impl Mountpoint {
                 fuser::MountOption::FSName("parsec".into()),
                 #[cfg(target_os = "macos")]
                 fuser::MountOption::CUSTOM(format!("volname={workspace_name}")),
+                #[cfg(target_os = "macos")]
+                fuser::MountOption::AllowOther,
                 fuser::MountOption::DefaultPermissions,
                 fuser::MountOption::NoSuid,
                 fuser::MountOption::Async,

--- a/newsfragments/10086.bugfix.rst
+++ b/newsfragments/10086.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug preventing some file operations using the Finder in MacOS


### PR DESCRIPTION
See https://docs.kernel.org/filesystems/fuse/fuse.html#mount-options:

```
default_permissions
By default FUSE doesn't check file access permissions, the filesystem is free to implement its access policy or leave it to the underlying file access mechanism (e.g. in case of network filesystems). This option enables permission checking, restricting access based on file mode. It is usually useful together with the 'allow_other' mount option.

allow_other
This option overrides the security measure restricting file access to the user mounting the filesystem. This option is by default only allowed to root, but this restriction can be removed with a (userspace) configuration option.
```

The issues we encountered with file operations through the Finder were permission issues. Toggling `allow_other` fixes these operations and restores the intended behaviour as it was in V2.