### PR TITLE
fix(cli): Flush man page file

### DIFF
--- a/cli/src/commands/man_page.rs
+++ b/cli/src/commands/man_page.rs
@@ -131,18 +131,20 @@ fn create_render_task(
     join_set.spawn(write_man_in_file(man, path));
 }
 
-async fn write_man_in_file(man: clap_mangen::Man, file: PathBuf) -> anyhow::Result<()> {
+async fn write_man_in_file(man: clap_mangen::Man, filepath: PathBuf) -> anyhow::Result<()> {
+    log::debug!("Writing man page to {}", filepath.display());
     let buff = render_man_in_memory(man)?;
 
-    let file = tokio::fs::File::create(file)
+    let mut file = tokio::fs::File::create(&filepath)
         .await
-        .context("Failed to open file")?;
-    let mut buffered = tokio::io::BufWriter::new(file);
+        .with_context(|| format!("Failed to open file {}", filepath.display()))?;
 
-    buffered
-        .write_all_buf(&mut Cursor::new(buff))
+    file.write_all_buf(&mut Cursor::new(buff))
         .await
-        .context("Failed to write manpage to writer")
+        .context("Failed to write manpage to writer")?;
+    file.flush().await.context("Failed to flush to file")?;
+    log::debug!("Done writing man page to {}", filepath.display());
+    Ok(())
 }
 
 fn render_man_in_memory(man: clap_mangen::Man) -> anyhow::Result<Vec<u8>> {

--- a/cli/tests/integration/manpage.rs
+++ b/cli/tests/integration/manpage.rs
@@ -19,17 +19,17 @@ async fn gen_man_page(#[case] mode: Mode, tmp_path: TmpPath) {
     match mode {
         Mode::AllInOne => {
             assert!(metadata.is_file());
-            #[cfg(target_family = "unix")]
-            {
-                use std::os::unix::fs::MetadataExt;
-                assert!(metadata.size() > 0);
-            }
+            assert!(metadata.len() > 20);
         }
         Mode::Separate => {
             assert!(metadata.is_dir());
             let mut entries = tokio::fs::read_dir(out_path).await.unwrap();
             let mut count = 0_usize;
-            while let Ok(Some(_)) = entries.next_entry().await {
+            while let Ok(Some(entry)) = entries.next_entry().await {
+                let metadata = entry.metadata().await.unwrap();
+                assert!(metadata.is_file());
+                assert!(metadata.len() > 20);
+
                 count += 1;
             }
             assert!(count > 1);


### PR DESCRIPTION
- Forget to flush the file after written the content of the manpage
- Directly use the file handle instead of `BufWriter`: We already do a single write OP, `BufWriter` is just overhead in this case.

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
