### PR TITLE
Migrate to anyio v4

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -113,6 +113,7 @@ endcall
 endmacro
 enterpictureinpicture
 eurosys
+excgrp
 executemany
 executescript
 executionpolicy

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -152,10 +152,6 @@ updates:
   - package-ecosystem: uv
     directory: /server
     versioning-strategy: increase-if-necessary
-    ignore:
-      - dependency-name: anyio
-        versions:
-          - ">=4.0.0"
     pull-request-branch-name:
       separator: "-"
     labels:

--- a/server/parsec/asgi/rpc.py
+++ b/server/parsec/asgi/rpc.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, AsyncIterator, Mapping, Sequence
+from collections.abc import AsyncGenerator, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from enum import Enum
@@ -1048,26 +1048,33 @@ class StreamingResponseMiddleware(StreamingResponse):
 
     async def __call__(self, scope, receive, send) -> None:
         self.client_ctx.logger.info("SSE session start")
+        # NOTE: since anyio>=4, functions using task groups always wrap exceptions in groups.
+        #       Thus the except* syntax below for exceptions raised from _run_session
+        #       See: https://anyio.readthedocs.io/en/stable/migration.html#task-groups-now-wrap-single-exceptions-in-groups
         try:
             await self._run_session(scope, receive, send)
-        except HTTPException as exc:
+        except* HTTPException as excgrp:
+            exc = excgrp.exceptions[0]
+            assert isinstance(exc, HTTPException)
             self.client_ctx.logger.info(
                 "SSE session HTTP error",
                 status_code=exc.status_code,
                 detail=exc.detail,
             )
-            raise
-        except Exception as exc:
+            raise exc
+        except* Exception as excgrp:
+            exc = excgrp.exceptions[0]
             self.client_ctx.logger.error("SSE session exception", exc_info=exc)
-            raise
-        except BaseException as exc:
+            raise exc
+        except* BaseException as excgrp:
+            exc = excgrp.exceptions[0]
             self.client_ctx.logger.debug("SSE session base exception", exc_info=exc)
-            raise
+            raise exc
         else:
             self.client_ctx.logger.info("SSE session end")
 
     @asynccontextmanager
-    async def listen_events_context(self) -> AsyncIterator[ApiEventListenOutcome]:
+    async def listen_events_context(self) -> AsyncGenerator[ApiEventListenOutcome]:
         # This task is responsible for registering the client to the SSE stream and unregistering it
         # when it finishes. It can either get cancelled internally (e.g. when the client gets frozen
         # or revoked) or externally by the task group below (e.g. when the client gets disconnected).

--- a/server/parsec/cli/options.py
+++ b/server/parsec/cli/options.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import sys
 from collections import defaultdict
-from collections.abc import Callable, Coroutine, Iterable, Iterator
+from collections.abc import Callable, Coroutine, Generator, Iterable
 from contextlib import contextmanager
 from functools import wraps
 from itertools import count
@@ -81,13 +81,13 @@ def logging_config_options(
             if log_file in (None, "-"):
 
                 @contextmanager
-                def open_log_file() -> Iterator[TextIO]:
+                def open_log_file() -> Generator[TextIO]:
                     yield sys.stderr
 
             else:
 
                 @contextmanager
-                def open_log_file() -> Iterator[TextIO]:
+                def open_log_file() -> Generator[TextIO]:
                     assert log_file is not None
                     yield cast(TextIO, click.open_file(filename=log_file, mode="w"))
 

--- a/server/parsec/cli/testbed.py
+++ b/server/parsec/cli/testbed.py
@@ -7,7 +7,7 @@ import hashlib
 import uuid
 from base64 import b64decode, b64encode
 from collections import defaultdict
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any
@@ -959,7 +959,7 @@ async def test_new_account(request: Request) -> Response:
 @asynccontextmanager
 async def testbed_backend_factory(
     server_addr: ParsecAddr, with_postgresql: str | None
-) -> AsyncIterator[TestbedBackend]:
+) -> AsyncGenerator[TestbedBackend]:
     blockstore_config = (
         MockedBlockStoreConfig() if with_postgresql is None else PostgreSQLBlockStoreConfig()
     )

