### PR TITLE
[MS] Fix visual bugs found in 3.9

### DIFF
--- a/client/src/common/validators.ts
+++ b/client/src/common/validators.ts
@@ -18,6 +18,7 @@ import {
 import { IValidator, Validity } from 'megashark-lib';
 
 const ENTRY_NAME_LIMIT = 128;
+const USER_NAME_LIMIT = 128;
 
 export const emailValidator: IValidator = async function (value: string) {
   value = value.trim();
@@ -39,6 +40,8 @@ export const userNameValidator: IValidator = async function (value: string) {
   value = value.trim();
   if (value.length === 0) {
     return { validity: Validity.Intermediate };
+  } else if (value.length > USER_NAME_LIMIT) {
+    return { validity: Validity.Invalid, reason: { key: 'validators.userInfo.nameTooLong', data: { limit: USER_NAME_LIMIT } } };
   }
   return (await isValidUserName(value)) ? { validity: Validity.Valid } : { validity: Validity.Invalid, reason: 'validators.userInfo.name' };
 };

--- a/client/src/components/profile/ProfileInfoCard.vue
+++ b/client/src/components/profile/ProfileInfoCard.vue
@@ -40,12 +40,12 @@ defineProps<{
 <style lang="scss" scoped>
 .profile-info-card {
   display: flex;
-  align-items: center;
   gap: 1rem;
 
   &__avatar {
     height: 3rem;
     color: var(--parsec-color-light-secondary-text);
+    flex-shrink: 0;
   }
 
   &-content {
@@ -55,7 +55,6 @@ defineProps<{
 
   &-item {
     display: flex;
-    align-items: center;
     gap: 0.75rem;
     justify-content: space-between;
     color: var(--parsec-color-light-secondary-text);

--- a/client/src/locales/en-US.json
+++ b/client/src/locales/en-US.json
@@ -2350,6 +2350,7 @@
         },
         "userInfo": {
             "name": "Name contains invalid characters.",
+            "nameTooLong": "Name is too long, limit is {limit} characters.",
             "email": "Wrong email address format."
         }
     },

--- a/client/src/locales/fr-FR.json
+++ b/client/src/locales/fr-FR.json
@@ -2351,6 +2351,7 @@
         },
         "userInfo": {
             "name": "Le nom contient des caractères invalides.",
+            "nameTooLong": "Le nom est trop long, la limite est de {limit} caractères.",
             "email": "Le format de l'adresse email est invalide."
         }
     },

--- a/client/src/theme/components/_modals.scss
+++ b/client/src/theme/components/_modals.scss
@@ -111,7 +111,6 @@ ion-modal {
         display: flex;
         align-items: center;
         gap: 1rem;
-        max-width: var(--parsec-modal-width-sm);
       }
 
       &__text {
@@ -315,6 +314,12 @@ ion-modal {
       position: relative;
       padding: 2rem 2rem 0 2rem;
       height: auto;
+    }
+  }
+
+  .Finish {
+    .title-toolbar {
+      white-space: normal;
     }
   }
 }
@@ -607,6 +612,14 @@ ion-modal {
     --height: 100%;
     height: 100%;
     overflow: auto;
+  }
+
+  .Summary {
+    .modal-content {
+      @include ms.responsive-breakpoint('sm') {
+        padding-inline: 1.5rem;
+      }
+    }
   }
 
   // manage the two columns on Contact details step

--- a/client/src/views/header/HeaderPage.vue
+++ b/client/src/views/header/HeaderPage.vue
@@ -140,18 +140,6 @@
             </ion-button>
 
             <ion-button
-              v-show="false"
-              v-if="!isMobile()"
-              slot="icon-only"
-              id="trigger-search-button"
-              class="topbar-right-buttons__item"
-            >
-              <ion-icon
-                slot="icon-only"
-                :icon="search"
-              />
-            </ion-button>
-            <ion-button
               slot="icon-only"
               id="trigger-notifications-button"
               class="topbar-right-buttons__item"
@@ -283,17 +271,7 @@ import {
   modalController,
   popoverController,
 } from '@ionic/vue';
-import {
-  archive,
-  checkmarkCircle,
-  chevronDown,
-  ellipseOutline,
-  ellipsisHorizontal,
-  home,
-  notifications,
-  search,
-  trash,
-} from 'ionicons/icons';
+import { archive, checkmarkCircle, chevronDown, ellipseOutline, ellipsisHorizontal, home, notifications, trash } from 'ionicons/icons';
 import { MsImage, MsModalResult, SidebarToggle, Translatable, useWindowSize } from 'megashark-lib';
 import { Ref, computed, inject, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue';
 

--- a/client/src/views/header/ProfileHeaderOrganization.vue
+++ b/client/src/views/header/ProfileHeaderOrganization.vue
@@ -12,9 +12,9 @@
       class="avatar small"
       :class="{ online: isOnline, offline: !isOnline }"
     >
-      <ion-icon
-        :icon="personCircle"
-        class="avatar-icon"
+      <ms-image
+        :image="PersonCircle"
+        class="profile-info-card__avatar"
       />
     </div>
     <div class="text-content">
@@ -39,6 +39,7 @@
 </template>
 
 <script setup lang="ts">
+import PersonCircle from '@/assets/images/person-circle.svg?raw';
 import { openBugReportModal } from '@/components/misc';
 import { getClientInfo, UserProfile } from '@/parsec';
 import { navigateTo, ProfilePages, Routes } from '@/router';
@@ -49,8 +50,8 @@ import { Information, InformationLevel, InformationManager, InformationManagerKe
 import UpdateAppModal from '@/views/about/UpdateAppModal.vue';
 import ProfileHeaderOrganizationPopover, { ProfilePopoverOption } from '@/views/header/ProfileHeaderOrganizationPopover.vue';
 import { IonIcon, IonItem, IonText, modalController, popoverController } from '@ionic/vue';
-import { chevronDown, personCircle } from 'ionicons/icons';
-import { Answer, askQuestion, MsModalResult } from 'megashark-lib';
+import { chevronDown } from 'ionicons/icons';
+import { Answer, askQuestion, MsImage, MsModalResult } from 'megashark-lib';
 import { inject, onMounted, onUnmounted, ref, Ref } from 'vue';
 
 const isOnline = ref(false);
@@ -223,8 +224,8 @@ async function openOrganizationPopover(event: Event): Promise<void> {
   &::after {
     content: '';
     position: absolute;
-    bottom: 0px;
-    right: 0px;
+    bottom: 2px;
+    right: 1px;
     height: 0.5rem;
     width: 0.5rem;
     border-radius: 50%;

--- a/client/src/views/home/OrganizationListPage.vue
+++ b/client/src/views/home/OrganizationListPage.vue
@@ -537,7 +537,7 @@ async function openDocumentation(): Promise<void> {
   overflow: hidden;
   height: 100%;
   border-radius: var(--parsec-radius-12) var(--parsec-radius-12) 0 0;
-  padding: 2rem 2rem 0 2rem;
+  padding: 2rem 2rem 1rem 2rem;
   width: 100%;
   max-width: 40rem;
   background: var(--parsec-color-light-secondary-white);

--- a/client/src/views/home/UserJoinOrganizationModal.vue
+++ b/client/src/views/home/UserJoinOrganizationModal.vue
@@ -617,6 +617,10 @@ onMounted(async () => {
   }
 }
 
+.modal-header__title {
+  text-wrap: break-word;
+}
+
 .modal-footer-buttons {
   padding-top: 2rem;
 

--- a/client/src/views/invitations/InvitationsPage.vue
+++ b/client/src/views/invitations/InvitationsPage.vue
@@ -830,6 +830,7 @@ async function refreshAll(): Promise<void> {
       &::part(native) {
         display: flex;
         width: fit-content;
+        padding: 0.5rem 0.75rem;
       }
 
       &__icon {

--- a/client/src/views/users/GreetUserModal.vue
+++ b/client/src/views/users/GreetUserModal.vue
@@ -130,11 +130,7 @@
           v-if="guestInfoPageRef"
           class="final-step"
         >
-          <user-avatar-name
-            class="avatar"
-            :user-name="guestInfoPageRef.fullName"
-            :user-avatar="guestInfoPageRef.fullName"
-          />
+          <ion-text class="user-name title-h4">{{ guestInfoPageRef.fullName }}</ion-text>
           <div class="user-info">
             <div class="user-info__email">
               <ion-text class="info-label body">{{ $msTranslate('UsersPage.success.email') }}</ion-text>
@@ -181,7 +177,6 @@ import SmallDisplayModalHeader from '@/components/header/SmallDisplayModalHeader
 import SmallDisplayStepModalHeader from '@/components/header/SmallDisplayStepModalHeader.vue';
 import SasCodeChoice from '@/components/sas-code/SasCodeChoice.vue';
 import SasCodeProvide from '@/components/sas-code/SasCodeProvide.vue';
-import UserAvatarName from '@/components/users/UserAvatarName.vue';
 import UserInformation from '@/components/users/UserInformation.vue';
 import UserProfileTag from '@/components/users/UserProfileTag.vue';
 import { CancelledGreetingAttemptReason, GreetInProgressErrorTag, UserGreet, UserInvitation, UserProfile } from '@/parsec';
@@ -534,37 +529,44 @@ onMounted(async () => {
   flex-direction: column;
   justify-content: space-between;
   color: var(--parsec-color-light-secondary-text);
-  gap: 1rem;
+  background-color: var(--parsec-color-light-secondary-inversed-contrast);
+  box-shadow: var(--parsec-shadow-card);
+  border-radius: var(--parsec-radius-8);
+  overflow: hidden;
 
-  @include ms.responsive-breakpoint('sm') {
-    padding-inline: 1.5rem;
-  }
+  // @include ms.responsive-breakpoint('sm') {
+  //   margin-inline: 1.5rem;
+  // }
 
-  .avatar {
-    padding-left: 0.725rem;
-    border-left: 2px solid var(--parsec-color-light-secondary-disabled);
+  .user-name {
+    padding: 1rem;
+    border-bottom: 1px solid var(--parsec-color-light-secondary-medium);
+    background-color: var(--parsec-color-light-secondary-premiere);
   }
 
   .user-info {
     display: flex;
     flex-direction: column;
-    gap: 1.5rem;
-    background: var(--parsec-color-light-secondary-background);
-    padding: 1rem;
     border-radius: var(--parsec-radius-6);
 
     & > [class^='user-info'] {
       display: flex;
       align-items: center;
-      gap: 1rem;
+      gap: 0.75rem;
+      padding: 0.75rem;
+
+      &:not(:last-child) {
+        border-bottom: 1px solid var(--parsec-color-light-secondary-medium);
+      }
     }
 
     .info-label {
-      color: var(--parsec-color-light-secondary-grey);
+      color: var(--parsec-color-light-secondary-hard-grey);
       flex-shrink: 0;
     }
 
     .info-cell {
+      font-weight: 600;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;

--- a/client/tests/e2e/specs/user_greet.spec.ts
+++ b/client/tests/e2e/specs/user_greet.spec.ts
@@ -85,7 +85,7 @@ msTest('Greet user whole process in small display', async ({ usersPage }) => {
   await expect(greetData.title).toHaveText('User has been added successfully!');
   await expect(greetData.nextButton).not.toHaveDisabledAttribute();
   await expect(greetData.nextButton).toBeVisible();
-  await expect(greetData.content.locator('.final-step').locator('.person-name')).toHaveText('Gordon Freeman');
+  await expect(greetData.content.locator('.final-step').locator('.user-name')).toHaveText('Gordon Freeman');
   await expect(greetData.content.locator('.final-step').locator('.user-info__email').locator('.cell')).toHaveText(
     'gordon.freeman@blackmesa.nm',
   );
@@ -205,7 +205,7 @@ msTest('Greet user whole process in large display', { tag: '@important' }, async
   await expect(greetData.title).toHaveText('User has been added successfully!');
   await expect(greetData.nextButton).not.toHaveDisabledAttribute();
   await expect(greetData.nextButton).toBeVisible();
-  await expect(greetData.content.locator('.final-step').locator('.person-name')).toHaveText('Gordon Freeman');
+  await expect(greetData.content.locator('.final-step').locator('.user-name')).toHaveText('Gordon Freeman');
   await expect(greetData.content.locator('.final-step').locator('.user-info__email').locator('.cell')).toHaveText(
     'gordon.freeman@blackmesa.nm',
   );
@@ -628,7 +628,7 @@ msTest.skip('Greet user whole process with smartcard auth', async ({ usersPage }
   await expect(greetData.title).toHaveText('User has been added successfully!');
   await expect(greetData.nextButton).not.toHaveDisabledAttribute();
   await expect(greetData.nextButton).toBeVisible();
-  await expect(greetData.content.locator('.final-step').locator('.person-name')).toHaveText('Gordon Freeman');
+  await expect(greetData.content.locator('.final-step').locator('.user-name')).toHaveText('Gordon Freeman');
   await expect(greetData.content.locator('.final-step').locator('.user-info__email').locator('.cell')).toHaveText(
     'gordon.freeman@blackmesa.nm',
   );


### PR DESCRIPTION
### What's changed

- In logged page, the profile header icon is now the same as in `ProfilePage`
- Long title in final step JoinOrganizationModal is now visible (no more ellipsis)
- Add a specific error when a name is more then 128 characters.
- Update the style of the final step when greeting a new user.
- Fixed padding for the switch button (Email / Async invitations)

<img width="1041" height="331" alt="image" src="https://github.com/user-attachments/assets/9930936f-174d-4a63-87d1-dea25b1056dc" />

<img width="634" height="434" alt="Screenshot 2026-06-18 at 15 21 59" src="https://github.com/user-attachments/assets/93332885-b6dd-47c3-892e-17aa9476ddfa" />


<img width="635" height="332" alt="Screenshot 2026-06-18 at 14 55 41" src="https://github.com/user-attachments/assets/88f5a251-d563-48ff-a5ed-a9b3caa28a3a" />

<img width="490" height="102" alt="image" src="https://github.com/user-attachments/assets/736c28e0-c789-4d09-89e1-fb489e618271" />


closes #12777 
