### PR TITLE
[MS] Fixed small context menu, reactivate skipped tests, add tests

### DIFF
--- a/client/src/components/small-display/SmallDisplayFileContextMenu.vue
+++ b/client/src/components/small-display/SmallDisplayFileContextMenu.vue
@@ -126,7 +126,7 @@
             button
             @click="onClick(FileAction.ShowHistory)"
             class="ion-no-padding list-group-item"
-            v-show="!multipleFiles && !isReadOnly"
+            v-if="!multipleFiles && !isReadOnly"
           >
             <ion-icon
               class="list-group-item__icon"
@@ -169,22 +169,7 @@
 
           <ion-item
             button
-            v-show="!multipleFiles"
-            @click="onClick(FileAction.CopyLink)"
-            class="ion-no-padding list-group-item"
-          >
-            <ion-icon
-              class="list-group-item__icon"
-              :icon="link"
-            />
-            <ion-text class="button-large list-group-item__label-small">
-              {{ $msTranslate('FoldersPage.fileContextMenu.actionCopyLink') }}
-            </ion-text>
-          </ion-item>
-
-          <ion-item
-            button
-            v-show="!multipleFiles"
+            v-if="!multipleFiles"
             @click="onClick(FileAction.ShowDetails)"
             class="ion-no-padding list-group-item"
           >
@@ -196,15 +181,12 @@
               {{ $msTranslate('FoldersPage.fileContextMenu.actionDetails') }}
             </ion-text>
           </ion-item>
-        </ion-item-group>
-        <ion-item-group
-          class="list-group"
-          v-if="!isReadOnly"
-        >
+
           <ion-item
             button
             @click="onClick(FileAction.Delete)"
             class="ion-no-padding list-group-item"
+            v-if="!isReadOnly"
           >
             <ion-icon
               class="list-group-item__icon"
@@ -212,6 +194,25 @@
             />
             <ion-text class="button-large list-group-item__label-small">
               {{ $msTranslate('FoldersPage.fileContextMenu.actionDelete') }}
+            </ion-text>
+          </ion-item>
+        </ion-item-group>
+        <ion-item-group
+          class="list-group"
+          v-if="!multipleFiles"
+        >
+          <ion-item
+            button
+            v-if="!multipleFiles"
+            @click="onClick(FileAction.CopyLink)"
+            class="ion-no-padding list-group-item"
+          >
+            <ion-icon
+              class="list-group-item__icon"
+              :icon="link"
+            />
+            <ion-text class="button-large list-group-item__label-small">
+              {{ $msTranslate('FoldersPage.fileContextMenu.actionCopyLink') }}
             </ion-text>
           </ion-item>
         </ion-item-group>

--- a/client/src/views/files/FileContextMenu.vue
+++ b/client/src/views/files/FileContextMenu.vue
@@ -131,7 +131,7 @@
           button
           @click="onClick(FileAction.ShowHistory)"
           class="ion-no-padding list-group-item"
-          v-show="!multipleFiles && !isReadOnly"
+          v-if="!multipleFiles && !isReadOnly"
         >
           <ion-icon
             class="list-group-item__icon"

--- a/client/tests/e2e/helpers/fixtures.ts
+++ b/client/tests/e2e/helpers/fixtures.ts
@@ -236,6 +236,7 @@ export async function setupNewPage(page: MsPage, opts: SetupOptions = {}): Promi
     return page.displaySize;
   };
   await page.setDisplaySize(opts.displaySize ?? DisplaySize.Large);
