### PR TITLE
refactor(cli): Add `value_hint` to most options of sub-commands

### DIFF
--- a/cli/src/commands/device/change_authentication.rs
+++ b/cli/src/commands/device/change_authentication.rs
@@ -9,9 +9,9 @@ use crate::utils::*;
 crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, device, password_stdin]
     pub struct Args {
-   #[clap(long, short, action)]
+       #[clap(long, short, action)]
         password: bool,
-   #[clap(long, short, action)]
+       #[clap(long, short, action)]
         keyring: bool,
     }
 );

--- a/cli/src/commands/device/export_recovery_device.rs
+++ b/cli/src/commands/device/export_recovery_device.rs
@@ -10,6 +10,7 @@ crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, device, password_stdin]
     pub struct Args {
         /// Path where to save recovery device data
+        #[arg(value_hint = clap::ValueHint::FilePath)]
         output: PathBuf,
     }
 );

--- a/cli/src/commands/device/import_recovery_device.rs
+++ b/cli/src/commands/device/import_recovery_device.rs
@@ -10,10 +10,10 @@ crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, password_stdin]
     pub struct Args {
         /// Path where encrypted recovery device data is
-        #[arg(short, long)]
+        #[arg(short, long, value_hint = clap::ValueHint::FilePath)]
         input: PathBuf,
         /// new device label
-        #[arg(short, long)]
+        #[arg(short, long, value_hint = clap::ValueHint::Other)]
         label: String,
     }
 );

--- a/cli/src/commands/device/overwrite_server_url.rs
+++ b/cli/src/commands/device/overwrite_server_url.rs
@@ -12,7 +12,7 @@ crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, device, password_stdin]
     pub struct Args {
         /// The new server URL
-        #[arg(short, long, value_parser = ParsecAddr::from_http_url)]
+        #[arg(short, long, value_parser = ParsecAddr::from_http_url, value_hint = clap::ValueHint::Url)]
         server_url: ParsecAddr,
     }
 );

--- a/cli/src/commands/invite/cancel.rs
+++ b/cli/src/commands/invite/cancel.rs
@@ -9,7 +9,7 @@ crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, device, password_stdin]
     pub struct Args {
         /// Invitation token
-        #[arg(value_parser = AccessToken::from_hex)]
+        #[arg(value_parser = AccessToken::from_hex, value_hint = clap::ValueHint::Other)]
         token: AccessToken,
     }
 );

--- a/cli/src/commands/invite/claim.rs
+++ b/cli/src/commands/invite/claim.rs
@@ -28,6 +28,7 @@ crate::clap_parser_with_shared_opts_builder!(
         // cspell:disable-next-line
         /// Server invitation address (e.g.: parsec3://127.0.0.1:41997/Org?no_ssl=true&a=claim_shamir_recovery&p=xBA2FaaizwKy4qG5cGDFlXaL`
         /// or http://127.0.0.1:41997/Org?no_ssl=true&a=claim_shamir_recovery&p=xBA2FaaizwKy4qG5cGDFlXaL`)
+        #[arg(value_hint = clap::ValueHint::Url)]
         addr: Url,
         /// Use keyring to store the password for the device.
         #[arg(long, default_value_t, conflicts_with = "password_stdin")]

--- a/cli/src/commands/invite/greet.rs
+++ b/cli/src/commands/invite/greet.rs
@@ -22,7 +22,7 @@ crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, device, password_stdin]
     pub struct Args {
         /// Invitation token
-        #[arg(value_parser = AccessToken::from_hex)]
+        #[arg(value_parser = AccessToken::from_hex, value_hint = clap::ValueHint::Other)]
         token: AccessToken,
     }
 );

--- a/cli/src/commands/invite/shared_recovery.rs
+++ b/cli/src/commands/invite/shared_recovery.rs
@@ -8,6 +8,7 @@ crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, device, password_stdin]
     pub struct Args {
         /// Claimer email (i.e.: The invitee)
+        #[arg(value_hint = clap::ValueHint::EmailAddress)]
         email: EmailAddress,
         /// Send email to the invitee
         #[arg(long, default_value_t)]

--- a/cli/src/commands/invite/user.rs
+++ b/cli/src/commands/invite/user.rs
@@ -9,6 +9,7 @@ crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, device, password_stdin]
     pub struct Args {
         /// Claimer email (i.e.: The invitee)
+        #[arg(value_hint = clap::ValueHint::EmailAddress)]
         email: EmailAddress,
         /// Send email to the invitee
         #[arg(short, long, default_value_t)]

--- a/cli/src/commands/ls.rs
+++ b/cli/src/commands/ls.rs
@@ -6,7 +6,7 @@ crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, device, password_stdin, workspace]
     pub struct Args {
         /// The absolute workspace path to list contents (e.g. "/foo/bar")
-        #[arg(default_value_t)]
+        #[arg(default_value_t, value_hint = clap::ValueHint::AnyPath)]
         path: FsPath,
     }
 );

