### PR TITLE
feat(parsec-cli): Generate it's own manpages by inspecting itself

### DIFF
--- a/.cspell/names.txt
+++ b/.cspell/names.txt
@@ -1,4 +1,5 @@
 Adamy
+clap_mangen
 Alicey
 Alicy
 ANSSI

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,6 +510,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "clap_mangen"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82842b45bf9f6a3be090dd860095ac30728042c08e0d6261ca7259b5d850f07"
+dependencies = [
+ "clap",
+ "roff",
+]
+
+[[package]]
 name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3497,6 +3507,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "clap_mangen",
  "criterion",
  "ctrlc",
  "dialoguer",
@@ -4238,6 +4249,12 @@ dependencies = [
  "rmp",
  "serde",
 ]
+
+[[package]]
+name = "roff"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rpassword"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ blake2 = { version = "0.10.6", default-features = false }
 bytes = { version = "1.11.1", default-features = false }
 chrono = { version = "0.4.44", default-features = false }
 clap = { version = "4.6.1", default-features = false }
+clap_mangen = { version = "0.3.0", default-features = false }
 console_error_panic_hook = { version = "=0.1.6", default-features = false }
 console_log = { version = "1.0.0", default-features = false }
 crc32fast = { version = "1.5.0", default-features = false }                        # Fast hasher used only by the testbed

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,10 +18,12 @@ name = "integration"
 path = "tests/integration/mod.rs"
 
 [features]
+default = ["manpage"]
 use-libsodium = ["libparsec_crypto/use-libsodium"]
 vendored-openssl = ["libparsec_crypto/vendored-openssl"]
 vendored-dbus = ["libparsec/vendored-dbus"]
 testenv = []
+manpage = ["dep:clap_mangen"]
 
 [dependencies]
 libparsec = { workspace = true }
@@ -43,12 +45,13 @@ rpassword = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 spinners = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "io-std"] }
 url = { workspace = true, optional = true }
 uuid = { workspace = true }
 itertools = { workspace = true, features = ["use_std"] }
 thiserror = { workspace = true }
 shadow-rs.workspace = true
+clap_mangen = { workspace = true, features = ["env"], optional = true }
 
 [dev-dependencies]
 libparsec = { workspace = true, features = ["cli-tests"] }

