### PR TITLE
docs(sequester): Update sequester documentation to use `parsec-cli`

### DIFF
--- a/docs/hosting/sequester/index.rst
+++ b/docs/hosting/sequester/index.rst
@@ -77,11 +77,11 @@ You can do that either via ``parsec-cli``:
 .. code-block:: bash
 
   ./parsec-cli organization bootstrap \
-               --addr="$BOOTSTRAP_LINK" \
-               --device-label "my device" \
-               --label "John Doe" \
-               --email john.doe@example.com \
-               --sequester-key ./authority_key.pub
+      --addr="$BOOTSTRAP_LINK" \
+      --device-label "my device" \
+      --label "John Doe" \
+      --email john.doe@example.com \
+      --sequester-key ./authority_key.pub
 
 Or using the GUI application:
 
@@ -117,12 +117,25 @@ You can create the service key and certificate with the following commands:
 
       You must ensure that the computer clock is on time with the server (you can use ``date --utc`` to compare the clocks)
 
+   You can generate the sequester certificate using the server CLI:
+
+   .. version-added:: 3.10.0
+
+      ``parsec-cli`` can generate the sequester certificate
+
+      .. code-block:: bash
+
+         parsec-cli sequester generate-service-certificate \
+            --service-label="Sequester service" \
+            --service-public-key=./sequester_key.pub \
+            --authority-private-key=./authority_key.private
+
    .. code-block:: bash
 
      python -m parsec sequester generate_service_certificate \
-               --service-label="Sequester service" \
-               --service-public-key=./sequester_key.pub \
-               --authority-private-key=./authority_key.private
+       --service-label="Sequester service" \
+       --service-public-key=./sequester_key.pub \
+       --authority-private-key=./authority_key.private
 
    .. tip::
 
@@ -137,8 +150,8 @@ Enable sequester service
    .. code-block:: bash
 
      python -m parsec sequester create_service \
-               --organization=organization-sequester-test \
-               --service-certificate=./sequester_service_certificate-ef9adae7ee9f44cc9f974fdcaaff8839-2025-02-23T21:19:35.484948Z.pem
+       --organization=organization-sequester-test \
+       --service-certificate=./sequester_service_certificate-ef9adae7ee9f44cc9f974fdcaaff8839-2025-02-23T21:19:35.484948Z.pem
 
    .. note::
 
@@ -175,20 +188,25 @@ Overview:
 
     # On Parsec server, identity real (workspace) to export
     python -m parsec human_accesses \
-              --organization=organization-sequester-test [--db=$POSTGRESQL_URL]
+      --organization=organization-sequester-test [--db=$POSTGRESQL_URL]
 
     # This creates a file "parsec-export-$ORG-realm-$REALM-$TIMESTAMP.sqlite".
     python -m parsec export_realm
-              --organization=organization-sequester-test \
-              --realm=<id-realm> [--db=$POSTGRESQL_URL --blockstore=$S3_URL]
+      --organization=organization-sequester-test \
+      --realm=<id-realm> [--db=$POSTGRESQL_URL --blockstore=$S3_URL]
 
 
 Using exported data
 ===================
 
+Use ``parsec-cli`` to mount a virtual drive with decrypted data:
+
 .. code-block:: bash
 
-  # This command mount a disk drive with decrypted data
-  ./parsec-cli mount-realm-export \
-               parsec-export-organization-sequester-test-realm-f749b8035f6e4bd88e96ae557828a583-20250225T135312Z.sqlite \
-               -d sequester:7bd707ce86df42288634f2a78db7f10e:./sequester_key.private
+  parsec-cli sequester mount \
+    --decryptor sequester:7bd707ce86df42288634f2a78db7f10e:./sequester_key.private \
+    parsec-export-organization-sequester-test-realm-f749b8035f6e4bd88e96ae557828a583-20250225T135312Z.sqlite
+
+.. version-changed:: 3.10.0
+
+   The command ``mount-realm-export`` was renamed to ``sequester mount``

--- a/docs/locale/fr/LC_MESSAGES/hosting/sequester/index.po
+++ b/docs/locale/fr/LC_MESSAGES/hosting/sequester/index.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Parsec 3.3.0-rc.12+dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 08:15+0000\n"
+"POT-Creation-Date: 2026-08-12 10:30+0000\n"
 "PO-Revision-Date: 2025-02-26 23:56-0300\n"
 "Last-Translator: Marcos Medrano <marcos.medrano@scille.fr>\n"
 "Language: fr\n"
@@ -240,7 +240,17 @@ msgstr ""
 "celle du serveur (vous pouvez utiliser ``date --utc`` pour comparer les "
 "horloges)"
 
-#: ../../hosting/sequester/index.rst:129
+#: ../../hosting/sequester/index.rst:122
+msgid "``parsec-cli`` can generate the sequester certificate"
+msgstr "``parsec-cli`` peut generer le certificat du sequestre"
+
+#: ../../hosting/sequester/index.rst:132
+msgid "You can generate the sequester certificate using the server CLI:"
+msgstr ""
+"Vous pouvez créer le certificat de séquestre à l'aide de la commande "
+"suivante :"
+
+#: ../../hosting/sequester/index.rst:143
 msgid ""
 "This step while using the parsec server CLI does not require to be executed "
 "on the same machine as the service."
