### PR TITLE
[CLI] Add keyring support for import recovery device.

### DIFF
--- a/cli/src/commands/device/import_recovery_device.rs
+++ b/cli/src/commands/device/import_recovery_device.rs
@@ -8,12 +8,12 @@ use libparsec::DeviceLabel;
 use crate::{ui::compat::AvailableDeviceDisplay, utils::*};
 
 crate::clap_parser_with_shared_opts_builder!(
-    #[with = config_dir, password_stdin]
+    #[with = config_dir, password_stdin, auth]
     pub struct Args {
         /// Path where encrypted recovery device data is
         #[arg(short, long, value_hint = clap::ValueHint::FilePath)]
         input: PathBuf,
-        /// new device label
+        /// New device label
         #[arg(short, long, value_hint = clap::ValueHint::Other)]
         label: String,
     }
@@ -25,7 +25,9 @@ pub async fn main(ui: crate::Ui, args: Args) -> anyhow::Result<()> {
         config_dir,
         password_stdin,
         label,
+        auth,
     } = args;
+    // TODO: fail if password std and keyring ?
     log::trace!(
         "Importing recovery device from {} (confdir={})",
         input.display(),
@@ -40,21 +42,14 @@ pub async fn main(ui: crate::Ui, args: Args) -> anyhow::Result<()> {
             prompt: "Enter passphrase for the recovery file:",
         }
     })?;
-    let password = choose_password(if password_stdin {
-        ReadPasswordFrom::Stdin
-    } else {
-        ReadPasswordFrom::Tty {
-            prompt: "Enter password for the new device:",
-        }
-    })?;
-
+    let strategy = auth.get_client_save_strategy(password_stdin).await?;
     let device_label = DeviceLabel::try_from(label.as_str())?;
     let new_device = libparsec_client::import_recovery_device(
         &config_dir,
         &recovery_device,
         passphrase.to_string(),
         device_label.clone(),
-        libparsec_client::DeviceSaveStrategy::new_password(password),
+        strategy,
     )
     .await
     .map(AvailableDeviceDisplay)?;