--- a/cli/src/commands/man_page.rs
+++ b/cli/src/commands/man_page.rs
@@ -1,0 +1,153 @@
+use std::{
+    fmt::Display,
+    io::Cursor,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Context;
+use clap::{CommandFactory, ValueEnum};
+use tokio::{
+    io::{AsyncWrite, AsyncWriteExt, BufWriter},
+    task::JoinSet,
+};
+
+#[derive(clap::Parser)]
+pub struct Args {
+    /// Man page(s) output path
+    ///
+    /// The output path should be a file or a directory depending on `mode`.
+    // TODO: Support `-` once PR sequester is merged #13116
+    #[arg(default_value = "-")]
+    output: PathBuf,
+    /// How the man pages would be written to the output path
+    #[arg(long, default_value_t)]
+    mode: Mode,
+}
+
+#[derive(clap::ValueEnum, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Mode {
+    /// All man entries are written in the single file
+    #[default]
+    AllInOne,
+    /// Each man entry is written to its own file
+    Separate,
+}
+
+impl Display for Mode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Using a similar approach to `clap::ColorChoice`
+        self.to_possible_value()
+            .expect("no values are skipped")
+            .get_name()
+            .fmt(f)
+    }
+}
+
+pub async fn main(_ui: crate::Ui, args: Args) -> anyhow::Result<()> {
+    let Args { output, mode } = args;
+
+    anyhow::ensure!(
+        output.as_os_str() != "-" || mode == Mode::AllInOne,
+        "Cannot output separated manpage on stdout"
+    );
+
+    let mut cmd = crate::Arg::command();
+    // Required introspection.
+    cmd.build();
+
+    if output.as_os_str() == AsRef::<std::ffi::OsStr>::as_ref("-") {
+        // let stdout = tokio::io::stdout();
+        // let mut buffered = tokio::io::BufWriter::new(stdout);
+        // render_allinone_commands(&cmd, &mut buffered).await?;
+        // buffered
+        //     .flush()
+        //     .await
+        //     .context("Cannot flush data to output")
+        todo!()
+    } else {
+        match mode {
+            Mode::AllInOne => {
+                let file = tokio::fs::File::create(output)
+                    .await
+                    .context("Cannot create output file")?;
+                let mut buffered = tokio::io::BufWriter::new(file);
+                render_allinone_commands(&cmd, &mut buffered).await?;
+                buffered
+                    .flush()
+                    .await
+                    .context("Cannot flush data to output")
+            }
+            Mode::Separate => render_separate_commands(cmd, &output).await,
+        }
+    }
+}
+
+async fn render_allinone_commands<W: AsyncWrite + Unpin>(
+    cmd: &clap::Command,
+    w: &mut BufWriter<W>,
+) -> anyhow::Result<()> {
+    write_man_to_file(cmd, w).await?;
+    for sub_command in cmd.get_subcommands() {
+        Box::pin(render_allinone_commands(sub_command, w)).await?;
+    }
+    Ok(())
+}
+
+async fn write_man_to_file<W: AsyncWrite + Unpin>(
+    cmd: &clap::Command,
+    w: &mut BufWriter<W>,
+) -> anyhow::Result<()> {
+    let man = clap_mangen::Man::new(cmd.clone());
+    let buff = render_man_in_memory(man).with_context(|| {
+        let cmd_name = cmd.get_name();
+
+        format!("Failed to render man for command {cmd_name}")
+    })?;
+    w.write_all_buf(&mut std::io::Cursor::new(buff)).await?;
+    Ok(())
+}
+
+async fn render_separate_commands(cmd: clap::Command, out_dir: &Path) -> anyhow::Result<()> {
+    let mut tasks = tokio::task::JoinSet::new();
+    create_render_task(cmd.clone(), out_dir, &mut tasks);
+    for sub_command in cmd.get_subcommands() {
+        if sub_command.get_name() != "help" {
+            create_render_task(sub_command.clone(), out_dir, &mut tasks);
+        }
+    }
+    while let Some(task) = tasks.join_next().await {
+        task??;
+    }
+    Ok(())
+}
+
+fn create_render_task(
+    cmd: clap::Command,
+    out_dir: &Path,
+    join_set: &mut JoinSet<anyhow::Result<()>>,
+) {
+    let man = clap_mangen::Man::new(cmd);
+    let path = out_dir.join(man.get_filename());
+    log::debug!("Will write a man page to {}", path.display());
+    join_set.spawn(write_man_in_file(man, path));
+}
+
+async fn write_man_in_file(man: clap_mangen::Man, file: PathBuf) -> anyhow::Result<()> {
+    let buff = render_man_in_memory(man)?;
+
+    let file = tokio::fs::File::create(file)
+        .await
+        .context("Failed to open file")?;
+    let mut buffered = tokio::io::BufWriter::new(file);
+
+    buffered
+        .write_all_buf(&mut Cursor::new(buff))
+        .await
+        .context("Failed to write manpage to writer")
+}
+
+fn render_man_in_memory(man: clap_mangen::Man) -> anyhow::Result<Vec<u8>> {
+    let mut buff = Vec::with_capacity(1024);
+    man.render(&mut buff).context("Failed to render man page")?;
+    Ok(buff)
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -2,6 +2,8 @@ pub mod certificate;
 pub mod device;
 pub mod invite;
 pub mod ls;
+#[cfg(feature = "manpage")]
+pub mod man_page;
 pub mod mount_realm_export;
 pub mod organization;
 pub mod rm;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -10,3 +10,96 @@ mod unit_tests;
 pub mod utils;
 
 pub(crate) use ui::Ui;
+
+use commands::*;
+
+/// Parsec cli
+#[derive(clap::Parser)]
+#[command(version(LongVersion))]
+pub struct Arg {
+    #[command(subcommand)]
+    pub command: Command,
+    /// How message are displayed
+    #[arg(long, default_value_t)]
+    pub progress: ui::ProgressStyle,
+    /// How to format outputted data
+    #[arg(long, default_value_t)]
+    pub format: ui::DataFormat,
+    #[arg(long, default_value_t)]
+    pub color: clap::ColorChoice,
+}
+
+#[derive(clap::Subcommand)]
+pub enum Command {
+    /// Contains subcommands related to server operations
+    #[command(subcommand)]
+    Server(server::Group),
+    /// Contains subcommands related to devices
+    #[command(subcommand)]
+    Device(device::Group),
+    /// Contains subcommands related to invitation
+    #[command(subcommand)]
+    Invite(invite::Group),
+    /// Contains subcommands related to organization
+    #[command(subcommand)]
+    Organization(organization::Group),
+    /// Contains subcommands related to user
+    #[command(subcommand)]
+    User(user::Group),
+    /// Contains subcommands related to workspace
+    #[command(subcommand)]
+    Workspace(workspace::Group),
+    /// Contains subcommands related to certificate
+    #[command(subcommand)]
+    Certificate(certificate::Group),
+    #[cfg(feature = "testenv")]
+    /// Create a temporary environment and initialize a test setup for parsec.
+    /// #### WARNING: it also leaves an in-memory server running in the background.
+    /// This command creates three users, `Alice`, `Bob` and `Toto`,
+    /// To run testenv, see the script run_testenv in the current directory.
+    RunTestenv(run_testenv::RunTestenv),
+    /// List workspace contents
+    Ls(ls::Args),
+    /// Remove a file from a workspace
+    Rm(rm::Args),
+    /// Contains subcommands related to Term of Service (TOS).
+    #[command(subcommand)]
+    Tos(tos::Group),
+    /// Contains subcommands related to shared recovery devices (shamir)
+    #[command(subcommand)]
+    SharedRecovery(shared_recovery::Group),
+    /// Mount a realm export as a workspace.
+    MountRealmExport(mount_realm_export::Args),
+    /// Print CLI man pages to the console or a file
+    #[cfg(feature = "manpage")]
+    ManPage(man_page::Args),
+}
+
+struct LongVersion;
+
+shadow_rs::shadow!(build);
+
+impl From<LongVersion> for clap::builder::Str {
+    fn from(_value: LongVersion) -> Self {
+        use build::*;
+        use libparsec_crypto::CRYPTO_BACKEND;
+
+        // cspell: words: formatcp
+        shadow_rs::formatcp!(
+            // One the same line since `clap` prefix with the cli name and expect the version to follow
+            r#"{PKG_VERSION}
+branch: {BRANCH}
+commit_hash: {SHORT_COMMIT}
+build_target: {BUILD_TARGET}
+build_os: {BUILD_OS}
+build_profile: {BUILD_RUST_CHANNEL}
+cli_features: {CARGO_FEATURES}
+crypto_backend: {CRYPTO_BACKEND}
+rust_version: {RUST_VERSION}
+rust_channel: {RUST_CHANNEL}
+cargo_version: {CARGO_VERSION}
+git_clean: {GIT_CLEAN}"#,
+        )
+        .into()
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,67 +1,8 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-use parsec_cli::{commands::*, ui};
+use parsec_cli::{commands::*, ui, Arg, Command};
 
-use clap::{Parser, Subcommand};
-
-/// Parsec cli
-#[derive(Parser)]
-#[command(version(LongVersion))]
-struct Arg {
-    #[command(subcommand)]
-    command: Command,
-    /// How message are displayed
-    #[arg(long, default_value_t)]
-    progress: ui::ProgressStyle,
-    /// How to format outputted data
-    #[arg(long, default_value_t)]
-    format: ui::DataFormat,
-    #[arg(long, default_value_t)]
-    color: clap::ColorChoice,
-}
-
-#[derive(Subcommand)]
-enum Command {
-    /// Contains subcommands related to server operations
-    #[command(subcommand)]
-    Server(server::Group),
-    /// Contains subcommands related to devices
-    #[command(subcommand)]
-    Device(device::Group),
-    /// Contains subcommands related to invitation
-    #[command(subcommand)]
-    Invite(invite::Group),
-    /// Contains subcommands related to organization
-    #[command(subcommand)]
-    Organization(organization::Group),
-    /// Contains subcommands related to user
-    #[command(subcommand)]
-    User(user::Group),
-    /// Contains subcommands related to workspace
-    #[command(subcommand)]
-    Workspace(workspace::Group),
-    /// Contains subcommands related to certificate
-    #[command(subcommand)]
-    Certificate(certificate::Group),
-    #[cfg(feature = "testenv")]
-    /// Create a temporary environment and initialize a test setup for parsec.
-    /// #### WARNING: it also leaves an in-memory server running in the background.
-    /// This command creates three users, `Alice`, `Bob` and `Toto`,
-    /// To run testenv, see the script run_testenv in the current directory.
-    RunTestenv(run_testenv::RunTestenv),
-    /// List workspace contents
-    Ls(ls::Args),
-    /// Remove a file from a workspace
-    Rm(rm::Args),
-    /// Contains subcommands related to Term of Service (TOS).
-    #[command(subcommand)]
-    Tos(tos::Group),
-    /// Contains subcommands related to shared recovery devices (shamir)
-    #[command(subcommand)]
-    SharedRecovery(shared_recovery::Group),
-    /// Mount a realm export as a workspace.
-    MountRealmExport(mount_realm_export::Args),
-}
+use clap::Parser;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -93,34 +34,7 @@ async fn main() -> anyhow::Result<()> {
         Command::MountRealmExport(mount_realm_export) => {
             mount_realm_export::main(mount_realm_export).await
         }
-    }
-}
-
-struct LongVersion;
-
-shadow_rs::shadow!(build);
-
-impl From<LongVersion> for clap::builder::Str {
-    fn from(_value: LongVersion) -> Self {
-        use build::*;
-        use libparsec_crypto::CRYPTO_BACKEND;
-
-        // cspell: words: formatcp
-        shadow_rs::formatcp!(
-            // One the same line since `clap` prefix with the cli name and expect the version to follow
-            r#"{PKG_VERSION}
-branch: {BRANCH}
-commit_hash: {SHORT_COMMIT}
-build_target: {BUILD_TARGET}
-build_os: {BUILD_OS}
-build_profile: {BUILD_RUST_CHANNEL}
-cli_features: {CARGO_FEATURES}
-crypto_backend: {CRYPTO_BACKEND}
-rust_version: {RUST_VERSION}
-rust_channel: {RUST_CHANNEL}
-cargo_version: {CARGO_VERSION}
-git_clean: {GIT_CLEAN}"#,
-        )
-        .into()
+        #[cfg(feature = "manpage")]
+        Command::ManPage(args) => man_page::main(ui, args).await,
     }
 }

--- a/cli/tests/integration/invitations/device.rs
+++ b/cli/tests/integration/invitations/device.rs
@@ -30,9 +30,9 @@ async fn invite_device(tmp_path: TmpPath) {
 
 #[cfg(target_family = "unix")] // rexpect doesn't support Windows
 #[rstest::rstest]
-#[tokio::test]
 #[case("http")]
 #[case("parsec3")]
+#[tokio::test]
 async fn invite_device_dance(tmp_path: TmpPath, #[case] scheme: &str) {
     let (_, TestOrganization { alice, .. }, _) = bootstrap_cli_test(&tmp_path).await.unwrap();
 

--- a/cli/tests/integration/invitations/shared_recovery.rs
+++ b/cli/tests/integration/invitations/shared_recovery.rs
@@ -33,9 +33,9 @@ async fn invite_shared_recovery(tmp_path: TmpPath) {
 
 #[cfg(target_family = "unix")] // rexpect doesn't support Windows
 #[rstest::rstest]
-#[tokio::test]
 #[case("http")]
 #[case("parsec3")]
+#[tokio::test]
 async fn invite_shared_recovery_dance(tmp_path: TmpPath, #[case] scheme: &str) {
     let (_, TestOrganization { alice, bob, .. }, _) = bootstrap_cli_test(&tmp_path).await.unwrap();
 

--- a/cli/tests/integration/invitations/user.rs
+++ b/cli/tests/integration/invitations/user.rs
@@ -37,9 +37,9 @@ async fn invite_user(tmp_path: TmpPath) {
 
 #[cfg(target_family = "unix")] // rexpect doesn't support Windows
 #[rstest::rstest]
-#[tokio::test]
 #[case("http")]
 #[case("parsec3")]
+#[tokio::test]
 async fn invite_user_dance(tmp_path: TmpPath, #[case] scheme: &str) {
     let (_, TestOrganization { alice, .. }, _) = bootstrap_cli_test(&tmp_path).await.unwrap();
 

--- a/cli/tests/integration/manpage.rs
+++ b/cli/tests/integration/manpage.rs
@@ -1,0 +1,43 @@
+use libparsec::{tmp_path, TmpPath};
+use parsec_cli::commands::man_page::Mode;
+
+#[rstest::rstest]
+#[case::all_in_one(Mode::AllInOne)]
+#[case::separate(Mode::Separate)]
+#[tokio::test]
+async fn gen_man_page(#[case] mode: Mode, tmp_path: TmpPath) {
+    let out_path = tmp_path.join("man");
+
+    if mode == Mode::Separate {
+        tokio::fs::create_dir(&out_path).await.unwrap();
+    }
+    crate::assert_cmd_success!(
+        "man-page",
+        "--mode",
+        &mode.to_string(),
+        &out_path.to_string_lossy()
+    )
+    .stdout(predicates::str::is_empty())
+    .stderr(predicates::str::is_empty());
+
+    let metadata = tokio::fs::metadata(&out_path).await.unwrap();
+    match mode {
+        Mode::AllInOne => {
+            assert!(metadata.is_file());
+            #[cfg(target_family = "unix")]
+            {
+                use std::os::unix::fs::MetadataExt;
+                assert!(metadata.size() > 0);
+            }
+        }
+        Mode::Separate => {
+            assert!(metadata.is_dir());
+            let mut entries = tokio::fs::read_dir(out_path).await.unwrap();
+            let mut count = 0_usize;
+            while let Ok(Some(_)) = entries.next_entry().await {
+                count += 1;
+            }
+            assert!(count > 1);
+        }
+    }
+}

--- a/cli/tests/integration/mod.rs
+++ b/cli/tests/integration/mod.rs
@@ -5,6 +5,8 @@ mod device;
 mod device_option;
 mod invitations;
 mod ls;
+#[cfg(feature = "manpage")]
+mod manpage;
 mod mount_realm_export;
 mod organization;
 mod rm;

--- a/cli/tests/integration/organization/bootstrap.rs
+++ b/cli/tests/integration/organization/bootstrap.rs
@@ -8,9 +8,9 @@ use crate::{
 use parsec_cli::commands::organization::create::create_organization_req;
 
 #[rstest::rstest]
-#[tokio::test]
 #[case("http")]
 #[case("parsec3")]
+#[tokio::test]
 async fn bootstrap_organization(tmp_path: TmpPath, #[case] scheme: &str) {
     bootstrap_cli_test(&tmp_path).await.unwrap();
 


### PR DESCRIPTION
Use `clap_mangen` to generate `parsec-cli`'s manpages.

```
cargo r -p parsec-cli --features manpage | man -l -
```