### PR TITLE
Treat missing device data dir as success when forgetting a device

### DIFF
--- a/libparsec/crates/platform_storage/src/native/cleanup.rs
+++ b/libparsec/crates/platform_storage/src/native/cleanup.rs
@@ -11,10 +11,16 @@ pub async fn remove_device_data(
     let path = data_base_dir.join(device_id.hex());
     log::debug!("Removing device data at {}", path.display());
 
-    tokio::fs::remove_dir_all(&path)
-        .await
-        .map_err(anyhow::Error::from)
-        .map_err(Into::into)
+    match tokio::fs::remove_dir_all(&path).await {
+        Ok(()) => Ok(()),
+        // Devices created on old organizations never got a per-device data
+        // directory, so there may be nothing to remove (see #12807).
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            log::debug!("No device data to remove at {}", path.display());
+            Ok(())
+        }
+        Err(err) => Err(anyhow::Error::from(err).into()),
+    }
 }
 
 #[cfg(test)]

--- a/libparsec/crates/platform_storage/tests/unit/native/cleanup.rs
+++ b/libparsec/crates/platform_storage/tests/unit/native/cleanup.rs
@@ -33,5 +33,19 @@ async fn cleanup_device_data(tmp_path: TmpPath, env: &TestbedEnv) {
     assert!(!device_dir.exists(), "device dir still exists");
 }
 
+#[parsec_test(testbed = "minimal")]
+async fn cleanup_device_data_missing_dir(tmp_path: TmpPath, env: &TestbedEnv) {
+    let alice = env.local_device("alice@dev1");
+
+    // The device data dir was never created (e.g. device from an old
+    // organization, see #12807): cleanup must succeed anyway.
+    let device_dir = tmp_path.join(alice.device_id.hex());
+    assert!(!device_dir.exists(), "device dir should not exist");
+
+    remove_device_data(&tmp_path, alice.device_id)
+        .await
+        .unwrap();
+}
+
 // TODO: Convert this test be compatible with web
 // see https://github.com/Scille/parsec-cloud/issues/10007

--- a/newsfragments/12807.bugfix.rst
+++ b/newsfragments/12807.bugfix.rst
@@ -1,0 +1,3 @@
+Fix the CLI ``device forget-local`` command failing with ``No such file or
+directory`` when the device has no associated data directory (devices created
+on old organizations).


### PR DESCRIPTION
## Summary
`parsec-cli device forget-local` no longer errors with `Failed to remove device data: Failed to remove data: No such file or directory (os error 2)` when the device has no data directory. `remove_device_data` now treats `ErrorKind::NotFound` from `remove_dir_all` as success, making the cleanup idempotent; any other io error still propagates as before.

## Why this matters
#12807 reports the confusing hard error on what is actually a successful forget operation - the device key file is removed correctly, but the follow-up data-dir removal fails. AureliaDolo noted in-thread this affects devices created on old organizations, which never got a per-device data directory. The fix is localized to the storage cleanup helper (`libparsec/crates/platform_storage/src/native/cleanup.rs`); the CLI command and `client` wrapper are unchanged.

How to test: `parsec-cli device forget-local` on a device whose `<data_base_dir>/<device_id_hex>/` directory does not exist completes without the error; with the directory present, it is removed exactly as before.

## Testing
- New `cleanup_device_data_missing_dir` test: forgetting a device whose data dir was never created returns `Ok` (this fails on master with `NotFound`)
- Existing `cleanup_device_data` still passes (directory present and removed)
- `cargo test -p libparsec_platform_storage --lib --features test-with-testbed cleanup`: 3 passed
- News fragment added: `newsfragments/12807.bugfix.rst`

Fixes #12807