--- a/cli/src/commands/mount_realm_export.rs
+++ b/cli/src/commands/mount_realm_export.rs
@@ -10,13 +10,14 @@ crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, password_stdin]
     pub struct Args {
         /// Path to the realm export database
+        #[arg(value_hint = clap::ValueHint::FilePath)]
         export_db_path: PathBuf,
         /// Sequester service or user to use for decryption.
         /// Allowed format `device:<device_id>` or `sequester:<service_id>:<path/to/private_key.pem>`.
-        #[arg(short, long)]
+        #[arg(short, long, value_hint = clap::ValueHint::Other)]
         decryptor: Vec<Decryptor>,
         /// Browse the realm at a specific point in time.
-        #[arg(short, long)]
+        #[arg(short, long, value_hint = clap::ValueHint::Other)]
         timestamp: Option<DateTime>,
     }
 );

--- a/cli/src/commands/organization/bootstrap.rs
+++ b/cli/src/commands/organization/bootstrap.rs
@@ -14,19 +14,19 @@ pub struct Args {
     /// Bootstrap address
     /// (e.g: parsec3://127.0.0.1:6770/Org?no_ssl=true&action=bootstrap_organization&token=59961ba6dcc9b018d2fdc9da1c0c762b716a27cff30594562dc813e4b765871a
     /// or http://127.0.0.1:6770/Org?no_ssl=true&action=bootstrap_organization&token=59961ba6dcc9b018d2fdc9da1c0c762b716a27cff30594562dc813e4b765871a)
-    #[arg(short, long)]
+    #[arg(short, long, value_hint = clap::ValueHint::Url)]
     addr: Url,
     /// Device label
-    #[arg(short, long)]
+    #[arg(short, long, value_hint = clap::ValueHint::Hostname)]
     device_label: DeviceLabel,
     /// User fullname
-    #[arg(short, long)]
+    #[arg(short, long, value_hint = clap::ValueHint::Username)]
     label: String,
     /// User email
-    #[arg(short, long)]
+    #[arg(short, long, value_hint = clap::ValueHint::EmailAddress)]
     email: EmailAddress,
     /// Sequester authority verify key path
-    #[arg(long)]
+    #[arg(long, value_hint = clap::ValueHint::FilePath)]
     sequester_key: Option<PathBuf>,
     /// Read the password from stdin instead of TTY
     #[arg(long, default_value_t)]

--- a/cli/src/commands/organization/create.rs
+++ b/cli/src/commands/organization/create.rs
@@ -8,6 +8,7 @@ crate::clap_parser_with_shared_opts_builder!(
     #[with = addr, token]
     pub struct Args {
         /// The organization name that will be created
+        #[arg(value_hint = clap::ValueHint::Other)]
         organization: OrganizationID,
     }
 );

--- a/cli/src/commands/rm.rs
+++ b/cli/src/commands/rm.rs
@@ -6,6 +6,7 @@ crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, device, password_stdin, workspace]
     pub struct Args {
         /// Path to remove
+        #[arg(value_hint = clap::ValueHint::FilePath)]
         path: FsPath,
     }
 );

