### PR TITLE
refactor server email templates

### DIFF
--- a/server/parsec/cli/render_email.py
+++ b/server/parsec/cli/render_email.py
@@ -20,6 +20,7 @@ from parsec.templates import get_environment
 
 DEFAULT_SENDER_EMAIL = EmailAddress("parsec@example.com")
 DEFAULT_RECIPIENT_EMAIL = EmailAddress("alice@example.com")
+DEFAULT_RECIPIENT_LABEL = "Alice"
 DEFAULT_ORGANIZATION_ID = OrganizationID("CoolOrg")
 DEFAULT_INVITATION_URL = "https://invitation.parsec.example.com"
 DEFAULT_BASE_SERVER_URL = "https://parsec.example.com"
@@ -74,6 +75,11 @@ def mail_templates_shared_options[**P, T](fn: Callable[P, T]) -> Callable[P, T]:
             default=DEFAULT_RECIPIENT_EMAIL.str,
         ),
         click.option(
+            "--recipient-label",
+            show_default=True,
+            default=DEFAULT_RECIPIENT_LABEL,
+        ),
+        click.option(
             "--output-dir",
             show_default=True,
             default=".",
@@ -125,6 +131,7 @@ def render_email():
 def invite(
     sender: EmailAddress,
     recipient: EmailAddress,
+    recipient_label: str,  # TODO: support user label
     invitation_type: InvitationType,
     organization_id: OrganizationID,
     invitation_url: str,
@@ -150,7 +157,7 @@ def invite(
     write_mail_file_to_filesystem(message, output_dir, "invitation_mail")
 
 
-@render_email.command(short_help="Generate account create validation email")
+@render_email.command(short_help="Generate Parsec Account create validation email")
 @mail_templates_shared_options
 @click.option(
     "--validation-code",
@@ -161,6 +168,7 @@ def invite(
 def account_create(
     sender: EmailAddress,
     recipient: EmailAddress,
+    recipient_label: str,  # TODO: support user label
     validation_code: ValidationCode,
     server_url: str,
     output_dir: Path,
@@ -178,7 +186,7 @@ def account_create(
     write_mail_file_to_filesystem(message, output_dir, "account_create_validation_email")
 
 
-@render_email.command(short_help="Generate account delete validation email")
+@render_email.command(short_help="Generate Parsec Account delete validation email")
 @mail_templates_shared_options
 @click.option(
     "--validation-code",
@@ -189,6 +197,7 @@ def account_create(
 def account_delete(
     sender: EmailAddress,
     recipient: EmailAddress,
+    recipient_label: str,  # TODO: support user label
     validation_code: ValidationCode,
     server_url: str,
     output_dir: Path,
@@ -219,6 +228,7 @@ def account_delete(
 def totp_reset(
     sender: EmailAddress,
     recipient: EmailAddress,
+    recipient_label: str,  # TODO: support user label
     organization_id: OrganizationID,
     totp_reset_url: str,
     server_url: str,
@@ -235,10 +245,10 @@ def totp_reset(
         server_url=server_url,
     )
 
-    write_mail_file_to_filesystem(message, output_dir, "account_delete_validation_email")
+    write_mail_file_to_filesystem(message, output_dir, "totp_reset_email")
 
 
-@render_email.command(short_help="Generate async enrollment email")
+@render_email.command(short_help="Generate async enrollment accepted email")
 @mail_templates_shared_options
 @click.option(
     "--organization-id", type=OrganizationID, default=DEFAULT_ORGANIZATION_ID, show_default=True
@@ -246,6 +256,7 @@ def totp_reset(
 def async_enroll(
     sender: EmailAddress,
     recipient: EmailAddress,
+    recipient_label: str,
     organization_id: OrganizationID,
     server_url: str,
     output_dir: Path,
@@ -257,7 +268,8 @@ def async_enroll(
         from_addr=sender,
         to_addr=recipient,
         organization_id=organization_id,
+        user_label=recipient_label,
         server_url=server_url,
     )
 
-    write_mail_file_to_filesystem(message, output_dir, "async_enrollment_accept")
+    write_mail_file_to_filesystem(message, output_dir, "async_enrollment_accepted_email")

--- a/server/parsec/components/async_enrollment.py
+++ b/server/parsec/components/async_enrollment.py
@@ -774,6 +774,7 @@ async def send_accepted_enrollment_email(
     config: BackendConfig,
     organization_id: OrganizationID,
     claimer_email: EmailAddress,
+    user_label: str,
 ) -> SendEmailBadOutcome | None:
     if not config.server_addr:
         return SendEmailBadOutcome.BAD_SMTP_CONFIG
@@ -782,6 +783,7 @@ async def send_accepted_enrollment_email(
         from_addr=config.email_config.sender,
         to_addr=claimer_email,
         organization_id=organization_id,
+        user_label=user_label,
         server_url=config.server_addr.to_http_url(),
     )
     return await send_email(
@@ -796,6 +798,7 @@ def generate_accepted_enrollment_email(
     from_addr: EmailAddress,
     to_addr: EmailAddress,
     organization_id: OrganizationID,
+    user_label: str,
     server_url: str,
 ) -> Message:
     # Quick fix to have a similar behavior between Rust and Python
@@ -803,17 +806,19 @@ def generate_accepted_enrollment_email(
 
     html = jinja_env.get_template("email/async_enrollment_accepted.html.j2").render(
         organization_id=organization_id.str,
+        user_label=user_label,
         server_url=server_url,
     )
     text = jinja_env.get_template("email/async_enrollment_accepted.txt.j2").render(
         organization_id=organization_id.str,
+        user_label=user_label,
         server_url=server_url,
     )
 
     # mail settings
     message = MIMEMultipart("alternative")
 
-    message["Subject"] = f"[Parsec] Request accepted to join {organization_id.str}"
+    message["Subject"] = f"[Parsec] Your request to join {organization_id.str} has been accepted"
     message["From"] = str(from_addr)
     message["To"] = str(to_addr)
 

--- a/server/parsec/components/memory/async_enrollment.py
+++ b/server/parsec/components/memory/async_enrollment.py
@@ -421,7 +421,10 @@ class MemoryAsyncEnrollmentComponent(BaseAsyncEnrollmentComponent):
             # Send mail
             if send_mail:
                 await send_accepted_enrollment_email(
-                    self._config, organization_id, u_certif.human_handle.email
+                    config=self._config,
+                    organization_id=organization_id,
+                    claimer_email=u_certif.human_handle.email,
+                    user_label=u_certif.human_handle.label,
                 )
 
             return u_certif, d_certif

--- a/server/parsec/components/postgresql/async_enrollment.py
+++ b/server/parsec/components/postgresql/async_enrollment.py
@@ -222,9 +222,10 @@ class PGAsyncEnrollmentComponent(BaseAsyncEnrollmentComponent):
         # operation can be long.
         if send_mail:
             mail_outcome = await send_accepted_enrollment_email(
-                self._config,
+                config=self._config,
                 organization_id=organization_id,
                 claimer_email=user_cert.human_handle.email,
+                user_label=user_cert.human_handle.label,
             )
             match mail_outcome:
                 case None:

--- a/server/parsec/templates/email/README.md
+++ b/server/parsec/templates/email/README.md
@@ -1,0 +1,21 @@
+# README
+
+This directory contains email templates used by Parsec Server.
+
+The templates are written in [Jinja format](https://jinja.palletsprojects.com/en/stable/templates/).
+
+## Email templates in plain text
+
+For plain text templates, extend the base template and define the following jinja blocks:
+
+- `main_content`: the main content of the email
+
+## Email templates in HTML
+
+For HTML templates, extend the base template and define the following jinja blocks:
+
+- `document_title`: the title for the `<head>` element, in the browser's title bar or the page's tab
+- `preheader`: ???
+- `title`: the title for the email content (not to be confused with the email subject)
+- `description`: a short description of the email purpose
+- `main_content`: the main content of the email

--- a/server/parsec/templates/email/account_create.html.j2
+++ b/server/parsec/templates/email/account_create.html.j2
@@ -1,9 +1,11 @@
 {% extends "email/base.html.j2" %}
-{% block document_title %}Parsec Account: Confirm your email address{% endblock %}
+{% block document_title %}Parsec Account creation{% endblock %}
 
-{% block preheader %}Please confirm your email address to get started with your Parsec Account.{% endblock %}
+{% block preheader %}Confirm your email address to get started with your Parsec Account.{% endblock %}
 
 {% block title %}Confirm your email address{% endblock %}
+
+{% block description %}Please confirm your email address to get started with your Parsec Account.{% endblock %}
 
 {% block main_content %}
 {% from "email/macros.html.j2" import gen_contents, render_link, render_fallback_link, render_code %}

--- a/server/parsec/templates/email/account_create.txt.j2
+++ b/server/parsec/templates/email/account_create.txt.j2
@@ -1,17 +1,14 @@
-Hello!
-
+{% extends "email/base.txt.j2" %}
+{% block main_content %}
 Please confirm your email address to get started with your Parsec Account.
 
 To confirm your email address:
 
-1. Make sure to download and install Parsec app (https://parsec.cloud/en/start-parsec)
+1. If you haven't already, download and install Parsec: https://parsec.cloud/en/start-parsec
 2. Once installed, use the following code to confirm your email address:
+
 {{ validation_code }}
 
-Thank you,
-
-Parsec Cloud team
-https://parsec.cloud/
-
-If you didn’t request this email, then someone has probably entered your email address by mistake.
-Sorry about that. You can safely ignore this email or get in touch with us to report it.
+If you didn't request this email, then someone has probably entered your email address by mistake.
+You can safely ignore this email or get in touch with us to report it.
+{% endblock %}

--- a/server/parsec/templates/email/account_delete.html.j2
+++ b/server/parsec/templates/email/account_delete.html.j2
@@ -1,9 +1,11 @@
 {% extends "email/base.html.j2" %}
-{% block document_title %}Parsec Account: Confirm account deletion{% endblock %}
+{% block document_title %}Parsec Account deletion{% endblock %}
 
 {% block preheader %}You have requested to delete your Parsec Account.{% endblock %}
 
 {% block title %}Confirm your Parsec Account deletion{% endblock %}
+
+{% block description %}You will find below the code to confirm your Parsec Account deletion.{% endblock %}
 
 {% block main_content %}
 {% from "email/macros.html.j2" import gen_contents, render_code %}

--- a/server/parsec/templates/email/account_delete.txt.j2
+++ b/server/parsec/templates/email/account_delete.txt.j2
@@ -1,15 +1,11 @@
-Hello!
-
+{% extends "email/base.txt.j2" %}
+{% block main_content %}
 You have requested to delete your Parsec Account.
 
 To confirm your Parsec Account deletion, use the following code:
 
 {{ validation_code }}
 
-Thank you,
-
-Parsec Cloud team
-https://parsec.cloud/
-
-If you didn’t request this email, then someone has access to your account you should take the appropriate actions.
-Sorry about that. You can safely ignore this email or get in touch with us to report it.
+If you didn't request this email, someone may have accessed your account.
+Please get in touch with us to report it.
+{% endblock %}

--- a/server/parsec/templates/email/account_recover.html.j2
+++ b/server/parsec/templates/email/account_recover.html.j2
@@ -1,9 +1,11 @@
 {% extends "email/base.html.j2" %}
-{% block document_title %}Parsec Account: Confirm account recovery{% endblock %}
+{% block document_title %}Parsec Account recovery{% endblock %}
 
 {% block preheader %}You have requested to recover your Parsec Account.{% endblock %}
 
-{% block title %}Your account recovery code{% endblock %}
+{% block title %}Confirm your Parsec Account recovery{% endblock %}
+
+{% block description %}You will find below the code to confirm your Parsec Account recovery.{% endblock %}
 
 {% block main_content %}
 {% from "email/macros.html.j2" import gen_contents, render_code %}

--- a/server/parsec/templates/email/account_recover.txt.j2
+++ b/server/parsec/templates/email/account_recover.txt.j2
@@ -1,15 +1,11 @@
-Hello!
-
+{% extends "email/base.txt.j2" %}
+{% block main_content %}
 You have requested to recover your Parsec Account.
 
-To confirm the recovery, use the following code:
+To confirm your Parsec Account recovery, use the following code:
 
 {{ validation_code }}
 
-Thank you,
-
-Parsec Cloud team
-https://parsec.cloud/
-
-If you didn’t request this email, then someone has access to your account you should take the appropriate actions.
-Sorry about that. You can safely ignore this email or get in touch with us to report it.
+If you didn't request this email, someone may have accessed your account.
+Please get in touch with us to report it.
+{% endblock %}

--- a/server/parsec/templates/email/async_enrollment_accepted.html.j2
+++ b/server/parsec/templates/email/async_enrollment_accepted.html.j2
@@ -1,25 +1,30 @@
 {% extends "email/base.html.j2" %}
 
-{% block document_title %}Join request accepted{% endblock %}
+{% block document_title %}Parsec join request accepted{% endblock %}
 
 {% block preheader %}Your request to join {{ organization_id }} has been accepted.{% endblock %}
 
 {% block title %}You are now part of {{ organization_id }}{% endblock %}
 
+{% block description %}Your request to join <b>{{ organization_id }}</b> has been accepted.{% endblock %}
+
 {% block main_content %}
-{% from "email/macros.html.j2" import render_note %}
-
-<p>Your request to join <strong>{{ organization_id }}</strong> has been accepted.</p>
-
-<p>Follow the next steps to add it to your organizations:
-<ol>
-  <li><strong>Open Parsec</strong>: {{ server_url }}</li>
-  <li>Choose to continue on <strong>Web</strong> or <strong>Desktop</strong> depending on where you submitted your join request</li>
-  <li>Click on <strong>Add to my organizations</strong> next to your join request</li>
-</ol>
-</p>
-
-<p>You can now log into {{ organization_id }} and start sharing your data securely.</p>
+{% from "email/macros.html.j2" import gen_contents, render_link, render_fallback_link, render_note %}
+{{
+  gen_contents([
+    namespace(
+      title="Open Parsec",
+      text="Open Parsec and continue on <strong>Web</strong> or <strong>Desktop</strong> depending on where you submitted your join request from.",
+      extras=[
+        render_link(server_url, "Open Parsec")
+      ]
+    ),
+    namespace(
+      title="Add your new organization",
+      text="Click on <strong>Add to my organizations</strong> next to your join request. You can now login and start sharing your data securely.",
+    )
+  ])
+}}
 
 {% call render_note() %}
 <p style="font-size: 14px; color: #51517B; padding-bottom: 8px;">

--- a/server/parsec/templates/email/async_enrollment_accepted.txt.j2
+++ b/server/parsec/templates/email/async_enrollment_accepted.txt.j2
@@ -1,5 +1,5 @@
-Hi,
-
+{% extends "email/base.txt.j2" %}
+{% block main_content %}
 Your request to join {{ organization_id }} has been accepted.
 
 Follow the next steps to add it to your organizations:
@@ -12,8 +12,4 @@ You can now log into {{ organization_id }} and start sharing your data securely.
 
 For more information please refer to the User Guide:
 https://docs.parsec.cloud/en/stable/userguide/join-organization.html#join-an-organization-with-a-join-request
-
-
-Thank you,
-Parsec Cloud team
-https://parsec.cloud/
+{% endblock %}

--- a/server/parsec/templates/email/base.html.j2
+++ b/server/parsec/templates/email/base.html.j2
@@ -26,10 +26,23 @@
                   </td>
                 </tr>
                 <tr class="title">
-                  <td><h1>{% block title %}{% endblock %}</h1></td>
+                  <td><h1 style="padding-bottom: 10px;">{% block title %}{% endblock %}</h1></td>
                 </tr>
+                {% if user_label is defined %}
                 <tr>
-                  <td>{% block description %}{% endblock %}</td>
+                  <td>
+                    <p style="line-height: 1.6; color: #51517B; font-size: 16px;">
+                    Hi {{ user_label }},
+                    </p>
+                  </td>
+                </tr>
+                {% endif %}
+                <tr>
+                  <td>
+                    <p style="line-height: 1.6; color: #51517B; font-size: 16px;">
+                    {% block description %}{% endblock %}
+                    </p>
+                  </td>
                 </tr>
               </table>
             </td>

--- a/server/parsec/templates/email/base.txt.j2
+++ b/server/parsec/templates/email/base.txt.j2
@@ -1,0 +1,6 @@
+{% if user_label is defined %}Hi {{ user_label }},{% endif %}
+{% block main_content required %}{% endblock %}
+
+Thank you,
+The Parsec team
+https://parsec.cloud/

--- a/server/parsec/templates/email/footer.html.j2
+++ b/server/parsec/templates/email/footer.html.j2
@@ -6,7 +6,7 @@
                     <table cellspacing="0" cellpadding="0" align="left">
                         <tr>
                             <td>
-                                <p>Sincerely,<br />
+                                <p>Thank you,<br />
                                 The Parsec team</p>
                             </td>
                         </tr>

--- a/server/parsec/templates/email/invitation.html.j2
+++ b/server/parsec/templates/email/invitation.html.j2
@@ -1,26 +1,23 @@
 {% extends "email/base.html.j2" %}
-{% block document_title %}Parsec Invitation{% endblock %}
+{% block document_title %}Parsec invitation{% endblock %}
 
-{% block preheader %}Follow these steps to join your new workspace on Parsec.{% endblock %}
+{% block preheader %}You have been invited to join {{ organization_id }} on Parsec.{% endblock %}
 
 {% block title %}
-{% if is_user_invitation %}
-Invitation to join the organization {{ organization_id}}
+{% if is_user_invitation %}You have been invited to join {{ organization_id }}
+{% elif is_device_invitation %}You want to add a new device for {{ organization_id }}
+{% elif is_shamir_recovery_invitation %}You have been invited to recover access to {{ organization_id }}
 {% endif %}
 {% endblock %}
 
 {% block description %}
-<p style="line-height: 28.9px; color: #51517B; font-size: 16px;">
 {% if is_user_invitation %}
 You have received an invitation from <b>{{ greeter }}</b> to join the <b>{{ organization_id }}</b> organization on Parsec.
 {% elif is_device_invitation %}
-You have received an invitation to add a new device to the <b>{{ organization_id }}</b>
-organization on Parsec.
+You want to add a new device for the <b>{{ organization_id }}</b> organization on Parsec.
 {% elif is_shamir_recovery_invitation %}
-You have received an invitation to start a recovery procedure on the <b>{{ organization_id }}</b>
-organization on Parsec.
+You have received an invitation to recover access to the <b>{{ organization_id }}</b> organization on Parsec.
 {% endif %}
-</p>
 {% endblock %}
 
 {% block main_content %}

--- a/server/parsec/templates/email/invitation.txt.j2
+++ b/server/parsec/templates/email/invitation.txt.j2
@@ -1,25 +1,18 @@
-{% if is_user_invitation %}
-You have received an invitation from {{ greeter }} to join the {{ organization_id }} organization on Parsec.
-{% elif is_device_invitation %}
-You have received an invitation to add a new device to the {{ organization_id}} organization on Parsec.
-{% elif is_shamir_recovery_invitation %}
-You have received an invitation to start a recovery procedure on the {{ organization_id }} organization on Parsec.
+{% extends "email/base.txt.j2" %}
+{% block main_content %}
+{% if is_user_invitation %}You have received an invitation from {{ greeter }} to join the {{ organization_id }} organization on Parsec.
+{% elif is_device_invitation %}You have received an invitation to add a new device to the {{ organization_id}} organization on Parsec.
+{% elif is_shamir_recovery_invitation %}You have received an invitation to start a recovery procedure on the {{ organization_id }} organization on Parsec.
 {% endif %}
-
 Your next steps:
 
-1. If you haven't yet installed, download the Parsec client via the following link: https://parsec.cloud/en/start-parsec
-
+1. If you haven't already, download and install Parsec: https://parsec.cloud/en/start-parsec
 2. Once installed, open the following link to proceed to Parsec: {{ invitation_url }}
-
-{% if is_user_invitation %}
-3. Get in touch with {{ greeter }} and follow the next steps on the Parsec client.
-{% elif is_device_invitation %}
-3. Start the invitation process from a device already part of the organization,
+{% if is_user_invitation %}3. Get in touch with {{ greeter }} and follow the next steps on the Parsec client.
+{% elif is_device_invitation %}3. Start the invitation process from a device already part of the organization,
 then follow the steps on the Parsec client.
-{% elif is_shamir_recovery_invitation %}
-3. Get in touch with {{ greeter }} and follow the next steps on the Parsec client.
+{% elif is_shamir_recovery_invitation %}3. Get in touch with {{ greeter }} and follow the next steps on the Parsec client.
 {% endif %}
-
 For more information please refer to the User Guide:
 https://docs.parsec.cloud/en/stable/userguide/join-organization.html
+{% endblock %}

--- a/server/parsec/templates/email/macros.html.j2
+++ b/server/parsec/templates/email/macros.html.j2
@@ -41,9 +41,7 @@
 
 {% macro render_note() %}
 <tr class="content-footer">
-    <td class="note">
-        {{ caller() }}
-    </td>
+  <td class="note">{{ caller() }}</td>
 </tr>
 {% endmacro %}
 
@@ -55,9 +53,9 @@ origin page using window.opener unless link type noopener or noreferrer is speci
 
 {% macro render_fallback_link(url) %}
 <p style="font-size: 14px; color: #51517B;">
-    If the button does not work, please click on the following link:
+  If the button does not work, please click on the following link:
+  <a href="{{ url }}" style="font-size: 13px; color: #51517B;" rel="noopener noreferrer" target="_blank">{{ url }}</a>
 </p>
-<a href="{{ url }}" style="font-size: 13px; color: #51517B;" rel="noopener noreferrer" target="_blank">{{ url }}</a>
 {% endmacro %}
 
 {% macro render_code(code) %}

--- a/server/parsec/templates/email/totp_reset.html.j2
+++ b/server/parsec/templates/email/totp_reset.html.j2
@@ -1,26 +1,20 @@
 {% extends "email/base.html.j2" %}
-{% block document_title %}Your MFA has been reset in Parsec{% endblock %}
 
-{% block preheader %}Your MFA has been reset for the {{ organization_id }} organization in Parsec.{% endblock %}
+{% block document_title %}Parsec MFA reset{% endblock %}
 
-{% block title %}
-Your MFA has been reset for <b>{{ organization_id }}</b>
-{% endblock %}
+{% block preheader %}Your MFA has been reset for <b>{{ organization_id }}{% endblock %}
 
-{% block description %}
-<p style="line-height: 28.9px; color: #51517B; font-size: 16px;">
-Your MFA (Multi-Factor Authentication) has been reset for the <b>{{ organization_id }}</b> organization in Parsec.
-</p>
-{% endblock %}
+{% block title %}Your MFA has been reset for <b>{{ organization_id }}</b>{% endblock %}
+
+{% block description %}Your MFA has been reset for the <b>{{ organization_id }}</b>.{% endblock %}
 
 {% block main_content %}
 {% from "email/macros.html.j2" import gen_contents, render_link, render_fallback_link, render_note %}
-
 {{
   gen_contents([
     namespace(
-      title="Re-enable MFA",
-      text="Use the link below to re-enable MFA:",
+      title="Enable MFA",
+      text="Click on the following link to re-enable MFA:",
       extras=[
         render_link(totp_reset_url, "Enable MFA"),
         render_fallback_link(totp_reset_url)

--- a/server/parsec/templates/email/totp_reset.txt.j2
+++ b/server/parsec/templates/email/totp_reset.txt.j2
@@ -1,8 +1,11 @@
+{% extends "email/base.txt.j2" %}
+{% block main_content %}
 Your MFA (Multi-Factor Authentication) has been reset for the {{ organization_id }} organization in Parsec.
 
-Use the link below to re-enable MFA.
+Use the link below to re-enable MFA:
 
 {{ totp_reset_url }}
 
 For more information please refer to the User Guide:
 https://docs.parsec.cloud/en/stable/userguide/mfa.html
+{% endblock %}

--- a/server/tests/cli/test_render_email.py
+++ b/server/tests/cli/test_render_email.py
@@ -1,0 +1,33 @@
+# Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from parsec.cli import cli
+
+
+@pytest.mark.parametrize(
+    "args",
+    (
+        ["render_email", "account-create"],
+        ["render_email", "account-delete"],
+        # ["render_email", "account-recover"],  # TODO: does not exist yet
+        ["render_email", "async-enroll"],
+        ["render_email", "invite"],
+        ["render_email", "totp-reset"],
+    ),
+    ids=[
+        "account-create",
+        "account-delete",
+        # "account-recover",  # TODO: does not exist yet
+        "async-enroll",
+        "invite",
+        "totp-reset",
+    ],
+)
+def test_render_email(args: list[str]) -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, args)
+    # Minimal test, just check the command does not fail
+    assert result.exit_code == 0, result.output


### PR DESCRIPTION
- Add missing tests for `render_email` command
- Add email greeting to base templates (e.g. "Hi Alice")
  - currently only supported for the async enrollment accepted email
- Add `base.txt.j2` for text templates to reuse common texts
- Add missing `description` block to Parsec Account emails
- Add missing `title` blocks for _device_ and _shamir_ invitation emails
- Update async enrollment accepted email to use the "namespace approach"
  to render steps (to be consistent with `invite` and `totp-reset` emails)
- Add `README.md` describing template syntax
