### PR TITLE
[MS] Refactor list style files

### DIFF
--- a/client/src/components/files/explorer/FileCard.vue
+++ b/client/src/components/files/explorer/FileCard.vue
@@ -5,7 +5,7 @@
     class="file-card-item ion-no-padding"
     :class="{
       selected: entry.isSelected,
-      'file-hovered': !entry.isSelected && (menuOpened || isHovered),
+      'file-card-item--hovered': !entry.isSelected && (menuOpened || isHovered),
     }"
     @dblclick="$emit('openItem', $event, entry)"
     @mouseenter="isHovered = true"
@@ -229,11 +229,5 @@ async function onOptionsClick(event: Event): Promise<void> {
   justify-content: center;
   align-items: center;
   flex-direction: column;
-}
-
-/* No idea how to change the color of the ion-item */
-.file-card__title::part(native),
-.file-card-last-update::part(native) {
-  background-color: var(--parsec-color-light-secondary-background);
 }
 </style>

--- a/client/src/components/files/explorer/FileGridDisplay.vue
+++ b/client/src/components/files/explorer/FileGridDisplay.vue
@@ -12,7 +12,7 @@
       ref="containerScroll"
       @contextmenu="onContextMenu"
     >
-      <div class="folders-container-grid">
+      <div class="grid-container files-grid-container">
         <file-card
           class="folder-grid-item"
           ref="folderItems"