--- a/cli/src/commands/run_testenv.rs
+++ b/cli/src/commands/run_testenv.rs
@@ -15,7 +15,7 @@ use crate::{
 #[derive(clap::Parser)]
 pub struct RunTestenv {
     /// Sourced script file
-    #[arg(long)]
+    #[arg(long, value_hint = clap::ValueHint::FilePath)]
     source_file: Option<PathBuf>,
     /// Main process id.
     /// When this process stops, the server will be automatically killed
@@ -25,7 +25,7 @@ pub struct RunTestenv {
     #[arg(short, long, default_value_t)]
     empty: bool,
     /// The organization ID to use for the test environment.
-    #[arg(default_value_os = "Org")]
+    #[arg(default_value_os = "Org", value_hint = clap::ValueHint::Other)]
     organization: libparsec::OrganizationID,
 }
 

--- a/cli/src/commands/server/stats.rs
+++ b/cli/src/commands/server/stats.rs
@@ -12,7 +12,7 @@ crate::clap_parser_with_shared_opts_builder!(
         #[arg(short, long, default_value_t = Format::Json)]
         format: Format,
         /// Ignore everything after this date (e.g: 2024-01-01T00:00:00-00:00)
-        #[arg(short, long)]
+        #[arg(short, long, value_hint = clap::ValueHint::Other)]
         end_date: Option<DateTime>,
     }
 );

--- a/cli/src/commands/shared_recovery/create.rs
+++ b/cli/src/commands/shared_recovery/create.rs
@@ -54,7 +54,7 @@ crate::clap_parser_with_shared_opts_builder!(
         /// If missing organization's admins will be used instead.
         /// Author must not be included as recipient.
         /// email or email:weight format is expected (weight defaults to one if not provided).
-        #[arg(long, num_args = 1..=255)]
+        #[arg(long, num_args = 1..=255, value_hint = clap::ValueHint::EmailAddress)]
         recipients: Option<Vec<WeightedEmail>>,
         /// Threshold number of shares required to proceed with recovery.
         #[arg(short, long, requires = "recipients")]

--- a/cli/src/commands/tos/config.rs
+++ b/cli/src/commands/tos/config.rs
@@ -9,10 +9,11 @@ crate::clap_parser_with_shared_opts_builder!(
         #[arg(long)]
         remove: bool,
         /// Read the TOS configuration from a JSON file.
-        #[arg(long)]
+        #[arg(long, value_hint = clap::ValueHint::FilePath)]
         from_json: Option<PathBuf>,
         /// List of locale and url for TOS configuration
         /// Each arguments should be in the form of `{locale}={url}`
+        #[arg(value_hint = clap::ValueHint::Other)]
         raw: Vec<String>,
     }
 );

--- a/cli/src/commands/user/revoke.rs
+++ b/cli/src/commands/user/revoke.rs
@@ -9,6 +9,7 @@ crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, device, password_stdin]
     pub struct Args {
         /// Email of the user to revoke
+        #[arg(value_hint = clap::ValueHint::EmailAddress)]
         email: EmailAddress,
     }
 );

--- a/cli/src/commands/user/totp_reset.rs
+++ b/cli/src/commands/user/totp_reset.rs
@@ -9,10 +9,10 @@ crate::clap_parser_with_shared_opts_builder!(
     #[command(group(clap::ArgGroup::new("user_ref").required(true)))]
     pub struct Args {
         /// User ID (hex) of the user to reset TOTP for (mutually exclusive with --user-email)
-        #[arg(long, group = "user_ref", value_parser = UserID::from_hex)]
+        #[arg(long, group = "user_ref", value_parser = UserID::from_hex, value_hint = clap::ValueHint::Other)]
         user_id: Option<UserID>,
         /// Email of the user to reset TOTP for (mutually exclusive with --user-id)
-        #[arg(long, group = "user_ref")]
+        #[arg(long, group = "user_ref", value_hint = clap::ValueHint::EmailAddress)]
         user_email: Option<EmailAddress>,
         /// Request the server to send the an email informing the user of the reset
         #[arg(long, default_value_t)]

--- a/cli/src/commands/workspace/create.rs
+++ b/cli/src/commands/workspace/create.rs
@@ -8,6 +8,7 @@ crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, device, password_stdin]
     pub struct Args {
         /// New workspace name
+        #[arg(value_hint = clap::ValueHint::Other)]
         name: EntryName,
     }
 );

--- a/cli/src/commands/workspace/import.rs
+++ b/cli/src/commands/workspace/import.rs
@@ -15,6 +15,7 @@ crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, device, password_stdin, workspace]
     pub struct Args {
         /// Local file or folder to import (e.g. "myfile.txt")
+        #[arg(value_hint = clap::ValueHint::FilePath)]
         pub(crate) src: PathBuf,
         /// Destination path in the workspace (e.g. "/path/to/myfile.txt")
         ///
@@ -22,6 +23,7 @@ crate::clap_parser_with_shared_opts_builder!(
         /// parent directories do not exist, unless the `parents` option is enabled.
         ///
         /// If the destination file already exists, its content will be replaced.
+        #[arg(value_hint = clap::ValueHint::DirPath)]
         pub(crate) dest: FsPath,
         /// If specified, create parent directories as needed
         ///

--- a/cli/src/commands/workspace/share.rs
+++ b/cli/src/commands/workspace/share.rs
@@ -8,10 +8,10 @@ crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, device, workspace, password_stdin]
     pub struct Args {
         /// The user ID to share the workspace with
-        #[arg(short, long, value_parser = UserID::from_hex)]
+        #[arg(short, long, value_parser = UserID::from_hex, value_hint = clap::ValueHint::Other)]
         user: UserID,
         /// Role (owner/manager/contributor/reader)
-        #[arg(short, long)]
+        #[arg(short, long, value_hint = clap::ValueHint::Other)]
         role: RealmRole,
     }
 );

