### PR TITLE
[MS] Refactoring of file actions

### DIFF
--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -22,8 +22,8 @@ export default defineConfig({
   forbidOnly: IN_CI,
   /* Retry on CI only */
   retries: IN_CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: IN_CI ? '80%' : '50%',
+  /* Opt out of parallel tests on CI. Keep 1 worker when running locally, easier to debug */
+  workers: IN_CI ? '80%' : 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: IN_CI ? 'blob' : 'list',
   webServer: {

--- a/client/src/plugins/libparsec/index.ts
+++ b/client/src/plugins/libparsec/index.ts
@@ -52,6 +52,10 @@ const FUNCTIONS_TO_SKIP: Array<SkipData> = [
     tag: 'WorkspaceCreateFolderErrorEntryExists',
     function: 'workspaceCreateFolderAll',
   },
+  {
+    tag: 'ClientListFrozenUsersErrorAuthorNotAllowed',
+    function: 'clientListFrozenUsers',
+  },
 ];
 
 const FUNCTIONS_TO_SLOW_DOWN: Array<string> = [

--- a/client/src/services/contextMenu/fileActions.ts
+++ b/client/src/services/contextMenu/fileActions.ts
@@ -1,12 +1,13 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 import { entryNameValidator } from '@/common/validators';
-import { copyPathLinkToClipboard, EntryModel, selectFolder } from '@/components/files';
+import { copyPathLinkToClipboard, selectFolder } from '@/components/files';
 import { showWorkspace } from '@/components/workspaces/utils';
 import {
   deleteFile,
   deleteFolder,
   EntryName,
+  EntryStat,
   entryStat,
   EntryStatFile,
   FsPath,
@@ -38,7 +39,7 @@ export function useFileActions() {
   const eventDistributor: Ref<EventDistributor> = inject(EventDistributorKey)!;
   const storageManager: StorageManager = inject(StorageManagerKey)!;
 
-  async function deleteEntries(entries: EntryModel[], workspaceInfo: WorkspaceInfo): Promise<void> {
+  async function deleteEntries(entries: EntryStat[], workspaceInfo: WorkspaceInfo): Promise<void> {
     if (entries.length === 0) {
       return;
     }
@@ -123,8 +124,9 @@ export function useFileActions() {
     }
   }
 
-  async function renameEntry(entry: EntryModel, workspaceInfo: WorkspaceInfo): Promise<void> {
+  async function renameEntry(entry: EntryStat, workspaceInfo: WorkspaceInfo): Promise<void> {
     const ext = Path.getFileExtension(entry.name);
+    const parent = await Path.parent(entry.path);
     const newName = await getTextFromUser(
       {
         title: entry.isFile() ? 'FoldersPage.RenameModal.fileTitle' : 'FoldersPage.RenameModal.folderTitle',
@@ -132,7 +134,7 @@ export function useFileActions() {
         validator: entryNameValidator(entry.isFile(), {
           checkExists: {
             workspaceHandle: workspaceInfo.handle,
-            path: entry.parent,
+            path: parent,
           },
           checkConfined: true,
         }),
@@ -180,11 +182,11 @@ export function useFileActions() {
     }
   }
 
-  async function copyLink(entry: EntryModel, workspaceInfo: WorkspaceInfo): Promise<void> {
+  async function copyLink(entry: EntryStat, workspaceInfo: WorkspaceInfo): Promise<void> {
     copyPathLinkToClipboard(entry.path, workspaceInfo.handle, informationManager.value);
   }
 
-  async function moveEntriesTo(entries: EntryModel[], workspaceInfo: WorkspaceInfo, currentPath: string): Promise<void> {
+  async function moveEntriesTo(entries: EntryStat[], workspaceInfo: WorkspaceInfo): Promise<void> {
     if (entries.length === 0) {
       return;
     }
@@ -194,9 +196,10 @@ export function useFileActions() {
         excludePaths.push(entry.path);
       }
     }
+    const startingPath = await Path.parent(entries[0].path);
     const folder = await selectFolder({
       title: { key: 'FoldersPage.moveSelectFolderTitle', data: { count: entries.length }, count: entries.length },
-      startingPath: currentPath,
+      startingPath: startingPath,
       workspaceHandle: workspaceInfo.handle,
       excludePaths: excludePaths,
     });
@@ -204,7 +207,7 @@ export function useFileActions() {
       return;
     }
 
-    const existing: Array<EntryModel> = [];
+    const existing: Array<EntryStat> = [];
 
     for (const entry of entries) {
       const destPath = await Path.join(folder, entry.name);
@@ -239,7 +242,7 @@ export function useFileActions() {
     await fileOperationManager.value.move(workspaceInfo.handle, entries, folder, dupPolicy);
   }
 
-  async function showDetails(entry: EntryModel, workspaceInfo: WorkspaceInfo, userProfile: UserProfile): Promise<void> {
+  async function showDetails(entry: EntryStat, workspaceInfo: WorkspaceInfo, userProfile: UserProfile): Promise<void> {
     const modal = await modalController.create({
       component: FileDetailsModal,
       cssClass: 'file-details-modal',
@@ -253,7 +256,7 @@ export function useFileActions() {
     await modal.onWillDismiss();
   }
 
-  async function copyEntries(entries: EntryModel[], workspaceInfo: WorkspaceInfo, currentPath: string): Promise<void> {
+  async function copyEntries(entries: EntryStat[], workspaceInfo: WorkspaceInfo): Promise<void> {
     if (entries.length === 0) {
       return;
     }
@@ -264,9 +267,11 @@ export function useFileActions() {
         excludePaths.push(entry.path);
       }
     }
+
+    const startingPath = await Path.parent(entries[0].path);
     const folder = await selectFolder({
       title: { key: 'FoldersPage.copySelectFolderTitle', data: { count: entries.length }, count: entries.length },
-      startingPath: currentPath,
+      startingPath: startingPath,
       workspaceHandle: workspaceInfo.handle,
       excludePaths: excludePaths,
       allowStartingPath: true,
@@ -276,7 +281,7 @@ export function useFileActions() {
       return;
     }
 
-    const existing: Array<EntryModel> = [];
+    const existing: Array<EntryStat> = [];
 
     for (const entry of entries) {
       const destPath = await Path.join(folder, entry.name);
@@ -310,13 +315,7 @@ export function useFileActions() {
     await fileOperationManager.value.copy(workspaceInfo.handle, entries, folder, dupPolicy);
   }
 
-  async function downloadEntries(
-    entries: EntryModel[],
-    workspaceInfo: WorkspaceInfo,
-    currentFolder: string,
-    currentPath: string | undefined,
-    asArchive?: boolean,
-  ): Promise<void> {
+  async function downloadEntries(entries: EntryStat[], workspaceInfo: WorkspaceInfo, asArchive?: boolean): Promise<void> {
     if (entries.length < 1) {
       return;
     }
@@ -326,6 +325,9 @@ export function useFileActions() {
       return;
     }
 
+    const currentPath = await Path.parent(entries[0].path);
+    const currentFolder = await Path.filename(currentPath);
+
     function _getArchiveName(): EntryName {
       if (!workspaceInfo) {
         return 'archive.zip';
@@ -333,7 +335,7 @@ export function useFileActions() {
       if (entries.length === 1) {
         return `${entries[0].name}.zip`;
       }
-      if (currentFolder === '/') {
+      if (!currentFolder || currentFolder === '/') {
         return `${workspaceInfo.name}.zip`;
       }
       return `${workspaceInfo.name}_${currentFolder}.zip`;
@@ -357,7 +359,7 @@ export function useFileActions() {
     });
   }
 
-  async function showHistory(entries: EntryModel[], workspaceInfo: WorkspaceInfo): Promise<void> {
+  async function showHistory(entries: EntryStat[], workspaceInfo: WorkspaceInfo): Promise<void> {
     if (entries.length !== 1) {
       return;
     }
@@ -371,7 +373,7 @@ export function useFileActions() {
     });
   }
 
-  async function openEntry(entryToOpen: EntryModel, options: OpenPathOptions, workspaceInfo: WorkspaceInfo): Promise<void> {
+  async function openEntry(entryToOpen: EntryStat, options: OpenPathOptions, workspaceInfo: WorkspaceInfo): Promise<void> {
     if (!entryToOpen.isFile()) {
       window.electronAPI.log('warn', 'Trying to open an entry that is not a file.');
       return;
@@ -427,7 +429,7 @@ export function useFileActions() {
     await pathOpener.showInExplorer(workspaceInfo.handle, path);
   }
 
-  async function showEnclosingFolder(entry: EntryModel, workspaceInfo: WorkspaceInfo): Promise<void> {
+  async function showEnclosingFolder(entry: EntryStat, workspaceInfo: WorkspaceInfo): Promise<void> {
     const parent = await Path.parent(entry.path);
     await navigateTo(Routes.Documents, {
       query: { documentPath: parent, workspaceHandle: workspaceInfo.handle, selectFile: entry.name },

--- a/client/src/services/contextMenu/fileContextMenu.ts
+++ b/client/src/services/contextMenu/fileContextMenu.ts
@@ -1,0 +1,189 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+import { SmallDisplayCategoryFileContextMenu, SmallDisplayFileContextMenu } from '@/components/small-display';
+import { EntryStat, UserProfile, WorkspaceInfo } from '@/parsec';
+import { useFileActions } from '@/services/contextMenu/fileActions';
+import { isFileEditable } from '@/services/cryptpad';
+import { FileAction, FileContextMenu, FolderGlobalAction, FolderGlobalContextMenu } from '@/views/files';
+import { modalController, popoverController } from '@ionic/vue';
+import { useWindowSize } from 'megashark-lib';
+
+export function useFileContextMenu() {
+  const { isLargeDisplay } = useWindowSize();
+  const fileActions = useFileActions();
+
+  async function openGlobalContextMenu(event: Event, isReadOnly: boolean, isEmpty: boolean): Promise<FolderGlobalAction | undefined> {
+    let action: FolderGlobalAction | undefined;
+
+    if (isLargeDisplay.value) {
+      if (isReadOnly) {
+        return;
+      }
+
+      const popover = await popoverController.create({
+        component: FolderGlobalContextMenu,
+        cssClass: 'folder-global-context-menu',
+        event: event,
+        reference: event.type === 'contextmenu' ? 'event' : 'trigger',
+        translucent: true,
+        showBackdrop: false,
+        dismissOnSelect: true,
+        alignment: 'start',
+        componentProps: {
+          isReadOnly: isReadOnly,
+        },
+      });
+      await popover.present();
+      action = (await popover.onDidDismiss()).data?.action;
+      await popover.dismiss();
+    } else {
+      const modal = await modalController.create({
+        component: SmallDisplayCategoryFileContextMenu,
+        cssClass: 'file-context-sheet-modal',
+        canDismiss: true,
+        breakpoints: [0, 0.5],
+        expandToScroll: true,
+        initialBreakpoint: 0.5,
+        showBackdrop: true,
+        componentProps: {
+          disableSelect: isEmpty,
+        },
+      });
+
+      await modal.present();
+      action = (await modal.onWillDismiss()).data?.action;
+      await modal.dismiss();
+    }
+    return action;
+  }
+
+  async function openEntryContextMenu(
+    event: Event,
+    entries: EntryStat[],
+    isReadOnly: boolean,
+    navigateFromAnywhere?: boolean,
+  ): Promise<FileAction | undefined> {
+    let action: FileAction | undefined;
+
+    if (isLargeDisplay.value) {
+      const popover = await popoverController.create({
+        component: FileContextMenu,
+        cssClass: 'file-context-menu',
+        event: event,
+        reference: event.type === 'contextmenu' ? 'event' : 'trigger',
+        translucent: true,
+        showBackdrop: false,
+        dismissOnSelect: true,
+        alignment: 'start',
+        componentProps: {
+          isReadOnly: isReadOnly,
+          multipleFiles: entries.length > 1,
+          isFile: entries.length === 1 && entries[0].isFile(),
+          isEditable: entries.length === 1 && isFileEditable(entries[0].name),
+          navigateFromAnywhere: navigateFromAnywhere,
+        },
+      });
+
+      await popover.present();
+      action = (await popover.onDidDismiss()).data?.action;
+      await popover.dismiss();
+    } else {
+      const modal = await modalController.create({
+        component: SmallDisplayFileContextMenu,
+        cssClass: 'file-context-sheet-modal',
+        breakpoints: [0, 0.5, 1],
+        initialBreakpoint: 0.5,
+        expandToScroll: false,
+        showBackdrop: true,
+        componentProps: {
+          isReadOnly: isReadOnly,
+          multipleFiles: entries.length > 1,
+          isFile: entries.length === 1 && entries[0].isFile(),
+          isEditable: entries.length === 1 && isFileEditable(entries[0].name),
+          navigateFromAnywhere: navigateFromAnywhere,
+        },
+      });
+
+      await modal.present();
+      action = (await modal.onDidDismiss()).data?.action;
+      await modal.dismiss();
+    }
+
+    return action;
+  }
+
+  async function dispatchContextMenuAction(
+    action: FileAction,
+    entries: Array<EntryStat>,
+    workspaceInfo: WorkspaceInfo,
+    readOnlyWorkspace: boolean,
+    userProfile: UserProfile,
+  ): Promise<void> {
+    switch (action) {
+      case FileAction.Preview: {
+        await fileActions.openEntry(entries[0], { disallowSystem: true, skipViewers: false, readOnly: true }, workspaceInfo);
+        break;
+      }
+      case FileAction.Rename: {
+        await fileActions.renameEntry(entries[0], workspaceInfo);
+        break;
+      }
+      case FileAction.Edit: {
+        await fileActions.openEntry(entries[0], { readOnly: readOnlyWorkspace }, workspaceInfo);
+        break;
+      }
+      case FileAction.MoveTo: {
+        await fileActions.moveEntriesTo(entries, workspaceInfo);
+        break;
+      }
+      case FileAction.MakeACopy: {
+        await fileActions.copyEntries(entries, workspaceInfo);
+        break;
+      }
+      case FileAction.Open: {
+        await fileActions.openEntry(entries[0], { skipViewers: true }, workspaceInfo);
+        break;
+      }
+      case FileAction.ShowHistory: {
+        await fileActions.showHistory(entries, workspaceInfo);
+        break;
+      }
+      case FileAction.Download: {
+        await fileActions.downloadEntries(entries, workspaceInfo, false);
+        break;
+      }
+      case FileAction.DownloadAsArchive: {
+        await fileActions.downloadEntries(entries, workspaceInfo, true);
+        break;
+      }
+      case FileAction.ShowDetails: {
+        await fileActions.showDetails(entries[0], workspaceInfo, userProfile);
+        break;
+      }
+      case FileAction.CopyLink: {
+        await fileActions.copyLink(entries[0], workspaceInfo);
+        break;
+      }
+      case FileAction.Delete: {
+        await fileActions.deleteEntries(entries, workspaceInfo);
+        break;
+      }
+      case FileAction.SeeInExplorer: {
+        await fileActions.seeInExplorer(entries[0].path, workspaceInfo);
+        break;
+      }
+      case FileAction.ShowEnclosingFolder:
+        await fileActions.showEnclosingFolder(entries[0], workspaceInfo);
+        break;
+      default:
+        window.electronAPI.log('warn', `Unknown file action ${action}`);
+        break;
+    }
+  }
+
+  return {
+    openGlobalContextMenu,
+    openEntryContextMenu,
+    dispatchContextMenuAction,
+  };
+}

--- a/client/src/services/contextMenu/index.ts
+++ b/client/src/services/contextMenu/index.ts
@@ -1,0 +1,4 @@
+// Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+
+export * from '@/services/contextMenu/fileActions';
+export * from '@/services/contextMenu/fileContextMenu';

--- a/client/src/views/files/FoldersPage.vue
+++ b/client/src/views/files/FoldersPage.vue
@@ -247,6 +247,7 @@ import {
   EyeOpenIcon,
   I18n,
   MsActionBar,
+  MsActionBarAction,
   MsGridListToggle,
   MsImage,
   MsModalResult,
@@ -306,6 +307,7 @@ import {
   listWorkspaces,
 } from '@/parsec';
 import { Routes, currentRouteIs, getCurrentRouteQuery, getDocumentPath, getWorkspaceHandle, navigateTo, watchRoute } from '@/router';
+import { useFileContextMenu } from '@/services/contextMenu';
 import { useFileActions } from '@/services/contextMenu/fileActions';
 import { isFileEditable } from '@/services/cryptpad';
 import {
@@ -336,7 +338,7 @@ import { HotkeyGroup, HotkeyManager, HotkeyManagerKey, Modifiers, Platforms } fr
 import { Information, InformationLevel, InformationManager, InformationManagerKey, PresentationMode } from '@/services/informationManager';
 import { OpenPathOptions } from '@/services/pathOpener';
 import { StorageManager, StorageManagerKey } from '@/services/storageManager';
-import { FileAction, FolderGlobalAction, getDuplicatePolicy, isFolderGlobalAction, useFileContextMenu } from '@/views/files';
+import { FileAction, FolderGlobalAction, getDuplicatePolicy, isFolderGlobalAction } from '@/views/files';
 import { MenuAction, TabBarOptions, useCustomTabBar } from '@/views/menu';
 import { IonContent, IonIcon, IonPage, IonText, popoverController } from '@ionic/vue';
 import {
@@ -473,16 +475,24 @@ const tabBarActions = computed(() => {
     if (selectedEntries.length === 1) {
       actions.push({
         label: 'FoldersPage.tabbar.rename',
-        action: async () => await renameEntries(getSelectedEntries()),
+        action: async () => await dispatchContextMenuAction(FileAction.Rename, getSelectedEntries()),
         image: RenameIcon,
       });
     } else {
-      actions.push({ label: 'FoldersPage.tabbar.duplicate', action: async () => await copyEntries(getSelectedEntries()), icon: duplicate });
+      actions.push({
+        label: 'FoldersPage.tabbar.duplicate',
+        action: async () => await dispatchContextMenuAction(FileAction.MakeACopy, getSelectedEntries()),
+        icon: duplicate,
+      });
     }
-    actions.push({ label: 'FoldersPage.tabbar.move', action: async () => await moveEntriesTo(getSelectedEntries()), icon: arrowRedo });
+    actions.push({
+      label: 'FoldersPage.tabbar.move',
+      action: async () => await dispatchContextMenuAction(FileAction.MoveTo, getSelectedEntries()),
+      icon: arrowRedo,
+    });
     actions.push({
       label: 'FoldersPage.tabbar.delete',
-      action: async () => await deleteEntries(getSelectedEntries()),
+      action: async () => await dispatchContextMenuAction(FileAction.Delete, getSelectedEntries()),
       icon: trashBin,
       danger: true,
     });
@@ -502,10 +512,14 @@ const tabBarActions = computed(() => {
     }
   }
   if (selectedEntries.length > folders.value.getSelectedEntries().length && isWeb()) {
-    actions.push({ label: 'FoldersPage.tabbar.download', action: async () => await downloadEntries(getSelectedEntries()), icon: download });
+    actions.push({
+      label: 'FoldersPage.tabbar.download',
+      action: async () => await dispatchContextMenuAction(FileAction.Download, getSelectedEntries()),
+      icon: download,
+    });
     actions.push({
       label: 'FoldersPage.tabbar.downloadAsArchive',
-      action: async () => await downloadEntries(getSelectedEntries(), true),
+      action: async () => await dispatchContextMenuAction(FileAction.DownloadAsArchive, getSelectedEntries()),
       image: ZipFolderIcon,
     });
   }
@@ -514,7 +528,7 @@ const tabBarActions = computed(() => {
       if (selectedEntries[0].isFile()) {
         actions.push({
           label: 'FoldersPage.tabbar.seeInExplorer',
-          action: async () => await seeInExplorer(getSelectedEntries()),
+          action: async () => await dispatchContextMenuAction(FileAction.SeeInExplorer, getSelectedEntries()),
           image: EyeOpenIcon,
         });
       }
@@ -526,15 +540,39 @@ const tabBarActions = computed(() => {
     }
     if (isReadOnly.value) {
       actions.push(
-        { label: 'FoldersPage.tabbar.copyLink', action: async () => await copyLink(getSelectedEntries()), icon: link },
-        { label: 'FoldersPage.tabbar.details', action: async () => await showDetails(getSelectedEntries()), icon: informationCircle },
+        {
+          label: 'FoldersPage.tabbar.copyLink',
+          action: async () => await dispatchContextMenuAction(FileAction.CopyLink, getSelectedEntries()),
+          icon: link,
+        },
+        {
+          label: 'FoldersPage.tabbar.details',
+          action: async () => await dispatchContextMenuAction(FileAction.ShowDetails, getSelectedEntries()),
+          icon: informationCircle,
+        },
       );
     } else {
       actions.push(
-        { label: 'FoldersPage.tabbar.duplicate', action: async () => await copyEntries(getSelectedEntries()), icon: duplicate },
-        { label: 'FoldersPage.tabbar.copyLink', action: async () => await copyLink(getSelectedEntries()), icon: link },
-        { label: 'FoldersPage.tabbar.history', action: async () => await showHistory(getSelectedEntries()), icon: time },
-        { label: 'FoldersPage.tabbar.details', action: async () => await showDetails(getSelectedEntries()), icon: informationCircle },
+        {
+          label: 'FoldersPage.tabbar.duplicate',
+          action: async () => await dispatchContextMenuAction(FileAction.MakeACopy, getSelectedEntries()),
+          icon: duplicate,
+        },
+        {
+          label: 'FoldersPage.tabbar.copyLink',
+          action: async () => await dispatchContextMenuAction(FileAction.CopyLink, getSelectedEntries()),
+          icon: link,
+        },
+        {
+          label: 'FoldersPage.tabbar.history',
+          action: async () => await dispatchContextMenuAction(FileAction.ShowHistory, getSelectedEntries()),
+          icon: time,
+        },
+        {
+          label: 'FoldersPage.tabbar.details',
+          action: async () => await dispatchContextMenuAction(FileAction.ShowDetails, getSelectedEntries()),
+          icon: informationCircle,
+        },
       );
     }
   }
@@ -626,15 +664,15 @@ async function defineShortcuts(): Promise<void> {
   );
   hotkeys.add(
     { key: 'enter', modifiers: Modifiers.None, platforms: Platforms.MacOS, disableIfModal: true, route: Routes.Documents },
-    async () => await renameEntries(getSelectedEntries()),
+    async () => await dispatchContextMenuAction(FileAction.Rename, getSelectedEntries()),
   );
   hotkeys.add(
     { key: 'f2', modifiers: Modifiers.None, platforms: Platforms.Windows | Platforms.Linux, disableIfModal: true, route: Routes.Documents },
-    async () => await renameEntries(getSelectedEntries()),
+    async () => await dispatchContextMenuAction(FileAction.Rename, getSelectedEntries()),
   );
   hotkeys.add(
     { key: 'i', modifiers: Modifiers.Ctrl | Modifiers.Shift, platforms: Platforms.Desktop, disableIfModal: true, route: Routes.Documents },
-    async () => await showDetails(getSelectedEntries()),
+    async () => await dispatchContextMenuAction(FileAction.ShowDetails, getSelectedEntries()),
   );
   // FIXME: Reactivate `x` and `c` hotkeys when copy/move bindings are available
   // hotkeys.add(
@@ -647,7 +685,7 @@ async function defineShortcuts(): Promise<void> {
   // );
   hotkeys.add(
     { key: 'l', modifiers: Modifiers.Ctrl, platforms: Platforms.Desktop | Platforms.Web, disableIfModal: true, route: Routes.Documents },
-    async () => await copyLink(getSelectedEntries()),
+    async () => await dispatchContextMenuAction(FileAction.CopyLink, getSelectedEntries()),
   );
   hotkeys.add(
     {
@@ -657,11 +695,11 @@ async function defineShortcuts(): Promise<void> {
       disableIfModal: true,
       route: Routes.Documents,
     },
-    async () => await deleteEntries(getSelectedEntries()),
+    async () => await dispatchContextMenuAction(FileAction.Delete, getSelectedEntries()),
   );
   hotkeys.add(
     { key: 'backspace', modifiers: Modifiers.Ctrl, platforms: Platforms.MacOS, disableIfModal: true, route: Routes.Documents },
-    async () => await deleteEntries(getSelectedEntries()),
+    async () => await dispatchContextMenuAction(FileAction.Delete, getSelectedEntries()),
   );
   hotkeys.add(
     { key: 'g', modifiers: Modifiers.Ctrl, platforms: Platforms.Desktop, disableIfModal: true, route: Routes.Documents },
@@ -1056,15 +1094,6 @@ async function listFolder(options?: { selectFile?: EntryName; sameFolder?: boole
   }
 }
 
-async function showEnclosingFolder(entries: EntryModel[]): Promise<void> {
-  if (entries.length !== 1 || !workspaceInfo.value) {
-    return;
-  }
-  await fileActions.showEnclosingFolder(entries[0], workspaceInfo.value);
-  searchPattern.value = '';
-  await cancelSearch();
-}
-
 async function onSearchResultClick(entry: parsec.SearchResult): Promise<void> {
   await onSelectionCancel();
   if (!entry.stats.isFile()) {
@@ -1319,77 +1348,6 @@ function getSelectedEntries(): EntryModel[] {
   return [...folders.value.getSelectedEntries(), ...files.value.getSelectedEntries()];
 }
 
-async function deleteEntries(entries: EntryModel[]): Promise<void> {
-  if (!workspaceInfo.value) {
-    return;
-  }
-  await fileActions.deleteEntries(entries, workspaceInfo.value);
-  if (search.value) {
-    await startSearch(searchPattern.value);
-  }
-  await onSelectionCancel();
-  await listFolder({ sameFolder: true });
-}
-
-async function renameEntries(entries: EntryModel[]): Promise<void> {
-  if (entries.length !== 1 || !workspaceInfo.value) {
-    return;
-  }
-  await fileActions.renameEntry(entries[0], workspaceInfo.value);
-  if (search.value) {
-    await startSearch(searchPattern.value);
-  }
-  await onSelectionCancel();
-}
-
-async function copyLink(entries: EntryModel[]): Promise<void> {
-  if (entries.length !== 1 || !workspaceInfo.value) {
-    return;
-  }
-  await fileActions.copyLink(entries[0], workspaceInfo.value);
-}
-
-async function moveEntriesTo(entries: EntryModel[]): Promise<void> {
-  if (!workspaceInfo.value) {
-    return;
-  }
-  await fileActions.moveEntriesTo(entries, workspaceInfo.value, currentPath.value);
-  selectionEnabled.value = false;
-}
-
-async function showDetails(entries: EntryModel[]): Promise<void> {
-  if (entries.length !== 1 || !workspaceInfo.value || !userInfo.value) {
-    return;
-  }
-  await fileActions.showDetails(entries[0], workspaceInfo.value, userInfo.value.currentProfile);
-}
-
-async function copyEntries(entries: EntryModel[]): Promise<void> {
-  if (!workspaceInfo.value) {
-    return;
-  }
-  await fileActions.copyEntries(entries, workspaceInfo.value, currentPath.value);
-  selectionEnabled.value = false;
-}
-
-async function downloadEntries(entries: EntryModel[], asArchive?: boolean): Promise<void> {
-  if (!workspaceInfo.value) {
-    window.electronAPI.log('error', 'No workspace info when trying to download a file');
-    return;
-  }
-  await fileActions.downloadEntries(entries, workspaceInfo.value, currentFolder.value, currentPath.value, asArchive);
-  await onSelectionCancel();
-}
-
-async function showHistory(entries: EntryModel[]): Promise<void> {
-  if (!workspaceInfo.value) {
-    window.electronAPI.log('error', 'No workspace info when trying to navigate to history');
-    return;
-  }
-  await fileActions.showHistory(entries, workspaceInfo.value);
-  selectionEnabled.value = false;
-}
-
 async function openEntry(entryToOpen: EntryModel, options: OpenPathOptions): Promise<void> {
   if (!workspaceInfo.value) {
     window.electronAPI.log('warn', 'Trying to open an entry but missing workspace info.');
@@ -1467,44 +1425,35 @@ async function openGlobalContextMenu(event: Event): Promise<void> {
   await performFolderAction(action);
 }
 
-async function dispatchContextMenuAction(action: FileAction, entry: EntryModel, selectedEntries: Array<EntryModel>): Promise<void> {
-  const actions = new Map<FileAction, (file: EntryModel[]) => Promise<void>>([
-    [
-      FileAction.Preview,
-      async (entries: EntryModel[]): Promise<void> =>
-        await openEntry(entries[0], { disallowSystem: true, skipViewers: false, readOnly: true }),
-    ],
-    [FileAction.Rename, renameEntries],
-    [FileAction.Edit, async (entries: EntryModel[]): Promise<void> => await openEntry(entries[0], { readOnly: isReadOnly.value })],
-    [FileAction.MoveTo, moveEntriesTo],
-    [FileAction.MakeACopy, copyEntries],
-    [FileAction.Open, async (entries: EntryModel[]): Promise<void> => await openEntry(entries[0], { skipViewers: true })],
-    [FileAction.ShowHistory, showHistory],
-    [FileAction.Download, downloadEntries],
-    [FileAction.DownloadAsArchive, (entries) => downloadEntries(entries, true)],
-    [FileAction.ShowDetails, showDetails],
-    [FileAction.CopyLink, copyLink],
-    [FileAction.Delete, deleteEntries],
-    [FileAction.SeeInExplorer, seeInExplorer],
-    [FileAction.ShowEnclosingFolder, showEnclosingFolder],
-  ]);
-
-  const fn = actions.get(action);
-  if (fn) {
-    if (!selectedEntries.includes(entry)) {
-      await fn([entry]);
-    } else {
-      await fn(selectedEntries);
+async function dispatchContextMenuAction(action: FileAction, entries: Array<parsec.EntryStat>): Promise<void> {
+  if (!workspaceInfo.value || !userInfo.value || entries.length === 0) {
+    return;
+  }
+  await contextMenu.dispatchContextMenuAction(action, entries, workspaceInfo.value, isReadOnly.value, userInfo.value.currentProfile);
+  if ([FileAction.ShowHistory, FileAction.Open, FileAction.MakeACopy, FileAction.MoveTo].includes(action)) {
+    selectionEnabled.value = false;
+  }
+  if ([FileAction.Rename, FileAction.Download, FileAction.DownloadAsArchive, FileAction.Delete].includes(action)) {
+    await onSelectionCancel();
+  }
+  if ([FileAction.Delete].includes(action)) {
+    if (search.value) {
+      await startSearch(searchPattern.value);
     }
+    await listFolder({ sameFolder: true });
+  }
+  if ([FileAction.SeeInExplorer].includes(action)) {
+    searchPattern.value = '';
+    await cancelSearch();
   }
 }
 
 async function onSearchResultContextMenu(event: Event, entry: parsec.SearchResult, onFinished?: () => void): Promise<void> {
   await onSelectionCancel();
-  const action = await contextMenu.openEntryContextMenu(event, { ...entry.stats, isSelected: false }, [], isReadOnly.value, true);
+  const action = await contextMenu.openEntryContextMenu(event, [entry.stats], isReadOnly.value, true);
 
   if (action) {
-    await dispatchContextMenuAction(action, { ...entry.stats, isSelected: false }, []);
+    await dispatchContextMenuAction(action, [entry.stats]);
   }
   if (onFinished) {
     onFinished();
@@ -1513,10 +1462,20 @@ async function onSearchResultContextMenu(event: Event, entry: parsec.SearchResul
 
 async function openEntryContextMenu(event: Event, entry: EntryModel, onFinished?: () => void): Promise<void> {
   const selectedEntries = getSelectedEntries();
-  const action = await contextMenu.openEntryContextMenu(event, entry, selectedEntries, isReadOnly.value);
+
+  const entries: EntryModel[] = [];
+
+  if (!selectedEntries.includes(entry)) {
+    await onSelectionCancel();
+    entries.push(entry);
+  } else {
+    entries.push(...selectedEntries);
+  }
+
+  const action = await contextMenu.openEntryContextMenu(event, entries, isReadOnly.value);
 
   if (action) {
-    await dispatchContextMenuAction(action, entry, selectedEntries);
+    await dispatchContextMenuAction(action, entries);
   }
   if (onFinished) {
     onFinished();
@@ -1557,13 +1516,6 @@ async function shareEntries(): Promise<void> {
   copyPathLinkToClipboard(currentPath.value, workspaceInfo.value.handle, informationManager.value);
 }
 
-async function seeInExplorer(entries: EntryModel[]): Promise<void> {
-  if (!workspaceInfo.value || entries.length !== 1) {
-    return;
-  }
-  await fileActions.seeInExplorer(entries[0].path, workspaceInfo.value);
-}
-
 async function onDropAsReader(): Promise<void> {
   await informationManager.value.present(
     new Information({
@@ -1572,15 +1524,6 @@ async function onDropAsReader(): Promise<void> {
     }),
     PresentationMode.Toast,
   );
-}
-
-// Use megashark's typing when available
-interface MsActionBarAction {
-  label: Translatable;
-  icon?: string;
-  image?: string;
-  isDropdown?: boolean;
-  onClick?: (event: MouseEvent) => Promise<void>;
 }
 
 const actionBarOptionsFoldersPage = computed(() => {
@@ -1641,28 +1584,28 @@ const actionBarOptionsFoldersPage = computed(() => {
           label: 'FoldersPage.fileContextMenu.actionRename',
           image: RenameIcon,
           onClick: async () => {
-            await renameEntries(getSelectedEntries());
+            await dispatchContextMenuAction(FileAction.Rename, getSelectedEntries());
           },
         },
         {
           label: 'FoldersPage.fileContextMenu.actionMoveTo',
           icon: arrowRedo,
           onClick: async () => {
-            await moveEntriesTo(getSelectedEntries());
+            await dispatchContextMenuAction(FileAction.MoveTo, getSelectedEntries());
           },
         },
         {
           label: 'FoldersPage.fileContextMenu.actionMakeACopy',
           icon: duplicate,
           onClick: async () => {
-            await copyEntries(getSelectedEntries());
+            await dispatchContextMenuAction(FileAction.MakeACopy, getSelectedEntries());
           },
         },
         {
           label: 'FoldersPage.fileContextMenu.actionDelete',
           icon: trashBin,
           onClick: async () => {
-            await deleteEntries(getSelectedEntries());
+            await dispatchContextMenuAction(FileAction.Delete, getSelectedEntries());
           },
         },
       );
@@ -1672,14 +1615,14 @@ const actionBarOptionsFoldersPage = computed(() => {
         label: 'FoldersPage.fileContextMenu.actionDownload',
         icon: download,
         onClick: async () => {
-          await downloadEntries(getSelectedEntries());
+          await dispatchContextMenuAction(FileAction.Download, getSelectedEntries());
         },
       });
       actionArray.push({
         label: 'FoldersPage.fileContextMenu.actionDownloadAsArchive',
         icon: archive,
         onClick: async () => {
-          await downloadEntries(getSelectedEntries(), true);
+          await dispatchContextMenuAction(FileAction.DownloadAsArchive, getSelectedEntries());
         },
       });
     }
@@ -1688,14 +1631,14 @@ const actionBarOptionsFoldersPage = computed(() => {
         label: 'FoldersPage.fileContextMenu.actionDetails',
         icon: informationCircle,
         onClick: async () => {
-          await showDetails(getSelectedEntries());
+          await dispatchContextMenuAction(FileAction.ShowDetails, getSelectedEntries());
         },
       },
       {
         label: 'FoldersPage.fileContextMenu.actionCopyLink',
         icon: link,
         onClick: async () => {
-          await copyLink(getSelectedEntries());
+          await dispatchContextMenuAction(FileAction.CopyLink, getSelectedEntries());
         },
       },
     );
@@ -1707,21 +1650,21 @@ const actionBarOptionsFoldersPage = computed(() => {
           label: 'FoldersPage.fileContextMenu.actionMoveTo',
           icon: arrowRedo,
           onClick: async () => {
-            await moveEntriesTo(getSelectedEntries());
+            await dispatchContextMenuAction(FileAction.MoveTo, getSelectedEntries());
           },
         },
         {
           label: 'FoldersPage.fileContextMenu.actionMakeACopy',
           icon: duplicate,
           onClick: async () => {
-            await copyEntries(getSelectedEntries());
+            await dispatchContextMenuAction(FileAction.MakeACopy, getSelectedEntries());
           },
         },
         {
           label: 'FoldersPage.fileContextMenu.actionDelete',
           icon: trashBin,
           onClick: async () => {
-            await deleteEntries(getSelectedEntries());
+            await dispatchContextMenuAction(FileAction.Delete, getSelectedEntries());
           },
         },
       );
@@ -1731,14 +1674,14 @@ const actionBarOptionsFoldersPage = computed(() => {
         label: 'FoldersPage.fileContextMenu.actionDownload',
         icon: download,
         onClick: async () => {
-          await downloadEntries(getSelectedEntries());
+          await dispatchContextMenuAction(FileAction.Download, getSelectedEntries());
         },
       });
       actionArray.push({
         label: 'FoldersPage.fileContextMenu.actionDownloadAsArchive',
         image: ZipFolderIcon,
         onClick: async () => {
-          await downloadEntries(getSelectedEntries(), true);
+          await dispatchContextMenuAction(FileAction.DownloadAsArchive, getSelectedEntries());
         },
       });
     }

--- a/client/src/views/files/utils.ts
+++ b/client/src/views/files/utils.ts
@@ -1,128 +1,15 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-import { EntryModel } from '@/components/files';
-import { SmallDisplayCategoryFileContextMenu, SmallDisplayFileContextMenu } from '@/components/small-display';
 import { EntryName, EntryStat, EntryStatFile, WorkspaceHandle, WorkspaceID } from '@/parsec';
-import { isFileEditable } from '@/services/cryptpad';
 import { DuplicatePolicy } from '@/services/fileOperation';
 import { FileOperationManager } from '@/services/fileOperation/manager';
 import { Information, InformationLevel, InformationManager, PresentationMode } from '@/services/informationManager';
 import { StorageManager } from '@/services/storageManager';
-import { FileAction, FileContextMenu, FileOperationConflictsModal, FolderGlobalAction, FolderGlobalContextMenu } from '@/views/files';
+import { FileOperationConflictsModal } from '@/views/files';
 import DownloadWarningModal from '@/views/files/DownloadWarningModal.vue';
-import { modalController, popoverController } from '@ionic/vue';
-import { MsModalResult, useWindowSize } from 'megashark-lib';
+import { modalController } from '@ionic/vue';
+import { MsModalResult } from 'megashark-lib';
 import { showDirectoryPicker, showSaveFilePicker } from 'native-file-system-adapter';
-
-export function useFileContextMenu() {
-  const { isLargeDisplay } = useWindowSize();
-
-  async function openGlobalContextMenu(event: Event, isReadOnly: boolean, isEmpty: boolean): Promise<FolderGlobalAction | undefined> {
-    let action: FolderGlobalAction | undefined;
-
-    if (isLargeDisplay.value) {
-      if (isReadOnly) {
-        return;
-      }
-
-      const popover = await popoverController.create({
-        component: FolderGlobalContextMenu,
-        cssClass: 'folder-global-context-menu',
-        event: event,
-        reference: event.type === 'contextmenu' ? 'event' : 'trigger',
-        translucent: true,
-        showBackdrop: false,
-        dismissOnSelect: true,
-        alignment: 'start',
-        componentProps: {
-          isReadOnly: isReadOnly,
-        },
-      });
-      await popover.present();
-      action = (await popover.onDidDismiss()).data?.action;
-      await popover.dismiss();
-    } else {
-      const modal = await modalController.create({
-        component: SmallDisplayCategoryFileContextMenu,
-        cssClass: 'file-context-sheet-modal',
-        canDismiss: true,
-        breakpoints: [0, 0.5],
-        expandToScroll: true,
-        initialBreakpoint: 0.5,
-        showBackdrop: true,
-        componentProps: {
-          disableSelect: isEmpty,
-        },
-      });
-
-      await modal.present();
-      action = (await modal.onWillDismiss()).data?.action;
-      await modal.dismiss();
-    }
-    return action;
-  }
-
-  async function openEntryContextMenu(
-    event: Event,
-    entry: EntryModel,
-    selectedEntries: EntryModel[],
-    isReadOnly: boolean,
-    navigateFromAnywhere?: boolean,
-  ): Promise<FileAction | undefined> {
-    let action: FileAction | undefined;
-
-    if (isLargeDisplay.value) {
-      const popover = await popoverController.create({
-        component: FileContextMenu,
-        cssClass: 'file-context-menu',
-        event: event,
-        reference: event.type === 'contextmenu' ? 'event' : 'trigger',
-        translucent: true,
-        showBackdrop: false,
-        dismissOnSelect: true,
-        alignment: 'start',
-        componentProps: {
-          isReadOnly: isReadOnly,
-          multipleFiles: selectedEntries.length > 1 && selectedEntries.includes(entry),
-          isFile: entry.isFile(),
-          isEditable: isFileEditable(entry.name),
-          navigateFromAnywhere: navigateFromAnywhere,
-        },
-      });
-
-      await popover.present();
-      action = (await popover.onDidDismiss()).data?.action;
-      await popover.dismiss();
-    } else {
-      const modal = await modalController.create({
-        component: SmallDisplayFileContextMenu,
-        cssClass: 'file-context-sheet-modal',
-        breakpoints: [0, 0.5, 1],
-        initialBreakpoint: 0.5,
-        expandToScroll: false,
-        showBackdrop: true,
-        componentProps: {
-          isReadOnly: isReadOnly,
-          multipleFiles: selectedEntries.length > 1 && selectedEntries.includes(entry),
-          isFile: entry.isFile(),
-          isEditable: isFileEditable(entry.name),
-          navigateFromAnywhere: navigateFromAnywhere,
-        },
-      });
-
-      await modal.present();
-      action = (await modal.onDidDismiss()).data?.action;
-      await modal.dismiss();
-    }
-
-    return action;
-  }
-
-  return {
-    openGlobalContextMenu,
-    openEntryContextMenu,
-  };
-}
 
 export async function askDownloadConfirmation(multipleFiles?: boolean): Promise<{ result: MsModalResult; noReminder?: boolean }> {
   const modal = await modalController.create({

--- a/client/tests/e2e/specs/document_context_menu.spec.ts
+++ b/client/tests/e2e/specs/document_context_menu.spec.ts
@@ -6,6 +6,7 @@ import {
   DisplaySize,
   expect,
   fillInputModal,
+  fillIonInput,
   importDefaultFiles,
   ImportDocuments,
   MsPage,
@@ -367,6 +368,23 @@ msTest.describe(() => {
       } else {
         await expect(entry.locator('.file-card__title')).toHaveText('New Name');
       }
+    });
+
+    msTest(`Rename document name already exists in ${gridMode ? 'grid' : 'list'} mode`, async ({ documents }, testInfo: TestInfo) => {
+      await importDefaultFiles(documents, testInfo, ImportDocuments.Png | ImportDocuments.Txt, false);
+      if (gridMode) {
+        await toggleViewMode(documents);
+      }
+      await clickAction(await openPopover(documents, 0), 'Rename');
+
+      const modal = documents.locator('.text-input-modal');
+      await expect(modal).toBeVisible();
+      await fillIonInput(modal.locator('ion-input'), '');
+      const okButton = modal.locator('.ms-modal-footer-buttons').locator('#next-button');
+      await fillIonInput(modal.locator('ion-input'), 'text.txt');
+      await expect(okButton).toBeTrulyDisabled();
+      await expect(modal.locator('.form-error')).toBeVisible();
+      await expect(modal.locator('.form-error')).toHaveText('A file with this name already exists.');
     });
 
     msTest(`Delete document in ${gridMode ? 'grid' : 'list'} mode`, async ({ documents }, testInfo: TestInfo) => {


### PR DESCRIPTION
Additional refactoring of file actions using the composable added in #13080.

- Simplify some function calls
- Fix a bug when renaming a file
- Cancel the selection when the file right-clicked is not part of the selection
- Refactor the dispatching of the file action obtained with the context menu
- Adds a test for renaming a file when the file name exists