+  page.setupOptions = opts;
 }
 
 const debugTest = base.extend({

--- a/client/tests/e2e/helpers/types.ts
+++ b/client/tests/e2e/helpers/types.ts
@@ -75,6 +75,7 @@ export interface MsPage extends Page {
   defaultSmallSize: [number, number];
   setDisplaySize: (displaySize: DisplaySize) => Promise<void>;
   getDisplaySize: () => Promise<DisplaySize>;
+  setupOptions: SetupOptions;
 }
 
 export interface MsContext extends BrowserContext {

--- a/client/tests/e2e/helpers/utils.ts
+++ b/client/tests/e2e/helpers/utils.ts
@@ -484,6 +484,9 @@ export async function importDefaultFiles(
         paths.push(path.join(testInfo.config.rootDir, 'data', 'imports', document));
       }
     }
+    if (paths.length === 0) {
+      return;
+    }
 
     await dragAndDropFile(documentsPage, dropZone, paths);
     imported = paths.length;
@@ -586,21 +589,42 @@ export async function unselectFile(entry: Locator): Promise<void> {
   await expect(entry.locator('.ms-checkbox')).not.toBeChecked();
 }
 
-type ContextMenuMode = 'folder-full' | 'folder-readonly' | 'file-full' | 'file-readonly';
+type EntryContextMenuMode =
+  | 'folder-full'
+  | 'folder-readonly'
+  | 'file-full'
+  | 'file-readonly'
+  | 'multiple-entries-full'
+  | 'multiple-entries-readonly';
+interface EntryContextMenuOptions {
+  canEdit?: boolean;
+  fromSearch?: boolean;
+}
 
-export async function checkEntryContextMenu(page: MsPage, mode: ContextMenuMode, action?: string | 'dismiss'): Promise<void> {
-  const menu = page.locator('.file-context-menu');
+export async function checkEntryContextMenu(
+  page: MsPage,
+  mode: EntryContextMenuMode,
+  action?: string | 'dismiss',
+  options?: EntryContextMenuOptions,
+): Promise<void> {
+  const menu = page.locator(page.displaySize === DisplaySize.Large ? '.file-context-menu' : '.file-context-sheet-modal');
   await expect(menu).toBeVisible();
-  const actions = menu.locator('.menu-list').locator('.list-group-item');
+  const labels = menu
+    .locator('.menu-list')
+    .locator(page.displaySize === DisplaySize.Large ? '.list-group-item__label' : '.list-group-item__label-small');
   const titles = menu.locator('.menu-list').locator('.list-group-title');
+
   if (mode === 'file-full') {
-    await expect(titles).toHaveText(['File management', 'Collaboration']);
-    await expect(actions.locator('.list-group-item__label')).toHaveText([
+    if (page.displaySize === DisplaySize.Large) {
+      await expect(titles).toHaveText(['File management', 'Collaboration']);
+    }
+    await expect(labels).toHaveText([
       'Preview',
+      ...(options?.canEdit ? ['Edit'] : []),
       'Rename',
       'Move to',
       'Make a copy',
-      'Show enclosing folder',
+      ...(options?.fromSearch ? ['Show enclosing folder'] : []),
       'History',
       'Download',
       'Download as a ZIP file',
@@ -609,12 +633,14 @@ export async function checkEntryContextMenu(page: MsPage, mode: ContextMenuMode,
       'Copy link',
     ]);
   } else if (mode === 'folder-full') {
-    await expect(titles).toHaveText(['Folder management', 'Collaboration']);
-    await expect(actions.locator('.list-group-item__label')).toHaveText([
+    if (page.displaySize === DisplaySize.Large) {
+      await expect(titles).toHaveText(['Folder management', 'Collaboration']);
+    }
+    await expect(labels).toHaveText([
       'Rename',
       'Move to',
       'Make a copy',
-      'Show enclosing folder',
+      ...(options?.fromSearch ? ['Show enclosing folder'] : []),
       'History',
       'Download',
       'Download as a ZIP file',
@@ -623,32 +649,71 @@ export async function checkEntryContextMenu(page: MsPage, mode: ContextMenuMode,
       'Copy link',
     ]);
   } else if (mode === 'file-readonly') {
-    await expect(titles).toHaveText(['File management', 'Collaboration']);
-    await expect(actions.locator('.list-group-item__label')).toHaveText([
+    if (page.displaySize === DisplaySize.Large) {
+      await expect(titles).toHaveText(['File management', 'Collaboration']);
+    }
+    await expect(labels).toHaveText([
       'Preview',
-      'Show enclosing folder',
-      'History',
+      ...(options?.fromSearch ? ['Show enclosing folder'] : []),
       'Download',
       'Download as a ZIP file',
       'Details',
       'Copy link',
     ]);
   } else if (mode === 'folder-readonly') {
-    await expect(titles).toHaveText(['Folder management', 'Collaboration']);
-    await expect(actions.locator('.list-group-item__label')).toHaveText([
-      'Show enclosing folder',
-      'History',
+    if (page.displaySize === DisplaySize.Large) {
+      await expect(titles).toHaveText(['Folder management', 'Collaboration']);
+    }
+    await expect(labels).toHaveText([
+      ...(options?.fromSearch ? ['Show enclosing folder'] : []),
       'Download',
       'Download as a ZIP file',
       'Details',
       'Copy link',
     ]);
+  } else if (mode === 'multiple-entries-full') {
+    if (page.displaySize === DisplaySize.Large) {
+      await expect(titles).toHaveText(['Folder management']);
+    }
+    await expect(labels).toHaveText(['Move to', 'Make a copy', 'Download', 'Download as a ZIP file', 'Delete']);
+  } else if (mode === 'multiple-entries-readonly') {
+    if (page.displaySize === DisplaySize.Large) {
+      await expect(titles).toHaveText(['Folder management']);
+    }
+    await expect(labels).toHaveText(['Download', 'Download as a ZIP file']);
   }
   if (action === 'dismiss') {
-    await menu.click();
+    await menu.locator('ion-backdrop').click();
     await expect(menu).toBeHidden();
   } else if (action) {
-    await actions.locator('.list-group-item__label', { hasText: action }).click();
+    await labels.filter({ hasText: action }).click();
+    await expect(menu).toBeHidden();
+  }
+}
+
+export async function checkFolderGlobalContextMenu(page: MsPage, mode: 'full' | 'readonly', action?: string | 'dismiss'): Promise<void> {
+  const menu = page.locator('.folder-global-context-menu');
+
+  if (mode === 'full') {
+    await expect(menu).toBeVisible();
+    const actions = menu.locator('.menu-list').locator('.list-group-item');
+    await expect(actions.locator('.list-group-item__label')).toHaveText([
+      'New folder',
+      'Import files',
+      'Import a folder',
+      'Document',
+      'Spreadsheet',
+      'Presentation',
+      'Text',
+    ]);
+    if (action === 'dismiss') {
+      await menu.locator('ion-backdrop').click();
+      await expect(menu).toBeHidden();
+    } else if (action) {
+      await actions.locator('.list-group-item__label', { hasText: action }).click();
+      await expect(menu).toBeHidden();
+    }
+  } else if (mode === 'readonly') {
     await expect(menu).toBeHidden();
   }
 }

--- a/client/tests/e2e/specs/document_context_menu.spec.ts
+++ b/client/tests/e2e/specs/document_context_menu.spec.ts
@@ -3,12 +3,15 @@
 import { Locator, TestInfo } from '@playwright/test';
 import {
   answerQuestion,
+  checkEntryContextMenu,
+  checkFolderGlobalContextMenu,
   DisplaySize,
   expect,
   fillInputModal,
   fillIonInput,
   importDefaultFiles,
   ImportDocuments,
+  mockLibParsec,
   MsPage,
   msTest,
 } from '@tests/e2e/helpers';
@@ -75,23 +78,7 @@ msTest.describe(() => {
         await entry.hover();
         await entry.locator('.card-option').click();
       }
-      await expect(documents.locator('.file-context-menu')).toBeVisible();
-      const popover = documents.locator('.file-context-menu');
-      await expect(popover.getByRole('group')).toHaveCount(2);
-      await expect(popover.getByRole('listitem')).toHaveText([
-        'File management',
-        'Preview',
-        'Rename',
-        'Move to',
-        'Make a copy',
-        'History',
-        'Download',
-        'Download as a ZIP file',
-        'Details',
-        'Delete',
-        'Collaboration',
-        'Copy link',
-      ]);
+      await checkEntryContextMenu(documents, 'file-full', 'dismiss');
     });
 
     msTest(`Document actions default state in ${gridMode ? 'grid' : 'list'} mode for folder`, async ({ documents }, testInfo: TestInfo) => {
@@ -107,22 +94,7 @@ msTest.describe(() => {
         await entry.hover();
         await entry.locator('.card-option').click();
       }
-      await expect(documents.locator('.file-context-menu')).toBeVisible();
-      const popover = documents.locator('.file-context-menu');
-      await expect(popover.getByRole('group')).toHaveCount(2);
-      await expect(popover.getByRole('listitem')).toHaveText([
-        'Folder management',
-        'Rename',
-        'Move to',
-        'Make a copy',
-        'History',
-        'Download',
-        'Download as a ZIP file',
-        'Details',
-        'Delete',
-        'Collaboration',
-        'Copy link',
-      ]);
+      await checkEntryContextMenu(documents, 'folder-full', 'dismiss');
     });
 
     msTest(`Document popover on right click in ${gridMode ? 'grid' : 'list'} mode for file`, async ({ documents }, testInfo: TestInfo) => {
@@ -136,23 +108,7 @@ msTest.describe(() => {
         const entry = documents.locator('.folder-container').locator('.file-card-item').nth(0);
         await entry.click({ button: 'right' });
       }
-      await expect(documents.locator('.file-context-menu')).toBeVisible();
-      const popover = documents.locator('.file-context-menu');
-      await expect(popover.getByRole('group')).toHaveCount(2);
-      await expect(popover.getByRole('listitem')).toHaveText([
-        'File management',
-        'Preview',
-        'Rename',
-        'Move to',
-        'Make a copy',
-        'History',
-        'Download',
-        'Download as a ZIP file',
-        'Details',
-        'Delete',
-        'Collaboration',
-        'Copy link',
-      ]);
+      await checkEntryContextMenu(documents, 'file-full', 'dismiss');
     });
 
     msTest(
@@ -168,317 +124,154 @@ msTest.describe(() => {
           const entry = documents.locator('.folder-container').locator('.file-card-item').nth(0);
           await entry.click({ button: 'right' });
         }
-        await expect(documents.locator('.file-context-menu')).toBeVisible();
-        const popover = documents.locator('.file-context-menu');
-        await expect(popover.getByRole('group')).toHaveCount(2);
-        await expect(popover.getByRole('listitem')).toHaveText([
-          'Folder management',
-          'Rename',
-          'Move to',
-          'Make a copy',
-          'History',
-          'Download',
-          'Download as a ZIP file',
-          'Details',
-          'Delete',
-          'Collaboration',
-          'Copy link',
-        ]);
+        await checkEntryContextMenu(documents, 'folder-full', 'dismiss');
       },
     );
-
-    msTest(
-      `Document popover on right click in ${gridMode ? 'grid' : 'list'} mode for file with editics`,
-      async ({ parsecEditics }, testInfo: TestInfo) => {
-        await importDefaultFiles(parsecEditics, testInfo, ImportDocuments.Docx, false);
-        await expect(parsecEditics.locator('.file-context-menu')).toBeHidden();
-        if (!gridMode) {
-          const entry = parsecEditics.locator('.folder-container').locator('.file-list-item').nth(0);
-          await entry.click({ button: 'right' });
-        } else {
-          await toggleViewMode(parsecEditics);
-          const entry = parsecEditics.locator('.folder-container').locator('.file-card-item').nth(0);
-          await entry.click({ button: 'right' });
-        }
-        await expect(parsecEditics.locator('.file-context-menu')).toBeVisible();
-        const popover = parsecEditics.locator('.file-context-menu');
-        await expect(popover.getByRole('group')).toHaveCount(2);
-        await expect(popover.getByRole('listitem')).toHaveText([
-          'File management',
-          'Preview',
-          'Edit',
-          'Rename',
-          'Move to',
-          'Make a copy',
-          'History',
-          'Download',
-          'Download as a ZIP file',
-          'Details',
-          'Delete',
-          'Collaboration',
-          'Copy link',
-        ]);
-      },
-    );
-
-    msTest(
-      `Document popover on right click in ${gridMode ? 'grid' : 'list'} mode for file with editics on non-editable file`,
-      async ({ parsecEditics }, testInfo: TestInfo) => {
-        await importDefaultFiles(parsecEditics, testInfo, ImportDocuments.Png, false);
-        await expect(parsecEditics.locator('.file-context-menu')).toBeHidden();
-        if (!gridMode) {
-          const entry = parsecEditics.locator('.folder-container').locator('.file-list-item').nth(0);
-          await entry.click({ button: 'right' });
-        } else {
-          await toggleViewMode(parsecEditics);
-          const entry = parsecEditics.locator('.folder-container').locator('.file-card-item').nth(0);
-          await entry.click({ button: 'right' });
-        }
-        await expect(parsecEditics.locator('.file-context-menu')).toBeVisible();
-        const popover = parsecEditics.locator('.file-context-menu');
-        await expect(popover.getByRole('group')).toHaveCount(2);
-        await expect(popover.getByRole('listitem')).toHaveText([
-          'File management',
-          'Preview',
-          'Rename',
-          'Move to',
-          'Make a copy',
-          'History',
-          'Download',
-          'Download as a ZIP file',
-          'Details',
-          'Delete',
-          'Collaboration',
-          'Copy link',
-        ]);
-      },
-    );
-
-    msTest.fixme(
-      `Document popover on right click on multiple files in ${gridMode ? 'grid' : 'list'} only files`,
-      async ({ documents }, testInfo: TestInfo) => {
-        await importDefaultFiles(documents, testInfo, ImportDocuments.Pdf | ImportDocuments.Png, false);
-        await expect(documents.locator('.file-context-menu')).toBeHidden();
-        await documents.locator('.folder-container').locator('.folder-list-header').locator('.ms-checkbox').check();
-
-        let entries: Locator;
-
-        if (!gridMode) {
-          entries = documents.locator('.folder-container').locator('.file-list-item');
-        } else {
-          await toggleViewMode(documents);
-          entries = documents.locator('.folder-container').locator('.file-card-item');
-        }
-
-        await entries.nth(0).click({ button: 'right' });
-
-        await expect(documents.locator('.file-context-menu')).toBeVisible();
-        const popover = documents.locator('.file-context-menu');
-        await expect(popover.getByRole('group')).toHaveCount(1);
-        await expect(popover.getByRole('listitem')).toHaveText(['File management', 'Move to', 'Make a copy', 'Download', 'Delete']);
-      },
-    );
-
-    msTest.fixme(
-      `Document popover on right click on multiple files in ${gridMode ? 'grid' : 'list'} with a folder`,
-      async ({ documents }, testInfo: TestInfo) => {
-        await importDefaultFiles(documents, testInfo, ImportDocuments.Png, true);
-        await expect(documents.locator('.file-context-menu')).toBeHidden();
-        await documents.locator('.folder-container').locator('.folder-list-header').locator('.ms-checkbox').check();
-        let entries: Locator;
-
-        if (!gridMode) {
-          entries = documents.locator('.folder-container').locator('.file-list-item');
-        } else {
-          await toggleViewMode(documents);
-          entries = documents.locator('.folder-container').locator('.file-card-item');
-        }
-        await expect(entries).toHaveCount(2);
-        await expect(documents.locator('#folders-ms-action-bar').locator('.counter')).toHaveText('2 selected items');
-
-        if (gridMode) {
-          await entries.nth(0).locator('.file-card-last-update').click({ button: 'right' });
-        } else {
-          await entries.nth(0).locator('.file-last-update').click({ button: 'right' });
-        }
-
-        await expect(documents.locator('.file-context-menu')).toBeVisible();
-        const popover = documents.locator('.file-context-menu');
-        await expect(popover).toBeVisible();
-        await expect(popover.getByRole('listitem')).toHaveText(['Folder management', 'Move to', 'Make a copy', 'Delete']);
-      },
-    );
-
-    msTest(`Popover with right click on empty space in ${gridMode ? 'grid' : 'list'} mode`, async ({ documents }, testInfo: TestInfo) => {
-      await importDefaultFiles(documents, testInfo, ImportDocuments.Png, false);
-      await expect(documents.locator('.folder-global-context-menu')).toBeHidden();
-
-      if (gridMode) {
-        await toggleViewMode(documents);
-      }
-      await documents.locator('.folder-container').click({ button: 'right', position: { x: 100, y: 10 } });
-      await expect(documents.locator('.folder-global-context-menu')).toBeVisible();
-      const popover = documents.locator('.folder-global-context-menu');
-      await expect(popover.getByRole('group')).toHaveCount(1);
-      await expect(popover.getByRole('listitem')).toHaveCount(7);
-      await expect(popover.getByRole('listitem')).toHaveText([
-        'New folder',
-        'Import files',
-        'Import a folder',
-        'Document',
-        'Spreadsheet',
-        'Presentation',
-        'Text',
-      ]);
-    });
-
-    msTest(`Get document link in ${gridMode ? 'grid' : 'list'} mode`, async ({ documents, context }, testInfo: TestInfo) => {
-      await importDefaultFiles(documents, testInfo, ImportDocuments.Png, false);
-      if (gridMode) {
-        await toggleViewMode(documents);
-      }
-      await clickAction(await openPopover(documents, 0), 'Copy link');
-
-      // Fail to copy because no permission
-      await expect(documents).toShowToast('Failed to copy link. Your browser or device does not seem to support copy/paste.', 'Error');
-
-      // Grant the permissions
-      await context.grantPermissions(['clipboard-write']);
-
-      await clickAction(await openPopover(documents, 0), 'Copy link');
-      await expect(documents).toShowToast('Link has been copied to clipboard.', 'Info');
-      const filePath = await documents.evaluate(() => navigator.clipboard.readText());
-      expect(filePath).toMatch(/^https?:\/\/.+\/redirect\/.+a=path&p=.+$/);
-    });
-
-    msTest(`Rename document in ${gridMode ? 'grid' : 'list'} mode`, async ({ documents }, testInfo: TestInfo) => {
-      await importDefaultFiles(documents, testInfo, ImportDocuments.Png, false);
-      let entry;
-      if (gridMode) {
-        await toggleViewMode(documents);
-        entry = documents.locator('.folder-container').locator('.file-card-item').nth(0);
-      } else {
-        entry = documents.locator('.folder-container').locator('.file-list-item').nth(0);
-      }
-
-      await clickAction(await openPopover(documents, 0), 'Rename');
-      await fillInputModal(documents, 'New Name', true);
-      if (!gridMode) {
-        await expect(entry.locator('.file-name').locator('.label-name')).toHaveText('New Name');
-      } else {
-        await expect(entry.locator('.file-card__title')).toHaveText('New Name');
-      }
-    });
-
-    msTest(`Rename document name already exists in ${gridMode ? 'grid' : 'list'} mode`, async ({ documents }, testInfo: TestInfo) => {
-      await importDefaultFiles(documents, testInfo, ImportDocuments.Png | ImportDocuments.Txt, false);
-      if (gridMode) {
-        await toggleViewMode(documents);
-      }
-      await clickAction(await openPopover(documents, 0), 'Rename');
-
-      const modal = documents.locator('.text-input-modal');
-      await expect(modal).toBeVisible();
-      await fillIonInput(modal.locator('ion-input'), '');
-      const okButton = modal.locator('.ms-modal-footer-buttons').locator('#next-button');
-      await fillIonInput(modal.locator('ion-input'), 'text.txt');
-      await expect(okButton).toBeTrulyDisabled();
-      await expect(modal.locator('.form-error')).toBeVisible();
-      await expect(modal.locator('.form-error')).toHaveText('A file with this name already exists.');
-    });
-
-    msTest(`Delete document in ${gridMode ? 'grid' : 'list'} mode`, async ({ documents }, testInfo: TestInfo) => {
-      await importDefaultFiles(documents, testInfo, ImportDocuments.Png | ImportDocuments.Pdf, false);
-      if (gridMode) {
-        await toggleViewMode(documents);
-      }
-      let fileName;
-      let count = 0;
-      if (gridMode) {
-        fileName = await documents
-          .locator('.folder-container')
-          .locator('.file-card-item')
-          .nth(0)
-          .locator('.file-card__title')
-          .textContent();
-        count = await documents.locator('.folder-container').locator('.file-card-item').count();
-      } else {
-        fileName = await documents
-          .locator('.folder-container')
-          .locator('.file-list-item')
-          .nth(0)
-          .locator('.file-name')
-          .locator('.label-name')
-          .textContent();
-        count = await documents.locator('.folder-container').locator('.file-list-item').count();
-      }
-
-      await clickAction(await openPopover(documents, 0), 'Delete');
-
-      await answerQuestion(documents, true, {
-        expectedTitleText: 'Delete one file',
-        expectedQuestionText: `Are you sure you want to delete file ${fileName}?`,
-        expectedNegativeText: 'Keep file',
-        expectedPositiveText: 'Delete file',
-      });
-      if (gridMode) {
-        await expect(documents.locator('.folder-container').locator('.file-card-item')).toHaveCount(count - 1);
-      } else {
-        await expect(documents.locator('.folder-container').locator('.file-list-item')).toHaveCount(count - 1);
-      }
-    });
-
-    msTest(`Folder actions default state in a read only workspace in ${gridMode ? 'grid' : 'list'} mode`, async ({ documentsReadOnly }) => {
-      await expect(documentsReadOnly.locator('.file-context-menu')).toBeHidden();
-      if (!gridMode) {
-        const entry = documentsReadOnly.locator('.folder-container').locator('.file-list-item').nth(0);
-        await entry.hover();
-        await entry.locator('.options-button').click();
-      } else {
-        await toggleViewMode(documentsReadOnly);
-        const entry = documentsReadOnly.locator('.folder-container').locator('.file-card-item').nth(0);
-        await entry.hover();
-        await entry.locator('.card-option').click();
-      }
-      await expect(documentsReadOnly.locator('.file-context-menu')).toBeVisible();
-      const popover = documentsReadOnly.locator('.file-context-menu');
-      await expect(popover.getByRole('group')).toHaveCount(2);
-      await expect(popover.getByRole('listitem')).toHaveText([
-        'Folder management',
-        'Download',
-        'Download as a ZIP file',
-        'Details',
-        'Collaboration',
-        'Copy link',
-      ]);
-    });
-
-    msTest(`File actions default state in a read only workspace in ${gridMode ? 'grid' : 'list'} mode`, async ({ documentsReadOnly }) => {
-      await expect(documentsReadOnly.locator('.file-context-menu')).toBeHidden();
-      if (!gridMode) {
-        const entry = documentsReadOnly.locator('.folder-container').locator('.file-list-item').nth(1);
-        await entry.hover();
-        await entry.locator('.options-button').click();
-      } else {
-        await toggleViewMode(documentsReadOnly);
-        const entry = documentsReadOnly.locator('.folder-container').locator('.file-card-item').nth(1);
-        await entry.hover();
-        await entry.locator('.card-option').click();
-      }
-      await expect(documentsReadOnly.locator('.file-context-menu')).toBeVisible();
-      const popover = documentsReadOnly.locator('.file-context-menu');
-      await expect(popover.getByRole('group')).toHaveCount(2);
-      await expect(popover.getByRole('listitem')).toHaveText([
-        'File management',
-        'Preview',
-        'Download',
-        'Download as a ZIP file',
-        'Details',
-        'Collaboration',
-        'Copy link',
-      ]);
-    });
   }
+
+  msTest('Document popover on right click for file with editics', async ({ parsecEditics }, testInfo: TestInfo) => {
+    await importDefaultFiles(parsecEditics, testInfo, ImportDocuments.Docx, false);
+    const entry = parsecEditics.locator('.folder-container').locator('.file-list-item').nth(0);
+    await entry.click({ button: 'right' });
+    await checkEntryContextMenu(parsecEditics, 'file-full', 'dismiss', { canEdit: true });
+  });
+
+  msTest('Document popover on right click for file with editics on non-editable file', async ({ parsecEditics }, testInfo: TestInfo) => {
+    await importDefaultFiles(parsecEditics, testInfo, ImportDocuments.Png, false);
+    const entry = parsecEditics.locator('.folder-container').locator('.file-list-item').nth(0);
+    await entry.click({ button: 'right' });
+    await checkEntryContextMenu(parsecEditics, 'file-full', 'dismiss');
+  });
+
+  msTest('Document popover on right click on multiple files only files', async ({ documents }, testInfo: TestInfo) => {
+    await importDefaultFiles(documents, testInfo, ImportDocuments.Pdf | ImportDocuments.Png, false);
+    await documents.waitForTimeout(500);
+    await documents.locator('.folder-container').locator('.files-list-header').locator('.ms-checkbox').check();
+    await expect(documents.locator('.action-bar').locator('.counter')).toHaveText('2 selected items');
+
+    const entries = documents.locator('.folder-container').locator('.file-list-item');
+    await entries.nth(0).click({ button: 'right' });
+    await checkEntryContextMenu(documents, 'multiple-entries-full', 'dismiss');
+  });
+
+  msTest('Document popover on right click on multiple files in readonly', async ({ documentsReadOnly }) => {
+    await documentsReadOnly.locator('.folder-container').locator('.files-list-header').locator('.ms-checkbox').check();
+    const entries = documentsReadOnly.locator('.folder-container').locator('.file-list-item');
+
+    await entries.nth(0).click({ button: 'right' });
+    await checkEntryContextMenu(documentsReadOnly, 'multiple-entries-readonly', 'dismiss');
+  });
+
+  msTest('Document popover on right click on multiple files with a folder', async ({ documents }, testInfo: TestInfo) => {
+    await importDefaultFiles(documents, testInfo, ImportDocuments.Png, true);
+    await documents.waitForTimeout(300);
+    await documents.locator('.folder-container').locator('.files-list-header').locator('.ms-checkbox').check();
+    const entries = documents.locator('.folder-container').locator('.file-list-item');
+    await expect(entries).toHaveCount(2);
+    await expect(documents.locator('#folders-ms-action-bar').locator('.counter')).toHaveText('2 selected items');
+
+    await entries.nth(0).locator('.file-last-update').click({ button: 'right' });
+    await checkEntryContextMenu(documents, 'multiple-entries-full', 'dismiss');
+  });
+
+  msTest('Popover with right click on empty space', async ({ documents }, testInfo: TestInfo) => {
+    await importDefaultFiles(documents, testInfo, ImportDocuments.Png, false);
+
+    await documents.locator('.folder-container').click({ button: 'right', position: { x: 100, y: 10 } });
+    await checkFolderGlobalContextMenu(documents, 'full', 'dismiss');
+  });
+
+  msTest('Popover with right click on empty space readonly', async ({ documentsReadOnly }) => {
+    await documentsReadOnly.locator('.folder-container').click({ button: 'right', position: { x: 100, y: 10 } });
+    await checkFolderGlobalContextMenu(documentsReadOnly, 'readonly', 'dismiss');
+  });
+
+  msTest('Get document link', async ({ documents, context }, testInfo: TestInfo) => {
+    await importDefaultFiles(documents, testInfo, ImportDocuments.Png, false);
+    await clickAction(await openPopover(documents, 0), 'Copy link');
+
+    // Fail to copy because no permission
+    await expect(documents).toShowToast('Failed to copy link. Your browser or device does not seem to support copy/paste.', 'Error');
+
+    // Grant the permissions
+    await context.grantPermissions(['clipboard-write']);
+
+    await clickAction(await openPopover(documents, 0), 'Copy link');
+    await expect(documents).toShowToast('Link has been copied to clipboard.', 'Info');
+    const filePath = await documents.evaluate(() => navigator.clipboard.readText());
+    expect(filePath).toMatch(/^https?:\/\/.+\/redirect\/.+a=path&p=.+$/);
+  });
+
+  msTest('Rename document', async ({ documents }, testInfo: TestInfo) => {
+    await importDefaultFiles(documents, testInfo, ImportDocuments.Png, false);
+    const entry = documents.locator('.folder-container').locator('.file-list-item').nth(0);
+
+    await clickAction(await openPopover(documents, 0), 'Rename');
+    await fillInputModal(documents, 'New Name', true);
+    await expect(entry.locator('.file-name').locator('.label-name')).toHaveText('New Name');
+  });
+
+  msTest('Rename document name already exists', async ({ documents }, testInfo: TestInfo) => {
+    await importDefaultFiles(documents, testInfo, ImportDocuments.Png | ImportDocuments.Txt, false);
+    await clickAction(await openPopover(documents, 0), 'Rename');
+
+    const modal = documents.locator('.text-input-modal');
+    await expect(modal).toBeVisible();
+    await fillIonInput(modal.locator('ion-input'), '');
+    const okButton = modal.locator('.ms-modal-footer-buttons').locator('#next-button');
+    await fillIonInput(modal.locator('ion-input'), 'text.txt');
+    await expect(okButton).toBeTrulyDisabled();
+    await expect(modal.locator('.form-error')).toBeVisible();
+    await expect(modal.locator('.form-error')).toHaveText('A file with this name already exists.');
+  });
+
+  msTest('Open history on file', async ({ documents }, testInfo: TestInfo) => {
+    await importDefaultFiles(documents, testInfo, ImportDocuments.Png, false);
+    await documents.waitForTimeout(300);
+    await clickAction(await openPopover(documents, 0), 'History');
+    await expect(documents).toBeWorkspaceHistoryPage();
+  });
+
+  msTest('Delete document', async ({ documents }, testInfo: TestInfo) => {
+    await importDefaultFiles(documents, testInfo, ImportDocuments.Png | ImportDocuments.Pdf, false);
+    await clickAction(await openPopover(documents, 0), 'Delete');
+    await answerQuestion(documents, true, {
+      expectedTitleText: 'Delete one file',
+      expectedQuestionText: 'Are you sure you want to delete file image.png?',
+      expectedNegativeText: 'Keep file',
+      expectedPositiveText: 'Delete file',
+    });
+    await expect(documents.locator('.folder-container').locator('.file-list-item')).toHaveCount(1);
+  });
+
+  msTest('Delete folder', async ({ documents }, testInfo: TestInfo) => {
+    await importDefaultFiles(documents, testInfo, ImportDocuments.Png, true);
+    await clickAction(await openPopover(documents, 0), 'Delete');
+
+    await answerQuestion(documents, true, {
+      expectedTitleText: 'Delete one folder',
+      expectedQuestionText: 'Are you sure you want to delete folder Dir_Folder?',
+      expectedNegativeText: 'Keep folder',
+      expectedPositiveText: 'Delete folder',
+    });
+    await expect(documents.locator('.folder-container').locator('.file-list-item')).toHaveCount(1);
+  });
+
+  msTest('Folder actions default state in a read only workspace', async ({ documentsReadOnly }) => {
+    await expect(documentsReadOnly.locator('.file-context-menu')).toBeHidden();
+    const entry = documentsReadOnly.locator('.folder-container').locator('.file-list-item').nth(0);
+    await entry.hover();
+    await entry.locator('.options-button').click();
+    await checkEntryContextMenu(documentsReadOnly, 'folder-readonly', 'dismiss');
+  });
+
+  msTest('File actions default state in a read only workspace', async ({ documentsReadOnly }) => {
+    await expect(documentsReadOnly.locator('.file-context-menu')).toBeHidden();
+    const entry = documentsReadOnly.locator('.folder-container').locator('.file-list-item').nth(1);
+    await entry.hover();
+    await entry.locator('.options-button').click();
+    await checkEntryContextMenu(documentsReadOnly, 'file-readonly', 'dismiss');
+  });
 
   for (const gridMode of [false, true]) {
     msTest(
@@ -500,27 +293,15 @@ msTest.describe(() => {
         await expect(documents.locator('.file-context-sheet-modal')).toBeVisible();
         const modal = documents.locator('.file-context-sheet-modal');
         await expect(modal.getByRole('group')).toHaveCount(2);
-        await expect(modal.getByRole('listitem')).toHaveText([
-          'Preview',
-          'Rename',
-          'Move to',
-          'Make a copy',
-          'History',
-          'Download',
-          'Download as a ZIP file',
-          'Copy link',
-          'Details',
-          'Delete',
-        ]);
+        await checkEntryContextMenu(documents, 'file-full', 'dismiss');
       },
     );
 
-    msTest.fixme(
+    msTest(
       `Small display document actions default state in ${gridMode ? 'grid' : 'list'} mode for folder`,
       async ({ documents }, testInfo: TestInfo) => {
-        await importDefaultFiles(documents, testInfo, 0, true);
+        await importDefaultFiles(documents, testInfo, ImportDocuments.Png, true);
         await documents.setDisplaySize(DisplaySize.Small);
-        await expect(documents.locator('.file-context-menu')).toBeHidden();
         if (!gridMode) {
           const entry = documents.locator('.folder-container').locator('.file-list-item').nth(0);
           await entry.hover();
@@ -531,18 +312,7 @@ msTest.describe(() => {
           await entry.hover();
           await entry.locator('.card-option').click();
         }
-        await expect(documents.locator('.file-context-sheet-modal')).toBeVisible();
-        const modal = documents.locator('.file-context-sheet-modal');
-        await expect(modal.getByRole('group')).toHaveCount(2);
-        await expect(modal.getByRole('listitem')).toHaveText([
-          'Rename',
-          'Move to',
-          'Make a copy',
-          'History',
-          'Copy link',
-          'Details',
-          'Delete',
-        ]);
+        await checkEntryContextMenu(documents, 'folder-full', 'dismiss');
       },
     );
 
@@ -563,27 +333,17 @@ msTest.describe(() => {
         await expect(documents.locator('.file-context-sheet-modal')).toBeVisible();
         const modal = documents.locator('.file-context-sheet-modal');
         await expect(modal.getByRole('group')).toHaveCount(2);
-        await expect(modal.getByRole('listitem')).toHaveText([
-          'Preview',
-          'Rename',
-          'Move to',
-          'Make a copy',
-          'History',
-          'Download',
-          'Download as a ZIP file',
-          'Copy link',
-          'Details',
-          'Delete',
-        ]);
+        await checkEntryContextMenu(documents, 'file-full', 'dismiss');
       },
     );
 
-    msTest.fixme(
+    msTest(
       `Small display document popover on right click in ${gridMode ? 'grid' : 'list'} mode for folder`,
       async ({ documents }, testInfo: TestInfo) => {
         await importDefaultFiles(documents, testInfo, 0, true);
         await documents.setDisplaySize(DisplaySize.Small);
-        await expect(documents.locator('.file-context-menu')).toBeHidden();
+        await documents.waitForTimeout(300);
+
         if (!gridMode) {
           const entry = documents.locator('.folder-container').locator('.file-list-item').nth(0);
           await entry.click({ button: 'right' });
@@ -592,309 +352,193 @@ msTest.describe(() => {
           const entry = documents.locator('.folder-container').locator('.file-card-item').nth(0);
           await entry.click({ button: 'right' });
         }
-        await expect(documents.locator('.file-context-sheet-modal')).toBeVisible();
-        const modal = documents.locator('.file-context-sheet-modal');
-        await expect(modal.getByRole('group')).toHaveCount(2);
-        await expect(modal.getByRole('listitem')).toHaveText([
-          'Rename',
-          'Move to',
-          'Make a copy',
-          'History',
-          'Copy link',
-          'Details',
-          'Delete',
-        ]);
-      },
-    );
-
-    msTest.fixme(
-      `Small display popover on right click in ${gridMode ? 'grid' : 'list'} mode for file with editics`,
-      async ({ parsecEditics }, testInfo: TestInfo) => {
-        await importDefaultFiles(parsecEditics, testInfo, ImportDocuments.Docx, false);
-        await parsecEditics.setDisplaySize(DisplaySize.Small);
-        await expect(parsecEditics.locator('.file-context-menu')).toBeHidden();
-        if (!gridMode) {
-          const entry = parsecEditics.locator('.folder-container').locator('.file-list-item').nth(0);
-          await entry.click({ button: 'right' });
-        } else {
-          await toggleViewMode(parsecEditics);
-          const entry = parsecEditics.locator('.folder-container').locator('.file-card-item').nth(0);
-          await entry.click({ button: 'right' });
-        }
-        await expect(parsecEditics.locator('.file-context-sheet-modal')).toBeVisible();
-        const modal = parsecEditics.locator('.file-context-sheet-modal');
-        await expect(modal.getByRole('group')).toHaveCount(2);
-        await expect(modal.getByRole('listitem')).toHaveText([
-          'Preview',
-          'Edit',
-          'Rename',
-          'Move to',
-          'Make a copy',
-          'History',
-          'Download',
-          'Download as a ZIP file',
-          'Copy link',
-          'Details',
-          'Delete',
-        ]);
-      },
-    );
-
-    msTest.fixme(
-      `Small display popover on right click in ${gridMode ? 'grid' : 'list'} mode for file with editics on non-editable file`,
-      async ({ parsecEditics }, testInfo: TestInfo) => {
-        await importDefaultFiles(parsecEditics, testInfo, ImportDocuments.Png, false);
-        await parsecEditics.setDisplaySize(DisplaySize.Small);
-        await expect(parsecEditics.locator('.file-context-menu')).toBeHidden();
-        if (!gridMode) {
-          const entry = parsecEditics.locator('.folder-container').locator('.file-list-item').nth(0);
-          await entry.click({ button: 'right' });
-        } else {
-          await toggleViewMode(parsecEditics);
-          const entry = parsecEditics.locator('.folder-container').locator('.file-card-item').nth(0);
-          await entry.click({ button: 'right' });
-        }
-        await expect(parsecEditics.locator('.file-context-sheet-modal')).toBeVisible();
-        const modal = parsecEditics.locator('.file-context-sheet-modal');
-        await expect(modal.getByRole('group')).toHaveCount(2);
-        await expect(modal.getByRole('listitem')).toHaveText([
-          'Preview',
-          'Rename',
-          'Move to',
-          'Make a copy',
-          'History',
-          'Download',
-          'Download as a ZIP file',
-          'Copy link',
-          'Details',
-          'Delete',
-        ]);
-      },
-    );
-
-    msTest.fixme(
-      `Small display popover with right click on empty space in ${gridMode ? 'grid' : 'list'} mode`,
-      async ({ documents }, testInfo: TestInfo) => {
-        await importDefaultFiles(documents, testInfo, ImportDocuments.Png | ImportDocuments.Pdf, false);
-        await documents.setDisplaySize(DisplaySize.Small);
-        await expect(documents.locator('.folder-global-context-menu')).toBeHidden();
-
-        if (gridMode) {
-          await toggleViewMode(documents);
-        }
-        await documents.locator('.topbar-right-buttons').locator('.topbar-right-buttons__item').nth(0).click();
-        await expect(documents.locator('.file-context-sheet-modal')).toBeVisible();
-        const modal = documents.locator('.file-context-sheet-modal');
-        await expect(modal.locator('.button-left')).toHaveText('Selection');
-        await expect(modal.locator('.button-right')).toHaveText('Share');
-        await expect(modal.locator('.list-group-item')).toHaveCount(1);
-        await expect(modal.locator('.list-group-item').nth(0)).toHaveText('Select all');
-        await modal.locator('.list-group-item').nth(0).click();
-        await documents.waitForTimeout(300);
-
-        const headerElements = documents.locator('.small-display-selection-header').locator('ion-text');
-        await expect(headerElements).toHaveCount(3);
-        await expect(headerElements.nth(0)).toHaveText('Unselect');
-        await expect(headerElements.nth(1)).toHaveText('2 selected items');
-        await expect(headerElements.nth(2)).toHaveText('Cancel');
-        await headerElements.nth(0).click();
-        await expect(headerElements.nth(1)).toHaveText('wksp1');
-        await expect(headerElements.nth(0)).toBeVisible();
-        await expect(headerElements.nth(2)).toBeVisible();
-        await headerElements.nth(2).click();
-        await expect(headerElements).toBeHidden();
-      },
-    );
-
-    msTest.fixme(
-      `Small display document popover on right click on multiple files in ${gridMode ? 'grid' : 'list'} only files`,
-      async ({ documents }, testInfo: TestInfo) => {
-        await importDefaultFiles(documents, testInfo, ImportDocuments.Png | ImportDocuments.Pdf, true);
-        await documents.setDisplaySize(DisplaySize.Small);
-        await expect(documents.locator('.file-context-menu')).toBeHidden();
-        let entries: Locator;
-
-        if (!gridMode) {
-          entries = documents.locator('.folder-container').locator('.file-list-item');
-        } else {
-          await toggleViewMode(documents);
-          entries = documents.locator('.folder-container').locator('.file-card-item');
-        }
-        await documents.locator('.topbar-right-buttons').locator('.topbar-right-buttons__item').nth(0).click();
-
-        await documents.locator('.file-context-sheet-modal').locator('.list-group-item').nth(0).click();
-
-        await expect(documents.locator('.folder-content').locator('.title__text')).toContainText('3 selected items');
-
-        await expect(entries.nth(0).locator('.ms-checkbox')).toBeChecked();
-        await expect(entries.nth(1).locator('.ms-checkbox')).toBeChecked();
-        await expect(entries.nth(2).locator('.ms-checkbox')).toBeChecked();
-
-        // Unselect the folder
-        entries.nth(0).locator('.ms-checkbox').click();
-        await entries.nth(1).click({ button: 'right' });
-
-        await expect(documents.locator('.file-context-sheet-modal')).toBeVisible();
-        const modal = documents.locator('.file-context-sheet-modal');
-        await expect(modal.getByRole('group')).toHaveCount(2);
-        await expect(modal.getByRole('listitem')).toHaveText(['Move to', 'Make a copy', 'Download', 'Delete']);
-      },
-    );
-
-    msTest.fixme(
-      `Small display document popover on right click on multiple files in ${gridMode ? 'grid' : 'list'} with a folder`,
-      async ({ documents }, testInfo: TestInfo) => {
-        await importDefaultFiles(documents, testInfo, ImportDocuments.Png | ImportDocuments.Pdf, true);
-
-        await documents.setDisplaySize(DisplaySize.Small);
-        await expect(documents.locator('.file-context-menu')).toBeHidden();
-        let entries: Locator;
-
-        if (!gridMode) {
-          entries = documents.locator('.folder-container').locator('.file-list-item');
-        } else {
-          await toggleViewMode(documents);
-          entries = documents.locator('.folder-container').locator('.file-card-item');
-        }
-        await documents.locator('.topbar-right-buttons').locator('.topbar-right-buttons__item').nth(0).click();
-        await documents.locator('.file-context-sheet-modal').locator('.list-group-item').nth(0).click();
-        await expect(entries.nth(0).locator('.ms-checkbox')).toBeChecked();
-        await expect(entries.nth(1).locator('.ms-checkbox')).toBeChecked();
-        await expect(entries.nth(2).locator('.ms-checkbox')).toBeChecked();
-
-        await entries.nth(0).click({ button: 'right' });
-
-        await expect(documents.locator('.file-context-sheet-modal')).toBeVisible();
-        const modal = documents.locator('.file-context-sheet-modal');
-        await expect(modal.getByRole('group')).toHaveCount(2);
-        await expect(modal.getByRole('listitem')).toHaveText(['Move to', 'Make a copy', 'Delete']);
-      },
-    );
-
-    msTest(`Small display get document link in ${gridMode ? 'grid' : 'list'} mode`, async ({ documents, context }, testInfo: TestInfo) => {
-      await importDefaultFiles(documents, testInfo, ImportDocuments.Png, false);
-      await documents.setDisplaySize(DisplaySize.Small);
-      if (gridMode) {
-        await toggleViewMode(documents);
-      }
-      await clickAction(await openPopover(documents, 0), 'Copy link');
-
-      // Fail to copy because no permission
-      await expect(documents).toShowToast('Failed to copy link. Your browser or device does not seem to support copy/paste.', 'Error');
-
-      // Grant the permissions
-      await context.grantPermissions(['clipboard-write']);
-
-      await clickAction(await openPopover(documents, 0), 'Copy link');
-      await expect(documents).toShowToast('Link has been copied to clipboard.', 'Info');
-      const filePath = await documents.evaluate(() => navigator.clipboard.readText());
-      expect(filePath).toMatch(/^https?:\/\/.+\/redirect\/.+a=path&p=.+$/);
-    });
-
-    msTest(`Small display rename document in ${gridMode ? 'grid' : 'list'} mode`, async ({ documents }, testInfo: TestInfo) => {
-      await importDefaultFiles(documents, testInfo, ImportDocuments.Png, false);
-      await documents.setDisplaySize(DisplaySize.Small);
-      let entry;
-      if (gridMode) {
-        await toggleViewMode(documents);
-        entry = documents.locator('.folder-container').locator('.file-card-item').nth(0);
-      } else {
-        entry = documents.locator('.folder-container').locator('.file-list-item').nth(0);
-      }
-
-      await clickAction(await openPopover(documents, 0), 'Rename');
-      await fillInputModal(documents, 'New Name', true);
-      if (!gridMode) {
-        await expect(entry.locator('.file-name').locator('.label-name')).toHaveText('New Name');
-      } else {
-        await expect(entry.locator('.file-card__title')).toHaveText('New Name');
-      }
-    });
-
-    msTest(`Small display delete document in ${gridMode ? 'grid' : 'list'} mode`, async ({ documents }, testInfo: TestInfo) => {
-      await importDefaultFiles(documents, testInfo, ImportDocuments.Png | ImportDocuments.Pdf, false);
-      await documents.setDisplaySize(DisplaySize.Small);
-      if (gridMode) {
-        await toggleViewMode(documents);
-      }
-      let fileName;
-      let count = 0;
-      if (gridMode) {
-        fileName = await documents
-          .locator('.folder-container')
-          .locator('.file-card-item')
-          .nth(0)
-          .locator('.file-card__title')
-          .textContent();
-        count = await documents.locator('.folder-container').locator('.file-card-item').count();
-      } else {
-        fileName = await documents
-          .locator('.folder-container')
-          .locator('.file-list-item')
-          .nth(0)
-          .locator('.file-name')
-          .locator('.label-name')
-          .textContent();
-        count = await documents.locator('.folder-container').locator('.file-list-item').count();
-      }
-
-      await clickAction(await openPopover(documents, 0), 'Delete');
-
-      await answerQuestion(documents, true, {
-        expectedTitleText: 'Delete one file',
-        expectedQuestionText: `Are you sure you want to delete file ${fileName}?`,
-        expectedNegativeText: 'Keep file',
-        expectedPositiveText: 'Delete file',
-      });
-      if (gridMode) {
-        await expect(documents.locator('.folder-container').locator('.file-card-item')).toHaveCount(count - 1);
-      } else {
-        await expect(documents.locator('.folder-container').locator('.file-list-item')).toHaveCount(count - 1);
-      }
-    });
-
-    msTest(
-      `Small display folder actions default state in a read only workspace in ${gridMode ? 'grid' : 'list'} mode`,
-      async ({ documentsReadOnly }) => {
-        await documentsReadOnly.setDisplaySize(DisplaySize.Small);
-        await expect(documentsReadOnly.locator('.file-context-menu')).toBeHidden();
-        if (!gridMode) {
-          const entry = documentsReadOnly.locator('.folder-container').locator('.file-list-item').nth(0);
-          await entry.hover();
-          await entry.locator('.options-button').click();
-        } else {
-          await toggleViewMode(documentsReadOnly);
-          const entry = documentsReadOnly.locator('.folder-container').locator('.file-card-item').nth(0);
-          await entry.hover();
-          await entry.locator('.card-option').click();
-        }
-        await expect(documentsReadOnly.locator('.file-context-sheet-modal')).toBeVisible();
-        const modal = documentsReadOnly.locator('.file-context-sheet-modal');
-        await expect(modal.getByRole('group')).toHaveCount(1);
-        await expect(modal.getByRole('listitem')).toHaveText(['Download', 'Download as a ZIP file', 'Copy link', 'Details']);
-      },
-    );
-
-    msTest(
-      `Small display file actions default state in a read only workspace in ${gridMode ? 'grid' : 'list'} mode`,
-      async ({ documentsReadOnly }) => {
-        await documentsReadOnly.setDisplaySize(DisplaySize.Small);
-        await expect(documentsReadOnly.locator('.file-context-menu')).toBeHidden();
-        if (!gridMode) {
-          const entry = documentsReadOnly.locator('.folder-container').locator('.file-list-item').nth(1);
-          await entry.hover();
-          await entry.locator('.options-button').click();
-        } else {
-          await toggleViewMode(documentsReadOnly);
-          const entry = documentsReadOnly.locator('.folder-container').locator('.file-card-item').nth(1);
-          await entry.hover();
-          await entry.locator('.card-option').click();
-        }
-        await expect(documentsReadOnly.locator('.file-context-sheet-modal')).toBeVisible();
-        const modal = documentsReadOnly.locator('.file-context-sheet-modal');
-        await expect(modal.getByRole('group')).toHaveCount(1);
-        await expect(modal.getByRole('listitem')).toHaveText(['Preview', 'Download', 'Download as a ZIP file', 'Copy link', 'Details']);
+        await checkEntryContextMenu(documents, 'folder-full', 'dismiss');
       },
     );
   }
+
+  msTest('Small display popover on right click for file with editics', async ({ parsecEditics }, testInfo: TestInfo) => {
+    await importDefaultFiles(parsecEditics, testInfo, ImportDocuments.Docx, false);
+    await parsecEditics.setDisplaySize(DisplaySize.Small);
+    await parsecEditics.waitForTimeout(300);
+    const entry = parsecEditics.locator('.folder-container').locator('.file-list-item').nth(0);
+    await entry.click({ button: 'right' });
+    await checkEntryContextMenu(parsecEditics, 'file-full', 'dismiss', { canEdit: true });
+  });
+
+  msTest(
+    'Small display popover on right click for file with editics on non-editable file',
+    async ({ parsecEditics }, testInfo: TestInfo) => {
+      await importDefaultFiles(parsecEditics, testInfo, ImportDocuments.Png, false);
+      await parsecEditics.setDisplaySize(DisplaySize.Small);
+      await parsecEditics.waitForTimeout(300);
+      const entry = parsecEditics.locator('.folder-container').locator('.file-list-item').nth(0);
+      await entry.click({ button: 'right' });
+      await checkEntryContextMenu(parsecEditics, 'file-full', 'dismiss');
+    },
+  );
+
+  msTest('Small display popover with right click on empty space', async ({ documents }, testInfo: TestInfo) => {
+    await importDefaultFiles(documents, testInfo, ImportDocuments.Png | ImportDocuments.Txt, false);
+    await documents.setDisplaySize(DisplaySize.Small);
+    await documents.waitForTimeout(300);
+
+    await documents.locator('.topbar-right-buttons').locator('.topbar-right-buttons__item').nth(0).click();
+    await expect(documents.locator('.file-context-sheet-modal')).toBeVisible();
+    const modal = documents.locator('.file-context-sheet-modal');
+    await expect(modal.locator('.button-left')).toHaveText('Selection');
+    await expect(modal.locator('.button-right')).toHaveText('Share');
+    await expect(modal.locator('.list-group-item')).toHaveCount(1);
+    await expect(modal.locator('.list-group-item').nth(0)).toHaveText('Select all');
+    await modal.locator('.list-group-item').nth(0).click();
+    await documents.waitForTimeout(300);
+
+    const headerElements = documents.locator('.small-display-selection-header').locator('ion-text');
+    await expect(headerElements).toHaveCount(3);
+    await expect(headerElements.nth(0)).toHaveText('Unselect');
+    await expect(headerElements.nth(1)).toHaveText('2 selected items');
+    await expect(headerElements.nth(2)).toHaveText('Cancel');
+    await headerElements.nth(0).click();
+    await expect(headerElements.nth(1)).toHaveText('wksp1');
+    await expect(headerElements.nth(0)).toBeVisible();
+    await expect(headerElements.nth(2)).toBeVisible();
+    await headerElements.nth(2).click();
+    await expect(headerElements).toBeHidden();
+  });
+
+  msTest('Small display document popover on right click on multiple files only files', async ({ documents }, testInfo: TestInfo) => {
+    await importDefaultFiles(documents, testInfo, ImportDocuments.Png | ImportDocuments.Pdf, true);
+    await documents.setDisplaySize(DisplaySize.Small);
+    await documents.waitForTimeout(300);
+    const entries = documents.locator('.folder-container').locator('.file-list-item');
+    await documents.locator('.topbar-right-buttons').locator('.topbar-right-buttons__item').nth(0).click();
+
+    await documents.locator('.file-context-sheet-modal').locator('.list-group-item').nth(0).click();
+
+    await expect(documents.locator('.folder-content').locator('.title__text')).toContainText('3 selected items');
+
+    await expect(entries.nth(0).locator('.ms-checkbox')).toBeChecked();
+    await expect(entries.nth(1).locator('.ms-checkbox')).toBeChecked();
+    await expect(entries.nth(2).locator('.ms-checkbox')).toBeChecked();
+
+    // Unselect the folder
+    entries.nth(0).locator('.ms-checkbox').click();
+    await entries.nth(1).click({ button: 'right' });
+
+    await checkEntryContextMenu(documents, 'multiple-entries-full', 'dismiss');
+  });
+
+  msTest('Small display document popover on right click on multiple files with a folder', async ({ documents }, testInfo: TestInfo) => {
+    await importDefaultFiles(documents, testInfo, ImportDocuments.Png | ImportDocuments.Pdf, true);
+    await documents.setDisplaySize(DisplaySize.Small);
+    await documents.waitForTimeout(300);
+
+    const entries = documents.locator('.folder-container').locator('.file-list-item');
+    await documents.locator('.topbar-right-buttons').locator('.topbar-right-buttons__item').nth(0).click();
+    await documents.locator('.file-context-sheet-modal').locator('.list-group-item').nth(0).click();
+    await expect(entries.nth(0).locator('.ms-checkbox')).toBeChecked();
+    await expect(entries.nth(1).locator('.ms-checkbox')).toBeChecked();
+    await expect(entries.nth(2).locator('.ms-checkbox')).toBeChecked();
+
+    await entries.nth(0).click({ button: 'right' });
+
+    await checkEntryContextMenu(documents, 'multiple-entries-full', 'dismiss');
+  });
+
+  msTest('Small display get document link', async ({ documents, context }, testInfo: TestInfo) => {
+    await importDefaultFiles(documents, testInfo, ImportDocuments.Png, false);
+    await documents.setDisplaySize(DisplaySize.Small);
+    await clickAction(await openPopover(documents, 0), 'Copy link');
+
+    // Fail to copy because no permission
+    await expect(documents).toShowToast('Failed to copy link. Your browser or device does not seem to support copy/paste.', 'Error');
+
+    // Grant the permissions
+    await context.grantPermissions(['clipboard-write']);
+
+    await clickAction(await openPopover(documents, 0), 'Copy link');
+    await expect(documents).toShowToast('Link has been copied to clipboard.', 'Info');
+    const filePath = await documents.evaluate(() => navigator.clipboard.readText());
+    expect(filePath).toMatch(/^https?:\/\/.+\/redirect\/.+a=path&p=.+$/);
+  });
+
+  msTest('Small display rename document', async ({ documents }, testInfo: TestInfo) => {
+    await importDefaultFiles(documents, testInfo, ImportDocuments.Png, false);
+    await documents.setDisplaySize(DisplaySize.Small);
+    const entry = documents.locator('.folder-container').locator('.file-list-item').nth(0);
+
+    await clickAction(await openPopover(documents, 0), 'Rename');
+    await fillInputModal(documents, 'New Name', true);
+    await expect(entry.locator('.file-name').locator('.label-name')).toHaveText('New Name');
+  });
+
+  msTest('Small display delete document', async ({ documents }, testInfo: TestInfo) => {
+    await importDefaultFiles(documents, testInfo, ImportDocuments.Png, false);
+    await documents.setDisplaySize(DisplaySize.Small);
+
+    await clickAction(await openPopover(documents, 0), 'Delete');
+
+    await answerQuestion(documents, true, {
+      expectedTitleText: 'Delete one file',
+      expectedQuestionText: 'Are you sure you want to delete file image.png?',
+      expectedNegativeText: 'Keep file',
+      expectedPositiveText: 'Delete file',
+    });
+    await expect(documents.locator('.folder-container').locator('.file-list-item')).toHaveCount(0);
+  });
+
+  msTest('Small display folder actions default state in a read only workspace', async ({ documentsReadOnly }) => {
+    await documentsReadOnly.setDisplaySize(DisplaySize.Small);
+    await expect(documentsReadOnly.locator('.file-context-menu')).toBeHidden();
+    const entry = documentsReadOnly.locator('.folder-container').locator('.file-list-item').nth(0);
+    await entry.hover();
+    await entry.locator('.options-button').click();
+    await checkEntryContextMenu(documentsReadOnly, 'folder-readonly', 'dismiss');
+  });
+
+  msTest('Small display file actions default state in a read only workspace', async ({ documentsReadOnly }) => {
+    await documentsReadOnly.setDisplaySize(DisplaySize.Small);
+    await expect(documentsReadOnly.locator('.file-context-menu')).toBeHidden();
+    const entry = documentsReadOnly.locator('.folder-container').locator('.file-list-item').nth(1);
+    await entry.hover();
+    await entry.locator('.options-button').click();
+    await checkEntryContextMenu(documentsReadOnly, 'file-readonly', 'dismiss');
+  });
+
+  msTest('Rename document error', async ({ documents }, testInfo: TestInfo) => {
+    await importDefaultFiles(documents, testInfo, ImportDocuments.Png, false);
+    await mockLibParsec(documents, [
+      {
+        name: 'workspaceMoveEntry',
+        result: { ok: false, error: { tag: 'WorkspaceMoveEntryErrorOffline', error: 'failed' } },
+      },
+    ]);
+    const entry = documents.locator('.folder-container').locator('.file-list-item').nth(0);
+
+    await clickAction(await openPopover(documents, 0), 'Rename');
+    await fillInputModal(documents, 'New Name', true);
+    await expect(documents).toShowToast('Failed to rename file `image.png`, please try again.', 'Error');
+    await expect(entry.locator('.label-name')).toHaveText('image.png');
+  });
+
+  msTest('Delete document error', async ({ documents }, testInfo: TestInfo) => {
+    await importDefaultFiles(documents, testInfo, ImportDocuments.Png, false);
+    await mockLibParsec(documents, [
+      {
+        name: 'workspaceRemoveFile',
+        result: { ok: false, error: { tag: 'WorkspaceRemoveEntryErrorOffline', error: 'failed' } },
+      },
+    ]);
+    const entry = documents.locator('.folder-container').locator('.file-list-item').nth(0);
+
+    await clickAction(await openPopover(documents, 0), 'Delete');
+    await answerQuestion(documents, true, {
+      expectedTitleText: 'Delete one file',
+      expectedQuestionText: 'Are you sure you want to delete file image.png?',
+      expectedNegativeText: 'Keep file',
+      expectedPositiveText: 'Delete file',
+    });
+    await expect(documents).toShowToast('Failed to delete file `image.png`, please try again.', 'Error');
+    await expect(entry.locator('.label-name')).toHaveText('image.png');
+  });
 });

--- a/client/tests/e2e/specs/file_search.spec.ts
+++ b/client/tests/e2e/specs/file_search.spec.ts
@@ -203,7 +203,7 @@ msTest.describe(() => {
         }
         const detailsModal = documents.locator('.file-details-modal');
         await expect(detailsModal).toBeHidden();
-        await checkEntryContextMenu(documents, entryType === 'file' ? 'file-full' : 'folder-full', 'Details');
+        await checkEntryContextMenu(documents, entryType === 'file' ? 'file-full' : 'folder-full', 'Details', { fromSearch: true });
         await expect(detailsModal).toBeVisible();
       });
     }
@@ -229,7 +229,9 @@ msTest.describe(() => {
       await results.nth(0).click({ button: 'right' });
       const detailsModal = documentsReadOnly.locator('.file-details-modal');
       await expect(detailsModal).toBeHidden();
-      await checkEntryContextMenu(documentsReadOnly, entryType === 'file' ? 'file-readonly' : 'folder-readonly', 'Details');
+      await checkEntryContextMenu(documentsReadOnly, entryType === 'file' ? 'file-readonly' : 'folder-readonly', 'Details', {
+        fromSearch: true,
+      });
       await expect(detailsModal).toBeVisible();
     });
   }

--- a/client/tests/e2e/specs/workspaces_list.spec.ts
+++ b/client/tests/e2e/specs/workspaces_list.spec.ts
@@ -537,7 +537,7 @@ for (const entryType of ['file', 'folder']) {
     const detailsModal = workspaces.locator('.file-details-modal');
     await expect(detailsModal).toBeHidden();
     await searchItems.nth(0).click({ button: 'right' });
-    await checkEntryContextMenu(workspaces, entryType === 'file' ? 'file-full' : 'folder-full', 'Details');
+    await checkEntryContextMenu(workspaces, entryType === 'file' ? 'file-full' : 'folder-full', 'Details', { fromSearch: true });
     await expect(detailsModal).toBeVisible();
   });
 }


### PR DESCRIPTION
- Fixed small display file context menu by keeping the order the same as large display
- Adds some tests to check file actions errors
- Trimmed some redundant tests
- Reactived some skipped tests