### PR TITLE
fix(electron): Correct log cluttering json export

### DIFF
--- a/client/electron/package.cjs
+++ b/client/electron/package.cjs
@@ -118,7 +118,7 @@ function buildArtifactName() {
 }
 
 const ARTIFACT_NAME = buildArtifactName();
-console.log(`Using artifact name: ${ARTIFACT_NAME}`);
+console.warn(`Using artifact name: ${ARTIFACT_NAME}`);
 
 /**
  * @type {import('electron-builder').Configuration}


### PR DESCRIPTION
In [PR-12182](https://github.com/Scille/parsec-cloud/pull/12182) we rework `package.js` script for hardened build generation. In the rework, we added a log line from the expected artifact name. 

But that log line was displayed using `console.log` which when `package.js` is called with `--export` flag set will add that line before the printed JSON data (thus causing the JSON data to be invalid)

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
