### PR TITLE
chore(mountpoint): Update fuser to 0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,16 +1475,20 @@ dependencies = [
 
 [[package]]
 name = "fuser"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb29a3ae32279fe3e79a958fe01899f5fb23eadccee919cf88e145b54ed9367"
+checksum = "80a5eca878900c2e39e9e52fd797954b7fc39eeefc8558257114bfea6a698fcf"
 dependencies = [
+ "bitflags 2.10.0",
  "libc",
  "log",
  "memchr",
- "nix 0.29.0",
+ "nix 0.30.1",
+ "num_enum",
  "page_size",
+ "parking_lot",
  "pkg-config",
+ "ref-cast",
  "smallvec",
  "zerocopy",
 ]
@@ -1705,7 +1709,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1749,6 +1753,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -2118,12 +2128,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -3058,6 +3068,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mini-internal"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3170,14 +3189,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if 1.0.4",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -3315,6 +3335,28 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3695,7 +3737,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64",
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "quick-xml 0.41.0",
  "serde",
  "time",
@@ -3825,6 +3867,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -4088,22 +4139,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4810,7 +4861,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde_core",
@@ -5024,7 +5075,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.16.1",
  "hashlink",
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "percent-encoding",
@@ -5507,6 +5558,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5954,7 +6035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -5980,7 +6061,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.10.0",
  "hashbrown 0.15.5",
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -6336,6 +6417,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6369,7 +6459,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.119",
  "wasm-metadata",
@@ -6400,7 +6490,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -6419,7 +6509,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -6602,7 +6692,7 @@ checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "flate2",
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "memchr",
  "typed-path",
  "zopfli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ event-listener = { version = "5.4.1", default-features = false }
 eventsource-stream = { version = "0.2.3", default-features = false }
 flume = { version = "0.12.0", default-features = false }
 fnmatch-regex = { version = "0.3.0", default-features = false }
-fuser = { version = "0.16.0", default-features = false }
+fuser = { version = "0.17.0", default-features = false }
 futures = { version = "0.3.32", default-features = false }
 generic-array = { version = "0.14.7", default-features = false }
 getrandom = { package = "getrandom", version = "0.3.4", default-features = false }

--- a/bindings/electron/src/meths.rs
+++ b/bindings/electron/src/meths.rs
@@ -29904,16 +29904,14 @@ fn workspace_fd_close(mut cx: FunctionContext) -> JsResult<JsPromise> {
         }
     };
     let fd = {
-        let js_val = cx.argument::<JsNumber>(1)?;
+        let js_val = cx.argument::<JsBigInt>(1)?;
         {
-            let v = js_val.value(&mut cx);
-            if v < (u32::MIN as f64) || (u32::MAX as f64) < v {
-                cx.throw_type_error("Not an u32 number")?
-            }
-            let v = v as u32;
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            match custom_from_rs_u32(v) {
+            let v = js_val
+                .to_u64(&mut cx)
+                .or_else(|_| cx.throw_type_error("Not an u64 number"))?;
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            match custom_from_rs_u64(v) {
                 Ok(val) => val,
                 Err(err) => return cx.throw_type_error(err),
             }
@@ -29974,16 +29972,14 @@ fn workspace_fd_flush(mut cx: FunctionContext) -> JsResult<JsPromise> {
         }
     };
     let fd = {
-        let js_val = cx.argument::<JsNumber>(1)?;
+        let js_val = cx.argument::<JsBigInt>(1)?;
         {
-            let v = js_val.value(&mut cx);
-            if v < (u32::MIN as f64) || (u32::MAX as f64) < v {
-                cx.throw_type_error("Not an u32 number")?
-            }
-            let v = v as u32;
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            match custom_from_rs_u32(v) {
+            let v = js_val
+                .to_u64(&mut cx)
+                .or_else(|_| cx.throw_type_error("Not an u64 number"))?;
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            match custom_from_rs_u64(v) {
                 Ok(val) => val,
                 Err(err) => return cx.throw_type_error(err),
             }
@@ -30044,16 +30040,14 @@ fn workspace_fd_read(mut cx: FunctionContext) -> JsResult<JsPromise> {
         }
     };
     let fd = {
-        let js_val = cx.argument::<JsNumber>(1)?;
+        let js_val = cx.argument::<JsBigInt>(1)?;
         {
-            let v = js_val.value(&mut cx);
-            if v < (u32::MIN as f64) || (u32::MAX as f64) < v {
-                cx.throw_type_error("Not an u32 number")?
-            }
-            let v = v as u32;
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            match custom_from_rs_u32(v) {
+            let v = js_val
+                .to_u64(&mut cx)
+                .or_else(|_| cx.throw_type_error("Not an u64 number"))?;
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            match custom_from_rs_u64(v) {
                 Ok(val) => val,
                 Err(err) => return cx.throw_type_error(err),
             }
@@ -30131,16 +30125,14 @@ fn workspace_fd_resize(mut cx: FunctionContext) -> JsResult<JsPromise> {
         }
     };
     let fd = {
-        let js_val = cx.argument::<JsNumber>(1)?;
+        let js_val = cx.argument::<JsBigInt>(1)?;
         {
-            let v = js_val.value(&mut cx);
-            if v < (u32::MIN as f64) || (u32::MAX as f64) < v {
-                cx.throw_type_error("Not an u32 number")?
-            }
-            let v = v as u32;
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            match custom_from_rs_u32(v) {
+            let v = js_val
+                .to_u64(&mut cx)
+                .or_else(|_| cx.throw_type_error("Not an u64 number"))?;
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            match custom_from_rs_u64(v) {
                 Ok(val) => val,
                 Err(err) => return cx.throw_type_error(err),
             }
@@ -30214,16 +30206,14 @@ fn workspace_fd_stat(mut cx: FunctionContext) -> JsResult<JsPromise> {
         }
     };
     let fd = {
-        let js_val = cx.argument::<JsNumber>(1)?;
+        let js_val = cx.argument::<JsBigInt>(1)?;
         {
-            let v = js_val.value(&mut cx);
-            if v < (u32::MIN as f64) || (u32::MAX as f64) < v {
-                cx.throw_type_error("Not an u32 number")?
-            }
-            let v = v as u32;
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            match custom_from_rs_u32(v) {
+            let v = js_val
+                .to_u64(&mut cx)
+                .or_else(|_| cx.throw_type_error("Not an u64 number"))?;
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            match custom_from_rs_u64(v) {
                 Ok(val) => val,
                 Err(err) => return cx.throw_type_error(err),
             }
@@ -30280,16 +30270,14 @@ fn workspace_fd_write(mut cx: FunctionContext) -> JsResult<JsPromise> {
         }
     };
     let fd = {
-        let js_val = cx.argument::<JsNumber>(1)?;
+        let js_val = cx.argument::<JsBigInt>(1)?;
         {
-            let v = js_val.value(&mut cx);
-            if v < (u32::MIN as f64) || (u32::MAX as f64) < v {
-                cx.throw_type_error("Not an u32 number")?
-            }
-            let v = v as u32;
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            match custom_from_rs_u32(v) {
+            let v = js_val
+                .to_u64(&mut cx)
+                .or_else(|_| cx.throw_type_error("Not an u64 number"))?;
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            match custom_from_rs_u64(v) {
                 Ok(val) => val,
                 Err(err) => return cx.throw_type_error(err),
             }
@@ -30359,16 +30347,14 @@ fn workspace_fd_write_constrained_io(mut cx: FunctionContext) -> JsResult<JsProm
         }
     };
     let fd = {
-        let js_val = cx.argument::<JsNumber>(1)?;
+        let js_val = cx.argument::<JsBigInt>(1)?;
         {
-            let v = js_val.value(&mut cx);
-            if v < (u32::MIN as f64) || (u32::MAX as f64) < v {
-                cx.throw_type_error("Not an u32 number")?
-            }
-            let v = v as u32;
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            match custom_from_rs_u32(v) {
+            let v = js_val
+                .to_u64(&mut cx)
+                .or_else(|_| cx.throw_type_error("Not an u64 number"))?;
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            match custom_from_rs_u64(v) {
                 Ok(val) => val,
                 Err(err) => return cx.throw_type_error(err),
             }
@@ -30439,16 +30425,14 @@ fn workspace_fd_write_start_eof(mut cx: FunctionContext) -> JsResult<JsPromise> 
         }
     };
     let fd = {
-        let js_val = cx.argument::<JsNumber>(1)?;
+        let js_val = cx.argument::<JsBigInt>(1)?;
         {
-            let v = js_val.value(&mut cx);
-            if v < (u32::MIN as f64) || (u32::MAX as f64) < v {
-                cx.throw_type_error("Not an u32 number")?
-            }
-            let v = v as u32;
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            match custom_from_rs_u32(v) {
+            let v = js_val
+                .to_u64(&mut cx)
+                .or_else(|_| cx.throw_type_error("Not an u64 number"))?;
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            match custom_from_rs_u64(v) {
                 Ok(val) => val,
                 Err(err) => return cx.throw_type_error(err),
             }
@@ -30592,16 +30576,14 @@ fn workspace_history_fd_close(mut cx: FunctionContext) -> JsResult<JsPromise> {
         }
     };
     let fd = {
-        let js_val = cx.argument::<JsNumber>(1)?;
+        let js_val = cx.argument::<JsBigInt>(1)?;
         {
-            let v = js_val.value(&mut cx);
-            if v < (u32::MIN as f64) || (u32::MAX as f64) < v {
-                cx.throw_type_error("Not an u32 number")?
-            }
-            let v = v as u32;
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            match custom_from_rs_u32(v) {
+            let v = js_val
+                .to_u64(&mut cx)
+                .or_else(|_| cx.throw_type_error("Not an u64 number"))?;
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            match custom_from_rs_u64(v) {
                 Ok(val) => val,
                 Err(err) => return cx.throw_type_error(err),
             }
@@ -30650,16 +30632,14 @@ fn workspace_history_fd_read(mut cx: FunctionContext) -> JsResult<JsPromise> {
         }
     };
     let fd = {
-        let js_val = cx.argument::<JsNumber>(1)?;
+        let js_val = cx.argument::<JsBigInt>(1)?;
         {
-            let v = js_val.value(&mut cx);
-            if v < (u32::MIN as f64) || (u32::MAX as f64) < v {
-                cx.throw_type_error("Not an u32 number")?
-            }
-            let v = v as u32;
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            match custom_from_rs_u32(v) {
+            let v = js_val
+                .to_u64(&mut cx)
+                .or_else(|_| cx.throw_type_error("Not an u64 number"))?;
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            match custom_from_rs_u64(v) {
                 Ok(val) => val,
                 Err(err) => return cx.throw_type_error(err),
             }
@@ -30739,16 +30719,14 @@ fn workspace_history_fd_stat(mut cx: FunctionContext) -> JsResult<JsPromise> {
         }
     };
     let fd = {
-        let js_val = cx.argument::<JsNumber>(1)?;
+        let js_val = cx.argument::<JsBigInt>(1)?;
         {
-            let v = js_val.value(&mut cx);
-            if v < (u32::MIN as f64) || (u32::MAX as f64) < v {
-                cx.throw_type_error("Not an u32 number")?
-            }
-            let v = v as u32;
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            match custom_from_rs_u32(v) {
+            let v = js_val
+                .to_u64(&mut cx)
+                .or_else(|_| cx.throw_type_error("Not an u64 number"))?;
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            match custom_from_rs_u64(v) {
                 Ok(val) => val,
                 Err(err) => return cx.throw_type_error(err),
             }
@@ -30971,16 +30949,16 @@ fn workspace_history_open_file(mut cx: FunctionContext) -> JsResult<JsPromise> {
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = JsNumber::new(&mut cx, {
-                            let custom_to_rs_u32 =
+                        let js_value = JsBigInt::from_u64(&mut cx, {
+                            let custom_to_rs_u64 =
                                 |fd: libparsec::FileDescriptor| -> Result<_, &'static str> {
                                     Ok(fd.0)
                                 };
-                            match custom_to_rs_u32(ok) {
+                            match custom_to_rs_u64(ok) {
                                 Ok(ok) => ok,
                                 Err(err) => return cx.throw_type_error(err),
                             }
-                        } as f64);
+                        });
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -31047,17 +31025,16 @@ fn workspace_history_open_file_and_get_id(mut cx: FunctionContext) -> JsResult<J
                         let js_value = {
                             let (x0, x1) = ok;
                             let js_array = JsArray::new(&mut cx, 2);
-                            let js_value = JsNumber::new(&mut cx, {
-                                let custom_to_rs_u32 =
+                            let js_value = JsBigInt::from_u64(&mut cx, {
+                                let custom_to_rs_u64 =
                                     |fd: libparsec::FileDescriptor| -> Result<_, &'static str> {
                                         Ok(fd.0)
                                     };
-                                match custom_to_rs_u32(x0) {
+                                match custom_to_rs_u64(x0) {
                                     Ok(ok) => ok,
                                     Err(err) => return cx.throw_type_error(err),
                                 }
-                            }
-                                as f64);
+                            });
                             js_array.set(&mut cx, 0, js_value)?;
                             let js_value = JsString::try_new(&mut cx, {
                                 let custom_to_rs_string =
@@ -31136,16 +31113,16 @@ fn workspace_history_open_file_by_id(mut cx: FunctionContext) -> JsResult<JsProm
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = JsNumber::new(&mut cx, {
-                            let custom_to_rs_u32 =
+                        let js_value = JsBigInt::from_u64(&mut cx, {
+                            let custom_to_rs_u64 =
                                 |fd: libparsec::FileDescriptor| -> Result<_, &'static str> {
                                     Ok(fd.0)
                                 };
-                            match custom_to_rs_u32(ok) {
+                            match custom_to_rs_u64(ok) {
                                 Ok(ok) => ok,
                                 Err(err) => return cx.throw_type_error(err),
                             }
-                        } as f64);
+                        });
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -31961,16 +31938,16 @@ fn workspace_open_file(mut cx: FunctionContext) -> JsResult<JsPromise> {
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = JsNumber::new(&mut cx, {
-                            let custom_to_rs_u32 =
+                        let js_value = JsBigInt::from_u64(&mut cx, {
+                            let custom_to_rs_u64 =
                                 |fd: libparsec::FileDescriptor| -> Result<_, &'static str> {
                                     Ok(fd.0)
                                 };
-                            match custom_to_rs_u32(ok) {
+                            match custom_to_rs_u64(ok) {
                                 Ok(ok) => ok,
                                 Err(err) => return cx.throw_type_error(err),
                             }
-                        } as f64);
+                        });
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }
@@ -32039,17 +32016,16 @@ fn workspace_open_file_and_get_id(mut cx: FunctionContext) -> JsResult<JsPromise
                         let js_value = {
                             let (x0, x1) = ok;
                             let js_array = JsArray::new(&mut cx, 2);
-                            let js_value = JsNumber::new(&mut cx, {
-                                let custom_to_rs_u32 =
+                            let js_value = JsBigInt::from_u64(&mut cx, {
+                                let custom_to_rs_u64 =
                                     |fd: libparsec::FileDescriptor| -> Result<_, &'static str> {
                                         Ok(fd.0)
                                     };
-                                match custom_to_rs_u32(x0) {
+                                match custom_to_rs_u64(x0) {
                                     Ok(ok) => ok,
                                     Err(err) => return cx.throw_type_error(err),
                                 }
-                            }
-                                as f64);
+                            });
                             js_array.set(&mut cx, 0, js_value)?;
                             let js_value = JsString::try_new(&mut cx, {
                                 let custom_to_rs_string =
@@ -32130,16 +32106,16 @@ fn workspace_open_file_by_id(mut cx: FunctionContext) -> JsResult<JsPromise> {
                         let js_obj = JsObject::new(&mut cx);
                         let js_tag = JsBoolean::new(&mut cx, true);
                         js_obj.set(&mut cx, "ok", js_tag)?;
-                        let js_value = JsNumber::new(&mut cx, {
-                            let custom_to_rs_u32 =
+                        let js_value = JsBigInt::from_u64(&mut cx, {
+                            let custom_to_rs_u64 =
                                 |fd: libparsec::FileDescriptor| -> Result<_, &'static str> {
                                     Ok(fd.0)
                                 };
-                            match custom_to_rs_u32(ok) {
+                            match custom_to_rs_u64(ok) {
                                 Ok(ok) => ok,
                                 Err(err) => return cx.throw_type_error(err),
                             }
-                        } as f64);
+                        });
                         js_obj.set(&mut cx, "value", js_value)?;
                         js_obj
                     }

--- a/bindings/generator/api/workspace.py
+++ b/bindings/generator/api/workspace.py
@@ -20,7 +20,7 @@ from .common import (
     Result,
     SizeInt,
     Structure,
-    U32BasedType,
+    U64BasedType,
     Variant,
     VariantItemUnit,
     VersionInt,
@@ -497,9 +497,9 @@ class OpenOptions(Structure):
     create_new: bool
 
 
-class FileDescriptor(U32BasedType):
-    custom_from_rs_u32 = "|raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) }"
-    custom_to_rs_u32 = "|fd: libparsec::FileDescriptor| -> Result<_, &'static str> { Ok(fd.0) }"
+class FileDescriptor(U64BasedType):
+    custom_from_rs_u64 = "|raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) }"
+    custom_to_rs_u64 = "|fd: libparsec::FileDescriptor| -> Result<_, &'static str> { Ok(fd.0) }"
 
 
 class WorkspaceIsFileContentLocalError(ErrorVariant):

--- a/bindings/generator/templates/binding_web_meths.rs.j2
+++ b/bindings/generator/templates/binding_web_meths.rs.j2
@@ -561,7 +561,7 @@ JsValue::from({{ rs_value }})
     let custom_to_rs_u64 = {{ type.custom_to_rs_u64 }};
     let v = match custom_to_rs_u64({{ rs_value }}) {
         Ok(ok) => ok,
-        Err(err) => return Err(JsValue::from(TypeError::new(err.as_ref()))),
+        Err(err) => return Err(JsValue::from(TypeError::new(err))),
     };
     JsValue::from(v)
 }

--- a/bindings/web/src/meths.rs
+++ b/bindings/web/src/meths.rs
@@ -29860,12 +29860,12 @@ pub fn workspaceDecryptPathAddr(workspace: u32, link: String) -> Promise {
 // workspace_fd_close
 #[allow(non_snake_case)]
 #[wasm_bindgen]
-pub fn workspaceFdClose(workspace: u32, fd: u32) -> Promise {
+pub fn workspaceFdClose(workspace: u32, fd: u64) -> Promise {
     future_to_promise(libparsec::WithTaskIDFuture::from(async move {
         let fd = {
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            custom_from_rs_u32(fd).map_err(|e| TypeError::new(e.as_ref()))
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            custom_from_rs_u64(fd).map_err(|e| TypeError::new(e.as_ref()))
         }?;
 
         let ret = libparsec::workspace_fd_close(workspace, fd).await;
@@ -29895,12 +29895,12 @@ pub fn workspaceFdClose(workspace: u32, fd: u32) -> Promise {
 // workspace_fd_flush
 #[allow(non_snake_case)]
 #[wasm_bindgen]
-pub fn workspaceFdFlush(workspace: u32, fd: u32) -> Promise {
+pub fn workspaceFdFlush(workspace: u32, fd: u64) -> Promise {
     future_to_promise(libparsec::WithTaskIDFuture::from(async move {
         let fd = {
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            custom_from_rs_u32(fd).map_err(|e| TypeError::new(e.as_ref()))
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            custom_from_rs_u64(fd).map_err(|e| TypeError::new(e.as_ref()))
         }?;
 
         let ret = libparsec::workspace_fd_flush(workspace, fd).await;
@@ -29930,12 +29930,12 @@ pub fn workspaceFdFlush(workspace: u32, fd: u32) -> Promise {
 // workspace_fd_read
 #[allow(non_snake_case)]
 #[wasm_bindgen]
-pub fn workspaceFdRead(workspace: u32, fd: u32, offset: u64, size: u64) -> Promise {
+pub fn workspaceFdRead(workspace: u32, fd: u64, offset: u64, size: u64) -> Promise {
     future_to_promise(libparsec::WithTaskIDFuture::from(async move {
         let fd = {
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            custom_from_rs_u32(fd).map_err(|e| TypeError::new(e.as_ref()))
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            custom_from_rs_u64(fd).map_err(|e| TypeError::new(e.as_ref()))
         }?;
 
         let ret = libparsec::workspace_fd_read(workspace, fd, offset, size).await;
@@ -29961,12 +29961,12 @@ pub fn workspaceFdRead(workspace: u32, fd: u32, offset: u64, size: u64) -> Promi
 // workspace_fd_resize
 #[allow(non_snake_case)]
 #[wasm_bindgen]
-pub fn workspaceFdResize(workspace: u32, fd: u32, length: u64, truncate_only: bool) -> Promise {
+pub fn workspaceFdResize(workspace: u32, fd: u64, length: u64, truncate_only: bool) -> Promise {
     future_to_promise(libparsec::WithTaskIDFuture::from(async move {
         let fd = {
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            custom_from_rs_u32(fd).map_err(|e| TypeError::new(e.as_ref()))
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            custom_from_rs_u64(fd).map_err(|e| TypeError::new(e.as_ref()))
         }?;
 
         let ret = libparsec::workspace_fd_resize(workspace, fd, length, truncate_only).await;
@@ -29996,12 +29996,12 @@ pub fn workspaceFdResize(workspace: u32, fd: u32, length: u64, truncate_only: bo
 // workspace_fd_stat
 #[allow(non_snake_case)]
 #[wasm_bindgen]
-pub fn workspaceFdStat(workspace: u32, fd: u32) -> Promise {
+pub fn workspaceFdStat(workspace: u32, fd: u64) -> Promise {
     future_to_promise(libparsec::WithTaskIDFuture::from(async move {
         let fd = {
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            custom_from_rs_u32(fd).map_err(|e| TypeError::new(e.as_ref()))
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            custom_from_rs_u64(fd).map_err(|e| TypeError::new(e.as_ref()))
         }?;
 
         let ret = libparsec::workspace_fd_stat(workspace, fd).await;
@@ -30027,12 +30027,12 @@ pub fn workspaceFdStat(workspace: u32, fd: u32) -> Promise {
 // workspace_fd_write
 #[allow(non_snake_case)]
 #[wasm_bindgen]
-pub fn workspaceFdWrite(workspace: u32, fd: u32, offset: u64, data: Uint8Array) -> Promise {
+pub fn workspaceFdWrite(workspace: u32, fd: u64, offset: u64, data: Uint8Array) -> Promise {
     future_to_promise(libparsec::WithTaskIDFuture::from(async move {
         let fd = {
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            custom_from_rs_u32(fd).map_err(|e| TypeError::new(e.as_ref()))
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            custom_from_rs_u64(fd).map_err(|e| TypeError::new(e.as_ref()))
         }?;
 
         let data = data.to_vec();
@@ -30062,15 +30062,15 @@ pub fn workspaceFdWrite(workspace: u32, fd: u32, offset: u64, data: Uint8Array) 
 #[wasm_bindgen]
 pub fn workspaceFdWriteConstrainedIo(
     workspace: u32,
-    fd: u32,
+    fd: u64,
     offset: u64,
     data: Uint8Array,
 ) -> Promise {
     future_to_promise(libparsec::WithTaskIDFuture::from(async move {
         let fd = {
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            custom_from_rs_u32(fd).map_err(|e| TypeError::new(e.as_ref()))
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            custom_from_rs_u64(fd).map_err(|e| TypeError::new(e.as_ref()))
         }?;
 
         let data = data.to_vec();
@@ -30100,12 +30100,12 @@ pub fn workspaceFdWriteConstrainedIo(
 // workspace_fd_write_start_eof
 #[allow(non_snake_case)]
 #[wasm_bindgen]
-pub fn workspaceFdWriteStartEof(workspace: u32, fd: u32, data: Uint8Array) -> Promise {
+pub fn workspaceFdWriteStartEof(workspace: u32, fd: u64, data: Uint8Array) -> Promise {
     future_to_promise(libparsec::WithTaskIDFuture::from(async move {
         let fd = {
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            custom_from_rs_u32(fd).map_err(|e| TypeError::new(e.as_ref()))
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            custom_from_rs_u64(fd).map_err(|e| TypeError::new(e.as_ref()))
         }?;
 
         let data = data.to_vec();
@@ -30200,12 +30200,12 @@ pub fn workspaceGeneratePathAddr(workspace: u32, path: String) -> Promise {
 // workspace_history_fd_close
 #[allow(non_snake_case)]
 #[wasm_bindgen]
-pub fn workspaceHistoryFdClose(workspace_history: u32, fd: u32) -> Promise {
+pub fn workspaceHistoryFdClose(workspace_history: u32, fd: u64) -> Promise {
     future_to_promise(libparsec::WithTaskIDFuture::from(async move {
         let fd = {
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            custom_from_rs_u32(fd).map_err(|e| TypeError::new(e.as_ref()))
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            custom_from_rs_u64(fd).map_err(|e| TypeError::new(e.as_ref()))
         }?;
         let ret = libparsec::workspace_history_fd_close(workspace_history, fd);
         Ok(match ret {
@@ -30234,12 +30234,12 @@ pub fn workspaceHistoryFdClose(workspace_history: u32, fd: u32) -> Promise {
 // workspace_history_fd_read
 #[allow(non_snake_case)]
 #[wasm_bindgen]
-pub fn workspaceHistoryFdRead(workspace_history: u32, fd: u32, offset: u64, size: u64) -> Promise {
+pub fn workspaceHistoryFdRead(workspace_history: u32, fd: u64, offset: u64, size: u64) -> Promise {
     future_to_promise(libparsec::WithTaskIDFuture::from(async move {
         let fd = {
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            custom_from_rs_u32(fd).map_err(|e| TypeError::new(e.as_ref()))
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            custom_from_rs_u64(fd).map_err(|e| TypeError::new(e.as_ref()))
         }?;
 
         let ret = libparsec::workspace_history_fd_read(workspace_history, fd, offset, size).await;
@@ -30265,12 +30265,12 @@ pub fn workspaceHistoryFdRead(workspace_history: u32, fd: u32, offset: u64, size
 // workspace_history_fd_stat
 #[allow(non_snake_case)]
 #[wasm_bindgen]
-pub fn workspaceHistoryFdStat(workspace_history: u32, fd: u32) -> Promise {
+pub fn workspaceHistoryFdStat(workspace_history: u32, fd: u64) -> Promise {
     future_to_promise(libparsec::WithTaskIDFuture::from(async move {
         let fd = {
-            let custom_from_rs_u32 =
-                |raw: u32| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
-            custom_from_rs_u32(fd).map_err(|e| TypeError::new(e.as_ref()))
+            let custom_from_rs_u64 =
+                |raw: u64| -> Result<_, String> { Ok(libparsec::FileDescriptor(raw)) };
+            custom_from_rs_u64(fd).map_err(|e| TypeError::new(e.as_ref()))
         }?;
 
         let ret = libparsec::workspace_history_fd_stat(workspace_history, fd).await;
@@ -30415,9 +30415,9 @@ pub fn workspaceHistoryOpenFile(workspace_history: u32, path: String) -> Promise
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
                 let js_value = {
-                    let custom_to_rs_u32 =
+                    let custom_to_rs_u64 =
                         |fd: libparsec::FileDescriptor| -> Result<_, &'static str> { Ok(fd.0) };
-                    let v = match custom_to_rs_u32(value) {
+                    let v = match custom_to_rs_u64(value) {
                         Ok(ok) => ok,
                         Err(err) => return Err(JsValue::from(TypeError::new(err))),
                     };
@@ -30461,9 +30461,9 @@ pub fn workspaceHistoryOpenFileAndGetId(workspace_history: u32, path: String) ->
                     // Array::new_with_length allocates with `undefined` value, that's why we `set` value
                     let js_array = Array::new_with_length(2);
                     let js_value = {
-                        let custom_to_rs_u32 =
+                        let custom_to_rs_u64 =
                             |fd: libparsec::FileDescriptor| -> Result<_, &'static str> { Ok(fd.0) };
-                        let v = match custom_to_rs_u32(x1) {
+                        let v = match custom_to_rs_u64(x1) {
                             Ok(ok) => ok,
                             Err(err) => return Err(JsValue::from(TypeError::new(err))),
                         };
@@ -30519,9 +30519,9 @@ pub fn workspaceHistoryOpenFileById(workspace_history: u32, entry_id: String) ->
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
                 let js_value = {
-                    let custom_to_rs_u32 =
+                    let custom_to_rs_u64 =
                         |fd: libparsec::FileDescriptor| -> Result<_, &'static str> { Ok(fd.0) };
-                    let v = match custom_to_rs_u32(value) {
+                    let v = match custom_to_rs_u64(value) {
                         Ok(ok) => ok,
                         Err(err) => return Err(JsValue::from(TypeError::new(err))),
                     };
@@ -31016,9 +31016,9 @@ pub fn workspaceOpenFile(workspace: u32, path: String, mode: Object) -> Promise 
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
                 let js_value = {
-                    let custom_to_rs_u32 =
+                    let custom_to_rs_u64 =
                         |fd: libparsec::FileDescriptor| -> Result<_, &'static str> { Ok(fd.0) };
-                    let v = match custom_to_rs_u32(value) {
+                    let v = match custom_to_rs_u64(value) {
                         Ok(ok) => ok,
                         Err(err) => return Err(JsValue::from(TypeError::new(err))),
                     };
@@ -31065,9 +31065,9 @@ pub fn workspaceOpenFileAndGetId(workspace: u32, path: String, mode: Object) -> 
                     // Array::new_with_length allocates with `undefined` value, that's why we `set` value
                     let js_array = Array::new_with_length(2);
                     let js_value = {
-                        let custom_to_rs_u32 =
+                        let custom_to_rs_u64 =
                             |fd: libparsec::FileDescriptor| -> Result<_, &'static str> { Ok(fd.0) };
-                        let v = match custom_to_rs_u32(x1) {
+                        let v = match custom_to_rs_u64(x1) {
                             Ok(ok) => ok,
                             Err(err) => return Err(JsValue::from(TypeError::new(err))),
                         };
@@ -31126,9 +31126,9 @@ pub fn workspaceOpenFileById(workspace: u32, entry_id: String, mode: Object) -> 
                 let js_obj = Object::new().into();
                 Reflect::set(&js_obj, &"ok".into(), &true.into())?;
                 let js_value = {
-                    let custom_to_rs_u32 =
+                    let custom_to_rs_u64 =
                         |fd: libparsec::FileDescriptor| -> Result<_, &'static str> { Ok(fd.0) };
-                    let v = match custom_to_rs_u32(value) {
+                    let v = match custom_to_rs_u64(value) {
                         Ok(ok) => ok,
                         Err(err) => return Err(JsValue::from(TypeError::new(err))),
                     };

--- a/client/src/plugins/libparsec/definitions.ts
+++ b/client/src/plugins/libparsec/definitions.ts
@@ -168,12 +168,12 @@ export type U8 = number
 export type U16 = number
 export type I32 = number
 export type CacheSize = number
-export type FileDescriptor = number
 export type Handle = number
 export type U32 = number
 export type VersionInt = number
 export type { DateTime } from 'luxon'; import type { DateTime } from 'luxon';
 export type I64 = bigint
+export type FileDescriptor = bigint
 export type IndexInt = bigint
 export type SizeInt = bigint
 export type U64 = bigint

--- a/client/src/services/viewers.ts
+++ b/client/src/services/viewers.ts
@@ -1,5 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
+import type { FileDescriptor } from '@/plugins/libparsec';
 import { libparsec } from '@/plugins/libparsec';
 import * as pdfjs from 'pdfjs-dist';
 import pdfjsWorker from 'pdfjs-dist/build/pdf.worker?worker&url';
@@ -52,7 +53,7 @@ async function _initStreamingWorker(): Promise<void> {
       size: number;
       historyHandle: number | null;
     };
-    let fd: number | undefined;
+    let fd: FileDescriptor | undefined;
     try {
       if (historyHandle !== null) {
         const openResult = await libparsec.workspaceHistoryOpenFile(historyHandle, filePath);

--- a/libparsec/crates/platform_mountpoint/build.rs
+++ b/libparsec/crates/platform_mountpoint/build.rs
@@ -11,10 +11,9 @@ fn main() {
     // loaded ("delayload" option in MSVC) so that we will have time to first configure the
     // lookup directory.
     winfsp_wrs_build::build();
-    // TODO: enable this once cargo>1.80 is used
-    // #[cfg(target_family = "unix")]
     // Tell rust about the config `skip_fuse_atime_option`.
-    // println!("cargo::rustc-check-cfg=cfg(skip_fuse_atime_option)");
+    #[cfg(target_family = "unix")]
+    println!("cargo::rustc-check-cfg=cfg(skip_fuse_atime_option)");
     #[cfg(target_os = "linux")]
     {
         // The atime option is not supported in fuse >= 3.15.

--- a/libparsec/crates/platform_mountpoint/src/unix/filesystem.rs
+++ b/libparsec/crates/platform_mountpoint/src/unix/filesystem.rs
@@ -2,6 +2,7 @@
 
 use std::{
     ffi::OsStr,
+    fmt::Write,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -16,7 +17,8 @@ use libparsec_client::workspace::{
 };
 use libparsec_types::prelude::*;
 
-use super::inode::{Inode, InodesManager};
+use super::inode::{INodeNo, InodesManager};
+use fuser::{Errno, Generation, InitFlags, Request};
 
 /// Validity timeout set to zero to prevent FUSE from doing caching logic on it.
 /// This is because FUSE caching is not aware of external modification (i.e. sync
@@ -31,7 +33,7 @@ const TTL: std::time::Duration = std::time::Duration::ZERO;
 /// time). So if the file system reuses an inode after it has been deleted, it
 /// must assign a new, previously unused generation number to the inode at the
 /// same time.
-const GENERATION: u64 = 0;
+const GENERATION: Generation = Generation(0);
 /// The default block size, set to 512 KB.
 const BLOCK_SIZE: u64 = 512 * 1024;
 /// Read-write permissions for files and folders.
@@ -49,7 +51,7 @@ fn os_name_to_entry_name(name: &OsStr) -> EntryNameResult<EntryName> {
 
 fn file_stat_to_file_attr(
     stat: FileStat,
-    inode: Inode,
+    inode: INodeNo,
     uid: u32,
     gid: u32,
     is_read_only: bool,
@@ -82,7 +84,7 @@ fn file_stat_to_file_attr(
 
 fn entry_stat_to_file_attr(
     stat: EntryStat,
-    inode: Inode,
+    inode: INodeNo,
     uid: u32,
     gid: u32,
     is_read_only: bool,
@@ -173,7 +175,7 @@ async fn reply_with_lookup(
     ops: &WorkspaceOps,
     uid: u32,
     gid: u32,
-    inode: Inode,
+    inode: INodeNo,
     entry_id: VlobID,
     reply: fuser::ReplyEntry,
     is_read_only: bool,
@@ -190,9 +192,9 @@ async fn reply_with_lookup(
             GENERATION,
         ),
         Err(err) => match err {
-            WorkspaceStatEntryError::EntryNotFound => reply.error(libc::ENOENT),
-            WorkspaceStatEntryError::Offline(_) => reply.error(libc::EHOSTUNREACH),
-            WorkspaceStatEntryError::NoRealmAccess => reply.error(libc::EPERM),
+            WorkspaceStatEntryError::EntryNotFound => reply.error(Errno::ENOENT),
+            WorkspaceStatEntryError::Offline(_) => reply.error(Errno::EHOSTUNREACH),
+            WorkspaceStatEntryError::NoRealmAccess => reply.error(Errno::EPERM),
             WorkspaceStatEntryError::Stopped
             | WorkspaceStatEntryError::RealmDeleted
             | WorkspaceStatEntryError::InvalidKeysBundle(_)
@@ -200,7 +202,7 @@ async fn reply_with_lookup(
             | WorkspaceStatEntryError::InvalidManifest(_)
             | WorkspaceStatEntryError::Internal(_) => {
                 log::warn!("FUSE `{operation_name}` operation failed: {err:?}");
-                reply.error(libc::EIO)
+                reply.error(Errno::EIO)
             }
         },
     }
@@ -229,7 +231,7 @@ macro_rules! reply_on_drop_guard {
                     // Already replied
                     None => (),
                     // Not replied time to do it with ourself !
-                    Some(reply) => reply.error(libc::EIO),
+                    Some(reply) => reply.error(Errno::EIO),
                 }
             }
         }
@@ -249,36 +251,15 @@ pub(crate) static LOOKUP_HOOK: Mutex<
     Option<Box<dyn FnMut(&FsPath) -> Option<Result<EntryStat, WorkspaceStatEntryError>> + Send>>,
 > = Mutex::new(None);
 
-/// Helper macro to add one (or multiple) capabilities to fuser config.
-///
-/// Example:
-/// ```
-/// add_capabilities!(config, <capability>)
-/// add_capabilities!(config, <capability1>, ..., <capabilityN>)
-/// ```
-macro_rules! add_capabilities {
-    ($config:expr, $capability:ident) => {
-        $config
-            .add_capabilities(fuser::consts::$capability as u64)
-            .expect(concat!("Capability available: ", stringify!($capability)));
-    };
-
-    ($config:expr, $($capability:ident),*) => {
-        $(
-            add_capabilities!($config, $capability);
-        )*
-    };
-}
-
 // See https://libfuse.github.io/doxygen/structfuse__operations.html for documentation
 // of each of the methods implemented here.
 impl fuser::Filesystem for Filesystem {
     fn init(
         &mut self,
-        _req: &fuser::Request<'_>,
+        _req: &fuser::Request,
         // see https://libfuse.github.io/doxygen/structfuse__conn__info.html
         config: &mut fuser::KernelConfig,
-    ) -> Result<(), libc::c_int> {
+    ) -> std::io::Result<()> {
         // See libfuse & Linux documentation for a description of the capabilities.
         // See:
         // - https://github.com/torvalds/linux/blob/e32cde8d2bd7d251a8f9b434143977ddf13dcec6/include/uapi/linux/fuse.h#L376-L428
@@ -305,48 +286,62 @@ impl fuser::Filesystem for Filesystem {
         // - https://www.kernel.org/doc/html/latest/filesystems/fuse-io.html
         // - https://github.com/libfuse/libfuse/blob/2aeef499b84b596608181f9b48d589c4f8ffe24a/include/fuse_common.h#L322
 
-        add_capabilities!(
-            config,
+        let caps =
+
             // Do not send separate SETATTR request before open(O_TRUNC).
             // See https://github.com/libfuse/libfuse/blob/2aeef499b84b596608181f9b48d589c4f8ffe24a/include/fuse_common.h#L188
-            FUSE_ATOMIC_O_TRUNC
-        );
-
-        #[cfg(not(target_os = "macos"))]
-        {
-            // Capabilities not supported by MacFuse 4.8
-            add_capabilities!(
-                config,
+        InitFlags::FUSE_ATOMIC_O_TRUNC
+        ;
+        let caps = caps
+            | cfg_select! {
+                target_os = "macos" => { InitFlags::empty() },
+                _ => {
+                // Capabilities not supported by MacFuse 4.8
                 // Support IOCTL on directories.
                 // See https://github.com/libfuse/libfuse/blob/2aeef499b84b596608181f9b48d589c4f8ffe24a/include/fuse_common.h#L253
-                FUSE_IOCTL_DIR,
+                InitFlags::FUSE_HAS_IOCTL_DIR |
                 // Tell FUSE the data may change without going through the filesystem, hence attributes
                 // validity should be checked on each access (leading to `getattr()` on timeout).
                 // See https://github.com/libfuse/libfuse/blob/2aeef499b84b596608181f9b48d589c4f8ffe24a/include/fuse_common.h#L275
-                FUSE_AUTO_INVAL_DATA,
+                InitFlags::FUSE_AUTO_INVAL_DATA |
                 // Enable `readdirplus` support (readdir + lookup in one a single go).
                 // See https://github.com/libfuse/libfuse/blob/2aeef499b84b596608181f9b48d589c4f8ffe24a/include/fuse_common.h#L283
-                FUSE_DO_READDIRPLUS,
+                InitFlags::FUSE_DO_READDIRPLUS |
                 // Adaptative readdirplus optimization support: still use readdir when lookup is
                 // has already been done by the previous readdirplus.
                 // See https://github.com/libfuse/libfuse/blob/2aeef499b84b596608181f9b48d589c4f8ffe24a/include/fuse_common.h#L311
-                FUSE_READDIRPLUS_AUTO,
+                InitFlags::FUSE_READDIRPLUS_AUTO |
                 // Allow parallel lookups and readdir on any given folder (default is serialized).
                 // See https://github.com/libfuse/libfuse/blob/2aeef499b84b596608181f9b48d589c4f8ffe24a/include/fuse_common.h#L354
-                FUSE_PARALLEL_DIROPS
-            );
-            // Fuser doesn't provided splice config on macOS
-            add_capabilities!(
-                config,
+                InitFlags::FUSE_PARALLEL_DIROPS |
+
+                // Fuser doesn't provided splice config on macOS
                 // TODO: `FUSE_SPLICE_READ` seems to require `write_buf()` to be implemented, which is
                 //       not even exposed in fuser !
                 // Allow splice operations (see `man 2 splice`, basically kernel space page-based operations)
                 // See https://github.com/libfuse/libfuse/blob/2aeef499b84b596608181f9b48d589c4f8ffe24a/include/fuse_common.h#L216
-                FUSE_SPLICE_WRITE,
-                FUSE_SPLICE_MOVE,
-                FUSE_SPLICE_READ
-            );
-        }
+                InitFlags::FUSE_SPLICE_WRITE |
+                InitFlags::FUSE_SPLICE_MOVE |
+                InitFlags::FUSE_SPLICE_READ
+                }
+            };
+
+        config.add_capabilities(caps).map_err(|e| {
+            let mut s = "cannot add following fuse capabilities: ".to_owned();
+            let mut it_names = e.iter_names();
+            it_names
+                .try_for_each(|(name, v)| write!(s, "{name} ({v:#x})"))
+                .and_then(|_| {
+                    let remaining_bits = it_names.remaining().bits();
+                    if remaining_bits != 0 {
+                        write!(s, ", remaining bits: {remaining_bits:#x}")
+                    } else {
+                        Ok(())
+                    }
+                })
+                .expect("Cannot generator error message");
+            std::io::Error::new(std::io::ErrorKind::Unsupported, s)
+        })?;
 
         // Inform the Kernel about the granularity of the timestamps supported by our filesystem.
         // See https://github.com/libfuse/libfuse/blob/2aeef499b84b596608181f9b48d589c4f8ffe24a/include/fuse_common.h#L609-L622
@@ -368,9 +363,9 @@ impl fuser::Filesystem for Filesystem {
     /// The lookup transforms the path name to an `inode`.
     /// The `inode` is then used by all other operations and is freed by `forget`.
     fn lookup(
-        &mut self,
-        req: &fuser::Request<'_>,
-        parent: u64,
+        &self,
+        req: &Request,
+        parent: INodeNo,
         name: &std::ffi::OsStr,
         reply: fuser::ReplyEntry,
     ) {
@@ -382,11 +377,11 @@ impl fuser::Filesystem for Filesystem {
         let name = match os_name_to_entry_name(name) {
             Ok(name) => name,
             Err(EntryNameError::NameTooLong) => {
-                reply.manual().error(libc::ENAMETOOLONG);
+                reply.manual().error(Errno::ENAMETOOLONG);
                 return;
             }
             Err(EntryNameError::InvalidName) => {
-                reply.manual().error(libc::EINVAL);
+                reply.manual().error(Errno::EINVAL);
                 return;
             }
         };
@@ -432,9 +427,11 @@ impl fuser::Filesystem for Filesystem {
                     )
                 }
                 Err(err) => match err {
-                    WorkspaceStatEntryError::EntryNotFound => reply.manual().error(libc::ENOENT),
-                    WorkspaceStatEntryError::Offline(_) => reply.manual().error(libc::EHOSTUNREACH),
-                    WorkspaceStatEntryError::NoRealmAccess => reply.manual().error(libc::EPERM),
+                    WorkspaceStatEntryError::EntryNotFound => reply.manual().error(Errno::ENOENT),
+                    WorkspaceStatEntryError::Offline(_) => {
+                        reply.manual().error(Errno::EHOSTUNREACH)
+                    }
+                    WorkspaceStatEntryError::NoRealmAccess => reply.manual().error(Errno::EPERM),
                     WorkspaceStatEntryError::Stopped
                     | WorkspaceStatEntryError::RealmDeleted
                     | WorkspaceStatEntryError::InvalidKeysBundle(_)
@@ -442,21 +439,21 @@ impl fuser::Filesystem for Filesystem {
                     | WorkspaceStatEntryError::InvalidManifest(_)
                     | WorkspaceStatEntryError::Internal(_) => {
                         log::warn!("FUSE `lookup` operation cannot complete: {err:?}");
-                        reply.manual().error(libc::EIO)
+                        reply.manual().error(Errno::EIO)
                     }
                 },
             }
         });
     }
 
-    fn forget(&mut self, _req: &fuser::Request<'_>, ino: u64, nlookup: u64) {
+    fn forget(&self, _req: &Request, ino: INodeNo, nlookup: u64) {
         self.inodes
             .lock()
             .expect("mutex is poisoned")
             .remove_path_or_panic(ino, nlookup);
     }
 
-    fn statfs(&mut self, _req: &fuser::Request<'_>, ino: u64, reply: fuser::ReplyStatfs) {
+    fn statfs(&self, _req: &Request, ino: INodeNo, reply: fuser::ReplyStatfs) {
         log::debug!("[FUSE] statfs(ino: {ino:#x?})");
 
         // We have currently no way of easily getting the size of workspace
@@ -477,10 +474,10 @@ impl fuser::Filesystem for Filesystem {
     }
 
     fn getattr(
-        &mut self,
-        req: &fuser::Request<'_>,
-        ino: u64,
-        _fh: Option<u64>,
+        &self,
+        req: &Request,
+        ino: INodeNo,
+        _fh: Option<fuser::FileHandle>,
         reply: fuser::ReplyAttr,
     ) {
         log::debug!("[FUSE] getattr(ino: {ino:#x?})");
@@ -506,9 +503,9 @@ impl fuser::Filesystem for Filesystem {
     }
 
     fn mkdir(
-        &mut self,
-        req: &fuser::Request<'_>,
-        parent: u64,
+        &self,
+        req: &Request,
+        parent: INodeNo,
         name: &std::ffi::OsStr,
         _mode: u32,
         _umask: u32,
@@ -522,11 +519,11 @@ impl fuser::Filesystem for Filesystem {
         let name = match os_name_to_entry_name(name) {
             Ok(name) => name,
             Err(EntryNameError::NameTooLong) => {
-                reply.manual().error(libc::ENAMETOOLONG);
+                reply.manual().error(Errno::ENAMETOOLONG);
                 return;
             }
             Err(EntryNameError::InvalidName) => {
-                reply.manual().error(libc::EINVAL);
+                reply.manual().error(Errno::EINVAL);
                 return;
             }
         };
@@ -561,19 +558,19 @@ impl fuser::Filesystem for Filesystem {
                 }
                 Err(err) => match err {
                     WorkspaceCreateFolderError::EntryExists { .. } => {
-                        reply.manual().error(libc::EEXIST)
+                        reply.manual().error(Errno::EEXIST)
                     }
                     WorkspaceCreateFolderError::ParentNotAFolder => {
-                        reply.manual().error(libc::ENOENT)
+                        reply.manual().error(Errno::ENOENT)
                     }
                     WorkspaceCreateFolderError::ParentNotFound => {
-                        reply.manual().error(libc::ENOENT)
+                        reply.manual().error(Errno::ENOENT)
                     }
                     WorkspaceCreateFolderError::Offline(_) => {
-                        reply.manual().error(libc::EHOSTUNREACH)
+                        reply.manual().error(Errno::EHOSTUNREACH)
                     }
-                    WorkspaceCreateFolderError::NoRealmAccess => reply.manual().error(libc::EPERM),
-                    WorkspaceCreateFolderError::ReadOnlyRealm => reply.manual().error(libc::EROFS),
+                    WorkspaceCreateFolderError::NoRealmAccess => reply.manual().error(Errno::EPERM),
+                    WorkspaceCreateFolderError::ReadOnlyRealm => reply.manual().error(Errno::EROFS),
                     WorkspaceCreateFolderError::Stopped
                     | WorkspaceCreateFolderError::RealmDeleted
                     | WorkspaceCreateFolderError::InvalidKeysBundle(_)
@@ -581,7 +578,7 @@ impl fuser::Filesystem for Filesystem {
                     | WorkspaceCreateFolderError::InvalidManifest(_)
                     | WorkspaceCreateFolderError::Internal(_) => {
                         log::warn!("FUSE `mkdir` operation cannot complete: {err:?}");
-                        reply.manual().error(libc::EIO)
+                        reply.manual().error(Errno::EIO)
                     }
                 },
             }
@@ -589,9 +586,9 @@ impl fuser::Filesystem for Filesystem {
     }
 
     fn rmdir(
-        &mut self,
-        _req: &fuser::Request<'_>,
-        parent: u64,
+        &self,
+        _req: &Request,
+        parent: INodeNo,
         name: &std::ffi::OsStr,
         reply: fuser::ReplyEmpty,
     ) {
@@ -601,11 +598,11 @@ impl fuser::Filesystem for Filesystem {
         let name = match os_name_to_entry_name(name) {
             Ok(name) => name,
             Err(EntryNameError::NameTooLong) => {
-                reply.manual().error(libc::ENAMETOOLONG);
+                reply.manual().error(Errno::ENAMETOOLONG);
                 return;
             }
             Err(EntryNameError::InvalidName) => {
-                reply.manual().error(libc::EINVAL);
+                reply.manual().error(Errno::EINVAL);
                 return;
             }
         };
@@ -623,19 +620,19 @@ impl fuser::Filesystem for Filesystem {
                     reply.manual().ok();
                 }
                 Err(err) => match err {
-                    WorkspaceRemoveEntryError::EntryNotFound => reply.manual().error(libc::ENOENT),
-                    WorkspaceRemoveEntryError::EntryIsFile => reply.manual().error(libc::ENOTDIR),
+                    WorkspaceRemoveEntryError::EntryNotFound => reply.manual().error(Errno::ENOENT),
+                    WorkspaceRemoveEntryError::EntryIsFile => reply.manual().error(Errno::ENOTDIR),
                     WorkspaceRemoveEntryError::EntryIsNonEmptyFolder => {
-                        reply.manual().error(libc::ENOTEMPTY)
+                        reply.manual().error(Errno::ENOTEMPTY)
                     }
                     WorkspaceRemoveEntryError::Offline(_) => {
-                        reply.manual().error(libc::EHOSTUNREACH)
+                        reply.manual().error(Errno::EHOSTUNREACH)
                     }
                     WorkspaceRemoveEntryError::CannotRemoveRoot => {
-                        reply.manual().error(libc::EPERM)
+                        reply.manual().error(Errno::EPERM)
                     }
-                    WorkspaceRemoveEntryError::NoRealmAccess => reply.manual().error(libc::EPERM),
-                    WorkspaceRemoveEntryError::ReadOnlyRealm => reply.manual().error(libc::EROFS),
+                    WorkspaceRemoveEntryError::NoRealmAccess => reply.manual().error(Errno::EPERM),
+                    WorkspaceRemoveEntryError::ReadOnlyRealm => reply.manual().error(Errno::EROFS),
                     WorkspaceRemoveEntryError::Stopped
                     | WorkspaceRemoveEntryError::RealmDeleted
                     | WorkspaceRemoveEntryError::InvalidKeysBundle(_)
@@ -643,7 +640,7 @@ impl fuser::Filesystem for Filesystem {
                     | WorkspaceRemoveEntryError::InvalidManifest(_)
                     | WorkspaceRemoveEntryError::Internal(_) => {
                         log::warn!("FUSE `rmdir` operation cannot complete: {err:?}");
-                        reply.manual().error(libc::EIO)
+                        reply.manual().error(Errno::EIO)
                     }
                     // Never returned given we *are* removing a folder
                     WorkspaceRemoveEntryError::EntryIsFolder => unreachable!(),
@@ -653,9 +650,9 @@ impl fuser::Filesystem for Filesystem {
     }
 
     fn unlink(
-        &mut self,
-        _req: &fuser::Request<'_>,
-        parent: u64,
+        &self,
+        _req: &Request,
+        parent: INodeNo,
         name: &std::ffi::OsStr,
         reply: fuser::ReplyEmpty,
     ) {
@@ -665,11 +662,11 @@ impl fuser::Filesystem for Filesystem {
         let name = match os_name_to_entry_name(name) {
             Ok(name) => name,
             Err(EntryNameError::NameTooLong) => {
-                reply.manual().error(libc::ENAMETOOLONG);
+                reply.manual().error(Errno::ENAMETOOLONG);
                 return;
             }
             Err(EntryNameError::InvalidName) => {
-                reply.manual().error(libc::EINVAL);
+                reply.manual().error(Errno::EINVAL);
                 return;
             }
         };
@@ -687,19 +684,19 @@ impl fuser::Filesystem for Filesystem {
                     reply.manual().ok();
                 }
                 Err(err) => match err {
-                    WorkspaceRemoveEntryError::EntryNotFound => reply.manual().error(libc::ENOENT),
-                    WorkspaceRemoveEntryError::EntryIsFolder => reply.manual().error(libc::EISDIR),
+                    WorkspaceRemoveEntryError::EntryNotFound => reply.manual().error(Errno::ENOENT),
+                    WorkspaceRemoveEntryError::EntryIsFolder => reply.manual().error(Errno::EISDIR),
                     WorkspaceRemoveEntryError::EntryIsNonEmptyFolder => {
-                        reply.manual().error(libc::ENOTEMPTY)
+                        reply.manual().error(Errno::ENOTEMPTY)
                     }
                     WorkspaceRemoveEntryError::Offline(_) => {
-                        reply.manual().error(libc::EHOSTUNREACH)
+                        reply.manual().error(Errno::EHOSTUNREACH)
                     }
                     WorkspaceRemoveEntryError::CannotRemoveRoot => {
-                        reply.manual().error(libc::EPERM)
+                        reply.manual().error(Errno::EPERM)
                     }
-                    WorkspaceRemoveEntryError::NoRealmAccess => reply.manual().error(libc::EPERM),
-                    WorkspaceRemoveEntryError::ReadOnlyRealm => reply.manual().error(libc::EROFS),
+                    WorkspaceRemoveEntryError::NoRealmAccess => reply.manual().error(Errno::EPERM),
+                    WorkspaceRemoveEntryError::ReadOnlyRealm => reply.manual().error(Errno::EROFS),
                     WorkspaceRemoveEntryError::Stopped
                     | WorkspaceRemoveEntryError::RealmDeleted
                     | WorkspaceRemoveEntryError::InvalidKeysBundle(_)
@@ -707,7 +704,7 @@ impl fuser::Filesystem for Filesystem {
                     | WorkspaceRemoveEntryError::InvalidManifest(_)
                     | WorkspaceRemoveEntryError::Internal(_) => {
                         log::warn!("FUSE `unlink` operation cannot complete: {err:?}");
-                        reply.manual().error(libc::EIO)
+                        reply.manual().error(Errno::EIO)
                     }
                     // Never returned given we *are* removing a file
                     WorkspaceRemoveEntryError::EntryIsFile => unreachable!(),
@@ -717,13 +714,13 @@ impl fuser::Filesystem for Filesystem {
     }
 
     fn rename(
-        &mut self,
-        _req: &fuser::Request<'_>,
-        src_parent: u64,
+        &self,
+        _req: &Request,
+        src_parent: INodeNo,
         src_name: &std::ffi::OsStr,
-        dst_parent: u64,
+        dst_parent: INodeNo,
         dst_name: &std::ffi::OsStr,
-        flags: u32,
+        flags: fuser::RenameFlags,
         reply: fuser::ReplyEmpty,
     ) {
         log::debug!(
@@ -737,9 +734,9 @@ impl fuser::Filesystem for Filesystem {
         #[cfg(target_os = "macos")]
         let mode = MoveEntryMode::CanReplace;
         #[cfg(not(target_os = "macos"))]
-        let mode = if flags & libc::RENAME_NOREPLACE != 0 {
+        let mode = if flags.contains(fuser::RenameFlags::RENAME_NOREPLACE) {
             MoveEntryMode::NoReplace
-        } else if flags & libc::RENAME_EXCHANGE != 0 {
+        } else if flags.contains(fuser::RenameFlags::RENAME_EXCHANGE) {
             MoveEntryMode::Exchange
         } else {
             MoveEntryMode::CanReplace
@@ -748,22 +745,22 @@ impl fuser::Filesystem for Filesystem {
         let src_name = match os_name_to_entry_name(src_name) {
             Ok(name) => name,
             Err(EntryNameError::NameTooLong) => {
-                reply.manual().error(libc::ENAMETOOLONG);
+                reply.manual().error(Errno::ENAMETOOLONG);
                 return;
             }
             Err(EntryNameError::InvalidName) => {
-                reply.manual().error(libc::EINVAL);
+                reply.manual().error(Errno::EINVAL);
                 return;
             }
         };
         let dst_name = match os_name_to_entry_name(dst_name) {
             Ok(name) => name,
             Err(EntryNameError::NameTooLong) => {
-                reply.manual().error(libc::ENAMETOOLONG);
+                reply.manual().error(Errno::ENAMETOOLONG);
                 return;
             }
             Err(EntryNameError::InvalidName) => {
-                reply.manual().error(libc::EINVAL);
+                reply.manual().error(Errno::EINVAL);
                 return;
             }
         };
@@ -792,15 +789,17 @@ impl fuser::Filesystem for Filesystem {
                 Err(err) => match err {
                     WorkspaceMoveEntryError::SourceNotFound
                     | WorkspaceMoveEntryError::DestinationNotFound => {
-                        reply.manual().error(libc::ENOENT)
+                        reply.manual().error(Errno::ENOENT)
                     }
                     WorkspaceMoveEntryError::DestinationExists { .. } => {
-                        reply.manual().error(libc::EEXIST)
+                        reply.manual().error(Errno::EEXIST)
                     }
-                    WorkspaceMoveEntryError::CannotMoveRoot => reply.manual().error(libc::EPERM),
-                    WorkspaceMoveEntryError::Offline(_) => reply.manual().error(libc::EHOSTUNREACH),
-                    WorkspaceMoveEntryError::NoRealmAccess => reply.manual().error(libc::EPERM),
-                    WorkspaceMoveEntryError::ReadOnlyRealm => reply.manual().error(libc::EROFS),
+                    WorkspaceMoveEntryError::CannotMoveRoot => reply.manual().error(Errno::EPERM),
+                    WorkspaceMoveEntryError::Offline(_) => {
+                        reply.manual().error(Errno::EHOSTUNREACH)
+                    }
+                    WorkspaceMoveEntryError::NoRealmAccess => reply.manual().error(Errno::EPERM),
+                    WorkspaceMoveEntryError::ReadOnlyRealm => reply.manual().error(Errno::EROFS),
                     WorkspaceMoveEntryError::Stopped
                     | WorkspaceMoveEntryError::RealmDeleted
                     | WorkspaceMoveEntryError::InvalidKeysBundle(_)
@@ -808,7 +807,7 @@ impl fuser::Filesystem for Filesystem {
                     | WorkspaceMoveEntryError::InvalidManifest(_)
                     | WorkspaceMoveEntryError::Internal(_) => {
                         log::warn!("FUSE `rename` operation cannot complete: {err:?}");
-                        reply.manual().error(libc::EIO)
+                        reply.manual().error(Errno::EIO)
                     }
                 },
             }
@@ -816,7 +815,7 @@ impl fuser::Filesystem for Filesystem {
     }
 
     // Note flags doesn't contains O_CREAT, O_EXCL, O_NOCTTY and O_TRUNC
-    fn open(&mut self, _req: &fuser::Request<'_>, ino: u64, flags: i32, reply: fuser::ReplyOpen) {
+    fn open(&self, _req: &Request, ino: INodeNo, flags: fuser::OpenFlags, reply: fuser::ReplyOpen) {
         log::debug!("[FUSE] open(ino: {ino:#x?}, flags: {flags:#x?})");
         let reply = reply_on_drop_guard!(reply, fuser::ReplyOpen);
 
@@ -831,33 +830,27 @@ impl fuser::Filesystem for Filesystem {
                 let mut options = OpenOptions {
                     read: false,
                     write: false,
-                    // append: flags & libc::O_APPEND != 0,
-                    truncate: flags & libc::O_TRUNC != 0,
+                    truncate: flags.0 & libc::O_TRUNC != 0,
                     create: false,
                     create_new: false,
                 };
-                match flags & libc::O_ACCMODE {
-                    libc::O_RDONLY => {
+                match flags.acc_mode() {
+                    fuser::OpenAccMode::O_RDONLY => {
                         // Behavior is undefined, but most filesystems return EACCES
-                        if flags & libc::O_TRUNC != 0 {
-                            reply.manual().error(libc::EACCES);
+                        if options.truncate {
+                            reply.manual().error(Errno::EACCES);
                             return;
                         }
                         // TODO: Fuser's reference implementation mentions a `FMODE_EXEC` here
                         // (see: https://github.com/cberner/fuser/blob/be820a8080f229301028546e819b4997af26cf47/examples/simple.rs#L1336)
                         options.read = true;
                     }
-                    libc::O_WRONLY => {
+                    fuser::OpenAccMode::O_WRONLY => {
                         options.write = true;
                     }
-                    libc::O_RDWR => {
+                    fuser::OpenAccMode::O_RDWR => {
                         options.read = true;
                         options.write = true;
-                    }
-                    // Exactly one access mode flag must be specified
-                    _ => {
-                        reply.manual().error(libc::EINVAL);
-                        return;
                     }
                 }
                 options
@@ -867,18 +860,20 @@ impl fuser::Filesystem for Filesystem {
                 Ok(fd) => fd,
                 Err(err) => {
                     return match err {
-                        WorkspaceOpenFileError::EntryNotFound => reply.manual().error(libc::ENOENT),
+                        WorkspaceOpenFileError::EntryNotFound => {
+                            reply.manual().error(Errno::ENOENT)
+                        }
                         WorkspaceOpenFileError::Offline(_) => {
-                            reply.manual().error(libc::EHOSTUNREACH)
+                            reply.manual().error(Errno::EHOSTUNREACH)
                         }
                         WorkspaceOpenFileError::EntryExistsInCreateNewMode { .. } => {
-                            reply.manual().error(libc::EEXIST)
+                            reply.manual().error(Errno::EEXIST)
                         }
                         WorkspaceOpenFileError::EntryNotAFile { .. } => {
-                            reply.manual().error(libc::EISDIR)
+                            reply.manual().error(Errno::EISDIR)
                         }
-                        WorkspaceOpenFileError::NoRealmAccess => reply.manual().error(libc::EPERM),
-                        WorkspaceOpenFileError::ReadOnlyRealm => reply.manual().error(libc::EROFS),
+                        WorkspaceOpenFileError::NoRealmAccess => reply.manual().error(Errno::EPERM),
+                        WorkspaceOpenFileError::ReadOnlyRealm => reply.manual().error(Errno::EROFS),
                         WorkspaceOpenFileError::Stopped
                         | WorkspaceOpenFileError::RealmDeleted
                         | WorkspaceOpenFileError::InvalidKeysBundle(_)
@@ -886,23 +881,24 @@ impl fuser::Filesystem for Filesystem {
                         | WorkspaceOpenFileError::InvalidManifest(_)
                         | WorkspaceOpenFileError::Internal(_) => {
                             log::warn!("FUSE `open` operation cannot complete: {err:?}");
-                            reply.manual().error(libc::EIO)
+                            reply.manual().error(Errno::EIO)
                         }
                     }
                 }
             };
 
             // Flag is only to enable FOPEN_DIRECT_IO which we don't use
-            let open_flags = 0;
-            reply.manual().opened(fd.0.into(), open_flags);
+            // TODO: Investigate if we could use FOPEN_PARALLEL_DIRECT_WRITES.
+            let open_flags = fuser::FopenFlags::empty();
+            reply.manual().opened(fuser::FileHandle(fd.0), open_flags);
         });
     }
 
     // Note flags doesn't contains O_NOCTTY
     fn create(
-        &mut self,
-        req: &fuser::Request<'_>,
-        parent: u64,
+        &self,
+        req: &Request,
+        parent: INodeNo,
         name: &std::ffi::OsStr,
         // Mode & umask are for the file creation, but we don't support them
         _mode: u32,
@@ -918,11 +914,11 @@ impl fuser::Filesystem for Filesystem {
         let name = match os_name_to_entry_name(name) {
             Ok(name) => name,
             Err(EntryNameError::NameTooLong) => {
-                reply.manual().error(libc::ENAMETOOLONG);
+                reply.manual().error(Errno::ENAMETOOLONG);
                 return;
             }
             Err(EntryNameError::InvalidName) => {
-                reply.manual().error(libc::EINVAL);
+                reply.manual().error(Errno::EINVAL);
                 return;
             }
         };
@@ -954,7 +950,7 @@ impl fuser::Filesystem for Filesystem {
                     libc::O_RDONLY => {
                         // Behavior is undefined, but most filesystems return EACCES
                         if flags & libc::O_TRUNC != 0 {
-                            reply.manual().error(libc::EACCES);
+                            reply.manual().error(Errno::EACCES);
                             return;
                         }
                         // TODO: Fuser's reference implementation mentions a `FMODE_EXEC` here
@@ -970,7 +966,7 @@ impl fuser::Filesystem for Filesystem {
                     }
                     // Exactly one access mode flag must be specified
                     _ => {
-                        reply.manual().error(libc::EINVAL);
+                        reply.manual().error(Errno::EINVAL);
                         return;
                     }
                 }
@@ -981,18 +977,20 @@ impl fuser::Filesystem for Filesystem {
                 Ok(fd) => fd,
                 Err(err) => {
                     return match err {
-                        WorkspaceOpenFileError::EntryNotFound => reply.manual().error(libc::ENOENT),
+                        WorkspaceOpenFileError::EntryNotFound => {
+                            reply.manual().error(Errno::ENOENT)
+                        }
                         WorkspaceOpenFileError::Offline(_) => {
-                            reply.manual().error(libc::EHOSTUNREACH)
+                            reply.manual().error(Errno::EHOSTUNREACH)
                         }
                         WorkspaceOpenFileError::EntryExistsInCreateNewMode { .. } => {
-                            reply.manual().error(libc::EEXIST)
+                            reply.manual().error(Errno::EEXIST)
                         }
                         WorkspaceOpenFileError::EntryNotAFile { .. } => {
-                            reply.manual().error(libc::EISDIR)
+                            reply.manual().error(Errno::EISDIR)
                         }
-                        WorkspaceOpenFileError::NoRealmAccess => reply.manual().error(libc::EPERM),
-                        WorkspaceOpenFileError::ReadOnlyRealm => reply.manual().error(libc::EROFS),
+                        WorkspaceOpenFileError::NoRealmAccess => reply.manual().error(Errno::EPERM),
+                        WorkspaceOpenFileError::ReadOnlyRealm => reply.manual().error(Errno::EROFS),
                         WorkspaceOpenFileError::Stopped
                         | WorkspaceOpenFileError::RealmDeleted
                         | WorkspaceOpenFileError::InvalidKeysBundle(_)
@@ -1000,14 +998,14 @@ impl fuser::Filesystem for Filesystem {
                         | WorkspaceOpenFileError::InvalidManifest(_)
                         | WorkspaceOpenFileError::Internal(_) => {
                             log::warn!("FUSE `create` operation cannot complete: {err:?}");
-                            reply.manual().error(libc::EIO)
+                            reply.manual().error(Errno::EIO)
                         }
                     }
                 }
             };
 
             // Flag is only to enable FOPEN_DIRECT_IO which we don't use
-            let open_flags = 0;
+            let open_flags = fuser::FopenFlags::empty();
 
             let inode = {
                 let mut inodes_guard = inodes.lock().expect("mutex is poisoned");
@@ -1020,7 +1018,7 @@ impl fuser::Filesystem for Filesystem {
                     return match err {
                         // Unexpected: We have just created this file descriptor !
                         WorkspaceFdStatError::BadFileDescriptor
-                        | WorkspaceFdStatError::Internal(_) => reply.manual().error(libc::EIO),
+                        | WorkspaceFdStatError::Internal(_) => reply.manual().error(Errno::EIO),
                     };
                 }
             };
@@ -1029,7 +1027,7 @@ impl fuser::Filesystem for Filesystem {
                 &TTL,
                 &file_stat_to_file_attr(stat, inode, uid, gid, is_read_only),
                 GENERATION,
-                fd.0.into(),
+                fuser::FileHandle(fd.0),
                 open_flags,
             );
         });
@@ -1037,9 +1035,9 @@ impl fuser::Filesystem for Filesystem {
 
     // Set file attributes, mostly use for truncating files
     fn setattr(
-        &mut self,
-        req: &fuser::Request<'_>,
-        ino: u64,
+        &self,
+        req: &Request,
+        ino: INodeNo,
         mode: Option<u32>,
         uid: Option<u32>,
         gid: Option<u32>,
@@ -1047,11 +1045,11 @@ impl fuser::Filesystem for Filesystem {
         _atime: Option<fuser::TimeOrNow>,
         _mtime: Option<fuser::TimeOrNow>,
         _ctime: Option<std::time::SystemTime>,
-        fh: Option<u64>,
+        fh: Option<fuser::FileHandle>,
         _crtime: Option<std::time::SystemTime>,
         _chgtime: Option<std::time::SystemTime>,
         _bkuptime: Option<std::time::SystemTime>,
-        flags: Option<u32>,
+        flags: Option<fuser::BsdFileFlags>,
         reply: fuser::ReplyAttr,
     ) {
         log::debug!(
@@ -1069,18 +1067,18 @@ impl fuser::Filesystem for Filesystem {
                 let ops = self.ops.clone();
                 let is_read_only = self.is_read_only;
                 self.tokio_handle.spawn(async move {
-                    let fd = FileDescriptor(fh as u32);
+                    let fd = FileDescriptor(fh.into());
                     match ops.fd_resize(fd, size, false).await {
                         Ok(()) => (),
                         Err(err) => {
                             return match err {
                                 WorkspaceFdResizeError::NotInWriteMode => {
-                                    reply.manual().error(libc::EBADF)
+                                    reply.manual().error(Errno::EBADF)
                                 }
                                 // Unexpected: FUSE is supposed to only give us valid file descriptors !
                                 WorkspaceFdResizeError::BadFileDescriptor
                                 | WorkspaceFdResizeError::Internal(_) => {
-                                    reply.manual().error(libc::EIO)
+                                    reply.manual().error(Errno::EIO)
                                 }
                             };
                         }
@@ -1093,7 +1091,7 @@ impl fuser::Filesystem for Filesystem {
                                 // Unexpected: FUSE is supposed to only give us valid file descriptors !
                                 WorkspaceFdStatError::BadFileDescriptor
                                 | WorkspaceFdStatError::Internal(_) => {
-                                    reply.manual().error(libc::EIO)
+                                    reply.manual().error(Errno::EIO)
                                 }
                             };
                         }
@@ -1130,22 +1128,22 @@ impl fuser::Filesystem for Filesystem {
                         Err(err) => {
                             return match err {
                                 WorkspaceOpenFileError::EntryNotFound => {
-                                    reply.manual().error(libc::ENOENT)
+                                    reply.manual().error(Errno::ENOENT)
                                 }
                                 WorkspaceOpenFileError::Offline(_) => {
-                                    reply.manual().error(libc::EHOSTUNREACH)
+                                    reply.manual().error(Errno::EHOSTUNREACH)
                                 }
                                 WorkspaceOpenFileError::EntryExistsInCreateNewMode { .. } => {
-                                    reply.manual().error(libc::EEXIST)
+                                    reply.manual().error(Errno::EEXIST)
                                 }
                                 WorkspaceOpenFileError::EntryNotAFile { .. } => {
-                                    reply.manual().error(libc::EISDIR)
+                                    reply.manual().error(Errno::EISDIR)
                                 }
                                 WorkspaceOpenFileError::NoRealmAccess => {
-                                    reply.manual().error(libc::EPERM)
+                                    reply.manual().error(Errno::EPERM)
                                 }
                                 WorkspaceOpenFileError::ReadOnlyRealm => {
-                                    reply.manual().error(libc::EROFS)
+                                    reply.manual().error(Errno::EROFS)
                                 }
                                 WorkspaceOpenFileError::Stopped
                                 | WorkspaceOpenFileError::RealmDeleted
@@ -1154,7 +1152,7 @@ impl fuser::Filesystem for Filesystem {
                                 | WorkspaceOpenFileError::InvalidManifest(_)
                                 | WorkspaceOpenFileError::Internal(_) => {
                                     log::warn!("FUSE `setattr` operation cannot complete: {err:?}");
-                                    reply.manual().error(libc::EIO)
+                                    reply.manual().error(Errno::EIO)
                                 }
                             }
                         }
@@ -1168,7 +1166,7 @@ impl fuser::Filesystem for Filesystem {
                                 WorkspaceFdStatError::BadFileDescriptor
                                 | WorkspaceFdStatError::Internal(_) => {
                                     log::warn!("FUSE `setattr` operation cannot complete: {err:?}");
-                                    reply.manual().error(libc::EIO)
+                                    reply.manual().error(Errno::EIO)
                                 }
                             };
                         }
@@ -1184,7 +1182,7 @@ impl fuser::Filesystem for Filesystem {
                             | WorkspaceFdCloseError::Internal(_)
                             => {
                                 log::warn!("FUSE `setattr` operation cannot complete: {err:?}");
-                                reply.manual().error(libc::EIO)
+                                reply.manual().error(Errno::EIO)
                             }
                         };
                         }
@@ -1228,14 +1226,14 @@ impl fuser::Filesystem for Filesystem {
     }
 
     fn read(
-        &mut self,
-        _req: &fuser::Request<'_>,
-        ino: u64,
-        fh: u64,
-        offset: i64,
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        fh: fuser::FileHandle,
+        offset: u64,
         size: u32,
-        _flags: i32,
-        _lock_owner: Option<u64>,
+        _flags: fuser::OpenFlags,
+        _lock_owner: Option<fuser::LockOwner>,
         reply: fuser::ReplyData,
     ) {
         log::debug!("[FUSE] read(ino: {ino:#x?}, fh: {fh}, offset: {offset}, size: {size})",);
@@ -1243,19 +1241,17 @@ impl fuser::Filesystem for Filesystem {
 
         let ops = self.ops.clone();
         self.tokio_handle.spawn(async move {
-            let fd = FileDescriptor(fh as u32);
+            let fd = FileDescriptor(fh.into());
             let mut buf = Vec::with_capacity(size as usize);
-            // TODO: investigate if offset can be negative or if this is just poor typing on FUSE's part
-            let offset = u64::try_from(offset).expect("Offset is negative");
             match ops.fd_read(fd, offset, size as u64, &mut buf).await {
                 Ok(_) => {
                     reply.manual().data(&buf);
                 }
                 Err(err) => match err {
-                    WorkspaceFdReadError::Offline(_) => reply.manual().error(libc::EHOSTUNREACH),
-                    WorkspaceFdReadError::ServerBlockstoreUnavailable => reply.manual().error(libc::EHOSTUNREACH),
-                    WorkspaceFdReadError::NotInReadMode => reply.manual().error(libc::EBADF),
-                    WorkspaceFdReadError::NoRealmAccess => reply.manual().error(libc::EPERM),
+                    WorkspaceFdReadError::Offline(_) => reply.manual().error(Errno::EHOSTUNREACH),
+                    WorkspaceFdReadError::ServerBlockstoreUnavailable => reply.manual().error(Errno::EHOSTUNREACH),
+                    WorkspaceFdReadError::NotInReadMode => reply.manual().error(Errno::EBADF),
+                    WorkspaceFdReadError::NoRealmAccess => reply.manual().error(Errno::EPERM),
                     WorkspaceFdReadError::Stopped
                     | WorkspaceFdReadError::RealmDeleted
                     | WorkspaceFdReadError::InvalidBlockAccess(_)
@@ -1266,7 +1262,7 @@ impl fuser::Filesystem for Filesystem {
                     | WorkspaceFdReadError::Internal(_)
                     => {
                         log::warn!("FUSE `read` operation cannot complete: {err:?}");
-                        reply.manual().error(libc::EIO)
+                        reply.manual().error(Errno::EIO)
                     }
                 },
             }
@@ -1274,15 +1270,15 @@ impl fuser::Filesystem for Filesystem {
     }
 
     fn write(
-        &mut self,
-        _req: &fuser::Request<'_>,
-        ino: u64,
-        fh: u64,
-        offset: i64,
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        fh: fuser::FileHandle,
+        offset: u64,
         data: &[u8],
-        _write_flags: u32,
-        _flags: i32,
-        _lock_owner: Option<u64>,
+        _write_flags: fuser::WriteFlags,
+        _flags: fuser::OpenFlags,
+        _lock_owner: Option<fuser::LockOwner>,
         reply: fuser::ReplyWrite,
     ) {
         log::debug!(
@@ -1297,20 +1293,19 @@ impl fuser::Filesystem for Filesystem {
 
         let ops = self.ops.clone();
         self.tokio_handle.spawn(async move {
-            let fd = FileDescriptor(fh as u32);
+            let fd = FileDescriptor(fh.into());
             // TODO: investigate if offset can be negative or if this is just poor typing on FUSE's part
-            let offset = u64::try_from(offset).expect("Offset is negative");
             match ops.fd_write(fd, offset, &data).await {
                 Ok(written) => {
                     reply.manual().written(written as u32);
                 }
                 Err(err) => match err {
-                    WorkspaceFdWriteError::NotInWriteMode => reply.manual().error(libc::EBADF),
+                    WorkspaceFdWriteError::NotInWriteMode => reply.manual().error(Errno::EBADF),
                     // Unexpected: FUSE is supposed to only give us valid file descriptors !
                     WorkspaceFdWriteError::BadFileDescriptor
                     | WorkspaceFdWriteError::Internal(_) => {
                         log::warn!("FUSE `write` operation cannot complete: {err:?}");
-                        reply.manual().error(libc::EIO)
+                        reply.manual().error(Errno::EIO)
                     }
                 },
             }
@@ -1330,11 +1325,11 @@ impl fuser::Filesystem for Filesystem {
     /// the file right after closing a file descriptor that modified it might end up with
     /// outdated data !
     fn flush(
-        &mut self,
-        _req: &fuser::Request<'_>,
-        ino: u64,
-        fh: u64,
-        lock_owner: u64,
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        fh: fuser::FileHandle,
+        lock_owner: fuser::LockOwner,
         reply: fuser::ReplyEmpty,
     ) {
         log::debug!("[FUSE] flush(ino: {ino:#x?}, fh: {fh}, lock_owner: {lock_owner:?})");
@@ -1343,7 +1338,7 @@ impl fuser::Filesystem for Filesystem {
 
         let ops = self.ops.clone();
         self.tokio_handle.spawn(async move {
-            let fd = FileDescriptor(fh as u32);
+            let fd = FileDescriptor(fh.into());
             match ops.fd_flush(fd).await {
                 Ok(()) => {
                     reply.manual().ok();
@@ -1358,7 +1353,7 @@ impl fuser::Filesystem for Filesystem {
                     | WorkspaceFdFlushError::Internal(_)
                     => {
                         log::warn!("FUSE `flush` operation cannot complete: {err:?}");
-                        reply.manual().error(libc::EIO)
+                        reply.manual().error(Errno::EIO)
                     }
                 },
             }
@@ -1366,12 +1361,12 @@ impl fuser::Filesystem for Filesystem {
     }
 
     fn release(
-        &mut self,
-        _req: &fuser::Request<'_>,
-        ino: u64,
-        fh: u64,
-        flags: i32,
-        lock_owner: Option<u64>,
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        fh: fuser::FileHandle,
+        flags: fuser::OpenFlags,
+        lock_owner: Option<fuser::LockOwner>,
         flush: bool,
         reply: fuser::ReplyEmpty,
     ) {
@@ -1382,7 +1377,7 @@ impl fuser::Filesystem for Filesystem {
 
         let ops = self.ops.clone();
         self.tokio_handle.spawn(async move {
-            let fd = FileDescriptor(fh as u32);
+            let fd = FileDescriptor(fh.into());
             match ops.fd_close(fd).await {
                 Ok(()) => {
                     reply.manual().ok();
@@ -1394,7 +1389,7 @@ impl fuser::Filesystem for Filesystem {
                     | WorkspaceFdCloseError::Internal(_)
                     => {
                         log::warn!("FUSE `release` operation cannot complete: {err:?}");
-                        reply.manual().error(libc::EIO)
+                        reply.manual().error(Errno::EIO)
                     }
                 },
             }
@@ -1402,10 +1397,10 @@ impl fuser::Filesystem for Filesystem {
     }
 
     fn fsync(
-        &mut self,
-        _req: &fuser::Request<'_>,
-        ino: u64,
-        fh: u64,
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        fh: fuser::FileHandle,
         datasync: bool,
         reply: fuser::ReplyEmpty,
     ) {
@@ -1414,20 +1409,20 @@ impl fuser::Filesystem for Filesystem {
 
         let ops = self.ops.clone();
         self.tokio_handle.spawn(async move {
-            let fd = FileDescriptor(fh as u32);
+            let fd = FileDescriptor(fh.into());
             match ops.fd_flush(fd).await {
                 Ok(()) => {
                     reply.manual().ok();
                 }
                 Err(err) => match err {
-                    WorkspaceFdFlushError::NotInWriteMode => reply.manual().error(libc::EACCES),
+                    WorkspaceFdFlushError::NotInWriteMode => reply.manual().error(Errno::EACCES),
                     WorkspaceFdFlushError::Stopped
                     // Unexpected: FUSE is supposed to only give us valid file descriptors !
                     | WorkspaceFdFlushError::BadFileDescriptor
                     | WorkspaceFdFlushError::Internal(_)
                     => {
                         log::warn!("FUSE `fsync` operation cannot complete: {err:?}");
-                        reply.manual().error(libc::EIO)
+                        reply.manual().error(Errno::EIO)
                     }
                 },
             }
@@ -1451,10 +1446,10 @@ impl fuser::Filesystem for Filesystem {
     //
     // see https://unix.stackexchange.com/a/637666
     fn opendir(
-        &mut self,
-        _req: &fuser::Request<'_>,
-        ino: u64,
-        flags: i32,
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        flags: fuser::OpenFlags,
         reply: fuser::ReplyOpen,
     ) {
         log::debug!("[FUSE] opendir(ino: {ino:#x?}, flags: {flags:#x?})");
@@ -1472,16 +1467,16 @@ impl fuser::Filesystem for Filesystem {
                 Err(err) => {
                     return match err {
                         WorkspaceOpenFolderReaderError::EntryNotFound => {
-                            reply.manual().error(libc::ENOENT)
+                            reply.manual().error(Errno::ENOENT)
                         }
                         WorkspaceOpenFolderReaderError::EntryIsFile => {
-                            reply.manual().error(libc::ENOTDIR);
+                            reply.manual().error(Errno::ENOTDIR);
                         }
                         WorkspaceOpenFolderReaderError::Offline(_) => {
-                            reply.manual().error(libc::EHOSTUNREACH)
+                            reply.manual().error(Errno::EHOSTUNREACH)
                         }
                         WorkspaceOpenFolderReaderError::NoRealmAccess => {
-                            reply.manual().error(libc::EPERM)
+                            reply.manual().error(Errno::EPERM)
                         }
                         WorkspaceOpenFolderReaderError::Stopped
                         | WorkspaceOpenFolderReaderError::RealmDeleted
@@ -1490,35 +1485,36 @@ impl fuser::Filesystem for Filesystem {
                         | WorkspaceOpenFolderReaderError::InvalidManifest(_)
                         | WorkspaceOpenFolderReaderError::Internal(_) => {
                             log::warn!("FUSE `opendir` operation cannot complete: {err:?}");
-                            reply.manual().error(libc::EIO)
+                            reply.manual().error(Errno::EIO)
                         }
                     }
                 }
             };
 
-            let open_flags = 0; // TODO: what to set here ?
+            // Flag is only to enable FOPEN_DIRECT_IO which we don't use
+            let open_flags = fuser::FopenFlags::empty();
 
             // Hold my beer
             let boxed_path_and_folder_reader = Arc::new((path, folder_reader));
             let fh = Arc::into_raw(boxed_path_and_folder_reader) as u64;
 
-            reply.manual().opened(fh, open_flags);
+            reply.manual().opened(fuser::FileHandle(fh), open_flags);
         });
     }
 
     fn readdirplus(
-        &mut self,
-        req: &fuser::Request<'_>,
-        ino: u64,
-        fh: u64,
-        offset: i64,
+        &self,
+        req: &Request,
+        ino: INodeNo,
+        fh: fuser::FileHandle,
+        offset: u64,
         reply: fuser::ReplyDirectoryPlus,
     ) {
         log::debug!("[FUSE] readdirplus(ino: {ino:#x?}, fh: {fh}, offset: {offset})");
         let mut reply = reply_on_drop_guard!(reply, fuser::ReplyDirectoryPlus);
 
         let boxed_path_and_folder_reader = {
-            let ptr = fh as *mut (FsPath, FolderReader);
+            let ptr = fh.0 as *mut (FsPath, FolderReader);
             // SAFETY: `ptr` is a valid pointer that have been created by `opendir`
             // We must increment the refcount given `Arc::from_raw` use in the next line
             // "steal" the owner ship of the pointer (and hence will release the data
@@ -1550,10 +1546,10 @@ impl fuser::Filesystem for Filesystem {
                     Err(err) => {
                         return match err {
                             FolderReaderStatEntryError::Offline(_) => {
-                                reply.manual().error(libc::EHOSTUNREACH)
+                                reply.manual().error(Errno::EHOSTUNREACH)
                             }
                             FolderReaderStatEntryError::NoRealmAccess => {
-                                reply.manual().error(libc::EPERM)
+                                reply.manual().error(Errno::EPERM)
                             }
                             FolderReaderStatEntryError::Stopped
                             | FolderReaderStatEntryError::RealmDeleted
@@ -1562,7 +1558,7 @@ impl fuser::Filesystem for Filesystem {
                             | FolderReaderStatEntryError::InvalidManifest(_)
                             | FolderReaderStatEntryError::Internal(_) => {
                                 log::warn!("FUSE `readdirplus` operation cannot complete: {err:?}");
-                                reply.manual().error(libc::EIO)
+                                reply.manual().error(Errno::EIO)
                             }
                         }
                     }
@@ -1576,7 +1572,7 @@ impl fuser::Filesystem for Filesystem {
                 let buffer_full = match child_stat {
                     EntryStat::File { .. } => reply.borrow().add(
                         child_inode,
-                        (offset + 1) as i64,
+                        (offset + 1) as u64,
                         OsStr::new(child_name.as_ref()),
                         &TTL,
                         &entry_stat_to_file_attr(child_stat, child_inode, uid, gid, is_read_only),
@@ -1584,7 +1580,7 @@ impl fuser::Filesystem for Filesystem {
                     ),
                     EntryStat::Folder { .. } => reply.borrow().add(
                         child_inode,
-                        (offset + 1) as i64,
+                        (offset + 1) as u64,
                         OsStr::new(child_name.as_ref()),
                         &TTL,
                         &entry_stat_to_file_attr(child_stat, child_inode, uid, gid, is_read_only),
@@ -1605,18 +1601,18 @@ impl fuser::Filesystem for Filesystem {
     // `readdir` is only implemented as a fallback in case `readdirplus` is not available
     // on the current FUSE version.
     fn readdir(
-        &mut self,
-        _req: &fuser::Request<'_>,
-        ino: u64,
-        fh: u64,
-        offset: i64,
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        fh: fuser::FileHandle,
+        offset: u64,
         reply: fuser::ReplyDirectory,
     ) {
         log::debug!("[FUSE] readdir(ino: {ino:#x?}, fh: {fh}, offset: {offset})");
         let mut reply = reply_on_drop_guard!(reply, fuser::ReplyDirectory);
 
         let boxed_path_and_folder_reader = {
-            let ptr = fh as *mut (FsPath, FolderReader);
+            let ptr = fh.0 as *mut (FsPath, FolderReader);
             // SAFETY: `ptr` is a valid pointer that have been created by `opendir`
             // We must increment the refcount given `Arc::from_raw` use in the next line
             // "steal" the owner ship of the pointer (and hence will release the data
@@ -1645,10 +1641,10 @@ impl fuser::Filesystem for Filesystem {
                     Err(err) => {
                         return match err {
                             FolderReaderStatEntryError::Offline(_) => {
-                                reply.manual().error(libc::EHOSTUNREACH)
+                                reply.manual().error(Errno::EHOSTUNREACH)
                             }
                             FolderReaderStatEntryError::NoRealmAccess => {
-                                reply.manual().error(libc::EPERM)
+                                reply.manual().error(Errno::EPERM)
                             }
                             FolderReaderStatEntryError::Stopped
                             | FolderReaderStatEntryError::RealmDeleted
@@ -1657,7 +1653,7 @@ impl fuser::Filesystem for Filesystem {
                             | FolderReaderStatEntryError::InvalidManifest(_)
                             | FolderReaderStatEntryError::Internal(_) => {
                                 log::warn!("FUSE `readdir` operation cannot complete: {err:?}");
-                                reply.manual().error(libc::EIO)
+                                reply.manual().error(Errno::EIO)
                             }
                         }
                     }
@@ -1671,13 +1667,13 @@ impl fuser::Filesystem for Filesystem {
                 let buffer_full = match child_stat {
                     EntryStat::File { .. } => reply.borrow().add(
                         child_inode,
-                        (offset + 1) as i64,
+                        (offset + 1) as u64,
                         fuser::FileType::RegularFile,
                         OsStr::new(child_name.as_ref()),
                     ),
                     EntryStat::Folder { .. } => reply.borrow().add(
                         child_inode,
-                        (offset + 1) as i64,
+                        (offset + 1) as u64,
                         fuser::FileType::Directory,
                         OsStr::new(child_name.as_ref()),
                     ),
@@ -1694,18 +1690,18 @@ impl fuser::Filesystem for Filesystem {
     }
 
     fn releasedir(
-        &mut self,
-        _req: &fuser::Request<'_>,
-        ino: u64,
-        fh: u64,
-        flags: i32,
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        fh: fuser::FileHandle,
+        flags: fuser::OpenFlags,
         reply: fuser::ReplyEmpty,
     ) {
         log::debug!("[FUSE] releasedir(ino: {ino:#x?}, fh: {fh}, flags: {flags:#x?})");
         let reply = reply_on_drop_guard!(reply, fuser::ReplyEmpty);
 
         {
-            let ptr = fh as *mut (FsPath, FolderReader);
+            let ptr = fh.0 as *mut (FsPath, FolderReader);
             // SAFETY: `ptr` is a valid pointer that have been created by `opendir`
             let _ = unsafe { Arc::from_raw(ptr) };
         }
@@ -1731,11 +1727,11 @@ impl fuser::Filesystem for Filesystem {
 async fn getattr_from_path(
     ops: &WorkspaceOps,
     path: FsPath,
-    ino: u64,
+    ino: INodeNo,
     uid: u32,
     gid: u32,
     is_read_only: bool,
-) -> Result<fuser::FileAttr, i32> {
+) -> Result<fuser::FileAttr, Errno> {
     match ops
         .stat_entry(&path)
         .await
@@ -1745,9 +1741,9 @@ async fn getattr_from_path(
     {
         Ok(stat) => Ok(stat),
         Err(err) => match err {
-            WorkspaceStatEntryError::EntryNotFound => Err(libc::ENOENT),
-            WorkspaceStatEntryError::Offline(_) => Err(libc::EHOSTUNREACH),
-            WorkspaceStatEntryError::NoRealmAccess => Err(libc::EPERM),
+            WorkspaceStatEntryError::EntryNotFound => Err(Errno::ENOENT),
+            WorkspaceStatEntryError::Offline(_) => Err(Errno::EHOSTUNREACH),
+            WorkspaceStatEntryError::NoRealmAccess => Err(Errno::EPERM),
             WorkspaceStatEntryError::Stopped
             | WorkspaceStatEntryError::RealmDeleted
             | WorkspaceStatEntryError::InvalidKeysBundle(_)
@@ -1755,7 +1751,7 @@ async fn getattr_from_path(
             | WorkspaceStatEntryError::InvalidManifest(_)
             | WorkspaceStatEntryError::Internal(_) => {
                 log::warn!("FUSE `getattr_from_path` operation cannot complete: {err:?}");
-                Err(libc::EIO)
+                Err(Errno::EIO)
             }
         },
     }

--- a/libparsec/crates/platform_mountpoint/src/unix/history.rs
+++ b/libparsec/crates/platform_mountpoint/src/unix/history.rs
@@ -13,7 +13,8 @@ use libparsec_client::workspace_history::{
 };
 use libparsec_types::prelude::*;
 
-use super::inode::{Inode, InodesManager};
+use super::inode::{INodeNo, InodesManager};
+use fuser::{Errno, Generation, InitFlags, Request};
 
 /// Validity timeout set to zero to prevent FUSE from doing caching logic on it.
 /// This is because FUSE caching is not aware of external modification (i.e. sync
@@ -28,7 +29,7 @@ const TTL: std::time::Duration = std::time::Duration::ZERO;
 /// time). So if the file system reuses an inode after it has been deleted, it
 /// must assign a new, previously unused generation number to the inode at the
 /// same time.
-const GENERATION: u64 = 0;
+const GENERATION: Generation = Generation(0);
 const BLOCK_SIZE: u64 = 512;
 const PERMISSIONS: u16 = 0o700;
 
@@ -40,7 +41,7 @@ fn os_name_to_entry_name(name: &OsStr) -> EntryNameResult<EntryName> {
 
 fn entry_stat_to_file_attr(
     stat: WorkspaceHistoryEntryStat,
-    inode: Inode,
+    inode: INodeNo,
     uid: u32,
     gid: u32,
 ) -> fuser::FileAttr {
@@ -137,7 +138,7 @@ macro_rules! reply_on_drop_guard {
                     // Already replied
                     None => (),
                     // Not replied time to do it with ourself !
-                    Some(reply) => reply.error(libc::EIO),
+                    Some(reply) => reply.error(Errno::EIO),
                 }
             }
         }
@@ -170,12 +171,26 @@ pub(crate) static LOOKUP_HOOK: Mutex<
 impl fuser::Filesystem for Filesystem {
     fn init(
         &mut self,
-        _req: &fuser::Request<'_>,
+        _req: &Request,
         // see https://libfuse.github.io/doxygen/structfuse__conn__info.html
         config: &mut fuser::KernelConfig,
-    ) -> Result<(), libc::c_int> {
-        // Try to enable readdirplus optimisation, if it's not possible we fallback on regular readdir
-        let _ = config.add_capabilities(fuser::consts::FUSE_DO_READDIRPLUS);
+    ) -> std::io::Result<()> {
+        // Defined some desired capabilities, look in `filesystem.rs` for an explanation
+        let caps = InitFlags::FUSE_DO_READDIRPLUS
+            | InitFlags::FUSE_READDIRPLUS_AUTO
+            | InitFlags::FUSE_SPLICE_READ
+            | InitFlags::FUSE_PARALLEL_DIROPS;
+        // Try to enable some capabilities for optimization, We just ignore capabilities that was
+        // not able to be applied.
+        if let Err(e) = config.add_capabilities(caps) {
+            let mut it_names = e.iter_names();
+            (&mut it_names)
+                .for_each(|(name, v)| log::debug!("cannot add capability {name} ({v:#x})"));
+            let remaining_bits = it_names.remaining().bits();
+            if remaining_bits != 0 {
+                log::debug!("cannot add unnamed capability {remaining_bits:#x}",);
+            }
+        }
         Ok(())
     }
 
@@ -187,9 +202,9 @@ impl fuser::Filesystem for Filesystem {
     /// The lookup transforms the path name to an `inode`.
     /// The `inode` is then used by all other operations and is freed by `forget`.
     fn lookup(
-        &mut self,
-        req: &fuser::Request<'_>,
-        parent: u64,
+        &self,
+        req: &Request,
+        parent: INodeNo,
         name: &std::ffi::OsStr,
         reply: fuser::ReplyEntry,
     ) {
@@ -201,11 +216,11 @@ impl fuser::Filesystem for Filesystem {
         let name = match os_name_to_entry_name(name) {
             Ok(name) => name,
             Err(EntryNameError::NameTooLong) => {
-                reply.manual().error(libc::ENAMETOOLONG);
+                reply.manual().error(Errno::ENAMETOOLONG);
                 return;
             }
             Err(EntryNameError::InvalidName) => {
-                reply.manual().error(libc::EINVAL);
+                reply.manual().error(Errno::EINVAL);
                 return;
             }
         };
@@ -251,13 +266,13 @@ impl fuser::Filesystem for Filesystem {
                 }
                 Err(err) => match err {
                     WorkspaceHistoryStatEntryError::EntryNotFound => {
-                        reply.manual().error(libc::ENOENT)
+                        reply.manual().error(Errno::ENOENT)
                     }
                     WorkspaceHistoryStatEntryError::Offline(_) => {
-                        reply.manual().error(libc::EHOSTUNREACH)
+                        reply.manual().error(Errno::EHOSTUNREACH)
                     }
                     WorkspaceHistoryStatEntryError::NoRealmAccess => {
-                        reply.manual().error(libc::EPERM)
+                        reply.manual().error(Errno::EPERM)
                     }
                     WorkspaceHistoryStatEntryError::Stopped
                     | WorkspaceHistoryStatEntryError::RealmDeleted
@@ -267,21 +282,21 @@ impl fuser::Filesystem for Filesystem {
                     | WorkspaceHistoryStatEntryError::InvalidHistory(_)
                     | WorkspaceHistoryStatEntryError::Internal(_) => {
                         log::warn!("FUSE `lookup` operation cannot complete: {err:?}");
-                        reply.manual().error(libc::EIO)
+                        reply.manual().error(Errno::EIO)
                     }
                 },
             }
         });
     }
 
-    fn forget(&mut self, _req: &fuser::Request<'_>, ino: u64, nlookup: u64) {
+    fn forget(&self, _req: &Request, ino: INodeNo, nlookup: u64) {
         self.inodes
             .lock()
             .expect("mutex is poisoned")
             .remove_path_or_panic(ino, nlookup);
     }
 
-    fn statfs(&mut self, _req: &fuser::Request<'_>, ino: u64, reply: fuser::ReplyStatfs) {
+    fn statfs(&self, _req: &Request, ino: INodeNo, reply: fuser::ReplyStatfs) {
         log::debug!("[FUSE] statfs(ino: {ino:#x?})");
 
         // We have currently no way of easily getting the size of workspace
@@ -300,10 +315,10 @@ impl fuser::Filesystem for Filesystem {
     }
 
     fn getattr(
-        &mut self,
-        req: &fuser::Request<'_>,
-        ino: u64,
-        _fh: Option<u64>,
+        &self,
+        req: &Request,
+        ino: INodeNo,
+        _fh: Option<fuser::FileHandle>,
         reply: fuser::ReplyAttr,
     ) {
         log::debug!("[FUSE] getattr(ino: {ino:#x?})");
@@ -326,13 +341,13 @@ impl fuser::Filesystem for Filesystem {
                     .attr(&TTL, &entry_stat_to_file_attr(stat, ino, uid, gid)),
                 Err(err) => match err {
                     WorkspaceHistoryStatEntryError::EntryNotFound => {
-                        reply.manual().error(libc::ENOENT)
+                        reply.manual().error(Errno::ENOENT)
                     }
                     WorkspaceHistoryStatEntryError::Offline(_) => {
-                        reply.manual().error(libc::EHOSTUNREACH)
+                        reply.manual().error(Errno::EHOSTUNREACH)
                     }
                     WorkspaceHistoryStatEntryError::NoRealmAccess => {
-                        reply.manual().error(libc::EPERM)
+                        reply.manual().error(Errno::EPERM)
                     }
                     WorkspaceHistoryStatEntryError::Stopped
                     | WorkspaceHistoryStatEntryError::RealmDeleted
@@ -342,7 +357,7 @@ impl fuser::Filesystem for Filesystem {
                     | WorkspaceHistoryStatEntryError::InvalidHistory(_)
                     | WorkspaceHistoryStatEntryError::Internal(_) => {
                         log::warn!("FUSE `getattr` operation cannot complete: {err:?}");
-                        reply.manual().error(libc::EIO)
+                        reply.manual().error(Errno::EIO)
                     }
                 },
             }
@@ -350,7 +365,7 @@ impl fuser::Filesystem for Filesystem {
     }
 
     // Note flags doesn't contains O_CREAT, O_EXCL, O_NOCTTY and O_TRUNC
-    fn open(&mut self, _req: &fuser::Request<'_>, ino: u64, flags: i32, reply: fuser::ReplyOpen) {
+    fn open(&self, _req: &Request, ino: INodeNo, flags: fuser::OpenFlags, reply: fuser::ReplyOpen) {
         log::debug!("[FUSE] open(ino: {ino:#x?}, flags: {flags:#x?})");
         let reply = reply_on_drop_guard!(reply, fuser::ReplyOpen);
 
@@ -361,15 +376,10 @@ impl fuser::Filesystem for Filesystem {
 
         let ops = self.ops.clone();
 
-        match flags & libc::O_ACCMODE {
-            libc::O_RDONLY => (),
-            libc::O_WRONLY | libc::O_RDWR => {
-                reply.manual().error(libc::EACCES);
-                return;
-            }
-            // Exactly one access mode flag must be specified
-            _ => {
-                reply.manual().error(libc::EINVAL);
+        match flags.acc_mode() {
+            fuser::OpenAccMode::O_RDONLY => (),
+            fuser::OpenAccMode::O_WRONLY | fuser::OpenAccMode::O_RDWR => {
+                reply.manual().error(Errno::EACCES);
                 return;
             }
         }
@@ -380,16 +390,16 @@ impl fuser::Filesystem for Filesystem {
                 Err(err) => {
                     return match err {
                         WorkspaceHistoryOpenFileError::EntryNotFound => {
-                            reply.manual().error(libc::ENOENT)
+                            reply.manual().error(Errno::ENOENT)
                         }
                         WorkspaceHistoryOpenFileError::Offline(_) => {
-                            reply.manual().error(libc::EHOSTUNREACH)
+                            reply.manual().error(Errno::EHOSTUNREACH)
                         }
                         WorkspaceHistoryOpenFileError::EntryNotAFile { .. } => {
-                            reply.manual().error(libc::EISDIR)
+                            reply.manual().error(Errno::EISDIR)
                         }
                         WorkspaceHistoryOpenFileError::NoRealmAccess => {
-                            reply.manual().error(libc::EPERM)
+                            reply.manual().error(Errno::EPERM)
                         }
                         WorkspaceHistoryOpenFileError::Stopped
                         | WorkspaceHistoryOpenFileError::RealmDeleted
@@ -399,27 +409,27 @@ impl fuser::Filesystem for Filesystem {
                         | WorkspaceHistoryOpenFileError::InvalidHistory(_)
                         | WorkspaceHistoryOpenFileError::Internal(_) => {
                             log::warn!("FUSE `open` operation cannot complete: {err:?}");
-                            reply.manual().error(libc::EIO)
+                            reply.manual().error(Errno::EIO)
                         }
                     }
                 }
             };
 
             // Flag is only to enable FOPEN_DIRECT_IO which we don't use
-            let open_flags = 0;
-            reply.manual().opened(fd.0.into(), open_flags);
+            let open_flags = fuser::FopenFlags::empty();
+            reply.manual().opened(fuser::FileHandle(fd.0), open_flags);
         });
     }
 
     fn read(
-        &mut self,
-        _req: &fuser::Request<'_>,
-        ino: u64,
-        fh: u64,
-        offset: i64,
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        fh: fuser::FileHandle,
+        offset: u64,
         size: u32,
-        _flags: i32,
-        _lock_owner: Option<u64>,
+        _flags: fuser::OpenFlags,
+        _lock_owner: Option<fuser::LockOwner>,
         reply: fuser::ReplyData,
     ) {
         log::debug!("[FUSE] read(ino: {ino:#x?}, fh: {fh}, offset: {offset}, size: {size})",);
@@ -427,18 +437,16 @@ impl fuser::Filesystem for Filesystem {
 
         let ops = self.ops.clone();
         self.tokio_handle.spawn(async move {
-            let fd = FileDescriptor(fh as u32);
+            let fd = FileDescriptor(fh.0);
             let mut buf = Vec::with_capacity(size as usize);
-            // TODO: investigate if offset can be negative or if this is just poor typing on FUSE's part
-            let offset = u64::try_from(offset).expect("Offset is negative");
-            match ops.fd_read(fd, offset, size as u64, &mut buf).await.inspect_err(|e| log::trace!("Error on fd_read(fd={:?}, offset={}, buf.len={}) -> {e}", fd, offset, buf.len())) {
+            match ops.fd_read(fd, offset, size as u64, &mut buf).await {
                 Ok(_) => {
                     reply.manual().data(&buf);
                 }
                 Err(err) => match err {
                     WorkspaceHistoryFdReadError::Offline(_)
-                    | WorkspaceHistoryFdReadError::ServerBlockstoreUnavailable => reply.manual().error(libc::EHOSTUNREACH),
-                    WorkspaceHistoryFdReadError::NoRealmAccess => reply.manual().error(libc::EPERM),
+                    | WorkspaceHistoryFdReadError::ServerBlockstoreUnavailable => reply.manual().error(Errno::EHOSTUNREACH),
+                    WorkspaceHistoryFdReadError::NoRealmAccess => reply.manual().error(Errno::EPERM),
                     WorkspaceHistoryFdReadError::Stopped
                     | WorkspaceHistoryFdReadError::RealmDeleted
                     | WorkspaceHistoryFdReadError::InvalidBlockAccess(_)
@@ -449,7 +457,7 @@ impl fuser::Filesystem for Filesystem {
                     | WorkspaceHistoryFdReadError::Internal(_)
                     => {
                         log::warn!("FUSE `read` operation cannot complete: {err:?}");
-                        reply.manual().error(libc::EIO)
+                        reply.manual().error(Errno::EIO)
                     }
                 },
             }
@@ -457,12 +465,12 @@ impl fuser::Filesystem for Filesystem {
     }
 
     fn release(
-        &mut self,
-        _req: &fuser::Request<'_>,
-        ino: u64,
-        fh: u64,
-        flags: i32,
-        lock_owner: Option<u64>,
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        fh: fuser::FileHandle,
+        flags: fuser::OpenFlags,
+        lock_owner: Option<fuser::LockOwner>,
         flush: bool,
         reply: fuser::ReplyEmpty,
     ) {
@@ -473,7 +481,7 @@ impl fuser::Filesystem for Filesystem {
 
         let ops = self.ops.clone();
         self.tokio_handle.spawn(async move {
-            let fd = FileDescriptor(fh as u32);
+            let fd = FileDescriptor(fh.0);
             match ops.fd_close(fd) {
                 Ok(()) => {
                     reply.manual().ok();
@@ -483,7 +491,7 @@ impl fuser::Filesystem for Filesystem {
                     WorkspaceHistoryFdCloseError::BadFileDescriptor
                     | WorkspaceHistoryFdCloseError::Internal(_) => {
                         log::warn!("FUSE `release` operation cannot complete: {err:?}");
-                        reply.manual().error(libc::EIO)
+                        reply.manual().error(Errno::EIO)
                     }
                 },
             }
@@ -507,10 +515,10 @@ impl fuser::Filesystem for Filesystem {
     //
     // see https://unix.stackexchange.com/a/637666
     fn opendir(
-        &mut self,
-        _req: &fuser::Request<'_>,
-        ino: u64,
-        flags: i32,
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        flags: fuser::OpenFlags,
         reply: fuser::ReplyOpen,
     ) {
         log::debug!("[FUSE] opendir(ino: {ino:#x?}, flags: {flags:#x?})");
@@ -528,16 +536,16 @@ impl fuser::Filesystem for Filesystem {
                 Err(err) => {
                     return match err {
                         WorkspaceHistoryOpenFolderReaderError::EntryNotFound => {
-                            reply.manual().error(libc::ENOENT)
+                            reply.manual().error(Errno::ENOENT)
                         }
                         WorkspaceHistoryOpenFolderReaderError::EntryIsFile => {
-                            reply.manual().error(libc::ENOTDIR);
+                            reply.manual().error(Errno::ENOTDIR);
                         }
                         WorkspaceHistoryOpenFolderReaderError::Offline(_) => {
-                            reply.manual().error(libc::EHOSTUNREACH)
+                            reply.manual().error(Errno::EHOSTUNREACH)
                         }
                         WorkspaceHistoryOpenFolderReaderError::NoRealmAccess => {
-                            reply.manual().error(libc::EPERM)
+                            reply.manual().error(Errno::EPERM)
                         }
                         WorkspaceHistoryOpenFolderReaderError::Stopped
                         | WorkspaceHistoryOpenFolderReaderError::RealmDeleted
@@ -547,35 +555,36 @@ impl fuser::Filesystem for Filesystem {
                         | WorkspaceHistoryOpenFolderReaderError::InvalidHistory(_)
                         | WorkspaceHistoryOpenFolderReaderError::Internal(_) => {
                             log::warn!("FUSE `opendir` operation cannot complete: {err:?}");
-                            reply.manual().error(libc::EIO)
+                            reply.manual().error(Errno::EIO)
                         }
                     }
                 }
             };
 
-            let open_flags = 0; // TODO: what to set here ?
+            // Flag is only to enable FOPEN_DIRECT_IO which we don't use
+            let open_flags = fuser::FopenFlags::empty();
 
             // Hold my beer
             let boxed_path_and_folder_reader = Arc::new((path, folder_reader));
             let fh = Arc::into_raw(boxed_path_and_folder_reader) as u64;
 
-            reply.manual().opened(fh, open_flags);
+            reply.manual().opened(fuser::FileHandle(fh), open_flags);
         });
     }
 
     fn readdirplus(
-        &mut self,
-        req: &fuser::Request<'_>,
-        ino: u64,
-        fh: u64,
-        offset: i64,
+        &self,
+        req: &Request,
+        ino: INodeNo,
+        fh: fuser::FileHandle,
+        offset: u64,
         reply: fuser::ReplyDirectoryPlus,
     ) {
         log::debug!("[FUSE] readdirplus(ino: {ino:#x?}, fh: {fh}, offset: {offset})");
         let mut reply = reply_on_drop_guard!(reply, fuser::ReplyDirectoryPlus);
 
         let boxed_path_and_folder_reader = {
-            let ptr = fh as *mut (FsPath, WorkspaceHistoryFolderReader);
+            let ptr = fh.0 as *mut (FsPath, WorkspaceHistoryFolderReader);
             // SAFETY: `ptr` is a valid pointer that have been created by `opendir`
             // We must increment the refcount given `Arc::from_raw` use in the next line
             // "steal" the owner ship of the pointer (and hence will release the data
@@ -608,10 +617,10 @@ impl fuser::Filesystem for Filesystem {
                     Err(err) => {
                         return match err {
                             WorkspaceHistoryFolderReaderStatEntryError::Offline(_) => {
-                                reply.manual().error(libc::EHOSTUNREACH)
+                                reply.manual().error(Errno::EHOSTUNREACH)
                             }
                             WorkspaceHistoryFolderReaderStatEntryError::NoRealmAccess => {
-                                reply.manual().error(libc::EPERM)
+                                reply.manual().error(Errno::EPERM)
                             }
                             WorkspaceHistoryFolderReaderStatEntryError::Stopped
                             | WorkspaceHistoryFolderReaderStatEntryError::RealmDeleted
@@ -621,7 +630,7 @@ impl fuser::Filesystem for Filesystem {
                             | WorkspaceHistoryFolderReaderStatEntryError::InvalidHistory(_)
                             | WorkspaceHistoryFolderReaderStatEntryError::Internal(_) => {
                                 log::warn!("FUSE `readdirplus` operation cannot complete: {err:?}");
-                                reply.manual().error(libc::EIO)
+                                reply.manual().error(Errno::EIO)
                             }
                         }
                     }
@@ -635,7 +644,7 @@ impl fuser::Filesystem for Filesystem {
                 let buffer_full = match child_stat {
                     WorkspaceHistoryEntryStat::File { .. } => reply.borrow().add(
                         child_inode,
-                        (offset + 1) as i64,
+                        (offset + 1) as u64,
                         OsStr::new(child_name.as_ref()),
                         &TTL,
                         &entry_stat_to_file_attr(child_stat, child_inode, uid, gid),
@@ -643,7 +652,7 @@ impl fuser::Filesystem for Filesystem {
                     ),
                     WorkspaceHistoryEntryStat::Folder { .. } => reply.borrow().add(
                         child_inode,
-                        (offset + 1) as i64,
+                        (offset + 1) as u64,
                         OsStr::new(child_name.as_ref()),
                         &TTL,
                         &entry_stat_to_file_attr(child_stat, child_inode, uid, gid),
@@ -664,18 +673,18 @@ impl fuser::Filesystem for Filesystem {
     // `readdir` is only implemented as a fallback in case `readdirplus` is not available
     // on the current FUSE version.
     fn readdir(
-        &mut self,
-        _req: &fuser::Request<'_>,
-        ino: u64,
-        fh: u64,
-        offset: i64,
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        fh: fuser::FileHandle,
+        offset: u64,
         reply: fuser::ReplyDirectory,
     ) {
         log::debug!("[FUSE] readdir(ino: {ino:#x?}, fh: {fh}, offset: {offset})");
         let mut reply = reply_on_drop_guard!(reply, fuser::ReplyDirectory);
 
         let boxed_path_and_folder_reader = {
-            let ptr = fh as *mut (FsPath, WorkspaceHistoryFolderReader);
+            let ptr = fh.0 as *mut (FsPath, WorkspaceHistoryFolderReader);
             // SAFETY: `ptr` is a valid pointer that have been created by `opendir`
             // We must increment the refcount given `Arc::from_raw` use in the next line
             // "steal" the owner ship of the pointer (and hence will release the data
@@ -706,10 +715,10 @@ impl fuser::Filesystem for Filesystem {
                     Err(err) => {
                         return match err {
                             WorkspaceHistoryFolderReaderStatEntryError::Offline(_) => {
-                                reply.manual().error(libc::EHOSTUNREACH)
+                                reply.manual().error(Errno::EHOSTUNREACH)
                             }
                             WorkspaceHistoryFolderReaderStatEntryError::NoRealmAccess => {
-                                reply.manual().error(libc::EPERM)
+                                reply.manual().error(Errno::EPERM)
                             }
                             WorkspaceHistoryFolderReaderStatEntryError::Stopped
                             | WorkspaceHistoryFolderReaderStatEntryError::RealmDeleted
@@ -719,7 +728,7 @@ impl fuser::Filesystem for Filesystem {
                             | WorkspaceHistoryFolderReaderStatEntryError::InvalidHistory(_)
                             | WorkspaceHistoryFolderReaderStatEntryError::Internal(_) => {
                                 log::warn!("FUSE `readdir` operation cannot complete: {err:?}");
-                                reply.manual().error(libc::EIO)
+                                reply.manual().error(Errno::EIO)
                             }
                         }
                     }
@@ -733,13 +742,13 @@ impl fuser::Filesystem for Filesystem {
                 let buffer_full = match child_stat {
                     WorkspaceHistoryEntryStat::File { .. } => reply.borrow().add(
                         child_inode,
-                        (offset + 1) as i64,
+                        (offset + 1) as u64,
                         fuser::FileType::RegularFile,
                         OsStr::new(child_name.as_ref()),
                     ),
                     WorkspaceHistoryEntryStat::Folder { .. } => reply.borrow().add(
                         child_inode,
-                        (offset + 1) as i64,
+                        (offset + 1) as u64,
                         fuser::FileType::Directory,
                         OsStr::new(child_name.as_ref()),
                     ),
@@ -756,18 +765,18 @@ impl fuser::Filesystem for Filesystem {
     }
 
     fn releasedir(
-        &mut self,
-        _req: &fuser::Request<'_>,
-        ino: u64,
-        fh: u64,
-        flags: i32,
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        fh: fuser::FileHandle,
+        flags: fuser::OpenFlags,
         reply: fuser::ReplyEmpty,
     ) {
         log::debug!("[FUSE] releasedir(ino: {ino:#x?}, fh: {fh}, flags: {flags:#x?})");
         let reply = reply_on_drop_guard!(reply, fuser::ReplyEmpty);
 
         {
-            let ptr = fh as *mut (FsPath, WorkspaceHistoryFolderReader);
+            let ptr = fh.0 as *mut (FsPath, WorkspaceHistoryFolderReader);
             // SAFETY: `ptr` is a valid pointer that have been created by `opendir`
             let _ = unsafe { Arc::from_raw(ptr) };
         }

--- a/libparsec/crates/platform_mountpoint/src/unix/inode.rs
+++ b/libparsec/crates/platform_mountpoint/src/unix/inode.rs
@@ -4,12 +4,14 @@ use std::collections::HashMap;
 
 use libparsec_types::FsPath;
 
+pub use fuser::INodeNo;
+
 /// `paths_indexed_by_inode` allocator indexed by `inode`
 /// The index of path is the inode number and the free inodes are stored
 /// `Pasteur` must contain his rage when he sees this code
 struct PathsStore {
     paths_indexed_by_inode: Vec<FsPath>,
-    stack_unused_inodes: Vec<Inode>,
+    stack_unused_inodes: Vec<INodeNo>,
 }
 
 impl Default for PathsStore {
@@ -58,15 +60,10 @@ impl Counter {
     }
 }
 
-/// `Inode` wrapper used to interface with `FUSE` low level `API`.
-///
-/// We use that structure to provide a high level `API`
-pub(crate) type Inode = u64;
-
 #[derive(Default)]
 pub(crate) struct InodesManager {
     paths_store: PathsStore,
-    opened: HashMap<FsPath, (Counter, Inode)>,
+    opened: HashMap<FsPath, (Counter, INodeNo)>,
 }
 
 impl InodesManager {
@@ -77,20 +74,20 @@ impl InodesManager {
         }
     }
 
-    pub(super) fn insert_path(&mut self, path: FsPath) -> Inode {
+    pub(super) fn insert_path(&mut self, path: FsPath) -> INodeNo {
         if let Some((counter, inode)) = self.opened.get_mut(&path) {
             counter.increment();
             return *inode;
         }
 
         let inode = if let Some(inode) = self.paths_store.stack_unused_inodes.pop() {
-            let index = inode as usize;
+            let index = inode.0 as usize;
             self.paths_store.paths_indexed_by_inode[index] = path.clone();
             inode
         } else {
             let index = self.paths_store.paths_indexed_by_inode.len();
             self.paths_store.paths_indexed_by_inode.push(path.clone());
-            index as Inode
+            INodeNo(index as u64)
         };
 
         self.opened.insert(path, (Counter::default(), inode));
@@ -100,8 +97,8 @@ impl InodesManager {
     /// It will panic if:
     /// - `inode` does not exist
     /// - `nlookup` is greater than the `counter` associated to the `inode`
-    pub(super) fn remove_path_or_panic(&mut self, inode: Inode, nlookup: u64) {
-        let index = inode as usize;
+    pub(super) fn remove_path_or_panic(&mut self, inode: INodeNo, nlookup: u64) {
+        let index = inode.0 as usize;
         let path = &self.paths_store.paths_indexed_by_inode[index];
 
         if let Some((counter, _)) = self.opened.get_mut(path) {
@@ -116,8 +113,8 @@ impl InodesManager {
 
     /// It will panic if:
     /// - `inode` does not exist
-    pub(super) fn get_path_or_panic(&self, inode: Inode) -> FsPath {
-        let index = inode as usize;
+    pub(super) fn get_path_or_panic(&self, inode: INodeNo) -> FsPath {
+        let index = inode.0 as usize;
         self.paths_store.paths_indexed_by_inode[index].clone()
     }
 

--- a/libparsec/crates/platform_mountpoint/src/unix/mount.rs
+++ b/libparsec/crates/platform_mountpoint/src/unix/mount.rs
@@ -11,7 +11,6 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
     sync::Arc,
-    thread::JoinHandle,
 };
 
 use libparsec_client::MountpointMountStrategy;
@@ -19,9 +18,8 @@ use libparsec_types::prelude::*;
 
 #[derive(Debug)]
 pub struct Mountpoint {
-    unmounter: fuser::SessionUnmounter,
     path: std::path::PathBuf,
-    session_loop: Option<JoinHandle<std::io::Result<()>>>,
+    session_loop: Option<fuser::BackgroundSession>,
 }
 
 impl Mountpoint {
@@ -120,35 +118,42 @@ impl Mountpoint {
         // Mount operation consist of blocking code, so run it in a thread
         tokio::task::spawn_blocking(move || {
             log::debug!("Will mount {workspace_name} at {}", mount_path.display());
-            let options = [
-                fuser::MountOption::FSName("parsec".into()),
-                #[cfg(target_os = "macos")]
-                fuser::MountOption::CUSTOM(format!("volname={workspace_name}")),
-                #[cfg(target_os = "macos")]
-                fuser::MountOption::AllowOther,
-                fuser::MountOption::DefaultPermissions,
-                fuser::MountOption::NoSuid,
-                fuser::MountOption::Async,
-                #[cfg(not(skip_fuse_atime_option))]
-                fuser::MountOption::Atime,
-                #[cfg(skip_fuse_atime_option)]
-                fuser::MountOption::NoAtime,
-                fuser::MountOption::Exec,
-                // TODO: Should detect and re-mount when the workspace switched between read-only and read-write
-                if is_read_only {
-                    fuser::MountOption::RO
-                } else {
-                    fuser::MountOption::RW
-                },
-                fuser::MountOption::NoDev,
-            ];
 
-            let mut session = fuser::Session::new(filesystem, &mount_path, &options)
-                .map_err(|err| anyhow::anyhow!("cannot mount: {}", err))?;
+            let session_config = {
+                let mut cfg = fuser::Config::default();
+                cfg.mount_options = vec![
+                    fuser::MountOption::FSName("parsec".into()),
+                    #[cfg(target_os = "macos")]
+                    fuser::MountOption::CUSTOM(format!("volname={workspace_name}")),
+                    fuser::MountOption::DefaultPermissions,
+                    fuser::MountOption::NoSuid,
+                    fuser::MountOption::Async,
+                    #[cfg(not(skip_fuse_atime_option))]
+                    fuser::MountOption::Atime,
+                    #[cfg(skip_fuse_atime_option)]
+                    fuser::MountOption::NoAtime,
+                    fuser::MountOption::Exec,
+                    // TODO: Should detect and re-mount when the workspace switched between read-only and read-write
+                    if is_read_only {
+                        fuser::MountOption::RO
+                    } else {
+                        fuser::MountOption::RW
+                    },
+                    fuser::MountOption::NoDev,
+                ];
+                cfg.acl = cfg_select! {
+                    target_os = "macos" => fuser::SessionACL::All,
+                    _ => fuser::SessionACL::Owner,
+                };
+                cfg.n_threads = Some(1);
+                cfg.clone_fd = true;
+                cfg
+            };
 
-            let unmounter = session.unmount_callable();
+            let session = fuser::Session::new(filesystem, &mount_path, &session_config)
+                .context("creating fuser session")?;
 
-            let session_loop = std::thread::spawn(move || session.run());
+            let session_loop = session.spawn().context("starting fuser session")?;
 
             // Poll the FS to check if the mountpoint has appeared
             // (`st_dev` is the device number of the filesystem, hence it will change after unmounting)
@@ -172,7 +177,6 @@ impl Mountpoint {
             log::info!("mountpoint is ready at '{}'!", mount_path.display());
 
             Ok(Mountpoint {
-                unmounter,
                 path: mount_path,
                 session_loop: Some(session_loop),
             })
@@ -192,17 +196,10 @@ impl Mountpoint {
     ) -> anyhow::Result<()> {
         // Unmount operation consist of blocking code, so run it in a thread
         tokio::task::spawn_blocking(move || {
-            // `SessionUnmounter::unmount` is idempotent
-            self.unmounter
-                .unmount()
-                .map_err(|err| anyhow::anyhow!("cannot umount: {}", err))?;
-
-            // Session loop automatically stops once the unmount is called
             if let Some(session_loop) = self.session_loop.take() {
                 session_loop
-                    .join()
-                    .map_err(|err| anyhow::anyhow!("cannot join session loop thread: {:?}", err))?
-                    .map_err(|err| anyhow::anyhow!("unexpected error in session loop: {}", err))?;
+                    .umount_and_join()
+                    .context("cannot unmount and join fuser session")?;
             }
 
             // We do the same as WinFSP: remove the directory.
@@ -220,7 +217,7 @@ impl Mountpoint {
 
 impl Drop for Mountpoint {
     fn drop(&mut self) {
-        if self.session_loop.is_some() {
+        if let Some(session_loop) = self.session_loop.take() {
             // `unmount` hasn't been called, the two reasons for that are:
             // - a panic occurred
             // - WorkspaceOps is stopped from libparsec high level API (in that case,
@@ -229,8 +226,9 @@ impl Drop for Mountpoint {
             // In both cases, we must unmount the filesystem in best effort (i.e. we
             // cannot do anything if errors occur).
 
-            // `SessionUnmounter::unmount` is idempotent
-            let _ = self.unmounter.unmount();
+            if let Err(e) = session_loop.umount_and_join() {
+                log::warn!("Failed to unmount and join fuser session: {e}");
+            }
 
             // We do the same as WinFSP: remove the directory.
             let _ = std::fs::remove_dir(&self.path);

--- a/libparsec/crates/types/src/id.rs
+++ b/libparsec/crates/types/src/id.rs
@@ -868,7 +868,7 @@ impl Display for UserProfile {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct FileDescriptor(pub u32);
+pub struct FileDescriptor(pub u64);
 
 #[cfg(test)]
 #[path = "../tests/unit/id.rs"]


### PR DESCRIPTION
- Update include proper types for most elements in `trait FileSystem`
- No longer need to spawn our own thread, `Session::spawn` does that for ourself
- Remove `SessionUnmounter` in favor of `BackgroundSession::umount_and_join`

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
