### PR TITLE
Remove typing-extensions from dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -153,7 +153,6 @@ updates:
     directory: /server
     versioning-strategy: increase-if-necessary
     ignore:
-      - dependency-name: typing-extensions
       - dependency-name: anyio
         versions:
           - ">=4.0.0"


### PR DESCRIPTION
The `typing-extensions` dependency was removed in #9967
