### PR TITLE
feat(cli): Add command to mount a workspace

### DIFF
--- a/cli/src/commands/workspace/mod.rs
+++ b/cli/src/commands/workspace/mod.rs
@@ -3,6 +3,7 @@ pub mod create;
 pub mod import;
 pub mod list;
 pub mod list_users;
+pub mod mount;
 pub mod share;
 pub mod sync;
 
@@ -22,6 +23,8 @@ pub enum Group {
     Share(share::Args),
     /// Sync workspace data with the server
     Sync(sync::Args),
+    /// Mount a workspace on the filesystem
+    Mount(mount::Args),
 }
 
 pub async fn dispatch_command(command: Group) -> anyhow::Result<()> {
@@ -33,5 +36,6 @@ pub async fn dispatch_command(command: Group) -> anyhow::Result<()> {
         Group::Import(args) => import::main(args).await,
         Group::Share(args) => share::main(args).await,
         Group::Sync(args) => sync::main(args).await,
+        Group::Mount(args) => mount::main(args).await,
     }
 }

--- a/cli/src/commands/workspace/mount.rs
+++ b/cli/src/commands/workspace/mount.rs
@@ -1,0 +1,65 @@
+use anyhow::Context;
+use libparsec_platform_mountpoint::Mountpoint;
+
+use crate::utils::StartedClient;
+use std::path::PathBuf;
+
+crate::clap_parser_with_shared_opts_builder!(
+    #[with = config_dir, device, password_stdin, workspace]
+    pub struct Args {
+        /// Path where to mount the workspace
+        #[arg(value_hint = clap::ValueHint::DirPath)]
+        mount_dir: PathBuf,
+    }
+);
+
+crate::build_main_with_client!(
+    main,
+    mount_workspace,
+    libparsec::ClientConfig {
+        with_monitors: true, // Enable monitor to keep workspace's content updated
+        ..Default::default()
+    }
+    .into()
+);
+
+pub async fn mount_workspace(args: Args, client: &StartedClient) -> anyhow::Result<()> {
+    log::trace!("Mounting workspace");
+    let Args {
+        workspace,
+        mount_dir,
+        ..
+    } = args;
+    log::debug!(
+        "Starting workspace {workspace} with device {}",
+        client.device_id()
+    );
+    let wksp = client
+        .start_workspace(workspace)
+        .await
+        .context("Failed to start workspace")?;
+
+    let mountpoint = Mountpoint::mount_at_path(wksp, mount_dir)
+        .await
+        .context("Failed to mount workspace at specified directory")?;
+
+    println!("Workspace mounted, send SIGINT signal (Ctrl-C) to stop");
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+    ctrlc::set_handler(move || {
+        let _ = tx.try_send(());
+    })
+    .expect("Failed to set Ctrl-C handler");
+    rx.recv().await.expect("Ctrl-C handler failed");
+
+    println!("Signal received, stopping...");
+    let mut unmount_option = libparsec_platform_mountpoint::UnmountOptions::default();
+    unmount_option.remove_dir = false;
+    mountpoint
+        .unmount_with_options(unmount_option)
+        .await
+        .context("Failed to unmount workspace")?;
+
+    client.stop_workspace(workspace).await;
+    Ok(())
+}

