### PR TITLE
refactor(cli): Harden `server stats`

### DIFF
--- a/cli/src/commands/organization/create.rs
+++ b/cli/src/commands/organization/create.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 use libparsec::{OrganizationID, ParsecAddr, ParsecOrganizationBootstrapAddr};
 use std::fmt::Write;
@@ -61,7 +62,9 @@ pub async fn create_organization_req(
             "organization_id": organization_id,
         }))
         .send()
-        .await?;
+        .await?
+        .error_for_status()
+        .context("Unexpected response status")?;
 
     match rep.json::<CreateOrganizationRep>().await? {
         CreateOrganizationRep::Ok(res) => Ok(res.bootstrap_url),

--- a/cli/src/commands/organization/stats.rs
+++ b/cli/src/commands/organization/stats.rs
@@ -1,5 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
+use anyhow::Context;
 use serde_json::Value;
 
 use libparsec::{OrganizationID, ParsecAddr};
@@ -24,7 +25,9 @@ pub async fn stats_organization_req(
         .get(url)
         .bearer_auth(administration_token)
         .send()
-        .await?;
+        .await?
+        .error_for_status()
+        .context("Unexpected response status")?;
 
     Ok(rep.json::<Value>().await?)
 }

--- a/cli/src/commands/organization/status.rs
+++ b/cli/src/commands/organization/status.rs
@@ -1,5 +1,6 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
+use anyhow::Context;
 use serde_json::Value;
 
 use libparsec::{OrganizationID, ParsecAddr};
@@ -24,7 +25,9 @@ pub async fn status_organization_req(
         .get(url)
         .bearer_auth(administration_token)
         .send()
-        .await?;
+        .await?
+        .error_for_status()
+        .context("Unexpected response status")?;
 
     Ok(rep.json::<Value>().await?)
 }

--- a/cli/src/commands/server/stats.rs
+++ b/cli/src/commands/server/stats.rs
@@ -1,5 +1,8 @@
 // Parsec Cloud (https://parsec.cloud) Copyright (c) BUSL-1.1 2016-present Scille SAS
 
+use std::io::Write;
+
+use anyhow::Context;
 use reqwest::Response;
 use serde_json::Value;
 
@@ -72,17 +75,24 @@ pub async fn main(ui: crate::Ui, args: Args) -> anyhow::Result<()> {
     } = args;
     log::trace!("Retrieving server's stats (addr={addr})");
 
-    let rep = stats_server_req(&addr, &token, ui.format.into(), end_date).await?;
+    let rep = stats_server_req(&addr, &token, ui.format.into(), end_date)
+        .await?
+        .error_for_status()
+        .context("Unexpected response status")?;
+
+    std::debug_assert_matches!(rep.content_length(), Some(size) if size > 0, "Server should have replied with a response containing data");
 
     match ui.format {
         DataFormat::Json => {
+            let mut stdout = std::io::stdout().lock();
             let json = rep.json::<Value>().await?;
-            serde_json::to_writer_pretty(std::io::stdout().lock(), &json)?;
+            serde_json::to_writer_pretty(&mut stdout, &json)?;
+            stdout.flush()?;
         }
         DataFormat::Plain => {
-            tokio::io::stdout()
-                .write_all(rep.text().await?.as_bytes())
-                .await?
+            let mut stdout = tokio::io::stdout();
+            stdout.write_all(rep.text().await?.as_bytes()).await?;
+            stdout.flush().await?;
         }
     }
 


### PR DESCRIPTION
Sometime on the CI the `server stats` command fail to produce any output without any clear explanation, so:

- Check the response for unexpected response status
- Added a debug assert to ensure that the response has a chance to contain data
- Flush stdout to ensure that all data is outputed
- Verify HTTP response status for other commands

<!--

Pull request description should include:

- Any **details that should not be overlooked** by reviewers
- **How to test** your changes if not evident (e.g. commands to run)

Before you submit this pull request, please make sure to:

- Include as few changes as possible
- Sanitize commit history (meaningful commit messages, squash irrelevant commits)
- (feature or bugfix) Add or update relevant tests
- (feature or bugfix) Update user documentation
- (feature or bugfix) Add news fragment

-->
