### PR TITLE
Fix mixed-line-ending pre-commit rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
     rev: v6.0.0
     hooks:
       - id: mixed-line-ending
+        args: [--fix=lf]
         alias: eol
       - id: trailing-whitespace
         exclude_types: [svg, diff]


### PR DESCRIPTION
Without this option it seems this check doesn't reject `\r\n` (e.g. see fabc17c2db on `releases/3.9` that hasn't been rejected)