--- a/cli/tests/integration/mod.rs
+++ b/cli/tests/integration/mod.rs
@@ -61,6 +61,7 @@ fn set_env(tmp_dir: &str, url: &ParsecAddr) {
     std::env::remove_var("PARSEC_ADMINISTRATION_TOKEN");
     std::env::remove_var("PARSEC_CONFIG_DIR");
     std::env::remove_var("PARSEC_DATA_DIR");
+    std::env::remove_var(env_logger::DEFAULT_FILTER_ENV);
 }
 
 fn unique_org_id() -> OrganizationID {

--- a/cli/tests/integration/workspace/mod.rs
+++ b/cli/tests/integration/workspace/mod.rs
@@ -2,5 +2,6 @@ mod archive;
 mod create;
 mod import;
 mod list_users;
+mod mount;
 mod share;
 mod sync;

--- a/cli/tests/integration/workspace/mount.rs
+++ b/cli/tests/integration/workspace/mount.rs
@@ -1,0 +1,107 @@
+use std::{os::linux::fs::MetadataExt, sync::Arc};
+
+use libparsec::{LocalDevice, OpenOptions, VlobID};
+use libparsec_tests_fixtures::{tmp_path, TmpPath};
+use parsec_cli::{
+    testenv_utils::{TestOrganization, DEFAULT_DEVICE_PASSWORD},
+    utils::start_client,
+};
+
+use crate::bootstrap_cli_test;
+
+pub async fn setup_workspace(alice: Arc<LocalDevice>) -> VlobID {
+    log::debug!("Create a workspace for alice");
+    let alice_client = start_client(alice).await.unwrap();
+
+    let wid = alice_client
+        .create_workspace("new-workspace".parse().unwrap())
+        .await
+        .unwrap();
+    log::trace!("Workspace ID: {wid}");
+
+    alice_client.ensure_workspaces_bootstrapped().await.unwrap();
+
+    log::debug!("Create dummy files");
+    let workspace = alice_client.start_workspace(wid).await.unwrap();
+
+    workspace
+        .create_folder("/foo".parse().unwrap())
+        .await
+        .unwrap();
+    let fd = workspace
+        .open_file(
+            "/bar.txt".parse().unwrap(),
+            OpenOptions {
+                create_new: true,
+                ..OpenOptions::read_write()
+            },
+        )
+        .await
+        .unwrap();
+    workspace.fd_write(fd, 0, b"hello world").await.unwrap();
+    workspace.fd_close(fd).await.unwrap();
+
+    alice_client.stop_workspace(wid).await;
+
+    alice_client.stop().await;
+
+    wid
+}
+
+#[rstest::rstest]
+#[tokio::test]
+async fn mount_workspace(tmp_path: TmpPath) {
+    let (_, TestOrganization { alice, .. }, _) = bootstrap_cli_test(&tmp_path).await.unwrap();
+    let mount_dir = tmp_path.join("mountpoint");
+
+    std::assert_matches!(
+        tokio::fs::try_exists(&mount_dir).await,
+        Ok(false),
+        "Mountpoint dir should not exist beforehand"
+    );
+
+    tokio::fs::create_dir_all(&mount_dir).await.unwrap();
+
+    let parent_st_dev = tokio::fs::metadata(&*tmp_path).await.unwrap().st_dev();
+
+    let workspace_id = setup_workspace(alice.clone()).await;
+
+    let cmd = crate::std_cmd!(
+        "workspace",
+        "mount",
+        "--password-stdin",
+        "--device",
+        &alice.device_id.hex(),
+        "--workspace",
+        &workspace_id.hex(),
+        &mount_dir.to_string_lossy()
+    );
+    let mut p = crate::spawn_interactive_command(cmd, Some(1500)).unwrap();
+
+    p.send_line(DEFAULT_DEVICE_PASSWORD).unwrap();
+    p.exp_string("Workspace mount").unwrap();
+
+    std::assert_matches!(
+        tokio::fs::try_exists(&mount_dir).await,
+        Ok(true),
+        "Mountpoint should now exist"
+    );
+
+    let mount_st_dev = tokio::fs::metadata(&mount_dir).await.unwrap().st_dev();
+    assert_ne!(
+        parent_st_dev, mount_st_dev,
+        "st_dev should be different since it's not the same filesystems"
+    );
+
+    let blob = tokio::fs::read_to_string(mount_dir.join("bar.txt"))
+        .await
+        .unwrap();
+    assert_eq!(blob, "hello world");
+
+    p.process_mut()
+        .signal(rexpect::process::Signal::SIGINT)
+        .unwrap();
+
+    let status = p.process().wait().unwrap();
+    std::assert_matches!(status, rexpect::process::WaitStatus::Exited(_, 0));
+}

--- a/libparsec/crates/platform_mountpoint/src/lib.rs
+++ b/libparsec/crates/platform_mountpoint/src/lib.rs
@@ -23,3 +23,9 @@ pub use platform::Mountpoint;
 #[path = "../tests/unit/operations/mod.rs"]
 #[allow(clippy::unwrap_used)]
 mod operations;
+
+#[derive(Default)]
+#[non_exhaustive]
+pub struct UnmountOptions {
+    pub remove_dir: bool,
+}

--- a/libparsec/crates/platform_mountpoint/src/unix/history.rs
+++ b/libparsec/crates/platform_mountpoint/src/unix/history.rs
@@ -431,7 +431,7 @@ impl fuser::Filesystem for Filesystem {
             let mut buf = Vec::with_capacity(size as usize);
             // TODO: investigate if offset can be negative or if this is just poor typing on FUSE's part
             let offset = u64::try_from(offset).expect("Offset is negative");
-            match ops.fd_read(fd, offset, size as u64, &mut buf).await {
+            match ops.fd_read(fd, offset, size as u64, &mut buf).await.inspect_err(|e| log::trace!("Error on fd_read(fd={:?}, offset={}, buf.len={}) -> {e}", fd, offset, buf.len())) {
                 Ok(_) => {
                     reply.manual().data(&buf);
                 }

--- a/libparsec/crates/platform_mountpoint/src/unix/mount.rs
+++ b/libparsec/crates/platform_mountpoint/src/unix/mount.rs
@@ -126,7 +126,7 @@ impl Mountpoint {
             //   fetched from the server).
 
             for _ in 0..100 {
-                println!("polling for the start...");
+                log::debug!("polling for the start...");
                 if let Ok(new_st_dev) =
                     std::fs::metadata(&mountpoint_path).map(|stat| stat.st_dev())
                 {
@@ -136,7 +136,7 @@ impl Mountpoint {
                 }
                 std::thread::sleep(std::time::Duration::from_millis(30));
             }
-            println!("mountpoint is ready !");
+            log::info!("mountpoint is ready !");
 
             Ok(Mountpoint {
                 unmounter,
@@ -336,6 +336,9 @@ fn create_suitable_mountpoint_dir(
         "Workspace name `{workspace_name:?}` cannot form a valid path item"
     );
 
+    std::fs::create_dir_all(base_mountpoint_path)?;
+    let base_st_dev = std::fs::metadata(base_mountpoint_path)?.st_dev();
+
     for attempt in 1.. {
         let mountpoint_path = if attempt == 1 {
             base_mountpoint_path.join(workspace_name.as_ref())
@@ -344,9 +347,8 @@ fn create_suitable_mountpoint_dir(
         };
 
         // On POSIX systems, mounting target must exists
-        ok_or_continue!(std::fs::create_dir_all(&mountpoint_path));
+        ok_or_continue!(std::fs::create_dir(&mountpoint_path));
 
-        let base_st_dev = ok_or_continue!(std::fs::metadata(base_mountpoint_path)).st_dev();
         let initial_st_dev = ok_or_continue!(std::fs::metadata(&mountpoint_path)).st_dev();
 
         if initial_st_dev != base_st_dev {

--- a/libparsec/crates/platform_mountpoint/src/unix/mount.rs
+++ b/libparsec/crates/platform_mountpoint/src/unix/mount.rs
@@ -6,7 +6,13 @@ use std::os::macos::fs::MetadataExt;
 #[cfg(target_os = "linux")]
 use std::os::linux::fs::MetadataExt;
 
-use std::{io::ErrorKind, path::Path, process::Command, sync::Arc, thread::JoinHandle};
+use std::{
+    io::ErrorKind,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::Arc,
+    thread::JoinHandle,
+};
 
 use libparsec_client::MountpointMountStrategy;
 use libparsec_types::prelude::*;
@@ -79,12 +85,41 @@ impl Mountpoint {
             MountpointMountStrategy::Disabled => return Err(anyhow::anyhow!("Mount disabled !")),
         };
 
+        let mount_path = tokio::task::spawn_blocking(move || {
+            create_suitable_mountpoint_dir(&mountpoint_base_dir, &workspace_name)
+                .map(|(p, _)| p)
+                .context("cannot create mountpoint dir")
+        })
+        .await??;
+
+        Self::do_mount_at_path(mount_path, filesystem, is_read_only).await
+    }
+
+    pub async fn mount_at_path(
+        ops: Arc<libparsec_client::workspace::WorkspaceOps>,
+        path: PathBuf,
+    ) -> anyhow::Result<Self> {
+        let (workspace_name, is_read_only) = ops.get_workspace_external_info(|info| {
+            (info.entry.name.clone(), info.entry.is_read_only())
+        });
+        log::debug!("Mount workspace {workspace_name} (read only={is_read_only})");
+        let filesystem = super::filesystem::Filesystem::new(
+            ops,
+            tokio::runtime::Handle::current(),
+            is_read_only,
+        );
+        Self::do_mount_at_path(path, filesystem, is_read_only).await
+    }
+
+    async fn do_mount_at_path<FS: fuser::Filesystem + Send + 'static>(
+        mount_path: PathBuf,
+        filesystem: FS,
+        is_read_only: bool,
+    ) -> anyhow::Result<Self> {
+        let initial_st_dev = tokio::fs::metadata(&mount_path).await?.st_dev();
+
         // Mount operation consist of blocking code, so run it in a thread
         tokio::task::spawn_blocking(move || {
-            let (mountpoint_path, initial_st_dev) =
-                create_suitable_mountpoint_dir(&mountpoint_base_dir, &workspace_name)
-                    .context("cannot create mountpoint dir")?;
-
             let options = [
                 fuser::MountOption::FSName("parsec".into()),
                 #[cfg(target_os = "macos")]
@@ -108,7 +143,7 @@ impl Mountpoint {
                 fuser::MountOption::NoDev,
             ];
 
-            let mut session = fuser::Session::new(filesystem, &mountpoint_path, &options)
+            let mut session = fuser::Session::new(filesystem, &mount_path, &options)
                 .map_err(|err| anyhow::anyhow!("cannot mount: {}", err))?;
 
             let unmounter = session.unmount_callable();
@@ -127,20 +162,18 @@ impl Mountpoint {
 
             for _ in 0..100 {
                 log::debug!("polling for the start...");
-                if let Ok(new_st_dev) =
-                    std::fs::metadata(&mountpoint_path).map(|stat| stat.st_dev())
-                {
+                if let Ok(new_st_dev) = std::fs::metadata(&mount_path).map(|stat| stat.st_dev()) {
                     if new_st_dev != initial_st_dev {
                         break;
                     }
                 }
                 std::thread::sleep(std::time::Duration::from_millis(30));
             }
-            log::info!("mountpoint is ready !");
+            log::info!("mountpoint is ready at '{}'!", mount_path.display());
 
             Ok(Mountpoint {
                 unmounter,
-                path: mountpoint_path,
+                path: mount_path,
                 session_loop: Some(session_loop),
             })
         })
@@ -148,7 +181,15 @@ impl Mountpoint {
         .context("cannot run mount task")?
     }
 
-    pub async fn unmount(mut self) -> anyhow::Result<()> {
+    pub async fn unmount(self) -> anyhow::Result<()> {
+        self.unmount_with_options(crate::UnmountOptions { remove_dir: true })
+            .await
+    }
+
+    pub async fn unmount_with_options(
+        mut self,
+        options: crate::UnmountOptions,
+    ) -> anyhow::Result<()> {
         // Unmount operation consist of blocking code, so run it in a thread
         tokio::task::spawn_blocking(move || {
             // `SessionUnmounter::unmount` is idempotent
@@ -166,7 +207,9 @@ impl Mountpoint {
 
             // We do the same as WinFSP: remove the directory.
             // (and given this is more of a nice to have feature, we ignore any error)
-            let _ = std::fs::remove_dir(&self.path);
+            if options.remove_dir {
+                let _ = std::fs::remove_dir(&self.path);
+            }
 
             Ok(())
         })
@@ -347,13 +390,20 @@ fn create_suitable_mountpoint_dir(
         };
 
         // On POSIX systems, mounting target must exists
-        ok_or_continue!(std::fs::create_dir(&mountpoint_path));
+        ok_or_continue!(
+            std::fs::create_dir_all(&mountpoint_path).inspect_err(|e| log::warn!(
+                "Failed to create directory for mount path '{}': {e}",
+                mountpoint_path.display()
+            ))
+        );
 
         let initial_st_dev = ok_or_continue!(std::fs::metadata(&mountpoint_path)).st_dev();
 
         if initial_st_dev != base_st_dev {
-            // mountpoint_path seems to already have a mountpoint on it,
-            // hence find another place to setup our own mountpoint
+            log::warn!(
+                "Mount path '{}' seems to be already in use, will look for another",
+                mountpoint_path.display()
+            );
             continue;
         }
 
@@ -361,7 +411,7 @@ fn create_suitable_mountpoint_dir(
             .next()
             .is_some()
         {
-            // mountpoint_path not empty, cannot mount there
+            log::warn!("Mount path '{}' is not empty", mountpoint_path.display());
             continue;
         }
 

--- a/libparsec/crates/platform_mountpoint/src/windows/mount.rs
+++ b/libparsec/crates/platform_mountpoint/src/windows/mount.rs
@@ -186,7 +186,42 @@ impl Mountpoint {
         })
     }
 
-    pub async fn unmount(mut self) -> anyhow::Result<()> {
+    pub async fn mount_at_path(ops: Arc<WorkspaceOps>, path: PathBuf) -> anyhow::Result<Self> {
+        let (workspace_name, is_read_only, _workspace_index, _total_workspaces) = ops
+            .get_workspace_external_info(|info| {
+                (
+                    info.entry.name.clone(),
+                    info.entry.is_read_only(),
+                    info.workspace_index,
+                    info.total_workspaces,
+                )
+            });
+        let volume_label = generate_volume_label(&workspace_name);
+        log::debug!(
+            "Mount workspace {workspace_name} (read only={is_read_only}, label={})",
+            volume_label.display()
+        );
+
+        let filesystem_interface = super::filesystem::ParsecFileSystemInterface::new(
+            is_read_only,
+            ops.clone(),
+            tokio::runtime::Handle::current(),
+            volume_label,
+        );
+
+        Self::do_mount(filesystem_interface, is_read_only, path).await
+    }
+
+    pub async fn unmount(self) -> anyhow::Result<()> {
+        self.unmount_with_options(crate::UnmountOptions { remove_dir: true })
+            .await
+    }
+
+    pub async fn unmount_with_options(
+        mut self,
+        // TODO: Support option once `winfsp_wrs` does not force mountpoint cleanup on stop
+        _options: crate::UnmountOptions,
+    ) -> anyhow::Result<()> {
         if let Some(filesystem) = self.filesystem.take() {
             filesystem.stop();
         }

--- a/libparsec/crates/platform_mountpoint/tests/unit/operations/history/read_file.rs
+++ b/libparsec/crates/platform_mountpoint/tests/unit/operations/history/read_file.rs
@@ -198,28 +198,17 @@ async fn offline(tmp_path: TmpPath, env: &TestbedEnv) {
             // to avoid deadlock with tokio single threaded runtime when the
             // close waits for data flush.
             let bar_path = mountpoint_path.join("bar.txt");
-            tokio::task::spawn_blocking(move || {
+            let err = tokio::task::spawn_blocking(move || {
                 let mut fd = std::fs::OpenOptions::new()
                     .read(true)
                     .open(bar_path)
                     .unwrap();
 
                 let mut buff = Vec::new();
-                let err = fd.read_to_end(&mut buff).unwrap_err();
+                fd.read_to_end(&mut buff).unwrap_err()
+            }).await.unwrap();
 
-                // Cannot use `std::io::ErrorKind::HostUnreachable` as it is unstable
-                #[cfg(not(target_os = "windows"))]
-                p_assert_eq!(err.raw_os_error(), Some(libc::EHOSTUNREACH), "{}", err);
-                #[cfg(target_os = "windows")]
-                p_assert_eq!(
-                    err.raw_os_error(),
-                    Some(windows_sys::Win32::Foundation::ERROR_HOST_UNREACHABLE as i32),
-                    "{}",
-                    err
-                );
-            })
-            .await
-            .unwrap();
+            p_assert_eq!(err.kind(), std::io::ErrorKind::HostUnreachable, "{err:#?}(kind={})", err.kind());
         }
     );
 }


### PR DESCRIPTION
- Add `Mountpoint::mount_at_path` to allow specify a mount path over relying on `MountpointMountStrategy`

Closes #13137