--- a/server/parsec/cli/utils.py
+++ b/server/parsec/cli/utils.py
@@ -14,8 +14,11 @@ from typing import (
 )
 
 import anyio
+
+# Required because the top-level module of anyio does not correctly load the submodule to_thread
+# see https://github.com/microsoft/pyright/issues/10912
+import anyio.to_thread
 import click
-from anyio import to_thread
 
 from parsec._parsec import DateTime, ParsecAddr, SecretKey
 from parsec.backend import Backend, backend_factory
@@ -168,7 +171,7 @@ def generate_not_available_cmd(exc: BaseException, hint: str | None = None) -> c
 
 def async_wrapper[**P, R](fn: Callable[P, R]) -> Callable[P, Awaitable[R]]:
     async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-        return await to_thread.run_sync(partial(fn, *args, **kwargs))
+        return await anyio.to_thread.run_sync(partial(fn, *args, **kwargs))
 
     return wrapper
 

--- a/server/parsec/cli/utils.py
+++ b/server/parsec/cli/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import datetime
 import traceback
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
 from contextlib import asynccontextmanager, contextmanager
 from functools import partial
 from typing import (
@@ -15,6 +15,7 @@ from typing import (
 
 import anyio
 import click
+from anyio import to_thread
 
 from parsec._parsec import DateTime, ParsecAddr, SecretKey
 from parsec.backend import Backend, backend_factory
@@ -46,7 +47,7 @@ ko = click.style("✘", fg="red")
 
 
 @contextmanager
-def operation(txt: str) -> Iterator[None]:
+def operation(txt: str) -> Generator[None]:
     click.echo(txt, nl=False)
     try:
         yield
@@ -62,7 +63,7 @@ def operation(txt: str) -> Iterator[None]:
 @asynccontextmanager
 async def spinner(
     txt: str, sep: str = " ", scheme: str = "dots", color: str = "magenta"
-) -> AsyncIterator[None]:
+) -> AsyncGenerator[None]:
     scheme_theme = SCHEMES[scheme]
     interval = scheme_theme["interval"]
     frames = scheme_theme["frames"]
@@ -103,20 +104,21 @@ async def spinner(
 
 
 @contextmanager
-def cli_exception_handler(debug: bool) -> Iterator[bool]:
+def cli_exception_handler(debug: bool) -> Generator[bool]:
+    # NOTE: since anyio>=4, functions using task groups always wrap exceptions in groups (thus, the except* syntax below)
+    #       See: https://anyio.readthedocs.io/en/stable/migration.html#task-groups-now-wrap-single-exceptions-in-groups
     try:
         yield debug
-
-    except KeyboardInterrupt:
+    except* KeyboardInterrupt:
         raise SystemExit(0)
-
-    except Exception as exc:
+    except* Exception as excgrp:
+        exc = excgrp.exceptions[0]
         exc_msg = str(exc)
         if not exc_msg.strip():
             exc_msg = repr(exc)
         click.echo(click.style("Error: ", fg="red") + exc_msg)
         if debug:
-            raise
+            raise exc
         else:
             raise SystemExit(1)
 
@@ -166,7 +168,7 @@ def generate_not_available_cmd(exc: BaseException, hint: str | None = None) -> c
 
 def async_wrapper[**P, R](fn: Callable[P, R]) -> Callable[P, Awaitable[R]]:
     async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-        return await anyio.to_thread.run_sync(partial(fn, *args, **kwargs))
+        return await to_thread.run_sync(partial(fn, *args, **kwargs))
 
     return wrapper
 
@@ -261,7 +263,7 @@ async def start_backend(
     blockstore_config: BaseBlockStoreConfig,
     debug: bool,
     populate_with_template: str | None = None,
-):
+) -> AsyncGenerator[Backend, Any]:
     """
     Start backend for CLI usage.
 

--- a/server/parsec/components/email.py
+++ b/server/parsec/components/email.py
@@ -10,6 +10,10 @@ from enum import auto
 
 import anyio
 
+# Required because the top-level module of anyio does not correctly load the submodule to_thread
+# see https://github.com/microsoft/pyright/issues/10912
+import anyio.to_thread
+
 from parsec._parsec import DateTime, EmailAddress
 from parsec.config import EmailConfig, MockedEmailConfig, MockedSentEmail, SmtpEmailConfig
 from parsec.logging import get_logger
@@ -113,12 +117,16 @@ AT: {timestamp.to_rfc3339()}
     )
 
 
-async def send_email(
+def _send_email(
     email_config: EmailConfig, to_addr: EmailAddress, message: Message
 ) -> SendEmailBadOutcome | None:
     if isinstance(email_config, SmtpEmailConfig):
-        _send_email = _smtp_send_email
+        _smtp_send_email(email_config, to_addr, message)
     else:
-        _send_email = _mocked_send_email
+        _mocked_send_email(email_config, to_addr, message)
 
+
+async def send_email(
+    email_config: EmailConfig, to_addr: EmailAddress, message: Message
+) -> SendEmailBadOutcome | None:
     return await anyio.to_thread.run_sync(_send_email, email_config, to_addr, message)

--- a/server/parsec/components/events.py
+++ b/server/parsec/components/events.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import deque
-from collections.abc import AsyncIterator, Callable, Iterator, Sequence
+from collections.abc import AsyncGenerator, Callable, Generator, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field
 from enum import auto
@@ -204,7 +204,7 @@ class EventBus:
             pass
 
     @contextmanager
-    def create_waiter(self, filter: Callable[[Event], bool]) -> Iterator[EventWaiter]:
+    def create_waiter(self, filter: Callable[[Event], bool]) -> Generator[EventWaiter]:
         waiter = EventWaiter(filter)
         self.connect(waiter._cb)
         try:
@@ -213,7 +213,7 @@ class EventBus:
             self.disconnect(waiter._cb)
 
     @contextmanager
-    def spy(self) -> Iterator[EventBusSpy]:
+    def spy(self) -> Generator[EventBusSpy]:
         """Only for tests !"""
         spy = EventBusSpy()
         self.connect(spy._on_event_cb)
@@ -462,11 +462,11 @@ class BaseEventsComponent:
     @asynccontextmanager
     async def sse_api_events_listen(
         self, client_ctx: AuthenticatedClientContext, last_event_id: UUID | None
-    ) -> AsyncIterator[
+    ) -> AsyncGenerator[
         tuple[EventOrganizationConfig, ClientBroadcastableEventStream]
         | SseAPiEventsListenBadOutcome
     ]:
-        async with anyio.open_cancel_scope() as cancel_scope:
+        with anyio.CancelScope() as cancel_scope:
             outcome = await self._register_client(
                 client_ctx=client_ctx, last_event_id=last_event_id, cancel_scope=cancel_scope
             )

--- a/server/parsec/components/memory/datamodel.py
+++ b/server/parsec/components/memory/datamodel.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from asyncio import Event, Lock
 from collections import defaultdict
-from collections.abc import AsyncIterator, Iterable, Iterator
+from collections.abc import AsyncGenerator, Iterable, Iterator
 from contextlib import asynccontextmanager
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -183,7 +183,7 @@ class MemoryOrganization:
     _notify_me_on_topic_lock_release: Event | None = None
 
     @asynccontextmanager
-    async def advisory_lock_exclusive(self, lock: AdvisoryLock) -> AsyncIterator[None]:
+    async def advisory_lock_exclusive(self, lock: AdvisoryLock) -> AsyncGenerator[None]:
         """
         Equivalent to `SELECT pg_advisory_xact_lock(<lock ID>, _id) FROM organization WHERE organization_id = <org>`
         """
@@ -191,7 +191,7 @@ class MemoryOrganization:
             yield
 
     @asynccontextmanager
-    async def advisory_lock_shared(self, lock: AdvisoryLock) -> AsyncIterator[None]:
+    async def advisory_lock_shared(self, lock: AdvisoryLock) -> AsyncGenerator[None]:
         """
         Equivalent to `SELECT pg_advisory_xact_lock_shared(<lock ID>, _id) FROM organization WHERE organization_id = <org>`
         """
@@ -201,7 +201,7 @@ class MemoryOrganization:
     @asynccontextmanager
     async def topics_lock(
         self, read: Iterable[TopicAndDiscriminant] = (), write: Iterable[TopicAndDiscriminant] = ()
-    ) -> AsyncIterator[tuple[DateTime, ...]]:
+    ) -> AsyncGenerator[tuple[DateTime, ...]]:
         """
         Read is equivalent to `SELECT last_timestamp FROM <topic table> WHERE organization_id = <org> FOR SHARE`
 

--- a/server/parsec/components/memory/events.py
+++ b/server/parsec/components/memory/events.py
@@ -2,12 +2,12 @@
 
 import asyncio
 import math
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import override
 
 import anyio
-from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+from anyio.streams.memory import MemoryObjectSendStream
 
 from parsec._parsec import OrganizationID, UserID, UserProfile, VlobID
 from parsec.components.events import BaseEventsComponent, EventBus, SseAPiEventsListenBadOutcome
@@ -33,10 +33,8 @@ class MemoryEventBus(EventBus):
 
 
 @asynccontextmanager
-async def event_bus_factory() -> AsyncIterator[MemoryEventBus]:
-    # TODO: add typing once use anyio>=4 (currently incompatible with fastapi)
-    send_events_channel, receive_events_channel = anyio.create_memory_object_stream(math.inf)
-    receive_events_channel: MemoryObjectReceiveStream[Event]
+async def event_bus_factory() -> AsyncGenerator[MemoryEventBus]:
+    send_events_channel, receive_events_channel = anyio.create_memory_object_stream[Event](math.inf)
 
     event_bus = MemoryEventBus(send_events_channel)
 

--- a/server/parsec/components/postgresql/events.py
+++ b/server/parsec/components/postgresql/events.py
@@ -1,6 +1,6 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import cast, override
 
@@ -47,7 +47,7 @@ class PGEventBus(EventBus):
 
 
 @asynccontextmanager
-async def event_bus_factory(pool: AsyncpgPool) -> AsyncIterator[PGEventBus]:
+async def event_bus_factory(pool: AsyncpgPool) -> AsyncGenerator[PGEventBus]:
     _connection_lost = False
 
     def _on_notification_conn_termination(conn: object) -> None:

--- a/server/parsec/components/postgresql/handler.py
+++ b/server/parsec/components/postgresql/handler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import importlib.resources
 import json
 import re
-from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Iterable
+from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime
@@ -204,7 +204,7 @@ async def handle_json(conn: AsyncpgConnection) -> None:
 @asynccontextmanager
 async def asyncpg_pool_factory(
     url: str, min_connections: int, max_connections: int
-) -> AsyncIterator[AsyncpgPool]:
+) -> AsyncGenerator[AsyncpgPool]:
     # By default AsyncPG only work with Python standard `datetime.DateTime`
     # for timestamp types, here we override this behavior to uses our own custom
     # - DateTime type

