### PR TITLE
refactor(cli): Migrate some commands to new UI (p1)

### DIFF
--- a/cli/src/commands/ls.rs
+++ b/cli/src/commands/ls.rs
@@ -1,6 +1,7 @@
-use libparsec::FsPath;
+use libparsec::{EntryName, EntryStat, FsPath};
+use serde::{ser::SerializeSeq, Serialize};
 
-use crate::utils::StartedClient;
+use crate::{ui::CLIDisplay, utils::StartedClient};
 
 crate::clap_parser_with_shared_opts_builder!(
     #[with = config_dir, device, password_stdin, workspace]
@@ -13,7 +14,7 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, ls);
 
-pub async fn ls(_todo_ui: crate::Ui, args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn ls(ui: crate::Ui, args: Args, client: &StartedClient) -> anyhow::Result<()> {
     let Args {
         workspace, path, ..
     } = args;
@@ -22,9 +23,34 @@ pub async fn ls(_todo_ui: crate::Ui, args: Args, client: &StartedClient) -> anyh
     let workspace = client.start_workspace(workspace).await?;
     let entries = workspace.stat_folder_children(&path).await?;
 
-    for (entry, _stat) in entries {
-        println!("{entry}");
-    }
+    ui.data_print(&LsEntries(entries))?;
 
     Ok(())
+}
+
+struct LsEntries(Vec<(EntryName, EntryStat)>);
+
+impl Serialize for LsEntries {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        self.0
+            .iter()
+            .try_for_each(|(name, _stat)| seq.serialize_element(name))?;
+        seq.end()
+    }
+}
+
+impl CLIDisplay for LsEntries {
+    fn plain_write<W: std::io::prelude::Write>(
+        &self,
+        _fmt: &crate::ui::ColorFormatter,
+        mut w: W,
+    ) -> std::io::Result<()> {
+        self.0
+            .iter()
+            .try_for_each(|(name, _stat)| w.write_fmt(format_args!("{name}\n")))
+    }
 }

--- a/cli/src/commands/mount_realm_export.rs
+++ b/cli/src/commands/mount_realm_export.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{io::Write as _, path::PathBuf, sync::Arc};
 
 use libparsec::{DateTime, EntryName, SequesterPrivateKeyDer, SequesterServiceID};
 use libparsec_client::{WorkspaceHistoryOps, WorkspaceHistoryRealmExportDecryptor};
@@ -55,7 +55,7 @@ impl std::str::FromStr for Decryptor {
     }
 }
 
-pub async fn main(_todo_ui: crate::Ui, args: Args) -> anyhow::Result<()> {
+pub async fn main(ui: crate::Ui, args: Args) -> anyhow::Result<()> {
     let Args {
         config_dir,
         password_stdin,
@@ -102,13 +102,18 @@ pub async fn main(_todo_ui: crate::Ui, args: Args) -> anyhow::Result<()> {
         WorkspaceHistoryOps::start_with_realm_export(config, &export_db_path, decryptors).await?,
     );
 
-    println!("Organization: {}", wksp_history_ops.organization_id());
-    println!("Realm ID: {}", wksp_history_ops.realm_id());
-    println!(
-        "Export temporal bounds: {} to {}",
-        wksp_history_ops.timestamp_lower_bound(),
-        wksp_history_ops.timestamp_higher_bound()
-    );
+    ui.with_message(|_, out| {
+        writeln!(out, "Organization: {}", wksp_history_ops.organization_id())
+    })?;
+    ui.with_message(|_, out| writeln!(out, "Realm ID: {}", wksp_history_ops.realm_id()))?;
+    ui.with_message(|_, out| {
+        writeln!(
+            out,
+            "Export temporal bounds: {} to {}",
+            wksp_history_ops.timestamp_lower_bound(),
+            wksp_history_ops.timestamp_higher_bound()
+        )
+    })?;
 
     let timestamp = timestamp.unwrap_or(wksp_history_ops.timestamp_higher_bound());
     wksp_history_ops
@@ -121,7 +126,7 @@ pub async fn main(_todo_ui: crate::Ui, args: Args) -> anyhow::Result<()> {
         .unwrap_or("realm_export".parse().expect("valid entry name"));
 
     let mountpoint = Mountpoint::mount_history(wksp_history_ops, mountpoint_name_hint).await?;
-    println!("Mounted at {:?}", mountpoint.path());
+    ui.with_message(|_, out| writeln!(out, "Mounted at {:?}", mountpoint.path()))?;
 
     let (tx, mut rx) = tokio::sync::mpsc::channel(1);
     ctrlc::set_handler(move || {
@@ -130,7 +135,7 @@ pub async fn main(_todo_ui: crate::Ui, args: Args) -> anyhow::Result<()> {
     .expect("Failed to set Ctrl-C handler");
     rx.recv().await.expect("Ctrl-C handler failed");
 
-    println!("Bye ;-)");
+    ui.with_message(|_, out| writeln!(out, "Bye ;-)"))?;
     mountpoint.unmount().await?;
 
     Ok(())

--- a/cli/src/commands/rm.rs
+++ b/cli/src/commands/rm.rs
@@ -13,7 +13,7 @@ crate::clap_parser_with_shared_opts_builder!(
 
 crate::build_main_with_client!(main, rm);
 
-pub async fn rm(_todo_ui: crate::Ui, args: Args, client: &StartedClient) -> anyhow::Result<()> {
+pub async fn rm(_ui: crate::Ui, args: Args, client: &StartedClient) -> anyhow::Result<()> {
     let Args {
         workspace, path, ..
     } = args;

--- a/cli/src/ui/mod.rs
+++ b/cli/src/ui/mod.rs
@@ -20,12 +20,6 @@ pub struct Ui {
 }
 
 impl Ui {
-    pub fn data_println<T: CLIDisplay>(&self, data: &T) -> std::io::Result<()> {
-        let mut stdout = std::io::stdout().lock();
-        self.print_data(data, &mut stdout)?;
-        stdout.write_all(b"\n")
-    }
-
     pub fn data_print<T: CLIDisplay>(&self, data: &T) -> std::io::Result<()> {
         self.print_data(data, &mut std::io::stdout().lock())
     }
@@ -40,7 +34,8 @@ impl Ui {
         match self.format {
             DataFormat::Plain => data.plain_write(&color_formatter, out),
             DataFormat::Json => {
-                serde_json::to_writer_pretty(out, &data).map_err(std::io::Error::from)
+                serde_json::to_writer_pretty(&mut *out, &data).map_err(std::io::Error::from)?;
+                out.write_all(b"\n")
             }
         }
     }

--- a/newsfragments/0000.feature.rst
+++ b/newsfragments/0000.feature.rst
@@ -14,3 +14,7 @@ CLI revamped:
   - message indicating how much devices are found on stderr (if you want to count the number of devices you could pipe output into `wc -l`)
 - ``workspace sync``:
   - Most message are shown on stderr
+- ``ls``
+  - Support outputting JSON data
+- ``mount-realm-export``
+  - Support global ``progress`` option


### PR DESCRIPTION
Migration summary:

- `rm`: Not really much to do, we printed nothing
- `ls`: Need to display the entry list as data
- `mount-realm-export`: Adapt displaying messages

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