@@ -249,11 +259,11 @@ msgstr ""
 "serveur Parsec, n'a pas besoin d'être exécutée sur la même machine que le "
 "service."
 
-#: ../../hosting/sequester/index.rst:132
+#: ../../hosting/sequester/index.rst:146
 msgid "Enable sequester service"
 msgstr "Activer le service de séquestre"
 
-#: ../../hosting/sequester/index.rst:134
+#: ../../hosting/sequester/index.rst:148
 msgid ""
 "Next, provide to the parsec server's administrator the recently generated "
 "service certificate."
@@ -261,27 +271,27 @@ msgstr ""
 "Ensuite, fournissez à l'administrateur du serveur Parsec le certificat de "
 "service récemment généré."
 
-#: ../../hosting/sequester/index.rst:135
+#: ../../hosting/sequester/index.rst:149
 msgid "The admin now needs to create the service on the server:"
 msgstr "L'administrateur doit maintenant créer le service sur le serveur :"
 
-#: ../../hosting/sequester/index.rst:145
+#: ../../hosting/sequester/index.rst:159
 msgid "You need to have access to the database credentials for that operation."
 msgstr ""
 "Vous devez avoir accès aux identifiants de la base de données pour cette "
 "opération."
 
-#: ../../hosting/sequester/index.rst:149
+#: ../../hosting/sequester/index.rst:163
 msgid "The sequester service can only be enabled on bootstrapped organization."
 msgstr ""
 "Le service de séquestre ne peut être activé que sur une organisation "
 "initialisée."
 
-#: ../../hosting/sequester/index.rst:152
+#: ../../hosting/sequester/index.rst:166
 msgid "Exporting data with sequester service"
 msgstr "Exportation de données avec le service séquestre"
 
-#: ../../hosting/sequester/index.rst:154
+#: ../../hosting/sequester/index.rst:168
 msgid ""
 "Realm vs Workspace: In Parsec vocabulary, workspace and realm are two sides "
 "of the same coin. In a nutshell, the realm is a server-side concept that "
@@ -294,7 +304,7 @@ msgstr ""
 "cryptées, tandis que l'espace de travail est le concept côté client qui fait "
 "référence à ces données une fois décryptées."
 
-#: ../../hosting/sequester/index.rst:159
+#: ../../hosting/sequester/index.rst:173
 msgid ""
 "Hence the \"realm export\" is the operation of exporting from the server all "
 "the encrypted data that, when used with the right decryption keys, will "
@@ -307,15 +317,15 @@ msgstr ""
 "accès en lecture complet à un espace de travail à tout moment jusqu'à la "
 "date d'exportation."
 
-#: ../../hosting/sequester/index.rst:163
+#: ../../hosting/sequester/index.rst:177
 msgid "Overview:"
 msgstr "Vue d'ensemble :"
 
-#: ../../hosting/sequester/index.rst:165
+#: ../../hosting/sequester/index.rst:179
 msgid "An organization exists with a workspace"
 msgstr "Une organisation existe avec un espace de travail"
 
-#: ../../hosting/sequester/index.rst:166
+#: ../../hosting/sequester/index.rst:180
 msgid ""
 "From the server CLI, a realm is exported. This generates a large ``.sqlite`` "
 "file containing all encrypted data belonging to this realm."
@@ -324,7 +334,7 @@ msgstr ""
 "grand fichier ``.sqlite`` contenant toutes les données cryptées appartenant "
 "à ce realm."
 
-#: ../../hosting/sequester/index.rst:168
+#: ../../hosting/sequester/index.rst:182
 msgid ""
 "The realm export file is transferred to a machine containing the decryption "
 "keys:"
@@ -332,11 +342,11 @@ msgstr ""
 "Le fichier d'exportation du realm est transféré vers une machine contenant "
 "les clés de décryptage :"
 
-#: ../../hosting/sequester/index.rst:170
+#: ../../hosting/sequester/index.rst:184
 msgid "Sequestered service key in case of a sequestered organization."
 msgstr "Clé de service du séquestre dans le cas d'une organisation séquestrée."
 
-#: ../../hosting/sequester/index.rst:171
+#: ../../hosting/sequester/index.rst:185
 msgid ""
 "Device key otherwise (i.e. decrypt the realm export from a machine normally "
 "used to run the Parsec client)."
@@ -344,6 +354,17 @@ msgstr ""
 "Clé de l'appareil, sinon (c'est-à-dire décrypter l'exportation du realm à "
 "partir d'une machine normalement utilisée pour exécuter le client Parsec)."
 
-#: ../../hosting/sequester/index.rst:187
+#: ../../hosting/sequester/index.rst:201
 msgid "Using exported data"
 msgstr "Utilisation des données exportées"
+
+#: ../../hosting/sequester/index.rst:203
+msgid "Use ``parsec-cli`` to mount a virtual drive with decrypted data:"
+msgstr ""
+"Utiliser ``parsec-cli`` pour monter un disque virtuel avec la donnée "
+"déchiffrée :"
+
+#: ../../hosting/sequester/index.rst:213
+msgid "The command ``mount-realm-export`` was renamed to ``sequester mount``"
+msgstr ""
+"La commande ``mount-realm-export`` a été renommée vers ``sequester mount``"


### PR DESCRIPTION
- The CLI can be used to generate the certificate.
- The CLI moved the `mount` command to `sequester` namespace.
- Homogenize multiline commands indentation

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