--- a/cli/src/macros.rs
+++ b/cli/src/macros.rs
@@ -289,6 +289,31 @@ macro_rules! clap_parser_with_shared_opts_builder {
     // force option
     (
         #[with = force $(,$modifier:ident)*]
+                $(#[$struct_attr:meta])*
+        $visibility:vis struct $name:ident {
+            $(
+                $(#[$field_attr:meta])*
+                $field_vis:vis $field:ident: $field_type:ty,
+            )*
+        }
+    ) => {
+        $crate::clap_parser_with_shared_opts_builder!(
+            #[with = $($modifier),*]
+            $(#[$struct_attr])*
+            $visibility struct $name {
+                     #[doc = "force default option to bypass interaction"]
+                #[arg(long, default_value_t)]
+                pub(crate) force: bool,
+                 $(
+                    $(#[$field_attr])*
+                    $field_vis $field: $field_type,
+                )*
+            }
+        );
+    };
+     // New authentication method
+    (
+        #[with = auth $(,$modifier:ident)*]
         $(#[$struct_attr:meta])*
         $visibility:vis struct $name:ident {
             $(
@@ -301,9 +326,9 @@ macro_rules! clap_parser_with_shared_opts_builder {
             #[with = $($modifier),*]
             $(#[$struct_attr])*
             $visibility struct $name {
-                #[doc = "force default option to bypass interaction"]
-                #[arg(long, default_value_t)]
-                pub(crate) force: bool,
+                #[doc = "New authentication method for the new device"]
+                #[arg(long, value_hint = clap::ValueHint::Other, default_value_t )]
+                pub(crate) auth: NewAuthMethod,
                 $(
                     $(#[$field_attr])*
                     $field_vis $field: $field_type,

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -613,23 +613,13 @@ impl Display for NewAuthMethod {
 
 impl NewAuthMethod {
     // TODO delete when the CLI stops using internal libparsec crates
-    pub fn get_client_save_strategy(
+    pub async fn get_client_save_strategy(
         self,
         password_stdin: bool,
     ) -> anyhow::Result<libparsec_client::DeviceSaveStrategy> {
-        match self {
-            NewAuthMethod::Password => {
-                let password = choose_password(if password_stdin {
-                    ReadPasswordFrom::Stdin
-                } else {
-                    ReadPasswordFrom::Tty {
-                        prompt: "Enter password for the new device:",
-                    }
-                })?;
-                Ok(libparsec_client::DeviceSaveStrategy::new_password(password))
-            }
-            NewAuthMethod::Keyring => Ok(libparsec_client::DeviceSaveStrategy::new_keyring()),
-        }
+        self.get_save_strategy(password_stdin)?
+            .convert_with_side_effects()
+            .await
     }
 
     pub fn get_save_strategy(

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use anyhow::anyhow;
+use clap::ValueEnum;
 use dialoguer::FuzzySelect;
 use libparsec::{
     internal::{Client, EventBus},
@@ -588,6 +589,73 @@ impl clap::builder::TypedValueParser for OutputFileParser {
             path_parser
                 .parse_ref(cmd, arg, value)
                 .map(Self::Value::Path)
+        }
+    }
+}
+
+// TODO: use in device change authentication instead of NewAccessStrategyChoice
+// TODO: use in invite claim instead of SaveMode
+#[derive(ValueEnum, Debug, Clone, Default)]
+pub enum NewAuthMethod {
+    Keyring,
+    #[default]
+    Password,
+}
+
+impl Display for NewAuthMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        self.to_possible_value()
+            .expect("no values are skipped")
+            .get_name()
+            .fmt(f)
+    }
+}
+
+impl NewAuthMethod {
+    // TODO delete when the CLI stops using internal libparsec crates
+    pub fn get_client_save_strategy(
+        self,
+        password_stdin: bool,
+    ) -> anyhow::Result<libparsec_client::DeviceSaveStrategy> {
+        match self {
+            NewAuthMethod::Password => {
+                let password = choose_password(if password_stdin {
+                    ReadPasswordFrom::Stdin
+                } else {
+                    ReadPasswordFrom::Tty {
+                        prompt: "Enter password for the new device:",
+                    }
+                })?;
+                Ok(libparsec_client::DeviceSaveStrategy::new_password(password))
+            }
+            NewAuthMethod::Keyring => Ok(libparsec_client::DeviceSaveStrategy::new_keyring()),
+        }
+    }
+
+    pub fn get_save_strategy(
+        self,
+        password_stdin: bool,
+    ) -> anyhow::Result<libparsec::DeviceSaveStrategy> {
+        match self {
+            NewAuthMethod::Password => {
+                let password = choose_password(if password_stdin {
+                    ReadPasswordFrom::Stdin
+                } else {
+                    ReadPasswordFrom::Tty {
+                        prompt: "New device password:",
+                    }
+                })?;
+                Ok(libparsec::DeviceSaveStrategy {
+                    totp_protection: None,
+                    primary_protection: libparsec::DevicePrimaryProtectionStrategy::Password {
+                        password,
+                    },
+                })
+            }
+            NewAuthMethod::Keyring => Ok(libparsec::DeviceSaveStrategy {
+                totp_protection: None,
+                primary_protection: libparsec::DevicePrimaryProtectionStrategy::Keyring,
+            }),
         }
     }
 }

--- a/cli/tests/integration/device/import_recovery_device.rs
+++ b/cli/tests/integration/device/import_recovery_device.rs
@@ -7,8 +7,10 @@ use crate::{
 use parsec_cli::{ui::Ui, utils::start_client};
 
 #[rstest::rstest]
+#[case("password")]
+#[case("keyring")]
 #[tokio::test]
-async fn import_recovery_device(tmp_path: TmpPath, test_ui: &Ui) {
+async fn import_recovery_device_password(tmp_path: TmpPath, test_ui: &Ui, #[case] auth: &str) {
     let (_, TestOrganization { alice, .. }, _) =
         bootstrap_cli_test(test_ui, &tmp_path).await.unwrap();
 
@@ -29,7 +31,9 @@ async fn import_recovery_device(tmp_path: TmpPath, test_ui: &Ui) {
         "--input",
         &input,
         "--label",
-        "new_device"
+        "new_device",
+        "--auth",
+        auth
     )
     .stderr(predicates::str::contains("New device created:"));
 }

--- a/newsfragments/10028.feature.rst
+++ b/newsfragments/10028.feature.rst
@@ -1,0 +1,3 @@
+[CLI][Breaking] Add --auth common option to setup new authentication method.
+
+Impacted commands:

--- a/newsfragments/10028.feature.rst
+++ b/newsfragments/10028.feature.rst
@@ -1,3 +1,4 @@
 [CLI][Breaking] Add --auth common option to setup new authentication method.
 
 Impacted commands:
+- device import-recovery-device


### PR DESCRIPTION
Fix #8612


```
parsec-cli device import-recovery-device -h
Import recovery device

Usage: parsec-cli device import-recovery-device [OPTIONS] --input <INPUT> --label <LABEL>

Options:
     [...]
  -a, --auth <AUTH>              Authentication method for the new device [default: password] [possible values: keyring, password]

```