--- a/server/parsec/components/postgresql/sequester_export.py
+++ b/server/parsec/components/postgresql/sequester_export.py
@@ -9,6 +9,10 @@ from typing import NewType, cast
 
 import anyio
 
+# Required because the top-level module of anyio does not correctly load the submodule to_thread
+# see https://github.com/microsoft/pyright/issues/10912
+import anyio.to_thread
+
 from parsec._parsec import BlockID, OrganizationID, SequesterServiceID, VlobID
 from parsec.components.blockstore import BaseBlockStoreComponent
 from parsec.components.postgresql import AsyncpgConnection, AsyncpgPool

--- a/server/parsec/components/s3_blockstore.py
+++ b/server/parsec/components/s3_blockstore.py
@@ -5,6 +5,10 @@ from functools import partial
 from typing import override
 
 import anyio
+
+# Required because the top-level module of anyio does not correctly load the submodule to_thread
+# see https://github.com/microsoft/pyright/issues/10912
+import anyio.to_thread
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
 

--- a/server/parsec/components/swift_blockstore.py
+++ b/server/parsec/components/swift_blockstore.py
@@ -6,6 +6,10 @@ from typing import override
 from unittest.mock import Mock
 
 import anyio
+
+# Required because the top-level module of anyio does not correctly load the submodule to_thread
+# see https://github.com/microsoft/pyright/issues/10912
+import anyio.to_thread
 import pbr.version
 
 # TODO: is this still needed ? for what purpose ?

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 requires-python = "~=3.14.0"
 dependencies = [
     # Base requirements
-    "anyio>=3.7.1, <4",
+    "anyio>=3.7.1, <5",
     "click>=8.0, <9",
     "cryptography>=46.0.6",
     "httpx>=0.28.1, <0.29",

--- a/server/tests/cli/common.py
+++ b/server/tests/cli/common.py
@@ -17,6 +17,10 @@ from contextlib import asynccontextmanager, contextmanager
 from time import sleep
 
 import anyio
+
+# Required because the top-level module of anyio does not correctly load the submodule to_thread
+# see https://github.com/microsoft/pyright/issues/10912
+import anyio.to_thread
 from click.testing import CliRunner, Result
 
 from parsec._parsec import (

--- a/server/tests/common/client.py
+++ b/server/tests/common/client.py
@@ -1,7 +1,7 @@
 # Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
 from base64 import b64decode
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass, field
 
@@ -210,7 +210,7 @@ class AuthenticatedRpcClient(BaseAuthenticatedRpcClient, BaseTosRpcClient):
     @asynccontextmanager
     async def events_listen(  # pyright: ignore [reportIncompatibleMethodOverride]
         self, last_event_id: str | None = None, now: DateTime | None = None
-    ) -> AsyncIterator[EventsListenSSE]:
+    ) -> AsyncGenerator[EventsListenSSE]:
         now = now or DateTime.now()
         token = AuthenticatedToken.generate_raw(
             device_id=self.device_id,

--- a/server/tests/test_exception_group.py
+++ b/server/tests/test_exception_group.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 import anyio
 import pytest
 
-from tests.common import LogCaptureFixture
+
+# Simple task function to raise the exception received
+async def _raise(exc: Exception) -> None:
+    raise exc
 
 
 async def test_create_task_group_exists() -> None:
@@ -12,55 +15,55 @@ async def test_create_task_group_exists() -> None:
         pass
 
 
-@pytest.mark.xfail(reason="Should let @vxgmichel investigate if the behavior is ok")
-async def test_create_task_group_exception_group_collapse(caplog: LogCaptureFixture) -> None:
-    async def _raise(exc: Exception) -> None:
-        raise exc
-
-    with pytest.raises(ZeroDivisionError) as ctx:
+async def test_create_task_group_exception_group() -> None:
+    # A single exception should not "collapse", it should be wrapped in an ExceptionGroup (since anyio>=4)
+    # See: https://anyio.readthedocs.io/en/stable/migration.html#task-groups-now-wrap-single-exceptions-in-groups
+    with pytest.raises(ExceptionGroup) as exc:
         async with anyio.create_task_group():
             await _raise(ZeroDivisionError(1, 2, 3))
 
-    exception = ctx.value
-    assert isinstance(exception, ZeroDivisionError)
-    assert exception.args == (1, 2, 3)
+    assert not isinstance(exc, BaseExceptionGroup)
+    assert len(exc.value.exceptions) == 1
+    assert isinstance(exc.value.exceptions[0], ZeroDivisionError)
+    assert exc.value.exceptions[0].args, (1, 2, 3)
 
-    assert not isinstance(exception, BaseExceptionGroup)
-
-    with pytest.raises(ZeroDivisionError) as ctx:
+    # Multiple exceptions should be wrapped in an ExceptionGroup
+    with pytest.raises(ExceptionGroup) as exc:
         async with anyio.create_task_group() as tg:
-            tg.start_soon(_raise, RuntimeError())
-            await _raise(ZeroDivisionError(1, 2, 3))
+            tg.start_soon(_raise, RuntimeError())  # will raise RuntimeError
+            await _raise(ZeroDivisionError(1, 2, 3))  # will raise ZeroDivisionError
 
-    caplog.assert_occurred_once("[warning  ] A BaseExceptionGroup has been detected [parsec.utils]")
-
-    exception = ctx.value
-    assert isinstance(exception, ZeroDivisionError)
-    assert exception.args == (1, 2, 3)
-
-    assert isinstance(exception, BaseExceptionGroup)
-    assert len(exception.exceptions) == 2
-
-    a, b = exception.exceptions
-    assert isinstance(a, ZeroDivisionError)
-    assert not isinstance(a, BaseExceptionGroup)
-    assert isinstance(b, RuntimeError)
-    assert not isinstance(b, BaseExceptionGroup)
+    assert not isinstance(exc, BaseExceptionGroup)
+    assert len(exc.value.exceptions) == 2
+    zero_division_error, runtime_error = exc.value.exceptions
+    assert isinstance(runtime_error, RuntimeError)
+    assert isinstance(zero_division_error, ZeroDivisionError)
+    assert zero_division_error.args, (1, 2, 3)
 
 
-@pytest.mark.xfail(reason="Should let @vxgmichel investigate if the behavior is ok")
 async def test_create_task_group_exception_group_with_cancelled() -> None:
-    async def _raise(exc: Exception) -> None:
-        raise exc
-
-    with anyio.CancelScope() as cancel_scope:
+    # Cancel scope after raise in a task group should result in an ExceptionGroup
+    with pytest.raises(ExceptionGroup) as exc:
         async with anyio.create_task_group() as tg:
             tg.start_soon(_raise, ZeroDivisionError(1, 2, 3))
-            cancel_scope.cancel()
+            tg.cancel_scope.cancel()
             await anyio.sleep(1)
 
-    with anyio.CancelScope() as cancel_scope:
+    assert not isinstance(exc, BaseExceptionGroup)
+    assert len(exc.value.exceptions) == 1
+    assert isinstance(exc.value.exceptions[0], ZeroDivisionError)
+    assert exc.value.exceptions[0].args, (1, 2, 3)
+
+    # Cancel scope after raise in a task group should also result in an ExceptionGroup
+    with pytest.raises(ExceptionGroup) as exc:
         async with anyio.create_task_group() as tg:
             tg.start_soon(_raise, RuntimeError())
-            cancel_scope.cancel()
+            tg.cancel_scope.cancel()
             raise ZeroDivisionError(1, 2, 3)
+
+    assert not isinstance(exc, BaseExceptionGroup)
+    assert len(exc.value.exceptions) == 2
+    zero_division_error, runtime_error = exc.value.exceptions
+    assert isinstance(runtime_error, RuntimeError)
+    assert isinstance(zero_division_error, ZeroDivisionError)
+    assert zero_division_error.args, (1, 2, 3)

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -22,15 +22,14 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "3.7.1"
+version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
-    { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/99/2dfd53fd55ce9838e6ff2d4dac20ce58263798bd1a0dbe18b3a9af3fcfce/anyio-3.7.1.tar.gz", hash = "sha256:44a3c9aba0f5defa43261a8b3efb97891f2bd7d804e0e1f56419befa1adfc780", size = 142927, upload-time = "2023-07-05T16:45:02.294Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/24/44299477fe7dcc9cb58d0a57d5a7588d6af2ff403fdd2d47a246c91a3246/anyio-3.7.1-py3-none-any.whl", hash = "sha256:91dee416e570e92c64041bd18b900d1d6fa78dff7048769ce5ac5ddad004fbb5", size = 80896, upload-time = "2023-07-05T16:44:59.805Z" },
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
 ]
 
 [[package]]
@@ -707,7 +706,7 @@ testbed-server = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anyio", specifier = ">=3.7.1,<4" },
+    { name = "anyio", specifier = ">=3.7.1,<5" },
     { name = "asyncpg", specifier = "~=0.31" },
     { name = "boto3", specifier = ">=1.42,<2" },
     { name = "botocore", specifier = ">=1.42,<2" },
@@ -1222,15 +1221,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "sniffio"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
As stated in the [AnyIO migration guide](https://anyio.readthedocs.io/en/stable/migration.html#migrating-from-anyio-3-to-anyio-4):

> The most prominent backwards incompatible change in AnyIO 4 was that task groups now always raise exception groups when either the host task or any child tasks raise an exception (other than a cancellation exception).
> Previously, an exception group was only raised when more than one exception needed to be raised from the task group.
> The practical consequence is that if your code previously expected to catch a specific kind of exception falling out of a task group, you now need to either switch to the except* syntax or use the catch() context manager from the exceptiongroup backport.

That change impacted exception handling in the following cases:
- `StreamingResponseMiddleware` (`parsec/asgi/rpc.py`)
- `cli_exception_handler` (`cli/utils.py`)
- calls to `pytest.raises()` expecting a single exception from functions using task groups

Bonus:

- Fix type hints for contextmanager decorators
- Fix type hints for asynccontextmanager decorators
- Fix tests marked as xfail in `test_exception_group.py`