### PR TITLE
backport: Added AllowOther mount option in MacOS

### DIFF
--- a/libparsec/crates/platform_mountpoint/src/unix/mount.rs
+++ b/libparsec/crates/platform_mountpoint/src/unix/mount.rs
@@ -89,6 +89,8 @@ impl Mountpoint {
                 fuser::MountOption::FSName("parsec".into()),
                 #[cfg(target_os = "macos")]
                 fuser::MountOption::CUSTOM(format!("volname={workspace_name}")),
+                #[cfg(target_os = "macos")]
+                fuser::MountOption::AllowOther,
                 fuser::MountOption::DefaultPermissions,
                 fuser::MountOption::NoSuid,
                 fuser::MountOption::Async,

--- a/newsfragments/10086.bugfix.rst
+++ b/newsfragments/10086.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug preventing some file operations using the Finder in MacOS


### PR DESCRIPTION
Backport of https://github.com/Scille/parsec-cloud/pull/12883