@@ -130,7 +130,7 @@ async function scrollToSelected(): Promise<void> {
 </script>
 
 <style scoped lang="scss">
-.folders-container-grid {
+.files-grid-container {
   display: flex;
   flex-wrap: wrap;
   gap: 1.5rem;

--- a/client/src/components/files/explorer/FileListDisplay.vue
+++ b/client/src/components/files/explorer/FileListDisplay.vue
@@ -15,15 +15,16 @@
       @contextmenu="onContextMenu"
     >
       <ion-list
-        class="files-container-list"
+        class="list-container files-list-container"
         :class="{ 'file-list-mobile': isSmallDisplay }"
+        id="files-page-file-container"
       >
         <ion-list-header
-          class="folder-list-header"
+          class="list-header files-list-header"
           lines="full"
           v-if="isLargeDisplay"
         >
-          <ion-label class="folder-list-header__label ion-text-nowrap header-label-selected">
+          <ion-label class="list-header-label ion-text-nowrap header-label-selected">
             <ms-checkbox
               @change="selectAll"
               :checked="allSelected"
@@ -31,56 +32,56 @@
             />
           </ion-label>
           <ion-text
-            class="folder-list-header__label cell-title ion-text-nowrap header-label-name"
+            class="list-header-label cell-title ion-text-nowrap header-label-name"
             @click="onHeaderSortChange(SortProperty.Name)"
-            :class="{ 'header-label-name-sorted': currentSortProperty === SortProperty.Name }"
+            :class="{ 'list-header-label--sorted': currentSortProperty === SortProperty.Name }"
           >
-            <span class="header-label-name__text">{{ $msTranslate('FoldersPage.listDisplayTitles.name') }}</span>
+            <span class="label-text">{{ $msTranslate('FoldersPage.listDisplayTitles.name') }}</span>
             <ion-icon
               :icon="currentSortOrder ? arrowUp : arrowDown"
-              class="header-label-name__sort-icon"
+              class="sort-icon"
             />
           </ion-text>
           <ion-text
-            class="folder-list-header__label cell-title ion-text-nowrap header-label-updated-by"
+            class="list-header-label cell-title ion-text-nowrap header-label-updated-by"
             v-if="ownProfile !== UserProfile.Outsider"
           >
             {{ $msTranslate('FoldersPage.listDisplayTitles.updatedBy') }}
           </ion-text>
           <ion-text
-            class="folder-list-header__label cell-title ion-text-nowrap header-label-last-update"
+            class="list-header-label cell-title ion-text-nowrap header-label-last-update"
             @click="onHeaderSortChange(SortProperty.LastUpdate)"
-            :class="{ 'header-label-last-update-sorted': currentSortProperty === SortProperty.LastUpdate }"
+            :class="{ 'list-header-label--sorted': currentSortProperty === SortProperty.LastUpdate }"
           >
-            <span class="header-label-last-update__text">{{ $msTranslate('FoldersPage.listDisplayTitles.lastUpdate') }}</span>
+            <span class="label-text">{{ $msTranslate('FoldersPage.listDisplayTitles.lastUpdate') }}</span>
             <ion-icon
               :icon="currentSortOrder ? arrowUp : arrowDown"
-              class="header-label-last-update__sort-icon"
+              class="sort-icon"
             />
           </ion-text>
           <ion-text
-            class="folder-list-header__label cell-title ion-text-nowrap header-label-creation-date"
+            class="list-header-label cell-title ion-text-nowrap header-label-creation-date"
             @click="onHeaderSortChange(SortProperty.CreationDate)"
-            :class="{ 'header-label-creation-date-sorted': currentSortProperty === SortProperty.CreationDate }"
+            :class="{ 'list-header-label--sorted': currentSortProperty === SortProperty.CreationDate }"
           >
-            <span class="header-label-creation-date__text">{{ $msTranslate('FoldersPage.listDisplayTitles.creation') }}</span>
+            <span class="label-text">{{ $msTranslate('FoldersPage.listDisplayTitles.creation') }}</span>
             <ion-icon
               :icon="currentSortOrder ? arrowUp : arrowDown"
-              class="header-label-creation-date__sort-icon"
+              class="sort-icon"
             />
           </ion-text>
           <ion-text
-            class="folder-list-header__label cell-title ion-text-nowrap header-label-size"
+            class="list-header-label cell-title ion-text-nowrap header-label-size list-header-label"
             @click="onHeaderSortChange(SortProperty.Size)"
-            :class="{ 'header-label-size-sorted': currentSortProperty === SortProperty.Size }"
+            :class="{ 'list-header-label--sorted': currentSortProperty === SortProperty.Size }"
           >
-            <span class="header-label-size__text">{{ $msTranslate('FoldersPage.listDisplayTitles.size') }}</span>
+            <span class="label-text">{{ $msTranslate('FoldersPage.listDisplayTitles.size') }}</span>
             <ion-icon
               :icon="currentSortOrder ? arrowUp : arrowDown"
-              class="header-label-size__sort-icon"
+              class="sort-icon"
             />
           </ion-text>
-          <ion-text class="folder-list-header__label cell-title ion-text-nowrap header-label-space" />
+          <ion-text class="list-header-label list-item-end cell-title ion-text-nowrap header-label-space" />
         </ion-list-header>
         <div>
           <file-list-item
@@ -243,6 +244,10 @@ async function scrollToSelected(): Promise<void> {
 .container-scroll {
   flex-grow: 1;
   overflow: auto;
+
+  @include ms.responsive-breakpoint('sm') {
+    overflow: hidden;
+  }
 }
 
 .header-label-selected {

--- a/client/src/components/files/explorer/FileListItem.vue
+++ b/client/src/components/files/explorer/FileListItem.vue
@@ -12,10 +12,10 @@
       button
       :lines="isLargeDisplay ? 'full' : 'none'"
       :detail="false"
-      class="file-list-item"
+      class="list-item file-list-item"
       :class="{
         selected: entry.isSelected,
-        'file-hovered': !entry.isSelected && (menuOpened || isHovered),
+        'file-list-item--hovered': !entry.isSelected && (menuOpened || isHovered),
         'file-list-item-mobile': isSmallDisplay,
       }"
       @dblclick="$emit('openItem', $event, entry)"
@@ -26,7 +26,7 @@
     >
       <div class="list-item-container file-list-item-container">
         <div
-          class="file-selected"
+          class="list-item-column file-selected"
           v-if="isLargeDisplay || entry.isSelected || showCheckbox"
         >
           <ms-checkbox
@@ -40,16 +40,39 @@
 
         <!-- file name -->
         <div
-          class="file-name"
+          class="list-item-column file-name"
           :class="{ 'file-mobile-content': isSmallDisplay }"
         >
           <ms-image
             :image="entry.isFile() ? getFileIcon(entry.name) : Folder"
             class="file-icon"
           />
-          <div class="file-mobile-text">
+
+          <!-- large display view -->
+          <ion-text
+            v-if="isLargeDisplay"
+            class="list-item-label label-name cell"
+            :class="{ selection: showCheckbox }"
+            :title="entry.name"
+            @click="showCheckbox ? null : !($event.metaKey || $event.ctrlKey) && $emit('openItem', $event, entry)"
+            @dblclick.stop
+          >
+            {{ entry.name }}
+          </ion-text>
+
+          <ion-icon
+            class="cloud-overlay"
+            :class="syncStatus.class"
+            :icon="syncStatus.icon"
+          />
+
+          <!-- small display view -->
+          <div
+            v-if="isSmallDisplay"
+            class="file-mobile-text"
+          >
             <ion-text
-              class="label-name cell"
+              class="list-item-label label-name cell"
               :class="{ selection: showCheckbox }"
               :title="entry.name"
               @click="showCheckbox ? null : !($event.metaKey || $event.ctrlKey) && $emit('openItem', $event, entry)"
@@ -57,10 +80,7 @@
             >
               {{ entry.name }}
             </ion-text>
-            <ion-text
-              v-if="isSmallDisplay"
-              class="file-mobile-text__data body-sm"
-            >
+            <ion-text class="list-item-label label-data body-sm">
               <span class="data-date">{{ $msTranslate(formatTimeSince(entry.updated, '--', 'short')) }}</span>
               <span v-if="entry.isFile()"> &bull; </span>
               <span
@@ -71,11 +91,7 @@
               </span>
             </ion-text>
           </div>
-          <ion-icon
-            class="cloud-overlay"
-            :class="syncStatus.class"
-            :icon="syncStatus.icon"
-          />
+
           <span
             v-if="entry.syncStatus === EntrySyncStatus.Uploading && entry.syncProgress"
             class="upload-progress button-small"
@@ -86,7 +102,7 @@
 
         <!-- updated by -->
         <div
-          class="file-updated-by"
+          class="list-item-column file-updated-by"
           v-if="entry.lastUpdater && isLargeDisplay && ownProfile !== UserProfile.Outsider"
         >
           <user-avatar-name
@@ -96,31 +112,31 @@
         </div>
 
         <!-- last update -->
-        <div class="file-last-update">
-          <ion-text class="label-last-update cell">
+        <div class="list-item-column file-last-update">
+          <ion-text class="list-item-label label-last-update cell">
             {{ $msTranslate(formatTimeSince(entry.updated, '--', 'short')) }}
           </ion-text>
         </div>
 
         <!-- creation date -->
-        <div class="file-creation-date">
-          <ion-text class="label-creation-date cell">
+        <div class="list-item-column file-creation-date">
+          <ion-text class="list-item-label label-creation-date cell">
             {{ $msTranslate(formatTimeSince(entry.created, '--', 'short')) }}
           </ion-text>
         </div>
 
         <!-- file size -->
-        <div class="file-size">
+        <div class="list-item-column file-size">
           <ion-text
             v-if="entry.isFile()"
-            class="label-size cell"
+            class="list-item-label label-size cell"
           >
             {{ $msTranslate(formatFileSize((entry as FileModel).size)) }}
           </ion-text>
         </div>
 
         <!-- options -->
-        <div class="file-options ion-item-child-clickable">
+        <div class="list-item-end file-options ion-item-child-clickable">
           <ion-button
             fill="clear"
             v-show="isHovered || menuOpened || isSmallDisplay"
@@ -198,4 +214,8 @@ async function onOptionsClick(event: PointerEvent): Promise<void> {
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.drop-zone-item {
+  height: fit-content;
+}
+</style>

--- a/client/src/components/files/explorer/FileListItemProcessing.vue
+++ b/client/src/components/files/explorer/FileListItemProcessing.vue
@@ -4,49 +4,49 @@
   <ion-item
     button
     lines="full"
-    class="ion-no-padding file-list-item-processing"
+    class="ion-no-padding list-item file-list-item-processing"
   >
     <div class="list-item-container">
-      <div class="file-loading">
+      <div class="list-item-column file-loading">
         <ms-spinner class="file-loading__spinner" />
       </div>
 
       <!-- file name -->
-      <div class="file-name">
+      <div class="list-item-column file-name">
         <ms-image
           v-if="isLargeDisplay"
           :image="getFileIcon(operation.entryName)"
           class="file-icon"
         />
 
-        <ion-text class="label-name cell">
+        <ion-text class="list-item-label label-name cell">
           {{ operation.entryName }}
         </ion-text>
       </div>
 
       <!-- updated by -->
-      <div class="file-updated-by" />
+      <div class="list-item-column file-updated-by" />
 
       <!-- last update -->
       <div
         v-if="profile !== UserProfile.Outsider"
-        class="file-last-update"
+        class="list-item-column file-last-update"
       >
-        <ion-text class="label-last-update cell" />
+        <ion-text class="list-item-label label-last-update cell" />
       </div>
 
       <!-- creation date -->
-      <div class="file-creation-date">
-        <ion-text class="label-creation-date cell">
+      <div class="list-item-column file-creation-date">
+        <ion-text class="list-item-label label-creation-date cell">
           {{ $msTranslate(operationLabel) }}
         </ion-text>
       </div>
 
       <!-- file size -->
-      <div class="file-size" />
+      <div class="list-item-column file-size" />
 
       <!-- options -->
-      <div class="file-empty ion-item-child-clickable" />
+      <div class="list-item-end file-empty ion-item-child-clickable" />
     </div>
   </ion-item>
 </template>
@@ -91,10 +91,6 @@ const operationLabel: Translatable = (() => {
 }
 
 .file-name {
-  position: relative;
-  display: flex;
-  gap: 1rem;
-
   .file-icon {
     min-width: 2rem;
     height: 2rem;

--- a/client/src/components/files/explorer/FileSearchResultItem.vue
+++ b/client/src/components/files/explorer/FileSearchResultItem.vue
@@ -5,10 +5,10 @@
     button
     :lines="isLargeDisplay ? 'full' : 'none'"
     :detail="false"
-    class="file-list-item result-list-item"
+    class="list-item file-list-item result-list-item"
     :class="{
       'file-list-item-mobile': isSmallDisplay,
-      'file-hovered': menuOpened || isHovered,
+      'file-list-item--hovered': menuOpened || isHovered,
     }"
     @mouseenter="isHovered = true"
     @mouseleave="isHovered = false"
@@ -17,7 +17,7 @@
     <div class="list-item-container file-list-item-container">
       <!-- file name -->
       <div
-        class="file-name file-name-results"
+        class="list-item-column file-name file-name-results"
         :class="{ 'file-mobile-content': isSmallDisplay }"
       >
         <ms-image
@@ -26,7 +26,7 @@
         />
         <div class="file-name-content">
           <ion-text
-            class="label-name button-medium"
+            class="list-item-label label-name button-medium"
             :title="searchItem.stats.name"
             @click="onClick"
           >
@@ -84,24 +84,24 @@
       </div>
 
       <!-- last update -->
-      <div class="file-last-update">
-        <ion-text class="label-last-update cell">
+      <div class="list-item-column file-last-update">
+        <ion-text class="list-item-label label-last-update cell">
           {{ $msTranslate(formatTimeSince(searchItem.stats.updated, '--', 'short')) }}
         </ion-text>
       </div>
 
       <!-- file size -->
-      <div class="file-size">
+      <div class="list-item-column file-size">
         <ion-text
           v-if="searchItem.stats.isFile()"
-          class="label-size cell"
+          class="list-item-label label-size cell"
         >
           {{ $msTranslate(formatFileSize((searchItem.stats as EntryStatFile).size)) }}
         </ion-text>
       </div>
 
       <!-- options -->
-      <div class="file-options ion-item-child-clickable">
+      <div class="list-item-end file-options ion-item-child-clickable">
         <ion-button
           fill="clear"
           v-show="isHovered || menuOpened || isSmallDisplay"

--- a/client/src/components/files/explorer/FileSearchResults.vue
+++ b/client/src/components/files/explorer/FileSearchResults.vue
@@ -47,25 +47,26 @@
       <ms-spinner v-show="active" />
     </div>
 
-    <div
-      class="results-list"
+    <ion-list
+      class="list-container files-list-container results-list-container"
       v-show="hasResults"
+      id="search-page-file-list"
     >
       <ion-list-header
-        class="folder-list-header"
+        class="list-header files-list-header"
         lines="full"
         v-if="isLargeDisplay"
       >
-        <ion-text class="folder-list-header__label cell-title ion-text-nowrap header-label-name header-label-name-results">
-          <span class="header-label-name__text">{{ $msTranslate('FoldersPage.listDisplayTitles.name') }}</span>
+        <ion-text class="list-header-label cell-title ion-text-nowrap header-label-name">
+          <span class="label-text">{{ $msTranslate('FoldersPage.listDisplayTitles.name') }}</span>
         </ion-text>
-        <ion-text class="folder-list-header__label cell-title ion-text-nowrap header-label-last-update">
-          <span class="header-label-last-update__text">{{ $msTranslate('FoldersPage.listDisplayTitles.lastUpdate') }}</span>
+        <ion-text class="list-header-label cell-title ion-text-nowrap header-label-last-update">
+          <span class="label-text">{{ $msTranslate('FoldersPage.listDisplayTitles.lastUpdate') }}</span>
         </ion-text>
-        <ion-text class="folder-list-header__label cell-title ion-text-nowrap header-label-size">
-          <span class="header-label-size__text">{{ $msTranslate('FoldersPage.listDisplayTitles.size') }}</span>
+        <ion-text class="list-header-label cell-title ion-text-nowrap header-label-size">
+          <span class="label-text">{{ $msTranslate('FoldersPage.listDisplayTitles.size') }}</span>
         </ion-text>
-        <ion-text class="folder-list-header__label cell-title ion-text-nowrap header-label-space" />
+        <ion-text class="list-header-label list-item-end cell-title ion-text-nowrap header-label-space" />
       </ion-list-header>
       <file-search-result-item
         v-for="result in filteredResults"
@@ -75,7 +76,7 @@
         @click="$emit('itemClick', $event)"
         @menu-click="(event, entry, onFinished) => $emit('menuItemClick', event, entry, onFinished)"
       />
-    </div>
+    </ion-list>
     <div
       v-show="!hasResults"
       class="results-empty"
@@ -101,7 +102,7 @@ import DocumentFilter from '@/components/files/explorer/DocumentFilter.vue';
 import FileSearchResultItem from '@/components/files/explorer/FileSearchResultItem.vue';
 import { DocumentFilters, DocumentFiltersIncludeAll, DocumentFiltersIncludeNone } from '@/components/files/types';
 import { EntryName, SearchResult } from '@/parsec';
-import { IonButton, IonIcon, IonListHeader, IonText } from '@ionic/vue';
+import { IonButton, IonIcon, IonList, IonListHeader, IonText } from '@ionic/vue';
 import { checkmark, text } from 'ionicons/icons';
 import { MsImage, MsReportText, MsReportTheme, MsSpinner, useWindowSize } from 'megashark-lib';
 import { computed, ref } from 'vue';
@@ -202,6 +203,10 @@ const documentFilters = ref<DocumentFilters>(DocumentFiltersIncludeNone());
   }
 }
 
+#search-page-file-list {
+  padding: 0;
+}
+
 .results-header {
   display: flex;
   gap: 0.5rem;
@@ -290,11 +295,11 @@ const documentFilters = ref<DocumentFilters>(DocumentFiltersIncludeNone());
   }
 }
 
-.results-list {
+.results-list-container {
   flex-grow: 1;
   overflow: auto;
 
-  .folder-list-header {
+  .files-list-header {
     background: var(--parsec-color-light-secondary-white);
     backdrop-filter: none;
   }

--- a/client/src/components/files/explorer/FolderSelectionModal.vue
+++ b/client/src/components/files/explorer/FolderSelectionModal.vue
@@ -139,7 +139,7 @@
             class="file-last-update"
             v-if="isLargeDisplay"
           >
-            <ion-label class="label-last-update cell">
+            <ion-label class="list-item-label label-last-update cell">
               {{ $msTranslate(formatTimeSince(entry[0].updated, '--', 'short')) }}
             </ion-label>
           </div>

--- a/client/src/components/files/explorer/HistoryFileListItem.vue
+++ b/client/src/components/files/explorer/HistoryFileListItem.vue
@@ -7,17 +7,17 @@
     :detail="false"
     :class="{
       selected: entry.isSelected,
-      'file-hovered': !entry.isSelected && isHovered,
+      'file-list-item--hovered': !entry.isSelected && isHovered,
       'is-folder': !entry.isFile(),
     }"
-    class="file-list-item history-file-list-item"
+    class="list-item file-list-item history-file-list-item"
     @click.stop="onSelectEntry(entry, !entry.isSelected)"
     @dblclick="$emit('click', $event, entry)"
     @mouseenter="isHovered = true"
     @mouseleave="isHovered = false"
   >
     <div class="list-item-container">
-      <div class="file-selected">
+      <div class="list-item-column file-selected">
         <!-- eslint-disable vue/no-mutating-props -->
         <ms-checkbox
           v-model="entry.isSelected"
@@ -30,13 +30,13 @@
       </div>
 
       <!-- file name -->
-      <div class="file-name">
+      <div class="list-item-column file-name">
         <ms-image
           :image="entry.isFile() ? getFileIcon(entry.name) : Folder"
           class="file-icon"
         />
         <ion-label
-          class="label-name cell"
+          class="list-item-label label-name cell"
           :class="{ selection: showCheckbox }"
           @click.stop="showCheckbox ? onSelectEntry(entry, !entry.isSelected) : $emit('click', $event, entry)"
         >
@@ -45,17 +45,17 @@
       </div>
 
       <!-- last update -->
-      <div class="file-last-update">
-        <ion-label class="label-last-update cell">
+      <div class="list-item-column file-last-update">
+        <ion-label class="list-item-label label-last-update cell">
           {{ $msTranslate(formatTimeSince(entry.updated, '--', 'short')) }}
         </ion-label>
       </div>
 
       <!-- file size -->
-      <div class="file-size">
+      <div class="list-item-column file-size">
         <ion-label
           v-if="entry.isFile()"
-          class="label-size cell"
+          class="list-item-label label-size cell"
         >
           {{ $msTranslate(formatFileSize((entry as WorkspaceHistoryFileModel).size)) }}
         </ion-label>
@@ -112,8 +112,13 @@ onMounted(async () => {
 </script>
 
 <style lang="scss" scoped>
+.history-file-list-item {
+  .list-item-container:has(.label-name:not(.selection):hover) .ms-checkbox {
+    outline: none !important;
+  }
+}
+
 .file-selected {
-  flex-shrink: 0;
   overflow: visible;
   width: 2.5rem;
 
@@ -123,10 +128,6 @@ onMounted(async () => {
 }
 
 .file-name {
-  position: relative;
-  display: flex;
-  gap: 1rem;
-
   .file-icon {
     width: 2rem;
     height: 2rem;

--- a/client/src/components/invitations/AsyncEnrollmentRequestItem.vue
+++ b/client/src/components/invitations/AsyncEnrollmentRequestItem.vue
@@ -3,7 +3,7 @@
 <template>
   <ion-item
     button
-    class="request-list-item"
+    class="list-item request-list-item"
     lines="full"
     :class="{
       'request-list-item--corrupted': request.identitySystem.tag === AsyncEnrollmentIdentitySystemTag.PKICorrupted,
@@ -55,10 +55,10 @@
 
       <!-- request avatar -->
       <div
-        class="request-name"
+        class="list-item-column request-name"
         v-if="isLargeDisplay"
       >
-        <ion-text class="request-name__label cell">
+        <ion-text class="list-item-label label-name cell">
           <user-avatar-name
             :user-avatar="humanHandle.label"
             :user-name="humanHandle.label"
@@ -68,10 +68,10 @@
 
       <!-- request mail -->
       <div
-        class="request-email"
+        class="list-item-column request-email"
         v-if="isLargeDisplay"
       >
-        <ion-text class="request-email__label cell">
+        <ion-text class="list-item-label label-email cell">
           <ion-icon
             :icon="warning"
             class="error-icon"
@@ -84,17 +84,17 @@
 
       <!-- request created on -->
       <div
-        class="request-createdOn"
+        class="list-item-column request-createdOn"
         v-if="isLargeDisplay"
       >
-        <ion-text class="request-createdOn__label cell">
+        <ion-text class="list-item-label label-created-on cell">
           {{ $msTranslate(formatTimeSince(request.submittedOn, '--', 'short')) }}
         </ion-text>
       </div>
 
       <!-- request type -->
       <div
-        class="request-type button-medium"
+        class="list-item-column request-type button-medium"
         v-if="isLargeDisplay"
       >
         <ion-text
@@ -119,15 +119,18 @@
       </div>
 
       <!-- actions -->
-      <div class="request-actions">
-        <ion-button
-          v-show="canAccept"
-          @click="$emit('acceptClick', request)"
-          class="primary-button button-medium button-default"
-          size="default"
-        >
-          {{ $msTranslate('InvitationsPage.asyncEnrollmentRequest.accept') }}
-        </ion-button>
+      <div class="list-item-end request-actions">
+        <div class="request-actions-primary">
+          <ion-button
+            v-show="canAccept"
+            @click="$emit('acceptClick', request)"
+            class="primary-button button-medium button-default"
+            size="default"
+          >
+            {{ $msTranslate('InvitationsPage.asyncEnrollmentRequest.accept') }}
+          </ion-button>
+        </div>
+
         <ion-text
           class="request-actions-secondary__text button-medium"
           :class="{ 'request-actions-secondary__text--active': showErrorDetails }"
@@ -153,6 +156,7 @@
         >
           {{ $msTranslate('InvitationsPage.asyncEnrollmentRequest.reject') }}
         </ion-button>
+
         <div
           class="request-actions-secondary"
           v-if="request.identitySystem.tag !== AsyncEnrollmentIdentitySystemTag.PKICorrupted"
@@ -382,9 +386,8 @@ onMounted(async () => {
   --background: var(--parsec-color-light-danger-50);
   --background-hover: var(--parsec-color-light-danger-50);
 
-  .request-email__label {
+  .label-email {
     display: flex;
-    align-items: center;
   }
 
   .request-type__label {

--- a/client/src/components/invitations/InvitationItem.vue
+++ b/client/src/components/invitations/InvitationItem.vue
@@ -22,33 +22,35 @@
 
     <!-- invitation mail -->
     <div
-      class="invitation-email"
+      class="list-item-column invitation-email"
       v-if="isLargeDisplay"
     >
-      <ion-text class="invitation-email__label cell">
+      <ion-text class="list-item-label label-email cell">
         {{ invitation.claimerEmail }}
       </ion-text>
     </div>
 
     <!-- invitation created on -->
     <div
-      class="invitation-sentOn"
+      class="list-item-column invitation-sentOn"
       v-if="isLargeDisplay"
     >
-      <ion-text class="invitation-sentOn__label cell">
+      <ion-text class="list-item-label label-sent-on cell">
         {{ $msTranslate(formatTimeSince(invitation.createdOn, '--', 'short')) }}
       </ion-text>
     </div>
 
     <!-- actions -->
-    <div class="invitation-actions">
-      <ion-button
-        @click="$emit('greetClick', invitation)"
-        class="primary-button button-medium button-default"
-        size="default"
-      >
-        {{ $msTranslate('InvitationsPage.emailInvitation.greet') }}
-      </ion-button>
+    <div class="list-item-end invitation-actions">
+      <div class="invitation-actions-primary">
+        <ion-button
+          @click="$emit('greetClick', invitation)"
+          class="primary-button button-medium button-default"
+          size="default"
+        >
+          {{ $msTranslate('InvitationsPage.emailInvitation.greet') }}
+        </ion-button>
+      </div>
       <div class="invitation-actions-secondary">
         <ion-button
           @click="$emit('copyLinkClick', invitation)"
@@ -172,6 +174,24 @@ defineEmits<{
 
     &__createdOn {
       color: var(--parsec-color-light-secondary-grey);
+    }
+  }
+}
+
+.invitation-actions-secondary__button {
+  &:last-of-type {
+    position: relative;
+    display: flex;
+    align-items: center;
+
+    &::before {
+      content: '';
+      position: relative;
+      display: block;
+      width: 2px;
+      height: calc(100% - 0.825rem);
+      background: var(--parsec-color-light-secondary-medium);
+      margin-right: 0.75rem;
     }
   }
 }

--- a/client/src/components/users/UserCard.vue
+++ b/client/src/components/users/UserCard.vue
@@ -10,7 +10,7 @@
       suspended: user.isFrozen(),
       'current-user': user.isCurrent,
       'no-padding-end': !user.isSelected,
-      'user-hovered': !user.isSelected && (menuOpened || isHovered),
+      'user-card-item--hovered': !user.isSelected && (menuOpened || isHovered),
     }"
     @click="$emit('select', user, !user.isSelected)"
     @mouseenter="isHovered = true"
@@ -53,24 +53,24 @@
           <span>{{ user.humanHandle.label }}</span>
           <span
             v-if="user.isCurrent"
-            class="body name-you"
+            class="body user-name--self"
           >
             {{ $msTranslate('UsersPage.currentUser') }}
           </span>
         </ion-text>
-        <div
-          class="user-card-info__email"
+        <ion-text
+          class="user-card-info__email label-email body-sm"
           :title="user.humanHandle.email"
           @click.stop="onCopyEmailClicked(user.humanHandle.email)"
         >
-          <ion-text class="email-label body-sm">{{ user.humanHandle.email }}</ion-text>
+          <span class="label-email__text">{{ user.humanHandle.email }}</span>
           <ion-icon
             v-if="!user.isCurrent"
             :icon="emailCopied ? checkmark : copy"
             class="email-copy-icon"
             :class="{ 'email-copy-icon--copied': emailCopied }"
           />
-        </div>
+        </ion-text>
       </div>
       <div class="user-card-profile">
         <user-profile-tag :profile="user.currentProfile" />
@@ -178,6 +178,90 @@ async function onCopyEmailClicked(email: string): Promise<void> {
       --fill-color: var(--parsec-color-light-secondary-grey);
     }
   }
+
+  .user-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1rem 0.5rem 1rem 1rem;
+    width: 100%;
+    margin: auto;
+    color: var(--parsec-color-light-secondary-text);
+
+    &-info {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+
+      &__name {
+        color: var(--parsec-color-light-secondary-text);
+        display: flex;
+        gap: 0.5rem;
+
+        span {
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          overflow: hidden;
+        }
+
+        .user-name--self {
+          color: var(--parsec-color-light-secondary-grey);
+        }
+      }
+
+      &__email {
+        color: var(--parsec-color-light-secondary-grey);
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        cursor: pointer;
+        gap: 0.125rem;
+
+        .label-email {
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          overflow: hidden;
+        }
+
+        .email-copy-icon {
+          display: none;
+          color: var(--parsec-color-light-secondary-soft-grey);
+          padding: 0 0.375rem;
+          border-radius: var(--parsec-radius-6);
+          font-size: 1rem;
+          cursor: pointer;
+          color: var(--parsec-color-light-secondary-grey);
+          flex-shrink: 0;
+
+          &--copied {
+            color: var(--parsec-color-light-success-700) !important;
+            display: flex !important;
+          }
+        }
+      }
+    }
+
+    &-profile {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+  }
+
+  &.user-card-item--hovered {
+    .email-copy-icon {
+      display: flex;
+    }
+    .label-email:hover {
+      color: var(--parsec-color-light-primary-600);
+
+      .email-copy-icon {
+        color: var(--parsec-color-light-primary-600);
+      }
+    }
+  }
 }
 
 .card-checkbox {
@@ -189,95 +273,5 @@ async function onCopyEmailClicked(email: string): Promise<void> {
   padding: 1rem;
   right: 0;
   bottom: 0;
-}
-
-.user-card {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  padding: 1rem 0.5rem 1rem 1rem;
-  width: 100%;
-  margin: auto;
-  color: var(--parsec-color-light-secondary-text);
-
-  &-info {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-
-    &__name {
-      color: var(--parsec-color-light-secondary-text);
-      display: flex;
-      gap: 0.5rem;
-
-      span {
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        overflow: hidden;
-      }
-
-      .name-you {
-        color: var(--parsec-color-light-secondary-text);
-        font-weight: 700;
-      }
-    }
-
-    &__email {
-      color: var(--parsec-color-light-secondary-grey);
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      overflow: hidden;
-    }
-  }
-
-  &-profile {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-  }
-}
-
-.user-card-item {
-  .user-card-info__email {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    gap: 0.125rem;
-  }
-
-  .email-label {
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-  }
-
-  .email-copy-icon {
-    display: none;
-    color: var(--parsec-color-light-secondary-soft-grey);
-    padding: 0 0.375rem;
-    border-radius: var(--parsec-radius-6);
-    font-size: 1rem;
-    cursor: pointer;
-    color: var(--parsec-color-light-secondary-grey);
-    flex-shrink: 0;
-
-    &--copied {
-      color: var(--parsec-color-light-success-700) !important;
-      display: flex !important;
-    }
-  }
-
-  &.user-hovered {
-    .email-copy-icon {
-      display: flex;
-    }
-    .user-card-info__email:hover {
-      color: var(--parsec-color-light-primary-600);
-
-      .email-copy-icon {
-        color: var(--parsec-color-light-primary-600);
-      }
-    }
-  }
 }
 </style>

--- a/client/src/components/users/UserListItem.vue
+++ b/client/src/components/users/UserListItem.vue
@@ -3,7 +3,7 @@
 <template>
   <ion-item
     button
-    class="user-list-item"
+    class="list-item user-list-item"
     lines="full"
     :detail="false"
     :class="{
@@ -11,14 +11,14 @@
       revoked: user.isRevoked(),
       'current-user': user.isCurrent,
       'no-padding-end': !user.isSelected,
-      'user-hovered': !user.isSelected && (menuOpened || isHovered),
+      'user-list-item--hovered': !user.isSelected && (menuOpened || isHovered),
     }"
     @click="$emit('select', user, !user.isSelected)"
     @mouseenter="isHovered = true"
     @mouseleave="isHovered = false"
     @contextmenu="onOptionsClick"
   >
-    <div class="user-selected">
+    <div class="list-item-column user-selected">
       <ms-checkbox
         :class="{ 'checkbox-mobile': isSmallDisplay }"
         :checked="user.isSelected"
@@ -36,24 +36,24 @@
 
     <!-- user name -->
     <div
-      class="user-name"
+      class="list-item-column user-name"
       v-if="isLargeDisplay"
     >
-      <ion-text class="user-name__label cell">
+      <ion-text class="list-item-label label-name cell">
         <user-avatar-name
           :user-avatar="user.humanHandle.label"
           :user-name="user.humanHandle.label"
         />
         <span
           v-if="user.isCurrent"
-          class="body user-name__you"
+          class="body user-name--self"
         >
           {{ $msTranslate('UsersPage.currentUser') }}
         </span>
       </ion-text>
     </div>
     <div
-      class="user-mobile"
+      class="list-item-column user-mobile"
       v-if="isSmallDisplay"
     >
       <user-avatar-name
@@ -69,43 +69,43 @@
           <span class="user-mobile-text__name">{{ user.humanHandle.label }}</span>
           <span
             v-if="user.isCurrent"
-            class="body-sm user-mobile-text__you"
+            class="body-sm user-mobile-text__name--self"
           >
             {{ $msTranslate('UsersPage.currentUser') }}
           </span>
         </ion-text>
-        <ion-text class="cell user-mobile-text__email">
+        <ion-text class="button-medium user-mobile-text__email">
           {{ user.humanHandle.email }}
         </ion-text>
-        <div class="user-mobile-text__profile-status">
+        <div class="user-mobile-text-info">
           <user-profile-tag
             :profile="user.currentProfile"
-            class="user-mobile-text__profile"
+            class="user-mobile-text-info__profile"
           />
           <user-status-tag
             :revoked="user.isRevoked()"
             :frozen="user.isFrozen()"
             :show-tooltip="true"
             v-if="!user.isActive()"
-            class="user-mobile-text__status"
+            class="user-mobile-text-info__status"
           />
         </div>
       </div>
     </div>
 
     <!-- user profile -->
-    <div class="user-profile">
+    <div class="list-item-column user-profile">
       <user-profile-tag :profile="user.currentProfile" />
     </div>
 
     <!-- user mail -->
-    <div class="user-email">
+    <div class="list-item-column user-email">
       <ion-text
-        class="user-email__label cell"
+        class="list-item-label label-email cell"
         :title="user.humanHandle.email"
         @click.stop="onCopyEmailClicked(user.humanHandle.email)"
       >
-        {{ user.humanHandle.email }}
+        <span class="label-email__text">{{ user.humanHandle.email }}</span>
         <ion-icon
           v-if="!user.isCurrent"
           :icon="emailCopied ? checkmark : copy"
@@ -116,15 +116,15 @@
     </div>
 
     <!-- user joined on -->
-    <div class="user-join">
-      <ion-text class="user-join-label cell">
+    <div class="list-item-column user-join">
+      <ion-text class="list-item-label label-join-date cell">
         {{ $msTranslate(formatTimeSince(user.createdOn, '--', 'short')) }}
       </ion-text>
     </div>
 
     <!-- user status -->
     <div
-      class="user-status"
+      class="list-item-column user-status"
       :class="user.isRevoked() ? 'user-revoked' : ''"
     >
       <user-status-tag
@@ -135,7 +135,7 @@
     </div>
 
     <!-- options -->
-    <div class="user-options ion-item-child-clickable">
+    <div class="list-item-end user-options ion-item-child-clickable">
       <ion-button
         v-show="(isHovered || menuOpened || isSmallDisplay) && !user.isCurrent"
         fill="clear"
@@ -206,17 +206,22 @@ async function onOptionsClick(event: Event): Promise<void> {
 </script>
 
 <style scoped lang="scss">
+.user-selected .checkbox {
+  @include ms.responsive-breakpoint('sm') {
+    max-width: 100%;
+    width: 100%;
+  }
+}
+
 .user-name {
-  &__label {
+  .label-name {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    overflow: hidden;
   }
 
-  &__you {
-    color: var(--parsec-color-light-secondary-text);
-    font-weight: 700;
+  &--self {
+    color: var(--parsec-color-light-secondary-grey);
   }
 }
 
@@ -227,7 +232,7 @@ async function onOptionsClick(event: Event): Promise<void> {
   gap: 0.75rem;
   padding: 0.75rem 0.5rem;
 
-  .user-mobile-avatar {
+  &-avatar {
     pointer-events: none;
     padding: 0.5rem;
 
@@ -245,62 +250,67 @@ async function onOptionsClick(event: Event): Promise<void> {
     display: flex;
     flex-direction: column;
     gap: 0.375rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     &__name {
       color: var(--parsec-color-light-secondary-text);
-    }
-
-    &__you {
-      color: var(--parsec-color-light-primary-600);
-      margin-left: 0.25rem;
     }
 
     &__email {
       color: var(--parsec-color-light-secondary-grey);
     }
 
-    &__profile-status {
+    &-info {
+      margin-top: 0.25rem;
       display: flex;
       gap: 0.5rem;
     }
   }
 }
 
-.user-status,
-.user-join,
-.user-email {
-  color: var(--parsec-color-light-secondary-grey);
-}
-
+// manage copy email icon visibility on hover
 .user-list-item {
-  .user-email__label {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    gap: 0.125rem;
-  }
+  .user-email {
+    .label-email {
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      flex-wrap: nowrap;
+      width: 100%;
+      gap: 0.125rem;
 
-  .email-copy-icon {
-    display: none;
-    color: var(--parsec-color-light-secondary-soft-grey);
-    padding: 0.375rem;
-    border-radius: var(--parsec-radius-6);
-    font-size: 1rem;
-    cursor: pointer;
-    color: var(--parsec-color-light-secondary-grey);
-    flex-shrink: 0;
+      &__text {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
 
-    &--copied {
-      color: var(--parsec-color-light-success-700) !important;
-      display: flex !important;
+    .email-copy-icon {
+      display: none;
+      color: var(--parsec-color-light-secondary-soft-grey);
+      padding: 0.375rem;
+      border-radius: var(--parsec-radius-6);
+      font-size: 1rem;
+      cursor: pointer;
+      color: var(--parsec-color-light-secondary-grey);
+      flex-shrink: 0;
+
+      &--copied {
+        color: var(--parsec-color-light-success-700) !important;
+        display: flex !important;
+      }
     }
   }
 
-  &.user-hovered {
+  &.user-list-item--hovered {
     .email-copy-icon {
       display: flex;
     }
-    .user-email__label:hover {
+
+    .label-email:hover {
       color: var(--parsec-color-light-primary-600);
 
       .email-copy-icon {
@@ -308,14 +318,19 @@ async function onOptionsClick(event: Event): Promise<void> {
       }
     }
   }
+}
 
-  &.current-user {
-    --background: var(--parsec-color-light-secondary-background);
+.current-user {
+  --background: var(--parsec-color-light-secondary-background);
 
-    .lock-icon {
-      width: 1.25rem;
-      --fill-color: var(--parsec-color-light-secondary-grey);
-    }
+  .user-mobile-avatar {
+    visibility: hidden;
+  }
+
+  .lock-icon {
+    z-index: 2;
+    width: 1.25rem;
+    --fill-color: var(--parsec-color-light-secondary-grey);
   }
 }
 </style>

--- a/client/src/components/workspaces/WorkspaceCard.vue
+++ b/client/src/components/workspaces/WorkspaceCard.vue
@@ -4,7 +4,7 @@
   <div
     class="workspace-card-item ion-no-padding"
     :class="{
-      'workspace-hovered': isHovered || menuOpened,
+      'workspace-card-item--hovered': isHovered || menuOpened,
       'workspace-card-item--hidden': isHidden,
       'workspace-card-item--archived': workspace.isArchived,
       'workspace-card-item--trashed': workspace.isTrashed,

--- a/client/src/components/workspaces/WorkspaceListItem.vue
+++ b/client/src/components/workspaces/WorkspaceListItem.vue
@@ -6,7 +6,7 @@
     class="workspace-list-item no-padding-end"
     :detail="false"
     :class="{
-      'workspace-hovered': isHovered || menuOpened,
+      'workspace-list-item--hovered': isHovered || menuOpened,
       'workspace-list-item--hidden': isHidden || workspace.isArchived,
     }"
     @click="$emit('click', workspace, $event)"
@@ -17,7 +17,7 @@
     <div class="workspace-list-item-content">
       <div
         v-show="!workspace.isArchived"
-        class="workspace-favorite-icon"
+        class="list-item-column workspace-favorite-icon"
         :class="{
           'workspace-favorite-icon__on': isFavorite,
           'workspace-favorite-icon__off': !isFavorite,
@@ -34,7 +34,7 @@
       />
       <!-- workspace name -->
       <div
-        class="workspace-name"
+        class="list-item-column workspace-name"
         :title="workspace.name"
       >
         <ion-text class="workspace-name__label title-h4">
@@ -43,11 +43,11 @@
       </div>
       <ion-icon
         v-if="workspace.isArchived"
-        class="workspace-archive"
+        class="list-item-column workspace-archive"
         :icon="archive"
       />
       <div
-        class="workspace-hidden"
+        class="list-item-column workspace-hidden"
         v-if="isHidden && !workspace.isArchived"
       >
         <ion-icon
@@ -58,7 +58,7 @@
       </div>
 
       <!-- role user -->
-      <div class="workspace-role">
+      <div class="list-item-column workspace-role">
         <workspace-role-tag
           v-if="!workspace.isArchived && windowWidth > WindowSizeBreakpoints.XS"
           :role="workspace.selfRole"
@@ -82,7 +82,7 @@
 
       <!-- user avatars -->
       <div
-        class="workspace-users"
+        class="list-item-column workspace-users"
         v-show="clientProfile !== UserProfile.Outsider"
         v-if="isLargeDisplay && windowWidth >= WindowSizeBreakpoints.MD && !workspace.isArchived"
       >
@@ -104,17 +104,17 @@
 
       <!-- last update -->
       <div
-        class="workspace-last-update"
+        class="list-item-column workspace-last-update"
         v-show="workspace.isArchived"
       >
-        <ion-label class="label-last-update cell">
+        <ion-label class="list-item-label label-last-update cell">
           {{ $msTranslate(formatTimeSince(workspace.lastUpdated, '--', 'short')) }}
         </ion-label>
       </div>
 
       <!-- workspace size -->
       <div
-        class="workspace-size"
+        class="list-item-column workspace-size"
         v-show="false"
       >
         <ion-label class="label-size cell">
@@ -123,7 +123,7 @@
       </div>
 
       <!-- options -->
-      <div class="workspace-options">
+      <div class="list-item-end workspace-options">
         <ion-button
           fill="clear"
           class="options-button"
@@ -204,6 +204,7 @@ async function onOptionsClick(event: Event): Promise<void> {
   transition: all 0.15s ease-in-out;
 
   &::part(native) {
+    cursor: pointer !important;
     width: -webkit-fill-available;
     padding-left: 0;
     margin: 0.25rem;
@@ -217,6 +218,10 @@ async function onOptionsClick(event: Event): Promise<void> {
     align-items: center;
     width: 100%;
     height: 3rem;
+  }
+
+  .list-item-column {
+    cursor: pointer !important;
   }
 
   &:hover {

--- a/client/src/components/workspaces/WorkspaceUserRole.vue
+++ b/client/src/components/workspaces/WorkspaceUserRole.vue
@@ -9,7 +9,7 @@
       />
       <span
         v-if="isCurrentUser"
-        class="body content-user__you"
+        class="body content-user--self"
       >
         {{ $msTranslate('UsersPage.currentUser') }}
       </span>
@@ -113,7 +113,7 @@ function onRoleChanged(user: UserTuple, newRoleOption: MsOption, oldRoleOption?:
   align-items: center;
   gap: 0.5rem;
 
-  &__you {
+  &--self {
     color: var(--parsec-color-light-secondary-grey);
   }
 }

--- a/client/src/theme/components/_grid.scss
+++ b/client/src/theme/components/_grid.scss
@@ -4,6 +4,14 @@
 // at the moment, we are forced to put this in every scss file, since vite is not adding preprocessors additionalData to files imported by @use & @forward
 @use 'megashark-lib/theme' as ms;
 
+.grid-container {
+  padding-top: 2rem;
+
+  @include ms.responsive-breakpoint('sm') {
+    padding-top: 0;
+  }
+}
+
 .file-card-item,
 .user-card-item,
 .workspace-card-item {

--- a/client/src/theme/components/_list.scss
+++ b/client/src/theme/components/_list.scss
@@ -4,11 +4,9 @@
 // at the moment, we are forced to put this in every scss file, since vite is not adding preprocessors additionalData to files imported by @use & @forward
 @use 'megashark-lib/theme' as ms;
 
-/* ------- Workspaces, Files, Users ------- */
-.user-list-header,
-.folder-list-header,
-.invitations-list-header,
-.requests-list-header {
+/* ------- Global list header ------- */
+
+.list-header {
   color: var(--parsec-color-light-secondary-grey);
   padding-inline-start: 0;
   position: sticky;
@@ -16,14 +14,58 @@
   z-index: 100;
   background: var(--parsec-color-light-secondary-opacity30);
   backdrop-filter: blur(10px);
+
+  &::part(inner) {
+    border: none;
+    padding: 0 1rem 0 0;
+    width: 100%;
+  }
 }
 
-.file-list-item,
-.file-list-item-processing,
-.user-list-item {
+.list-header-label {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--parsec-color-light-secondary-soft-text);
+
+    .sort-icon {
+      display: block;
+    }
+  }
+
+  .label-text {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .sort-icon {
+    display: none;
+    flex-shrink: 0;
+    font-size: 0.875rem;
+  }
+
+  &--sorted {
+    color: var(--parsec-color-light-secondary-soft-text);
+
+    .sort-icon {
+      display: block;
+    }
+  }
+}
+
+/* ------- Global list items ------- */
+
+.list-item {
   border-radius: var(--parsec-radius-4);
   --show-full-highlight: 0;
-  display: flex;
   --padding-start: 0px;
   --inner-padding-end: 0px;
   --background-hover: var(--parsec-color-light-primary-30);
@@ -33,11 +75,7 @@
     border: none;
     width: 100%;
     cursor: default;
-  }
-
-  .options-button__icon {
-    font-size: 1.25rem;
-    flex-shrink: 0;
+    padding: 0 1rem 0 0;
   }
 
   // border between items
@@ -52,10 +90,6 @@
     background: var(--parsec-color-light-secondary-medium);
     z-index: 1;
     cursor: default;
-
-    @include ms.responsive-breakpoint('sm') {
-      left: 4rem;
-    }
   }
 
   &.selected {
@@ -89,79 +123,47 @@
   &-sorted {
     color: var(--parsec-color-light-secondary-soft-text);
 
-    ion-icon {
+    .sort-icon {
       display: block;
     }
   }
 }
 
-.workspace-list-item-content > [class^='workspace-'],
-.list-item-container > [class^='file-'],
-.user-list-item > [class^='user-'] {
-  padding: 0 1rem;
+.list-item-container {
+  display: flex;
+  width: 100%;
+  padding: 0;
+}
+
+.list-item-label {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+
+.list-item-column {
+  padding: 0.5rem 1rem;
   display: flex;
   align-items: center;
   overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--parsec-color-light-secondary-grey);
   --background-hover-opacity: 1;
   --background-hover: var(--parsec-color-light-primary-30);
   cursor: default !important;
-}
 
-// ------- File & User -------
-.files-container-list,
-.users-container-list {
-  .header-label-selected,
-  .header-label-name,
-  .header-label-updated-by,
-  .header-label-last-update,
-  .header-label-creation-date,
-  .header-label-join-date,
-  .header-label-profile,
-  .header-label-email,
-  .header-label-size {
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    padding: 0.5rem 1rem;
-    cursor: pointer;
-
-    &:hover {
-      color: var(--parsec-color-light-secondary-soft-text);
-
-      ion-icon {
-        display: block;
-      }
-    }
-
-    &__text {
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-    }
-
-    &__sort-icon {
-      display: none;
-      flex-shrink: 0;
-      font-size: 0.875rem;
-    }
-
-    &-sorted {
-      color: var(--parsec-color-light-secondary-soft-text);
-
-      ion-icon {
-        display: block;
-      }
-    }
+  .checkbox {
+    max-width: 1.25rem;
   }
 }
 
-.file-options,
-.user-options {
+.list-item-end {
   display: flex;
   justify-content: flex-end;
+  margin-left: auto;
+  flex-shrink: 0;
 
   .options-button {
     --background-hover: none;
@@ -172,6 +174,7 @@
 
     &__icon {
       color: var(--parsec-color-light-secondary-grey);
+      font-size: 1.25rem;
     }
 
     &:hover {
@@ -181,435 +184,297 @@
     }
   }
 }
-.file-selected,
-.user-selected {
-  .checkbox {
-    max-width: 1.25rem;
-  }
-}
 
-.user-selected {
-  .checkbox {
-    @include ms.responsive-breakpoint('sm') {
-      max-width: 100%;
-      width: 100%;
-    }
-  }
-}
+/* ------- Column sizing ------- */
 
-// Allow to keep hover when context menu is open
-.file-hovered,
-.user-hovered:not(.revoked) {
-  --background: var(--parsec-color-light-primary-30) !important;
-  background-color: var(--parsec-color-light-primary-30) !important;
+.list-container {
+  // File list
+  &:has(.files-list-container),
+  &:has(.file-list-item) {
+    .header-label-selected,
+    .file-selected,
+    .file-loading {
+      flex-basis: 4rem;
+      min-width: 4rem;
+      max-width: 4rem;
+      justify-content: end;
 
-  .ms-checkbox {
-    outline: 1px solid var(--parsec-color-light-primary-300);
-    outline-offset: 2px;
-  }
-}
-
-// ------- Workspaces only -------
-.workspace-list-item-content > [class^='workspace-'],
-.workspace-list-item::part(native) {
-  cursor: pointer !important;
-}
-
-.workspace-hovered {
-  background: var(--parsec-color-light-secondary-white);
-}
-
-// ------- Files/folders only -------
-.folder-container {
-  .list-item-container {
-    display: flex;
-    width: 100%;
-    padding: 0;
-  }
-
-  .label-name,
-  .label-last-update,
-  .label-creation-date,
-  .label-size {
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    width: 100%;
-  }
-
-  // Define the width of each cell
-  --width-cell-selected: 4rem;
-  --width-cell-name: calc(40% - var(--width-cell-selected) - var(--width-cell-options));
-  --width-cell-updated-by: 20%;
-  --width-cell-last-update: 15%;
-  --width-cell-creation-date: 15%;
-  --width-cell-size: 10%;
-  --width-cell-options: 4rem;
-
-  @include ms.responsive-breakpoint('xl') {
-    --width-cell-name: calc(45% - var(--width-cell-selected) - var(--width-cell-options));
-    --width-cell-updated-by: 25%;
-    --width-cell-last-update: 20%;
-    --width-cell-creation-date: 0;
-    --width-cell-size: 10%;
-  }
-
-  @include ms.responsive-breakpoint('lg') {
-    --width-cell-name: calc(60% - var(--width-cell-selected) - var(--width-cell-options));
-    --width-cell-updated-by: 0;
-    --width-cell-last-update: 20%;
-    --width-cell-size: 20%;
-  }
-
-  @include ms.responsive-breakpoint('md') {
-    --width-cell-name: calc(70% - var(--width-cell-selected) - var(--width-cell-options));
-    --width-cell-last-update: 15%;
-    --width-cell-size: 15%;
-  }
-
-  @include ms.responsive-breakpoint('sm') {
-    --width-cell-name: calc(100% - var(--width-cell-selected));
-    --width-cell-last-update: 0;
-    --width-cell-size: 0;
-  }
-
-  .header-label-selected,
-  .file-selected,
-  .file-loading {
-    flex-basis: var(--width-cell-selected);
-    max-width: var(--width-cell-selected);
-    justify-content: end;
-
-    @include ms.responsive-breakpoint('sm') {
-      padding: 0;
-    }
-  }
-
-  .header-label-name,
-  .file-name {
-    flex-basis: var(--width-cell-name);
-    padding: 0.5rem 1rem;
-
-    @include ms.responsive-breakpoint('sm') {
-      padding: 0.75rem 1rem;
-    }
-  }
-
-  .header-label-name-results,
-  .file-name-results {
-    flex-basis: 40rem;
-    padding: 0.5rem 1rem;
-
-    @include ms.responsive-breakpoint('sm') {
-      padding: 0.75rem 1rem;
-    }
-  }
-
-  .header-label-updated-by,
-  .file-updated-by {
-    flex-basis: var(--width-cell-updated-by);
-
-    @include ms.responsive-breakpoint('lg') {
-      display: none;
-    }
-  }
-
-  .header-label-last-update,
-  .file-last-update {
-    flex-basis: var(--width-cell-last-update);
-    min-width: 6rem;
-
-    @include ms.responsive-breakpoint('sm') {
-      display: none;
-    }
-  }
-
-  .header-label-creation-date,
-  .file-creation-date {
-    flex-basis: var(--width-cell-creation-date);
-
-    @include ms.responsive-breakpoint('xl') {
-      display: none;
-    }
-  }
-
-  .header-label-size,
-  .file-size {
-    flex-basis: var(--width-cell-size);
-
-    @include ms.responsive-breakpoint('sm') {
-      display: none;
-    }
-  }
-
-  .label-size:is(.cell),
-  .label-creation-date:is(.cell),
-  .label-last-update:is(.cell) {
-    color: var(--parsec-color-light-secondary-hard-grey);
-  }
-
-  .header-label-space,
-  .file-options,
-  .file-empty {
-    flex-basis: var(--width-cell-options);
-    position: sticky;
-    right: 0;
-    margin-left: auto;
-  }
-
-  // Set special drop zone style when dragging elements on folder
-  .files-list-container .drop-zone-active .drop-zone-dashed {
-    left: 0.5rem !important;
-    top: 0.25rem !important;
-    right: 0.5rem !important;
-    bottom: 0.25rem !important;
-    background: hsla(214, 100%, 60%, 0.3);
-  }
-
-  // for FileSearchResultItem and FileListItem components
-  // --- start ---
-  .drop-zone-item {
-    height: fit-content;
-  }
-
-  .file-name {
-    position: relative;
-    display: flex;
-    gap: 1rem;
-
-    .file-icon {
-      width: 2rem;
-      height: 2rem;
-      flex-shrink: 0;
-    }
-
-    .label-name {
-      color: var(--parsec-color-light-secondary-text);
-
-      &:not(.selection):hover {
-        text-decoration: underline;
-        cursor: pointer !important;
+      @include ms.responsive-breakpoint('sm') {
+        padding: 0;
+        flex-basis: 2.5rem;
+        max-width: 2.5rem;
       }
     }
 
-    .cloud-overlay {
-      font-size: 1rem;
-      flex-shrink: 0;
-      margin-left: auto;
-      position: absolute;
-      right: 0;
+    .header-label-name,
+    .file-name {
+      flex-basis: calc(40% - 8rem);
+
+      @include ms.responsive-breakpoint('xl') {
+        flex-basis: calc(45% - 8rem);
+      }
+
+      @include ms.responsive-breakpoint('lg') {
+        flex-basis: calc(60% - 8rem);
+      }
+
+      @include ms.responsive-breakpoint('md') {
+        flex-basis: calc(70% - 8rem);
+      }
+
+      @include ms.responsive-breakpoint('sm') {
+        flex-basis: calc(100% - 4rem);
+        padding: 0.75rem 1rem;
+      }
+    }
+
+    .files-list-header .header-label-name,
+    .result-list-item .file-name {
+      flex-basis: 40rem;
+
+      @include ms.responsive-breakpoint('sm') {
+        padding: 0.75rem 1rem;
+      }
+    }
+
+    .header-label-updated-by,
+    .file-updated-by {
+      flex-basis: 20%;
+      min-width: 20%;
+
+      @include ms.responsive-breakpoint('xl') {
+        min-width: 20%;
+        flex-basis: 25%;
+      }
+
+      @include ms.responsive-breakpoint('lg') {
+        display: none;
+      }
+    }
+
+    .header-label-last-update,
+    .file-last-update {
+      flex-basis: 15%;
+      min-width: 15%;
+
+      @include ms.responsive-breakpoint('xl') {
+        flex-basis: 20%;
+        min-width: 20%;
+      }
+
+      @include ms.responsive-breakpoint('md') {
+        flex-basis: 15%;
+        min-width: 15%;
+      }
 
       @include ms.responsive-breakpoint('sm') {
         display: none;
       }
-
-      &-ok {
-        color: var(--parsec-color-light-primary-500);
-      }
-
-      &-ko {
-        color: var(--parsec-color-light-secondary-grey);
-      }
-    }
-  }
-
-  .file-list-item-mobile {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    margin: 0 0.5rem;
-    border-radius: var(--parsec-radius-8);
-
-    .file-mobile-content {
-      gap: 1rem;
-      width: 100%;
     }
 
-    .file-selected {
-      max-width: 2.5rem;
-      overflow: visible;
-    }
-  }
+    .header-label-creation-date,
+    .file-creation-date {
+      flex-basis: 15%;
+      min-width: 15%;
 
-  .file-mobile-text {
-    flex-grow: 1;
-    overflow: hidden;
-    color: var(--parsec-color-light-secondary-grey);
-    display: flex;
-    gap: 0.125rem;
-    flex-direction: column;
-
-    &__data {
-      display: flex;
-      gap: 0.5rem;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-
-      span {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+      @include ms.responsive-breakpoint('xl') {
+        display: none;
       }
     }
-  }
 
-  .file-list-item.file-hovered,
-  .file-card-item.file-hovered {
-    .file-list-item-container:has(.label-name:not(.selection):hover) .ms-checkbox,
-    .drop-zone:has(.file-card__title:not(.selection):hover) .ms-checkbox {
-      outline: none;
+    .header-label-size,
+    .file-size {
+      flex-basis: 10%;
+      min-width: 10%;
+
+      @include ms.responsive-breakpoint('lg') {
+        flex-basis: 20%;
+        min-width: 20%;
+      }
+
+      @include ms.responsive-breakpoint('md') {
+        flex-basis: 15%;
+        min-width: 15%;
+      }
+
+      @include ms.responsive-breakpoint('sm') {
+        display: none;
+      }
+    }
+
+    .label-size:is(.cell),
+    .label-creation-date:is(.cell),
+    .label-last-update:is(.cell) {
+      color: var(--parsec-color-light-secondary-hard-grey);
+    }
+
+    .header-label-space,
+    .file-options,
+    .file-empty {
+      flex-basis: 4rem;
+      position: sticky;
+      right: 0;
     }
   }
-  // --- end ----
 
-  .history-file-list-item {
-    .list-item-container:has(.label-name:not(.selection):hover) .ms-checkbox {
-      outline: none;
-    }
-  }
-
-  &:has(.file-search-results) {
-    background: var(--parsec-color-light-secondary-background);
-    padding: 1.5rem;
-    overflow: hidden;
-
-    @include ms.responsive-breakpoint('sm') {
-      padding: 0;
-    }
-  }
-
-  // Show upload progress only on hover
-  .upload-progress {
-    color: var(--parsec-color-light-secondary-text);
-    visibility: hidden;
-  }
-
-  .file-list-item .upload-progress {
-    position: relative;
-    right: 0.375rem;
-  }
-
-  .file-card-item .upload-progress {
-    position: absolute;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: var(--parsec-radius-circle);
-    left: 58%;
-    bottom: -8px;
-    width: 1.75rem;
-    height: 1.75rem;
-    background: var(--parsec-color-light-secondary-white);
-    text-wrap: nowrap;
-  }
-
-  .file-list-item:hover,
-  .file-card-item:hover {
-    .upload-progress {
-      visibility: visible;
-    }
-  }
-}
-
-// ------- Users only -------
-.users-container-list {
-  .user-list-item {
-    display: flex;
-    width: 100%;
-  }
-
-  .user-list-header__label {
-    padding: 0 1rem;
-    height: 100%;
-    display: flex;
-    align-items: center;
-  }
-
-  .header-label-selected,
-  .user-selected {
-    min-width: 4rem;
-    flex-grow: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    @include ms.responsive-breakpoint('sm') {
-      padding: 1rem;
-      position: absolute;
+  // User list
+  &:has(.users-list-container),
+  &:has(.user-list-item) {
+    .header-label-selected,
+    .user-selected {
+      min-width: 4rem;
+      flex-grow: 0;
       justify-content: center;
+
+      @include ms.responsive-breakpoint('sm') {
+        padding: 1rem;
+        position: absolute;
+      }
+    }
+
+    .header-label-name,
+    .user-name {
+      width: 100%;
+      min-width: 11.25rem;
+      max-width: 25rem;
+
+      @include ms.responsive-breakpoint('sm') {
+        max-width: 100%;
+      }
+    }
+
+    .header-label-profile:not(.user-mobile-text-info__profile),
+    .user-profile {
+      max-width: 9.5rem;
+      width: 9.5rem;
+      flex-shrink: 0;
+
+      @include ms.responsive-breakpoint('sm') {
+        display: none;
+      }
+    }
+
+    .header-label-email,
+    .user-email {
+      min-width: 12rem;
+      width: 16rem;
+      flex-grow: 1;
+
+      @include ms.responsive-breakpoint('lg') {
+        display: none;
+      }
+    }
+
+    .header-label-join-date,
+    .user-join {
+      min-width: 11.25rem;
+      flex-grow: 0;
+
+      @include ms.responsive-breakpoint('xl') {
+        display: none;
+      }
+    }
+
+    .header-label-status:not(.user-mobile-text-info__status),
+    .user-status {
+      flex: 0 0 8rem;
+
+      @include ms.responsive-breakpoint('md') {
+        display: none;
+      }
+    }
+
+    .header-label-space,
+    .user-options {
+      min-width: 4rem;
+      flex: 1 0 4rem;
+      padding: 0.75rem;
     }
   }
 
-  .header-label-name,
-  .user-name {
-    width: 100%;
-    min-width: 11.25rem;
-    max-width: 25rem;
-    white-space: nowrap;
-    overflow: hidden;
-    padding: 0.5rem 1rem;
+  // PKI Requests
+  &:has(.requests-list-container),
+  &:has(.request-list-item) {
+    .label-name,
+    .request-name {
+      width: 100%;
+      min-width: 11.25rem;
+      max-width: 25rem;
 
-    @include ms.responsive-breakpoint('sm') {
-      max-width: 100%;
+      @include ms.responsive-breakpoint('sm') {
+        max-width: 100%;
+      }
+    }
+
+    .label-email,
+    .request-email {
+      min-width: 16rem;
+      max-width: 16rem;
+      flex-grow: 1;
+
+      @include ms.responsive-breakpoint('lg') {
+        display: none;
+      }
+    }
+
+    .label-createdOn,
+    .request-createdOn {
+      min-width: 11.25rem;
+      flex-grow: 0;
+
+      @include ms.responsive-breakpoint('xl') {
+        display: none;
+      }
+    }
+
+    .label-type,
+    .request-type {
+      min-width: 12rem;
+      max-width: 12rem;
+
+      @include ms.responsive-breakpoint('sm') {
+        min-width: fit-content;
+        flex-basis: auto;
+      }
+    }
+
+    .label-space,
+    .request-actions {
+      min-height: 1rem;
+      min-width: 15rem;
+      flex-grow: 0;
     }
   }
 
-  .header-label-profile:not(.user-mobile-text__profile),
-  .user-profile {
-    max-width: 9.5rem;
-    width: 9.5rem;
-    flex-shrink: 0;
+  // Invitations
+  &:has(.invitations-list-container),
+  &:has(.invitation-list-item) {
+    .label-email,
+    .invitation-email {
+      width: 100%;
+      min-width: 11.25rem;
+      max-width: 25rem;
 
-    @include ms.responsive-breakpoint('sm') {
-      display: none;
-    }
-  }
-
-  .header-label-email,
-  .user-email {
-    min-width: 12rem;
-    width: 16rem;
-    flex-grow: 1;
-    overflow: hidden;
-
-    @include ms.responsive-breakpoint('lg') {
-      display: none;
+      @include ms.responsive-breakpoint('sm') {
+        max-width: 100%;
+      }
     }
 
-    &__label {
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      overflow: hidden;
+    .label-sentOn,
+    .invitation-sentOn {
+      min-width: 11.25rem;
+      flex-grow: 0;
     }
-  }
 
-  .header-label-join-date,
-  .user-join {
-    min-width: 11.25rem;
-    flex-grow: 0;
-
-    @include ms.responsive-breakpoint('xl') {
-      display: none;
+    .label-space,
+    .invitation-actions {
+      min-width: 15.625rem;
+      flex-grow: 0;
     }
-  }
-
-  .header-label-status:not(.user-mobile-text__status),
-  .user-status {
-    flex: 0 0 8rem;
-
-    @include ms.responsive-breakpoint('md') {
-      display: none;
-    }
-  }
-
-  .header-label-space,
-  .user-options {
-    min-width: 4rem;
-    flex: 1 0 4rem;
-    padding: 0.75rem;
   }
 }
+
+/* ------- Specific User ------- */
 
 .user-list-item,
 .user-card-item,
@@ -637,15 +502,15 @@
   }
 }
 
-.user-list-item:nth-child(2)::before {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 1px;
-  background: var(--parsec-color-light-secondary-medium);
-  z-index: 2;
+// User items - Allow to keep hover when context menu is open
+.user-list-item--hovered {
+  --background: var(--parsec-color-light-primary-30) !important;
+  background-color: var(--parsec-color-light-primary-30) !important;
+
+  .ms-checkbox {
+    outline: 1px solid var(--parsec-color-light-primary-300);
+    outline-offset: 2px;
+  }
 }
 
 .revoked {
@@ -661,15 +526,184 @@
       color: var(--parsec-color-light-secondary-grey) !important;
     }
   }
+
   .tag {
     background: var(--parsec-color-light-secondary-disabled) !important;
     color: var(--parsec-color-light-secondary-grey) !important;
   }
 }
 
-// ------- Invitation emails + PKI -------
-.invitations-container-list,
-.requests-container-list {
+/* ------- Specific File ------- */
+
+// File items - Allow to keep hover when context menu is open
+.file-list-item--hovered {
+  --background: var(--parsec-color-light-primary-30) !important;
+  background-color: var(--parsec-color-light-primary-30) !important;
+
+  .ms-checkbox {
+    outline: 1px solid var(--parsec-color-light-primary-300);
+    outline-offset: 2px;
+  }
+}
+
+.file-name {
+  position: relative;
+  display: flex;
+  gap: 1rem;
+
+  .file-icon {
+    width: 2rem;
+    height: 2rem;
+    flex-shrink: 0;
+  }
+
+  .label-name {
+    color: var(--parsec-color-light-secondary-text);
+
+    &:not(.selection):hover {
+      text-decoration: underline;
+      cursor: pointer !important;
+    }
+  }
+
+  .cloud-overlay {
+    font-size: 1rem;
+    flex-shrink: 0;
+    margin-left: auto;
+    position: absolute;
+    right: 0;
+
+    &-ok {
+      color: var(--parsec-color-light-primary-500);
+    }
+
+    &-ko {
+      color: var(--parsec-color-light-secondary-grey);
+    }
+
+    @include ms.responsive-breakpoint('sm') {
+      left: 2.125rem;
+      top: 50%;
+      transform: translateY(16%);
+      right: auto;
+      background: var(--parsec-color-light-secondary-white);
+      border-radius: var(--parsec-radius-circle);
+      padding: 0.125rem;
+    }
+  }
+}
+
+.file-list-item-mobile {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin: 0 0.5rem;
+  border-radius: var(--parsec-radius-8);
+
+  .file-mobile-content {
+    gap: 1rem;
+    width: 100%;
+  }
+
+  .file-selected {
+    max-width: 2.5rem;
+    overflow: visible;
+  }
+
+  .file-mobile-text {
+    flex-grow: 1;
+    overflow: hidden;
+    color: var(--parsec-color-light-secondary-grey);
+    display: flex;
+    gap: 0.125rem;
+    flex-direction: column;
+
+    &__data {
+      display: flex;
+      gap: 0.5rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+
+      span {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+  }
+}
+
+.file-list-item.file-list-item--hovered,
+.file-card-item.file-list-item--hovered {
+  .file-list-item-container:has(.label-name:not(.selection):hover) .ms-checkbox,
+  .drop-zone:has(.file-card__title:not(.selection):hover) .ms-checkbox {
+    outline: none;
+  }
+}
+
+.upload-progress {
+  color: var(--parsec-color-light-secondary-hard-grey);
+  visibility: hidden;
+  flex-shrink: 0;
+
+  :is(.file-list-item) & {
+    position: relative;
+    right: 0.375rem;
+  }
+
+  :is(.file-card-item) & {
+    position: absolute;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--parsec-radius-circle);
+    left: 58%;
+    bottom: -8px;
+    width: 1.75rem;
+    height: 1.75rem;
+    background: var(--parsec-color-light-secondary-white);
+    text-wrap: nowrap;
+  }
+
+  :is(.file-list-item, .file-card-item):hover & {
+    visibility: visible;
+  }
+}
+
+// Set special drop zone style when dragging elements on folder
+.files-list-container .drop-zone-active .drop-zone-dashed {
+  left: 0.5rem !important;
+  top: 0.25rem !important;
+  right: 0.5rem !important;
+  bottom: 0.25rem !important;
+  background: hsla(214, 100%, 60%, 0.3);
+}
+
+// Set special style when search results are displayed
+.main-container:has(.file-search-results) {
+  background: var(--parsec-color-light-secondary-background);
+  padding: 1.5rem;
+  margin: 1rem 0 0;
+  overflow: hidden;
+
+  @include ms.responsive-breakpoint('sm') {
+    padding: 0;
+  }
+}
+
+/* ------- Specific Workspace ------- */
+
+// Workspace items - Manage hover state when context menu is open
+.workspace-card-item--hovered,
+.workspace-list-item--hovered {
+  background: var(--parsec-color-light-secondary-white);
+}
+
+/* ------- Specific Invitations ------- */
+
+// Invitation emails + PKI
+.list-container:has(.invitation-list-item, .request-list-item) {
   padding: 0 !important;
 
   @include ms.responsive-breakpoint('sm') {
@@ -683,6 +717,10 @@
     justify-content: center;
     align-items: center;
     flex-shrink: 0;
+
+    @include ms.responsive-breakpoint('sm') {
+      justify-content: flex-start;
+    }
 
     .primary-button {
       --background: var(--parsec-color-light-secondary-text);
@@ -723,9 +761,7 @@
 
   .invitations-list-header,
   .requests-list-header {
-    display: flex;
-    align-items: center;
-    padding: 0 1rem 0 2rem;
+    padding: 0 1rem;
   }
 
   .invitation-list-item,
@@ -737,7 +773,7 @@
     --background-hover-opacity: 1;
 
     &::part(native) {
-      padding: 0.625rem 1rem 0.625rem 2rem;
+      padding: 0.625rem 1rem;
       cursor: default;
 
       @include ms.responsive-breakpoint('sm') {
@@ -751,117 +787,5 @@
     @include ms.responsive-breakpoint('sm') {
       margin-bottom: 1rem;
     }
-  }
-}
-
-// ------- Invitations only -------
-.invitations-container-list {
-  .label-email,
-  .invitation-email {
-    width: 100%;
-    min-width: 11.25rem;
-    max-width: 25rem;
-    white-space: nowrap;
-    overflow: hidden;
-
-    @include ms.responsive-breakpoint('sm') {
-      max-width: 100%;
-    }
-  }
-
-  .label-sentOn,
-  .invitation-sentOn {
-    min-width: 11.25rem;
-    flex-grow: 0;
-  }
-
-  .label-space,
-  .invitation-actions {
-    min-width: 15.625rem;
-    margin-left: auto;
-    flex-grow: 0;
-  }
-
-  .invitation-actions-secondary__button {
-    &:last-of-type {
-      position: relative;
-      display: flex;
-      align-items: center;
-
-      &::before {
-        content: '';
-        position: relative;
-        display: block;
-        width: 2px;
-        height: calc(100% - 0.825rem);
-        background: var(--parsec-color-light-secondary-medium);
-        margin-right: 0.75rem;
-      }
-    }
-  }
-}
-
-// ------- PKI Requests only -------
-.requests-container-list {
-  .label-name,
-  .request-name {
-    width: 100%;
-    min-width: 11.25rem;
-    max-width: 25rem;
-    white-space: nowrap;
-    overflow: hidden;
-
-    @include ms.responsive-breakpoint('sm') {
-      max-width: 100%;
-    }
-  }
-
-  .label-email,
-  .request-email {
-    min-width: 16rem;
-    max-width: 16rem;
-    flex-grow: 1;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-
-    @include ms.responsive-breakpoint('lg') {
-      display: none;
-    }
-
-    &__label {
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      overflow: hidden;
-    }
-  }
-
-  .label-createdOn,
-  .request-createdOn {
-    min-width: 11.25rem;
-    flex-grow: 0;
-
-    @include ms.responsive-breakpoint('xl') {
-      display: none;
-    }
-  }
-
-  .label-type,
-  .request-type {
-    min-width: 12rem;
-    max-width: 12rem;
-
-    @include ms.responsive-breakpoint('sm') {
-      min-width: fit-content;
-      flex-basis: auto;
-    }
-  }
-
-  .label-space,
-  .request-actions {
-    min-height: 1rem;
-    min-width: 15rem;
-    margin-left: auto;
-    flex-grow: 0;
   }
 }

--- a/client/src/theme/global.scss
+++ b/client/src/theme/global.scss
@@ -59,17 +59,6 @@ svg {
     padding: 0;
     margin-bottom: 0;
   }
-
-  .list,
-  .users-container-grid,
-  .folders-container-grid,
-  .invitation-container-grid {
-    padding-top: 2rem;
-
-    @include ms.responsive-breakpoint('sm') {
-      padding-top: 0;
-    }
-  }
 }
 
 /* ----- item counter ------ */
@@ -104,7 +93,7 @@ svg {
 
 // add specific style for drop-zone on folders
 .drop-zone .list,
-.drop-zone .folders-container-grid {
+.drop-zone .files-grid-container {
   background: transparent;
   position: relative;
   z-index: 3;
@@ -121,7 +110,7 @@ svg {
   }
 }
 
-.drop-zone .folders-container-grid .drop-active {
+.drop-zone .files-grid-container .drop-active {
   border-radius: var(--parsec-radius-12) !important;
   width: 100%;
 }
@@ -270,7 +259,7 @@ svg {
     background: var(--parsec-color-light-secondary-white);
   }
 
-  .folders-container-grid {
+  .files-grid-container {
     padding: 1.5rem;
   }
 }

--- a/client/src/views/files/FoldersPage.vue
+++ b/client/src/views/files/FoldersPage.vue
@@ -91,7 +91,7 @@
         @cancel-selection="onSelectionCancel"
         :some-selected="selectedFilesCount > 0"
       />
-      <div class="folder-container scroll">
+      <div class="main-container folder-container scroll">
         <file-inputs
           ref="fileInputs"
           @files-added="startImportFiles"
@@ -181,10 +181,7 @@
             </div>
           </file-drop-zone>
         </div>
-        <div
-          v-else-if="!querying && !showErrorListPage && !search"
-          class="list-container"
-        >
+        <div v-else-if="!querying && !showErrorListPage && !search">
           <div v-if="displayView === DisplayState.List && userInfo">
             <file-list-display
               ref="fileListDisplay"
@@ -2093,14 +2090,6 @@ async function startSearch(pattern: string): Promise<void> {
 </script>
 
 <style scoped lang="scss">
-.list-container {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 0;
-  overflow-y: auto;
-  overflow-x: hidden;
-}
-
 .content-scroll {
   &::part(scroll) {
     -ms-overflow-style: -ms-autohiding-scrollbar;

--- a/client/src/views/invitations/AsyncEnrollmentRequestList.vue
+++ b/client/src/views/invitations/AsyncEnrollmentRequestList.vue
@@ -1,25 +1,25 @@
 <!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
 
 <template>
-  <ion-list class="list requests-container-list">
+  <ion-list class="list-container requests-list-container">
     <ion-list-header
-      class="requests-list-header"
+      class="list-header requests-list-header"
       lines="full"
       v-if="isLargeDisplay"
     >
-      <ion-text class="requests-list-header__label cell-title label-name">
+      <ion-text class="list-header-label cell-title label-name">
         {{ $msTranslate('InvitationsPage.asyncEnrollmentRequest.listDisplayTitles.name') }}
       </ion-text>
-      <ion-text class="requests-list-header__label cell-title label-email">
+      <ion-text class="list-header-label cell-title label-email">
         {{ $msTranslate('InvitationsPage.asyncEnrollmentRequest.listDisplayTitles.email') }}
       </ion-text>
-      <ion-text class="requests-list-header__label cell-title label-createdOn">
+      <ion-text class="list-header-label cell-title label-createdOn">
         {{ $msTranslate('InvitationsPage.asyncEnrollmentRequest.listDisplayTitles.createdOn') }}
       </ion-text>
-      <ion-text class="requests-list-header__label cell-title label-type">
+      <ion-text class="list-header-label cell-title label-type">
         {{ $msTranslate('InvitationsPage.asyncEnrollmentRequest.listDisplayTitles.type') }}
       </ion-text>
-      <ion-text class="requests-list-header__label cell-title label-space" />
+      <ion-text class="list-header-label list-item-end cell-title label-space" />
     </ion-list-header>
     <async-enrollment-request-item
       v-for="request in requests"

--- a/client/src/views/invitations/InvitationList.vue
+++ b/client/src/views/invitations/InvitationList.vue
@@ -1,19 +1,19 @@
 <!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
 
 <template>
-  <ion-list class="list invitations-container-list">
+  <ion-list class="list list-container invitations-list-container">
     <ion-list-header
-      class="invitations-list-header"
+      class="invitations-list-header list-header"
       lines="full"
       v-if="isLargeDisplay"
     >
-      <ion-text class="invitations-list-header__label cell-title label-email">
+      <ion-text class="list-header-label cell-title label-email">
         {{ $msTranslate('InvitationsPage.emailInvitation.listDisplayTitles.email') }}
       </ion-text>
-      <ion-text class="invitations-list-header__label cell-title label-sentOn">
+      <ion-text class="list-header-label cell-title label-sentOn">
         {{ $msTranslate('InvitationsPage.emailInvitation.listDisplayTitles.sentOn') }}
       </ion-text>
-      <ion-text class="invitations-list-header__label cell-title label-space" />
+      <ion-text class="list-header-label list-item-end cell-title label-space" />
     </ion-list-header>
     <invitation-item
       v-for="invitation in invitations"

--- a/client/src/views/users/MyProfilePage.vue
+++ b/client/src/views/users/MyProfilePage.vue
@@ -31,7 +31,7 @@
           </ion-text>
         </div>
       </ion-header>
-      <div class="profile-page-container">
+      <div class="main-container profile-page-container">
         <ion-radio-group
           v-if="isLargeDisplay || (isSmallDisplay && myProfileTab === undefined)"
           v-model="myProfileTab"

--- a/client/src/views/users/UserGridDisplay.vue
+++ b/client/src/views/users/UserGridDisplay.vue
@@ -1,21 +1,23 @@
 <!-- Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS -->
 
 <template>
-  <user-card
-    v-for="user in users.getUsers()"
-    :key="user.id"
-    :user="user"
-    :disabled="user.isCurrent"
-    :show-checkbox="someSelected || selectionEnabled === true"
-    @menu-click="onMenuClick"
-    @select="onUserSelected"
-  />
-  <ion-text
-    class="no-match-result body"
-    v-show="users.getUsers().length === 0"
-  >
-    {{ $msTranslate('UsersPage.noMatch') }}
-  </ion-text>
+  <div class="grid-container users-grid-container">
+    <user-card
+      v-for="user in users.getUsers()"
+      :key="user.id"
+      :user="user"
+      :disabled="user.isCurrent"
+      :show-checkbox="someSelected || selectionEnabled === true"
+      @menu-click="onMenuClick"
+      @select="onUserSelected"
+    />
+    <ion-text
+      class="no-match-result body"
+      v-show="users.getUsers().length === 0"
+    >
+      {{ $msTranslate('UsersPage.noMatch') }}
+    </ion-text>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -49,4 +51,20 @@ function onUserSelected(user: UserModel, selected: boolean): void {
 }
 </script>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+.users-grid-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  overflow-y: auto;
+
+  @include ms.responsive-breakpoint('sm') {
+    padding: 1.5rem 1rem 0;
+    gap: 1.5rem;
+  }
+
+  @include ms.responsive-breakpoint('xs') {
+    gap: 1rem;
+  }
+}
+</style>

--- a/client/src/views/users/UserListDisplay.vue
+++ b/client/src/views/users/UserListDisplay.vue
@@ -2,16 +2,16 @@
 
 <template>
   <ion-list
-    class="list users-container-list"
+    class="list-container users-list-container"
     id="users-page-user-list"
     :class="{ 'user-list-mobile': isSmallDisplay }"
   >
     <ion-list-header
-      class="user-list-header"
+      class="user-list-header list-header"
       lines="full"
       v-if="isLargeDisplay"
     >
-      <ion-label class="user-list-header__label header-label-selected">
+      <ion-label class="list-header-label header-label-selected">
         <ms-checkbox
           @change="users.selectAll($event)"
           :checked="allSelected"
@@ -19,57 +19,57 @@
         />
       </ion-label>
       <ion-label
-        class="user-list-header__label cell-title header-label-name"
+        class="list-header-label cell-title header-label-name"
         @click="headerSortChange(SortProperty.Name)"
-        :class="{ 'header-label-name-sorted': sortBy === SortProperty.Name }"
+        :class="{ 'list-header-label--sorted': sortBy === SortProperty.Name }"
       >
         {{ $msTranslate('UsersPage.listDisplayTitles.name') }}
         <ion-icon
           v-show="sortBy === SortProperty.Name"
           :icon="sortAscending ? arrowUp : arrowDown"
-          class="header-label-name__sort-icon"
+          class="sort-icon"
         />
       </ion-label>
       <ion-label
-        class="user-list-header__label cell-title header-label-profile"
+        class="list-header-label cell-title header-label-profile"
         @click="headerSortChange(SortProperty.Profile)"
-        :class="{ 'header-label-profile-sorted': sortBy === SortProperty.Profile }"
+        :class="{ 'list-header-label--sorted': sortBy === SortProperty.Profile }"
       >
         {{ $msTranslate('UsersPage.listDisplayTitles.profile') }}
         <ion-icon
           v-show="sortBy === SortProperty.Profile"
           :icon="sortAscending ? arrowUp : arrowDown"
-          class="header-label-name__sort-icon"
+          class="sort-icon"
         />
       </ion-label>
       <ion-label
-        class="user-list-header__label cell-title header-label-email"
+        class="list-header-label cell-title header-label-email"
         @click="headerSortChange(SortProperty.Email)"
-        :class="{ 'header-label-email-sorted': sortBy === SortProperty.Email }"
+        :class="{ 'list-header-label--sorted': sortBy === SortProperty.Email }"
       >
         {{ $msTranslate('UsersPage.listDisplayTitles.email') }}
         <ion-icon
           v-show="sortBy === SortProperty.Email"
           :icon="sortAscending ? arrowUp : arrowDown"
-          class="header-label-name__sort-icon"
+          class="sort-icon"
         />
       </ion-label>
       <ion-label
-        class="user-list-header__label cell-title header-label-join-date"
+        class="list-header-label cell-title header-label-join-date"
         @click="headerSortChange(SortProperty.JoinedDate)"
-        :class="{ 'header-label-join-date-sorted': sortBy === SortProperty.JoinedDate }"
+        :class="{ 'list-header-label--sorted': sortBy === SortProperty.JoinedDate }"
       >
         {{ $msTranslate('UsersPage.listDisplayTitles.joinedOn') }}
         <ion-icon
           v-show="sortBy === SortProperty.JoinedDate"
           :icon="sortAscending ? arrowUp : arrowDown"
-          class="header-label-name__sort-icon"
+          class="sort-icon"
         />
       </ion-label>
-      <ion-label class="user-list-header__label cell-title header-label-status">
+      <ion-label class="list-header-label cell-title header-label-status">
         {{ $msTranslate('UsersPage.listDisplayTitles.status') }}
       </ion-label>
-      <ion-label class="user-list-header__label cell-title header-label-space" />
+      <ion-label class="list-header-label list-item-end cell-title header-label-space" />
     </ion-list-header>
     <ion-text
       class="no-match-result body"

--- a/client/src/views/users/UsersPage.vue
+++ b/client/src/views/users/UsersPage.vue
@@ -62,7 +62,7 @@
         :options-disabled="users.selectableUsersCount() === 0"
       />
       <!-- users -->
-      <div class="users-container scroll">
+      <div class="main-container users-container scroll">
         <div
           v-show="users.totalUsersCount() === 0"
           class="no-active body-lg"
@@ -114,10 +114,7 @@
               @sort-update="onSortChange"
             />
           </div>
-          <div
-            v-else
-            class="users-container-grid"
-          >
+          <div v-else>
             <user-grid-display
               :users="users"
               @menu-click="openUserContextMenu"
@@ -797,12 +794,5 @@ const headerWatchCancel = watch([isSmallDisplay, selectionEnabled], () => {
 
 .users-container > div {
   height: 100%;
-}
-
-.users-container-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1.5em;
-  overflow-y: auto;
 }
 </style>

--- a/client/src/views/workspaces/WorkspaceHistoryPage.vue
+++ b/client/src/views/workspaces/WorkspaceHistoryPage.vue
@@ -176,7 +176,7 @@
               v-show="!querying && entries.entriesCount() > 0"
               class="folder-list"
             >
-              <ion-list class="folder-list-main ion-no-padding">
+              <ion-list class="list-container folder-list-main ion-no-padding">
                 <history-file-list-item
                   v-for="entry in entries.getEntries()"
                   :key="entry.id"

--- a/client/src/views/workspaces/WorkspacesPage.vue
+++ b/client/src/views/workspaces/WorkspacesPage.vue
@@ -58,7 +58,7 @@
       </div>
 
       <!-- workspaces -->
-      <div class="workspaces-container scroll">
+      <div class="main-container workspaces-container scroll">
         <div
           class="mobile-filters"
           v-if="isSmallDisplay"
@@ -178,7 +178,10 @@
         </div>
 
         <div v-if="filteredWorkspaces.length > 0 && displayView === DisplayState.List">
-          <ion-list class="workspaces-container-list list">
+          <ion-list
+            class="list-container workspaces-container-list"
+            id="workspaces-page-workspace-list"
+          >
             <workspace-list-item
               v-for="workspace in filteredWorkspaces"
               :key="workspace.id"
@@ -196,7 +199,7 @@
         </div>
         <div
           v-if="filteredWorkspaces.length > 0 && displayView === DisplayState.Grid"
-          class="workspaces-container-grid list"
+          class="workspaces-container-grid"
         >
           <workspace-card
             v-for="workspace in filteredWorkspaces"

--- a/client/tests/component/specs/testUserListItem.spec.ts
+++ b/client/tests/component/specs/testUserListItem.spec.ts
@@ -55,10 +55,10 @@ describe('User List Item', () => {
 
     // "JoJohn Smith" because the user is displayed with an avatar before their name,
     // currently using the first two letters for the avatar, (Jo) John Smith
-    expect(wrapper.get('.user-name__label').text()).to.equal('JoJohn Smith');
-    expect(wrapper.get('.user-email__label').text()).to.equal('john.smith@gmail.com');
+    expect(wrapper.get('.label-name').text()).to.equal('JoJohn Smith');
+    expect(wrapper.get('.label-email').text()).to.equal('john.smith@gmail.com');
     expect(wrapper.get('.user-profile').text()).to.equal('UserProfileStandard');
-    expect(wrapper.get('.user-join-label').text()).to.equal('now');
+    expect(wrapper.get('.label-join-date').text()).to.equal('now');
     wrapper.trigger('click');
     expect(wrapper.emitted('click')?.length).to.equal(1);
     expect(wrapper.emitted('click')?.at(0)?.at(1)).to.deep.equal(USER);

--- a/client/tests/e2e/specs/async_enrollment.spec.ts
+++ b/client/tests/e2e/specs/async_enrollment.spec.ts
@@ -113,7 +113,7 @@ for (const identitySystem of ['pki', 'openbao']) {
     await expect(linkRequests).toHaveCount(1);
     await expect(linkRequests.nth(0).locator('.request-type__label')).toHaveText(identitySystem === 'pki' ? 'PKI' : 'SSO');
     await expect(linkRequests.nth(0).locator('.person-name')).toHaveText(expectedPersonName);
-    await expect(linkRequests.nth(0).locator('.request-email__label')).toHaveText(
+    await expect(linkRequests.nth(0).locator('.label-email')).toHaveText(
       identitySystem === 'pki' ? 'bob@black-mesa.corp' : /^ [a-f0-9-]+@example\.invalid$/,
     );
 
@@ -263,7 +263,7 @@ for (const identitySystem of ['pki', 'openbao']) {
     await expect(linkRequests).toHaveCount(1);
     await expect(linkRequests.nth(0).locator('.request-type__label')).toHaveText(identitySystem === 'pki' ? 'PKI' : 'SSO');
     await expect(linkRequests.nth(0).locator('.person-name')).toHaveText(expectedPersonName);
-    await expect(linkRequests.nth(0).locator('.request-email__label')).toHaveText(
+    await expect(linkRequests.nth(0).locator('.label-email')).toHaveText(
       identitySystem === 'pki' ? 'bob@black-mesa.corp' : /^ [a-f0-9-]+@example\.invalid$/,
     );
 
@@ -352,7 +352,7 @@ msTest('Cannot accept PKI request', async ({ context }) => {
 
   await expect(linkRequests.nth(0).locator('.request-type__label')).toHaveText('PKI');
   await expect(linkRequests.nth(0).locator('.person-name')).toHaveText('Bob');
-  await expect(linkRequests.nth(0).locator('.request-email__label')).toHaveText('bob@black-mesa.corp');
+  await expect(linkRequests.nth(0).locator('.label-email')).toHaveText('bob@black-mesa.corp');
 
   const acceptButton = linkRequests.nth(0).locator('.request-actions').locator('ion-button').nth(0);
   await expect(acceptButton).toBeHidden();

--- a/client/tests/e2e/specs/documents_list.spec.ts
+++ b/client/tests/e2e/specs/documents_list.spec.ts
@@ -131,7 +131,7 @@ msTest.describe(() => {
     const sorterPopoverButton = actionBar.locator('#select-popover-button');
     await expect(entries).toHaveCount(4);
 
-    const headerNameLabel = documents.locator('.folder-list-header__label').nth(1);
+    const headerNameLabel = documents.locator('.list-header-label').nth(1);
     await expect(headerNameLabel).toBeVisible();
     await expect(headerNameLabel).toHaveText('Name');
     await expect(sorterPopoverButton).toHaveText('Name');
@@ -147,7 +147,7 @@ msTest.describe(() => {
     await expect(entries.locator('.label-name')).toHaveText(['Dir_Folder', 'pdfDocument.pdf', 'image.png', 'audio.mp3']);
     await expect(entries.locator('.file-size')).toHaveText(['', '76.9 KB', '6.18 KB', '40.9 KB']);
 
-    const headerSizeLabel = documents.locator('.folder-list-header__label').nth(5);
+    const headerSizeLabel = documents.locator('.list-header-label').nth(5);
     await expect(headerSizeLabel).toBeVisible();
     await expect(headerSizeLabel).toHaveText('Size');
     await headerSizeLabel.click();
@@ -671,7 +671,7 @@ msTest('Documents page default state in a read only workspace', async ({ documen
   await expect(entries.locator('.file-creation-date')).toHaveText(TIME_MATCHER_ARRAY);
   await expect(entries.locator('.file-size')).toHaveText(SIZE_MATCHER_ARRAY);
   // Useless click just to move the mouse
-  await documentsReadOnly.locator('.folder-list-header__label').nth(1).click();
+  await documentsReadOnly.locator('.list-header-label').nth(1).click();
   for (const checkbox of await entries.locator('.checkbox').all()) {
     await expect(checkbox).toBeHidden();
   }

--- a/client/tests/e2e/specs/file_details.spec.ts
+++ b/client/tests/e2e/specs/file_details.spec.ts
@@ -85,7 +85,7 @@ msTest.describe(() => {
 
     await expect(documents.locator('.topbar-left__breadcrumb')).toContainText('wksp1');
     await documents.locator('#folders-ms-action-bar').locator('#grid-view').click();
-    const files = documents.locator('.folders-container-grid').locator('.file-card-item');
+    const files = documents.locator('.files-grid-container').locator('.file-card-item');
     await expect(files).toHaveCount(1);
     await expect(documents.locator('.file-context-menu')).toBeHidden();
     await expect(documents.locator('.file-details-modal')).toBeHidden();

--- a/client/tests/e2e/specs/file_search.spec.ts
+++ b/client/tests/e2e/specs/file_search.spec.ts
@@ -42,7 +42,7 @@ msTest.describe(() => {
   });
 
   msTest('Search files state', async ({ documents }, testInfo: TestInfo) => {
-    const entries = documents.locator('.files-container-list').locator('.file-list-item');
+    const entries = documents.locator('.files-list-container').locator('.file-list-item');
     await importDefaultFiles(documents, testInfo, ImportDocuments.Png | ImportDocuments.Docx | ImportDocuments.Txt, false);
     await expect(entries).toHaveCount(3);
 
@@ -65,7 +65,7 @@ msTest.describe(() => {
     await fillIonInput(searchInput, 'image');
 
     await expect(searchContainer).toBeVisible();
-    await expect(documents.locator('.files-container-list')).toBeHidden();
+    await expect(documents.locator('.files-list-container:not(.results-list-container)')).toBeHidden();
     await expect(results).toHaveCount(1);
     await expect(actionBarButtons).toHaveCount(0);
     await expect(labelRole).toBeVisible();
@@ -76,7 +76,7 @@ msTest.describe(() => {
     await searchInput.locator('.input-clear-icon').click();
 
     await expect(searchContainer).toBeHidden();
-    await expect(documents.locator('.files-container-list')).toBeVisible();
+    await expect(documents.locator('.files-list-container:not(.results-list-container)')).toBeVisible();
     await expect(actionBarButtons).toHaveCount(3);
     await expect(labelRole).toBeVisible();
     await expect(counter).toBeVisible();

--- a/client/tests/e2e/specs/file_viewers.spec.ts
+++ b/client/tests/e2e/specs/file_viewers.spec.ts
@@ -505,7 +505,7 @@ msTest.describe(() => {
     await expect(header).toBeVisible();
 
     // Open first file and ensure it's loaded
-    await entries.nth(0).locator('.file-name .file-mobile-text .label-name').click();
+    await entries.nth(0).locator('.file-name .label-name').click();
     await expect(documents).toBeViewerPage();
     await expect(documents.locator('.file-handler-topbar .file-handler-topbar__title')).toHaveText('audio.mp3');
 
@@ -540,7 +540,7 @@ msTest.describe(() => {
     await expect(sidebar).toBeHidden();
 
     // Open second file
-    await entries.nth(1).locator('.file-name .file-mobile-text .label-name').click();
+    await entries.nth(1).locator('.file-name .label-name').click();
     await expect(documents.locator('.file-handler-topbar .file-handler-topbar__title')).toHaveText('image.png');
     await expect(documents).toBeViewerPage();
 
@@ -578,7 +578,7 @@ msTest.describe(() => {
     await expect(documents.locator('#connected-header .topbar')).toBeVisible();
 
     // Open file viewer
-    await entries.nth(0).locator('.file-name .file-mobile-text .label-name').click();
+    await entries.nth(0).locator('.file-name .label-name').click();
     await expect(documents).toBeViewerPage();
     await expect(documents.locator('.file-handler-topbar .file-handler-topbar__title')).toHaveText('audio.mp3');
 
@@ -603,7 +603,7 @@ msTest.describe(() => {
     await expect(documents.locator('.sidebar')).toBeHidden();
 
     // Open file viewer again
-    await entries.nth(1).locator('.file-name .file-mobile-text .label-name').click();
+    await entries.nth(1).locator('.file-name .label-name').click();
     await expect(documents).toBeViewerPage();
     await expect(documents.locator('.file-handler-topbar .file-handler-topbar__title')).toHaveText('image.png');
 

--- a/client/tests/e2e/specs/invitations_page.spec.ts
+++ b/client/tests/e2e/specs/invitations_page.spec.ts
@@ -3,12 +3,8 @@
 import { answerQuestion, expect, fillIonInput, getClipboardText, msTest, setWriteClipboardPermission } from '@tests/e2e/helpers';
 
 msTest('Email invitations default state', async ({ invitationsPage }) => {
-  await expect(invitationsPage.locator('.invitations-container-list').locator('.invitations-list-header__label')).toHaveText([
-    'Email',
-    'Sent on',
-    '',
-  ]);
-  const invites = invitationsPage.locator('.invitations-container-list').locator('.invitation-list-item');
+  await expect(invitationsPage.locator('.invitations-list-container').locator('.list-header-label')).toHaveText(['Email', 'Sent on', '']);
+  const invites = invitationsPage.locator('.invitations-list-container').locator('.invitation-list-item');
   await expect(invites).toHaveCount(1);
   await expect(invites.nth(0).locator('.invitation-email')).toHaveText('zack@example.invalid');
   await expect(invites.nth(0).locator('.invitation-sentOn')).toHaveText('Jan 7, 2000');
@@ -35,7 +31,7 @@ msTest('Email invitations default state', async ({ invitationsPage }) => {
 });
 
 msTest('Email invitations start greet', async ({ invitationsPage }) => {
-  const invites = invitationsPage.locator('.invitations-container-list').locator('.invitation-list-item');
+  const invites = invitationsPage.locator('.invitations-list-container').locator('.invitation-list-item');
   await expect(invites).toHaveCount(1);
   const actions = invites.nth(0).locator('.invitation-actions').locator('ion-button');
   await expect(invitationsPage.locator('.greet-organization-modal')).toBeHidden();
@@ -45,7 +41,7 @@ msTest('Email invitations start greet', async ({ invitationsPage }) => {
 
 for (const hasPerms in [true, false]) {
   msTest(`Email invitations copy link ${['without', 'with'][Number(hasPerms)]} permissions`, async ({ invitationsPage }) => {
-    const invites = invitationsPage.locator('.invitations-container-list').locator('.invitation-list-item');
+    const invites = invitationsPage.locator('.invitations-list-container').locator('.invitation-list-item');
     await expect(invites).toHaveCount(1);
     const actions = invites.nth(0).locator('.invitation-actions').locator('ion-button');
     if (hasPerms) {
@@ -65,7 +61,7 @@ for (const hasPerms in [true, false]) {
 }
 
 msTest('Email invitations resend email', async ({ invitationsPage }) => {
-  const invites = invitationsPage.locator('.invitations-container-list').locator('.invitation-list-item');
+  const invites = invitationsPage.locator('.invitations-list-container').locator('.invitation-list-item');
   await expect(invites).toHaveCount(1);
   const actions = invites.nth(0).locator('.invitation-actions').locator('ion-button');
   await actions.nth(2).click();
@@ -80,7 +76,7 @@ msTest('Email invitations resend email', async ({ invitationsPage }) => {
 
 for (const answer of [true, false]) {
   msTest(`Email invitations delete invitation answer ${answer}`, async ({ invitationsPage }) => {
-    const invites = invitationsPage.locator('.invitations-container-list').locator('.invitation-list-item');
+    const invites = invitationsPage.locator('.invitations-list-container').locator('.invitation-list-item');
     await expect(invites).toHaveCount(1);
     const actions = invites.nth(0).locator('.invitation-actions').locator('ion-button');
     await actions.nth(3).click();
@@ -161,7 +157,7 @@ const INVITATION_PARAMS: Array<InvitationParam> = [
 for (const params of INVITATION_PARAMS) {
   msTest(`Invite new email: ${params.description}`, async ({ invitationsPage }) => {
     const viewToggle = invitationsPage.locator('.toggle-view-container');
-    const invites = invitationsPage.locator('.invitations-container-list').locator('.invitation-list-item');
+    const invites = invitationsPage.locator('.invitations-list-container').locator('.invitation-list-item');
     await expect(invites).toHaveCount(1);
     await viewToggle.locator('#invite-user-button').click();
     const modal = invitationsPage.locator('.invite-modal');

--- a/client/tests/e2e/specs/users_list.spec.ts
+++ b/client/tests/e2e/specs/users_list.spec.ts
@@ -77,7 +77,7 @@ for (const displaySize of ['small', 'large']) {
       if (displaySize === 'small') {
         await expect(item.locator('.user-mobile-text').locator('.user-mobile-text__name')).toHaveText(user.name);
         await expect(item.locator('.user-mobile-text').locator('.user-mobile-text__email')).toHaveText(user.email);
-        await expect(item.locator('.user-mobile-text').locator('.user-mobile-text__profile')).toHaveText(user.profile);
+        await expect(item.locator('.user-mobile-text').locator('.user-mobile-text-info__profile')).toHaveText(user.profile);
         await expect(item.locator('.user-profile')).toBeHidden();
         await expect(item.locator('.user-email')).toBeHidden();
         await expect(item.locator('.user-status')).toBeHidden();
@@ -98,7 +98,7 @@ for (const displaySize of ['small', 'large']) {
 
 msTest('Check user grid items', async ({ usersPage }) => {
   await usersPage.locator('#activate-users-ms-action-bar').locator('.ms-grid-list-toggle').locator('#grid-view').click();
-  const usersGrid = usersPage.locator('.users-container-grid');
+  const usersGrid = usersPage.locator('.users-grid-container');
 
   for (const [index, user] of USERS.entries()) {
     const card = usersGrid.locator('.user-card-item').nth(index);
@@ -189,7 +189,7 @@ msTest('Revoke two users with selection', async ({ usersPage }) => {
 
 msTest('Selection in grid mode', async ({ usersPage }) => {
   await usersPage.locator('#activate-users-ms-action-bar').locator('.ms-grid-list-toggle').locator('#grid-view').click();
-  const item = usersPage.locator('.users-container-grid').locator('.user-card-item').nth(1);
+  const item = usersPage.locator('.users-grid-container').locator('.user-card-item').nth(1);
   await item.hover();
   await expect(item.locator('.ms-checkbox')).not.toBeChecked();
   // Selecting one user
@@ -286,7 +286,7 @@ msTest('Maintain selection between modes', async ({ usersPage }) => {
   for (const [index, user] of USERS.entries()) {
     // Revoked users do not have a checkbox
     if (user.active && !user.currentUser) {
-      const item = usersPage.locator('.users-container-grid').locator('.user-card-item').nth(index);
+      const item = usersPage.locator('.users-grid-container').locator('.user-card-item').nth(index);
       await item.hover();
       if (index === 1 || index === 2) {
         await expect(item.locator('.ms-checkbox')).toBeChecked();
@@ -296,11 +296,11 @@ msTest('Maintain selection between modes', async ({ usersPage }) => {
     }
   }
   // Uncheck one
-  await usersPage.locator('.users-container-grid').locator('.user-card-item').nth(2).locator('.ms-checkbox').uncheck();
+  await usersPage.locator('.users-grid-container').locator('.user-card-item').nth(2).locator('.ms-checkbox').uncheck();
   await expect(actionBar.locator('.counter')).toHaveText('1 user selected', { useInnerText: true });
   for (const [index, user] of USERS.entries()) {
     if (user.active && !user.currentUser) {
-      const item = usersPage.locator('.users-container-grid').locator('.user-card-item').nth(index);
+      const item = usersPage.locator('.users-grid-container').locator('.user-card-item').nth(index);
       await item.hover();
       if (index === 1) {
         await expect(item.locator('.ms-checkbox')).toBeChecked();
@@ -423,7 +423,7 @@ msTest('User sort popover default state', async ({ usersPage }) => {
 msTest('Sort users list with popover', async ({ usersPage }) => {
   const usersList = usersPage.locator('#users-page-user-list');
   const sortButton = usersPage.locator('#activate-users-ms-action-bar').locator('#select-popover-button');
-  const headers = usersPage.locator('.user-list-header').locator('.user-list-header__label');
+  const headers = usersPage.locator('.user-list-header').locator('.list-header-label');
 
   await sortBy(sortButton, 'Name');
   await expect(sortButton).toHaveText('Name');
@@ -457,7 +457,7 @@ msTest('Sort users list with popover', async ({ usersPage }) => {
 msTest('Sort users list with header', async ({ usersPage }) => {
   const usersList = usersPage.locator('#users-page-user-list');
   const sortButton = usersPage.locator('#activate-users-ms-action-bar').locator('#select-popover-button');
-  const headers = usersPage.locator('.user-list-header').locator('.user-list-header__label');
+  const headers = usersPage.locator('.user-list-header').locator('.list-header-label');
 
   await expect(headers).toHaveText(['', 'Name ', 'Profile ', 'Email ', 'Joined On ', 'Status', '']);
 
@@ -495,7 +495,7 @@ msTest('Search user list', async ({ usersPage }) => {
   const actionBar = usersPage.locator('#activate-users-ms-action-bar');
   const usersList = usersPage.locator('#users-page-user-list');
   const items = usersList.getByRole('listitem');
-  const gridItems = usersPage.locator('.users-container-grid').locator('.user-card-item');
+  const gridItems = usersPage.locator('.users-grid-container').locator('.user-card-item');
 
   await expect(actionBar.locator('.counter')).toHaveText('3 users', { useInnerText: true });
   await expect(items).toHaveCount(3);
@@ -557,7 +557,7 @@ msTest('Search user list', async ({ usersPage }) => {
 msTest('Search user grid', async ({ usersPage }) => {
   const searchInput = usersPage.locator('#search-input-users').locator('ion-input');
   const actionBar = usersPage.locator('#activate-users-ms-action-bar');
-  const usersList = usersPage.locator('.users-container-grid');
+  const usersList = usersPage.locator('.users-grid-container');
   const items = usersList.locator('.user-card-item');
 
   await usersPage.locator('#activate-users-ms-action-bar').locator('.ms-grid-list-toggle').locator('#grid-view').click();
@@ -853,7 +853,7 @@ msTest('Copy email address to clipboard', async ({ usersPage }) => {
   const item = usersPage.locator('#users-page-user-list').getByRole('listitem').nth(1);
   await item.hover();
   await setWriteClipboardPermission(usersPage.context(), true);
-  const copyButton = item.locator('.user-email__label');
+  const copyButton = item.locator('.label-email');
   await expect(copyButton).toBeVisible();
   await copyButton.click();
   await expect(usersPage).toShowToast('The email address has been copied to the clipboard.', 'Info');


### PR DESCRIPTION
## Refactoring list styles

CSS classes consolidation of specific to each entity (files, users, workspaces, invitations) into a system of reusable generic classes:
- **Headers**: `.*-list-header` → `.list-header` + `.list-header-label`
- **Items**: `.file-list-item`, `.user-list-item`, etc. → `.list-item` with `.list-item-column`, `.list-item-label`, `.list-item-end`
- **Containers**: `.*-container-list` → `.list-container` + specific class (ex: `.files-list-container`)
- **Grid**: Common addition of `.grid-container`, renaming `.folders-container-grid` → `.files-grid-container`
- **Hover**: BEM Convention— `.file-hovered` → `.file-list-item--hovered`, `.user-hovered` → `.user-list-item--hovered`, etc.
- **Sizing columns**: CSS Variables (`--width-cell-*`) replaced by `flex-basis` in blocks `:has()` targeted by list type

Shared global styles are factored out into `_list.scss`, whilst specific styles are moved into scoped Vue components.