--- a/cli/src/macros.rs
+++ b/cli/src/macros.rs
@@ -83,7 +83,13 @@ macro_rules! clap_parser_with_shared_opts_builder {
             $(#[$struct_attr])*
             $visibility struct $name {
                 #[doc = "Parsec config directory"]
-                #[arg(short, long, default_value_os_t = libparsec::get_default_config_dir(), env = $crate::utils::PARSEC_CONFIG_DIR)]
+                #[arg(
+                    short,
+                    long,
+                    default_value_os_t = libparsec::get_default_config_dir(),
+                    env = $crate::utils::PARSEC_CONFIG_DIR,
+                    value_hint = clap::ValueHint::DirPath
+                )]
                 pub(crate) config_dir: std::path::PathBuf,
                 $(
                     $(#[$field_attr])*
@@ -108,7 +114,13 @@ macro_rules! clap_parser_with_shared_opts_builder {
             $(#[$struct_attr])*
             $visibility struct $name {
                 #[doc = "Parsec data directory"]
-                #[arg(short, long, default_value_os_t = libparsec::get_default_data_base_dir(), env = $crate::utils::PARSEC_DATA_DIR)]
+                #[arg(
+                    short,
+                    long,
+                    default_value_os_t = libparsec::get_default_data_base_dir(),
+                    env = $crate::utils::PARSEC_DATA_DIR,
+                    value_hint = clap::ValueHint::DirPath
+                )]
                 pub(crate) data_dir: std::path::PathBuf,
                 $(
                     $(#[$field_attr])*
@@ -133,7 +145,7 @@ macro_rules! clap_parser_with_shared_opts_builder {
             $(#[$struct_attr])*
             $visibility struct $name {
                 #[doc = "Device ID"]
-                #[arg(short, long, env = "PARSEC_DEVICE_ID")]
+                #[arg(short, long, env = "PARSEC_DEVICE_ID", value_hint = clap::ValueHint::Other)]
                 pub(crate) device: Option<String>,
                 $(
                     $(#[$field_attr])*
@@ -158,7 +170,13 @@ macro_rules! clap_parser_with_shared_opts_builder {
             $(#[$struct_attr])*
             $visibility struct $name {
                 #[doc = "Workspace ID"]
-                #[arg(short, long, env = "PARSEC_WORKSPACE_ID", value_parser = libparsec::VlobID::from_hex)]
+                #[arg(
+                    short,
+                    long,
+                    env = "PARSEC_WORKSPACE_ID",
+                    value_parser = libparsec::VlobID::from_hex,
+                    value_hint = clap::ValueHint::Other
+                )]
                 pub(crate) workspace: libparsec::VlobID,
                 $(
                     $(#[$field_attr])*
@@ -183,7 +201,7 @@ macro_rules! clap_parser_with_shared_opts_builder {
             $(#[$struct_attr])*
             $visibility struct $name {
                 #[doc = "Organization ID"]
-                #[arg(short, long, env = "PARSEC_ORGANIZATION_ID")]
+                #[arg(short, long, env = "PARSEC_ORGANIZATION_ID", value_hint = clap::ValueHint::Other)]
                 pub(crate) organization: libparsec::OrganizationID,
                 $(
                     $(#[$field_attr])*
@@ -234,7 +252,7 @@ macro_rules! clap_parser_with_shared_opts_builder {
             $(#[$struct_attr])*
             $visibility struct $name {
                 #[doc = "Server address (e.g: parsec3://127.0.0.1:6770?no_ssl=true)"]
-                #[arg(short, long, env = "PARSEC_SERVER_ADDR")]
+                #[arg(short, long, env = "PARSEC_SERVER_ADDR", value_hint = clap::ValueHint::Url)]
                 pub(crate) addr: libparsec::ParsecAddr,
                 $(
                     $(#[$field_attr])*
@@ -259,7 +277,7 @@ macro_rules! clap_parser_with_shared_opts_builder {
             $(#[$struct_attr])*
             $visibility struct $name {
                 #[doc = "Administration token"]
-                #[arg(short, long, env = "PARSEC_ADMINISTRATION_TOKEN")]
+                #[arg(short, long, env = "PARSEC_ADMINISTRATION_TOKEN", value_hint = clap::ValueHint::Other)]
                 pub(crate) token: String,
                 $(
                     $(#[$field_attr])*


### PR DESCRIPTION
- `value_hint` is used by `clap_complete` to generate completion script.
- Not all option have a value hint because some are already correctly handled by `clap_complete` (e.g.: `ValueEnum`)

  And a the worst case, we would always add them later.

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
