### PR TITLE
[MS] Use keyring error

### DIFF
--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -2254,6 +2254,7 @@
         "errors": {
             "wrongAuthentication": "Invalid authentication.",
             "cannotChangeAuthentication": "Failed to update authentication",
+            "keyringFailed": "Failed to access system authentication.",
             "failedToRetrieveInformation": "Failed to retrieve information. Please make sure you are online.",
             "invalidTotpCode": "The multi-factor authentication code is invalid.",
             "totpOffline": "Failed to reach the server. Make sure you are online.",

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -2255,6 +2255,7 @@
         "errors": {
             "wrongAuthentication": "Authentification invalide.",
             "cannotChangeAuthentication": "Impossible de changer l'authentification",
+            "keyringFailed": "Impossible d'accéder à l'authentification système.",
             "failedToRetrieveInformation": "Impossible de récupérer les informations. Veuillez vérifier que vous êtes bien connecté(e) à Internet.",
             "invalidTotpCode": "Le code d'authentification multi-facteurs est invalide.",
             "totpOffline": "Impossible de contacter le serveur. Veuillez vérifier votre connexion Internet.",

--- a/client/src/views/home/HomePage.vue
+++ b/client/src/views/home/HomePage.vue
@@ -905,7 +905,7 @@ async function handleLoginError(device: AvailableDevice, error: ClientStartError
     }
   } else if (device.ty.tag === AvailableDeviceTypeTag.Keyring) {
     window.electronAPI.log('debug', 'Handling Keyring login error');
-    if (error.tag === ClientStartErrorTag.LoadDeviceDecryptionFailed) {
+    if (error.tag === ClientStartErrorTag.LoadDeviceDecryptionFailed || error.tag === ClientStartErrorTag.KeyringError) {
       const answer = await askQuestion('HomePage.loginErrors.keyringFailedTitle', 'HomePage.loginErrors.keyringFailedQuestion', {
         yesText: 'HomePage.loginErrors.keyringFailedUsedRecovery',
         noText: 'HomePage.loginErrors.keyringFailedAbort',

--- a/client/src/views/users/UpdateAuthenticationModal.vue
+++ b/client/src/views/users/UpdateAuthenticationModal.vue
@@ -285,6 +285,10 @@ async function changeAuthentication(): Promise<void> {
         errorMessage.value = 'MyProfilePage.errors.wrongPassword';
         break;
       }
+      case UpdateDeviceErrorTag.KeyringError: {
+        errorMessage.value = 'MyProfilePage.errors.keyringFailed';
+        break;
+      }
       default:
         props.informationManager.present(
           new Information({


### PR DESCRIPTION
It doesn't change much, just a cleaner error when keyring fails.

To test, without the testbed:
- rename the `keyring_user.txt` file inside parsec's config dir (%APPDATA%/parsec3 or ~/.config/parsec3)
- create a new test device with keyring
- in the credential manager, delete the newly created entry (careful!)
- try to log in or change your authentication

Don't forget to rename keyring_user.txt in the end.