### PR TITLE
refactor(cli): Add todo placeholder for ui integration

### DIFF
--- a/cli/src/commands/certificate/forget_all_certificates.rs
+++ b/cli/src/commands/certificate/forget_all_certificates.rs
@@ -12,7 +12,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, forget_all_certificates);
 
-pub async fn forget_all_certificates(_args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn forget_all_certificates(
+    _todo_ui: crate::Ui,
+    _args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     let short_id = &client.device_id().hex()[..3];
     let organization_id = client.organization_id();
     let human_handle = client.human_handle();

--- a/cli/src/commands/certificate/mod.rs
+++ b/cli/src/commands/certificate/mod.rs
@@ -16,9 +16,9 @@ pub enum Group {
     ForgetAllCertificates(forget_all_certificates::Args),
 }
 
-pub async fn dispatch_command(command: Group) -> anyhow::Result<()> {
+pub async fn dispatch_command(ui: crate::Ui, command: Group) -> anyhow::Result<()> {
     match command {
-        Group::Poll(args) => poll::main(args).await,
-        Group::ForgetAllCertificates(args) => forget_all_certificates::main(args).await,
+        Group::Poll(args) => poll::main(ui, args).await,
+        Group::ForgetAllCertificates(args) => forget_all_certificates::main(ui, args).await,
     }
 }

--- a/cli/src/commands/certificate/poll.rs
+++ b/cli/src/commands/certificate/poll.rs
@@ -10,7 +10,7 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, poll);
 
-pub async fn poll(_args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn poll(_todo_ui: crate::Ui, _args: Args, client: &StartedClient) -> anyhow::Result<()> {
     let mut spinner = start_spinner("Poll server for new certificates".into());
     let new_certificates = client.poll_server_for_new_certificates().await?;
     spinner.stop_with_message(format!(

--- a/cli/src/commands/device/change_authentication.rs
+++ b/cli/src/commands/device/change_authentication.rs
@@ -21,7 +21,7 @@ enum NewAccessStrategyChoice {
     Keyring,
 }
 
-pub async fn main(args: Args) -> anyhow::Result<()> {
+pub async fn main(_todo_ui: crate::Ui, args: Args) -> anyhow::Result<()> {
     let device = load_device_file(&args.config_dir, args.device).await?;
 
     let new_save_strategy_choice = match (args.password, args.keyring) {

--- a/cli/src/commands/device/export_recovery_device.rs
+++ b/cli/src/commands/device/export_recovery_device.rs
@@ -17,7 +17,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, export_recovery_device);
 
-pub async fn export_recovery_device(args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn export_recovery_device(
+    _todo_ui: crate::Ui,
+    args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     let Args { output, .. } = args;
     log::trace!("Exporting recovery device at {}", output.display());
 

--- a/cli/src/commands/device/import_recovery_device.rs
+++ b/cli/src/commands/device/import_recovery_device.rs
@@ -18,7 +18,7 @@ crate::clap_parser_with_shared_opts_builder!(
     }
 );
 
-pub async fn main(args: Args) -> anyhow::Result<()> {
+pub async fn main(_todo_ui: crate::Ui, args: Args) -> anyhow::Result<()> {
     let Args {
         input,
         config_dir,

--- a/cli/src/commands/device/mod.rs
+++ b/cli/src/commands/device/mod.rs
@@ -29,9 +29,9 @@ pub async fn dispatch_command(ui: crate::Ui, command: Group) -> anyhow::Result<(
     match command {
         Group::ForgetLocal(args) => forget_local::main(ui, args).await,
         Group::List(args) => list::main(ui, args).await,
-        Group::ChangeAuthentication(args) => change_authentication::main(args).await,
-        Group::ExportRecoveryDevice(args) => export_recovery_device::main(args).await,
-        Group::ImportRecoveryDevice(args) => import_recovery_device::main(args).await,
-        Group::OverwriteServerURL(args) => overwrite_server_url::main(args).await,
+        Group::ChangeAuthentication(args) => change_authentication::main(ui, args).await,
+        Group::ExportRecoveryDevice(args) => export_recovery_device::main(ui, args).await,
+        Group::ImportRecoveryDevice(args) => import_recovery_device::main(ui, args).await,
+        Group::OverwriteServerURL(args) => overwrite_server_url::main(ui, args).await,
     }
 }

--- a/cli/src/commands/device/overwrite_server_url.rs
+++ b/cli/src/commands/device/overwrite_server_url.rs
@@ -17,7 +17,7 @@ crate::clap_parser_with_shared_opts_builder!(
     }
 );
 
-pub async fn main(args: Args) -> anyhow::Result<()> {
+pub async fn main(_todo_ui: crate::Ui, args: Args) -> anyhow::Result<()> {
     let device = load_device_file(&args.config_dir, args.device).await?;
 
     if device.totp_opaque_key_id.is_some() {

--- a/cli/src/commands/invite/cancel.rs
+++ b/cli/src/commands/invite/cancel.rs
@@ -16,7 +16,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, invite_cancel);
 
-pub async fn invite_cancel(args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn invite_cancel(
+    _todo_ui: crate::Ui,
+    args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     let Args { token, .. } = args;
     log::trace!("Cancelling invitation");
 

--- a/cli/src/commands/invite/claim.rs
+++ b/cli/src/commands/invite/claim.rs
@@ -41,7 +41,7 @@ enum SaveMode {
     Keyring,
 }
 
-pub async fn main(args: Args) -> anyhow::Result<()> {
+pub async fn main(_todo_ui: crate::Ui, args: Args) -> anyhow::Result<()> {
     let Args {
         config_dir,
         data_dir,

--- a/cli/src/commands/invite/device.rs
+++ b/cli/src/commands/invite/device.rs
@@ -12,7 +12,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, invite_device);
 
-pub async fn invite_device(_args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn invite_device(
+    _todo_ui: crate::Ui,
+    _args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     log::trace!("Inviting a device");
 
     let mut handle = start_spinner("Creating device invitation".into());

--- a/cli/src/commands/invite/greet.rs
+++ b/cli/src/commands/invite/greet.rs
@@ -29,7 +29,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, device_greet);
 
-pub async fn device_greet(args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn device_greet(
+    _todo_ui: crate::Ui,
+    args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     let Args { token, .. } = args;
     log::trace!("Greeting invitation");
 

--- a/cli/src/commands/invite/list.rs
+++ b/cli/src/commands/invite/list.rs
@@ -11,7 +11,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, list_invite);
 
-pub async fn list_invite(_args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn list_invite(
+    _todo_ui: crate::Ui,
+    _args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     log::trace!("Listing invitations");
     poll_server_for_new_certificates(client).await?;
 

--- a/cli/src/commands/invite/mod.rs
+++ b/cli/src/commands/invite/mod.rs
@@ -24,14 +24,14 @@ pub enum Group {
     SharedRecovery(shared_recovery::Args),
 }
 
-pub async fn dispatch_command(command: Group) -> anyhow::Result<()> {
+pub async fn dispatch_command(ui: crate::Ui, command: Group) -> anyhow::Result<()> {
     match command {
-        Group::Cancel(args) => cancel::main(args).await,
-        Group::Claim(args) => claim::main(args).await,
-        Group::Greet(args) => greet::main(args).await,
-        Group::List(args) => list::main(args).await,
-        Group::User(args) => user::main(args).await,
-        Group::Device(args) => device::main(args).await,
-        Group::SharedRecovery(args) => shared_recovery::main(args).await,
+        Group::Cancel(args) => cancel::main(ui, args).await,
+        Group::Claim(args) => claim::main(ui, args).await,
+        Group::Greet(args) => greet::main(ui, args).await,
+        Group::List(args) => list::main(ui, args).await,
+        Group::User(args) => user::main(ui, args).await,
+        Group::Device(args) => device::main(ui, args).await,
+        Group::SharedRecovery(args) => shared_recovery::main(ui, args).await,
     }
 }

--- a/cli/src/commands/invite/shared_recovery.rs
+++ b/cli/src/commands/invite/shared_recovery.rs
@@ -18,7 +18,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, invite_shared_recovery);
 
-pub async fn invite_shared_recovery(args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn invite_shared_recovery(
+    _todo_ui: crate::Ui,
+    args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     let Args {
         email, send_email, ..
     } = args;

--- a/cli/src/commands/invite/user.rs
+++ b/cli/src/commands/invite/user.rs
@@ -19,7 +19,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, invite_user);
 
-pub async fn invite_user(args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn invite_user(
+    _todo_ui: crate::Ui,
+    args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     let Args {
         email, send_email, ..
     } = args;

--- a/cli/src/commands/ls.rs
+++ b/cli/src/commands/ls.rs
@@ -13,7 +13,7 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, ls);
 
-pub async fn ls(args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn ls(_todo_ui: crate::Ui, args: Args, client: &StartedClient) -> anyhow::Result<()> {
     let Args {
         workspace, path, ..
     } = args;

--- a/cli/src/commands/mount_realm_export.rs
+++ b/cli/src/commands/mount_realm_export.rs
@@ -55,7 +55,7 @@ impl std::str::FromStr for Decryptor {
     }
 }
 
-pub async fn main(args: Args) -> anyhow::Result<()> {
+pub async fn main(_todo_ui: crate::Ui, args: Args) -> anyhow::Result<()> {
     let Args {
         config_dir,
         password_stdin,

--- a/cli/src/commands/organization/bootstrap.rs
+++ b/cli/src/commands/organization/bootstrap.rs
@@ -63,7 +63,7 @@ pub async fn bootstrap_organization_req(
     .map_err(anyhow::Error::from)
 }
 
-pub async fn main(args: Args) -> anyhow::Result<()> {
+pub async fn main(_todo_ui: crate::Ui, args: Args) -> anyhow::Result<()> {
     let Args {
         email,
         label,

--- a/cli/src/commands/organization/create.rs
+++ b/cli/src/commands/organization/create.rs
@@ -69,7 +69,7 @@ pub async fn create_organization_req(
     }
 }
 
-pub async fn main(args: Args) -> anyhow::Result<()> {
+pub async fn main(_todo_ui: crate::Ui, args: Args) -> anyhow::Result<()> {
     let Args {
         organization,
         token,

--- a/cli/src/commands/organization/mod.rs
+++ b/cli/src/commands/organization/mod.rs
@@ -15,11 +15,11 @@ pub enum Group {
     Status(status::Args),
 }
 
-pub async fn dispatch_command(command: Group) -> anyhow::Result<()> {
+pub async fn dispatch_command(ui: crate::Ui, command: Group) -> anyhow::Result<()> {
     match command {
-        Group::Bootstrap(args) => bootstrap::main(args).await,
-        Group::Create(args) => create::main(args).await,
-        Group::Stats(args) => stats::main(args).await,
-        Group::Status(args) => status::main(args).await,
+        Group::Bootstrap(args) => bootstrap::main(ui, args).await,
+        Group::Create(args) => create::main(ui, args).await,
+        Group::Stats(args) => stats::main(ui, args).await,
+        Group::Status(args) => status::main(ui, args).await,
     }
 }

--- a/cli/src/commands/organization/stats.rs
+++ b/cli/src/commands/organization/stats.rs
@@ -29,7 +29,7 @@ pub async fn stats_organization_req(
     Ok(rep.json::<Value>().await?)
 }
 
-pub async fn main(args: Args) -> anyhow::Result<()> {
+pub async fn main(_todo_ui: crate::Ui, args: Args) -> anyhow::Result<()> {
     let Args {
         organization,
         token,

--- a/cli/src/commands/organization/status.rs
+++ b/cli/src/commands/organization/status.rs
@@ -29,7 +29,7 @@ pub async fn status_organization_req(
     Ok(rep.json::<Value>().await?)
 }
 
-pub async fn main(args: Args) -> anyhow::Result<()> {
+pub async fn main(_todo_ui: crate::Ui, args: Args) -> anyhow::Result<()> {
     let Args {
         organization,
         token,

--- a/cli/src/commands/rm.rs
+++ b/cli/src/commands/rm.rs
@@ -13,7 +13,7 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, rm);
 
-pub async fn rm(args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn rm(_todo_ui: crate::Ui, args: Args, client: &StartedClient) -> anyhow::Result<()> {
     let Args {
         workspace, path, ..
     } = args;

--- a/cli/src/commands/run_testenv.rs
+++ b/cli/src/commands/run_testenv.rs
@@ -29,7 +29,7 @@ pub struct RunTestenv {
     organization: libparsec::OrganizationID,
 }
 
-pub async fn run_testenv(run_testenv: RunTestenv) -> anyhow::Result<()> {
+pub async fn run_testenv(_todo_ui: crate::Ui, run_testenv: RunTestenv) -> anyhow::Result<()> {
     let RunTestenv {
         main_process_id,
         source_file,

--- a/cli/src/commands/server/mod.rs
+++ b/cli/src/commands/server/mod.rs
@@ -6,8 +6,8 @@ pub enum Group {
     Stats(stats::Args),
 }
 
-pub async fn dispatch_command(command: Group) -> anyhow::Result<()> {
+pub async fn dispatch_command(ui: crate::Ui, command: Group) -> anyhow::Result<()> {
     match command {
-        Group::Stats(args) => stats::main(args).await,
+        Group::Stats(args) => stats::main(ui, args).await,
     }
 }

--- a/cli/src/commands/server/stats.rs
+++ b/cli/src/commands/server/stats.rs
@@ -67,7 +67,7 @@ pub async fn stats_server_req(
         .await?)
 }
 
-pub async fn main(args: Args) -> anyhow::Result<()> {
+pub async fn main(_todo_ui: crate::Ui, args: Args) -> anyhow::Result<()> {
     let Args {
         format,
         end_date,

--- a/cli/src/commands/shared_recovery/create.rs
+++ b/cli/src/commands/shared_recovery/create.rs
@@ -67,7 +67,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, create_shared_recovery);
 
-pub async fn create_shared_recovery(args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn create_shared_recovery(
+    _todo_ui: crate::Ui,
+    args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     let Args {
         recipients,
         threshold,

--- a/cli/src/commands/shared_recovery/delete.rs
+++ b/cli/src/commands/shared_recovery/delete.rs
@@ -8,7 +8,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 build_main_with_client!(main, delete_shared_recovery);
 
-pub async fn delete_shared_recovery(_args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn delete_shared_recovery(
+    _todo_ui: crate::Ui,
+    _args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     poll_server_for_new_certificates(client).await?;
 
     let mut handle = start_spinner("Deleting shared recovery setup".into());

--- a/cli/src/commands/shared_recovery/info.rs
+++ b/cli/src/commands/shared_recovery/info.rs
@@ -12,7 +12,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 build_main_with_client!(main, shared_recovery_info);
 
-pub async fn shared_recovery_info(_args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn shared_recovery_info(
+    _todo_ui: crate::Ui,
+    _args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     poll_server_for_new_certificates(client).await?;
 
     let info = client.get_self_shamir_recovery().await?;

--- a/cli/src/commands/shared_recovery/list.rs
+++ b/cli/src/commands/shared_recovery/list.rs
@@ -12,7 +12,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 build_main_with_client!(main, shared_recovery_list);
 
-pub async fn shared_recovery_list(_args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn shared_recovery_list(
+    _todo_ui: crate::Ui,
+    _args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     poll_server_for_new_certificates(client).await?;
 
     let res = client.list_shamir_recoveries_for_others().await?;

--- a/cli/src/commands/shared_recovery/mod.rs
+++ b/cli/src/commands/shared_recovery/mod.rs
@@ -15,11 +15,11 @@ pub enum Group {
     Info(info::Args),
 }
 
-pub async fn dispatch_command(command: Group) -> anyhow::Result<()> {
+pub async fn dispatch_command(ui: crate::Ui, command: Group) -> anyhow::Result<()> {
     match command {
-        Group::Create(args) => create::main(args).await,
-        Group::List(args) => list::main(args).await,
-        Group::Delete(args) => delete::main(args).await,
-        Group::Info(args) => info::main(args).await,
+        Group::Create(args) => create::main(ui, args).await,
+        Group::List(args) => list::main(ui, args).await,
+        Group::Delete(args) => delete::main(ui, args).await,
+        Group::Info(args) => info::main(ui, args).await,
     }
 }

--- a/cli/src/commands/tos/accept.rs
+++ b/cli/src/commands/tos/accept.rs
@@ -12,7 +12,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, accept_tos);
 
-pub async fn accept_tos(args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn accept_tos(
+    _todo_ui: crate::Ui,
+    args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     let Args { yes, .. } = args;
 
     let tos = match client.get_tos().await {

--- a/cli/src/commands/tos/config.rs
+++ b/cli/src/commands/tos/config.rs
@@ -18,7 +18,7 @@ crate::clap_parser_with_shared_opts_builder!(
     }
 );
 
-pub async fn main(args: Args) -> anyhow::Result<()> {
+pub async fn main(_todo_ui: crate::Ui, args: Args) -> anyhow::Result<()> {
     let Args {
         organization,
         token,

--- a/cli/src/commands/tos/list.rs
+++ b/cli/src/commands/tos/list.rs
@@ -10,7 +10,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, list_tos);
 
-pub async fn list_tos(_args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn list_tos(
+    _todo_ui: crate::Ui,
+    _args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     log::trace!("Listing Term of Service");
 
     match client.get_tos().await {

--- a/cli/src/commands/tos/mod.rs
+++ b/cli/src/commands/tos/mod.rs
@@ -12,10 +12,10 @@ pub enum Group {
     Accept(accept::Args),
 }
 
-pub async fn dispatch_command(command: Group) -> anyhow::Result<()> {
+pub async fn dispatch_command(ui: crate::Ui, command: Group) -> anyhow::Result<()> {
     match command {
-        Group::List(args) => list::main(args).await,
-        Group::Config(args) => config::main(args).await,
-        Group::Accept(args) => accept::main(args).await,
+        Group::List(args) => list::main(ui, args).await,
+        Group::Config(args) => config::main(ui, args).await,
+        Group::Accept(args) => accept::main(ui, args).await,
     }
 }

--- a/cli/src/commands/user/list.rs
+++ b/cli/src/commands/user/list.rs
@@ -13,7 +13,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, list_user);
 
-pub async fn list_user(args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn list_user(
+    _todo_ui: crate::Ui,
+    args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     let Args { skip_revoked, .. } = args;
     log::trace!("Listing users (skip_revoked={skip_revoked})");
 

--- a/cli/src/commands/user/mod.rs
+++ b/cli/src/commands/user/mod.rs
@@ -12,10 +12,10 @@ pub enum Group {
     TotpReset(totp_reset::Args),
 }
 
-pub async fn dispatch_command(command: Group) -> anyhow::Result<()> {
+pub async fn dispatch_command(ui: crate::Ui, command: Group) -> anyhow::Result<()> {
     match command {
-        Group::List(args) => list::main(args).await,
-        Group::Revoke(args) => revoke::main(args).await,
-        Group::TotpReset(args) => totp_reset::main(args).await,
+        Group::List(args) => list::main(ui, args).await,
+        Group::Revoke(args) => revoke::main(ui, args).await,
+        Group::TotpReset(args) => totp_reset::main(ui, args).await,
     }
 }

--- a/cli/src/commands/user/revoke.rs
+++ b/cli/src/commands/user/revoke.rs
@@ -16,7 +16,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, revoke_user);
 
-pub async fn revoke_user(args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn revoke_user(
+    _todo_ui: crate::Ui,
+    args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     let Args { email, .. } = args;
     poll_server_for_new_certificates(client).await?;
     let users = client.list_users(true, None, None).await?;

--- a/cli/src/commands/user/totp_reset.rs
+++ b/cli/src/commands/user/totp_reset.rs
@@ -78,7 +78,7 @@ async fn totp_reset_req(
     }
 }
 
-pub async fn main(args: Args) -> anyhow::Result<()> {
+pub async fn main(_todo_ui: crate::Ui, args: Args) -> anyhow::Result<()> {
     let Args {
         organization,
         token,

--- a/cli/src/commands/workspace/archive.rs
+++ b/cli/src/commands/workspace/archive.rs
@@ -23,7 +23,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, archive_workspace);
 
-pub async fn archive_workspace(args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn archive_workspace(
+    _todo_ui: crate::Ui,
+    args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     let Args {
         workspace: wid,
         archived,

--- a/cli/src/commands/workspace/create.rs
+++ b/cli/src/commands/workspace/create.rs
@@ -15,7 +15,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, create_workspace);
 
-pub async fn create_workspace(args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn create_workspace(
+    _todo_ui: crate::Ui,
+    args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     let Args { name, .. } = args;
     log::trace!("Creating workspace {name}");
 

--- a/cli/src/commands/workspace/import.rs
+++ b/cli/src/commands/workspace/import.rs
@@ -57,7 +57,11 @@ crate::build_main_with_client!(
     .into()
 );
 
-pub async fn workspace_import(args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn workspace_import(
+    _todo_ui: crate::Ui,
+    args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     let Args {
         src,
         dest,

--- a/cli/src/commands/workspace/list.rs
+++ b/cli/src/commands/workspace/list.rs
@@ -12,7 +12,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, list_workspace);
 
-pub async fn list_workspace(_args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn list_workspace(
+    _todo_ui: crate::Ui,
+    _args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     log::trace!("Listing workspaces");
 
     poll_server_for_new_certificates(client).await?;

--- a/cli/src/commands/workspace/list_users.rs
+++ b/cli/src/commands/workspace/list_users.rs
@@ -10,7 +10,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, list_users_workspace);
 
-pub async fn list_users_workspace(args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn list_users_workspace(
+    _todo_ui: crate::Ui,
+    args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     let Args { workspace: wid, .. } = args;
 
     log::trace!("Listing users in the workspace");

--- a/cli/src/commands/workspace/mod.rs
+++ b/cli/src/commands/workspace/mod.rs
@@ -29,13 +29,13 @@ pub enum Group {
 
 pub async fn dispatch_command(ui: crate::Ui, command: Group) -> anyhow::Result<()> {
     match command {
-        Group::ListUsers(args) => list_users::main(args).await,
-        Group::Archive(args) => archive::main(args).await,
-        Group::Create(args) => create::main(args).await,
-        Group::List(args) => list::main(args).await,
-        Group::Import(args) => import::main(args).await,
-        Group::Share(args) => share::main(args).await,
+        Group::ListUsers(args) => list_users::main(ui, args).await,
+        Group::Archive(args) => archive::main(ui, args).await,
+        Group::Create(args) => create::main(ui, args).await,
+        Group::List(args) => list::main(ui, args).await,
+        Group::Import(args) => import::main(ui, args).await,
+        Group::Share(args) => share::main(ui, args).await,
         Group::Sync(args) => sync::main(ui, args).await,
-        Group::Mount(args) => mount::main(args).await,
+        Group::Mount(args) => mount::main(ui, args).await,
     }
 }

--- a/cli/src/commands/workspace/mount.rs
+++ b/cli/src/commands/workspace/mount.rs
@@ -23,7 +23,11 @@ crate::build_main_with_client!(
     .into()
 );
 
-pub async fn mount_workspace(args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn mount_workspace(
+    _todo_ui: crate::Ui,
+    args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     log::trace!("Mounting workspace");
     let Args {
         workspace,

--- a/cli/src/commands/workspace/share.rs
+++ b/cli/src/commands/workspace/share.rs
@@ -18,7 +18,11 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, share_workspace);
 
-pub async fn share_workspace(args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn share_workspace(
+    _todo_ui: crate::Ui,
+    args: Args,
+    client: &StartedClient,
+) -> anyhow::Result<()> {
     let Args {
         workspace: wid,
         user,

--- a/cli/src/macros.rs
+++ b/cli/src/macros.rs
@@ -6,7 +6,7 @@
 #[macro_export]
 macro_rules! build_main_with_client {
     ($fn_name:ident, $callback:expr, $config:expr) => {
-        pub async fn $fn_name(args: Args) -> anyhow::Result<()> {
+        pub async fn $fn_name(ui: $crate::Ui, args: Args) -> anyhow::Result<()> {
             let client = $crate::utils::load_client_with_config(
                 &args.config_dir,
                 args.device.clone(),
@@ -15,7 +15,7 @@ macro_rules! build_main_with_client {
             )
             .await?;
 
-            let res = ($callback)(args, client.as_ref()).await;
+            let res = ($callback)(ui, args, client.as_ref()).await;
 
             client.stop().await;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -76,22 +76,24 @@ async fn main() -> anyhow::Result<()> {
 
     match arg.command {
         Command::Device(device) => device::dispatch_command(ui, device).await,
-        Command::Invite(invitation) => invite::dispatch_command(invitation).await,
-        Command::Organization(organization) => organization::dispatch_command(organization).await,
-        Command::User(user) => user::dispatch_command(user).await,
-        Command::Server(server) => server::dispatch_command(server).await,
+        Command::Invite(invitation) => invite::dispatch_command(ui, invitation).await,
+        Command::Organization(organization) => {
+            organization::dispatch_command(ui, organization).await
+        }
+        Command::User(user) => user::dispatch_command(ui, user).await,
+        Command::Server(server) => server::dispatch_command(ui, server).await,
         Command::Workspace(workspace) => workspace::dispatch_command(ui, workspace).await,
-        Command::Certificate(certificate) => certificate::dispatch_command(certificate).await,
+        Command::Certificate(certificate) => certificate::dispatch_command(ui, certificate).await,
         #[cfg(feature = "testenv")]
-        Command::RunTestenv(run_testenv) => run_testenv::run_testenv(run_testenv).await,
-        Command::Ls(ls) => ls::main(ls).await,
-        Command::Rm(rm) => rm::main(rm).await,
-        Command::Tos(tos) => tos::dispatch_command(tos).await,
+        Command::RunTestenv(run_testenv) => run_testenv::run_testenv(ui, run_testenv).await,
+        Command::Ls(ls) => ls::main(ui, ls).await,
+        Command::Rm(rm) => rm::main(ui, rm).await,
+        Command::Tos(tos) => tos::dispatch_command(ui, tos).await,
         Command::SharedRecovery(shared_recovery) => {
-            shared_recovery::dispatch_command(shared_recovery).await
+            shared_recovery::dispatch_command(ui, shared_recovery).await
         }
         Command::MountRealmExport(mount_realm_export) => {
-            mount_realm_export::main(mount_realm_export).await
+            mount_realm_export::main(ui, mount_realm_export).await
         }
     }
 }


### PR DESCRIPTION
Add unused `_todo_ui` in the different commands as a place holder to indicate that a given command is not yet integrated with the new Cli's UI

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
