### PR TITLE
Fix testbed shamir seed

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -367,6 +367,7 @@ secretkeybytes
 secretservice
 sectionauthor
 seealso
+seedable
 seedbytes
 Sellsy
 SEPA

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,6 +2793,7 @@ dependencies = [
  "libparsec_types",
  "log",
  "paste",
+ "rand 0.8.7",
  "regex",
  "reqwest",
  "rmp-serde",

--- a/libparsec/crates/testbed/Cargo.toml
+++ b/libparsec/crates/testbed/Cargo.toml
@@ -21,6 +21,8 @@ serde = { workspace = true, features = ["derive", "rc"] }
 serde_with = { workspace = true }
 rmp-serde = { workspace = true }
 lazy_static = { workspace = true }
+# Used to deterministically generate shamir recovery shares (see `events.rs`)
+rand = { workspace = true, features = ["std", "std_rng"] }
 reqwest = { workspace = true, features = ["native-tls", "query"] }
 regex = { workspace = true, features = ["std", "perf", "unicode"] }
 log = { workspace = true }

--- a/libparsec/crates/testbed/src/template/events.rs
+++ b/libparsec/crates/testbed/src/template/events.rs
@@ -2168,11 +2168,23 @@ impl TestbedEventNewShamirRecovery {
             NonZeroU8::try_from(total_share_count).expect("Share must be > 0")
         };
 
+        // The shares must be generated deterministically: the testbed materializes
+        // this shamir recovery setup independently on the client and on the server,
+        // and recovering the secret only works if every party's share belongs to
+        // the same secret sharing polynomial. Seeding the RNG from `data_key` (which
+        // is itself deterministically derived from the template builder counters)
+        // guarantees byte-identical share certificates across processes.
+        let mut rng = {
+            let mut seed = <rand::rngs::StdRng as rand::SeedableRng>::Seed::default();
+            seed.copy_from_slice(self.data_key.as_ref());
+            <rand::rngs::StdRng as rand::SeedableRng>::from_seed(seed)
+        };
+
         let mut shark_shares = ShamirRecoverySecret {
             data_key: self.data_key.clone(),
             reveal_token: self.reveal_token,
         }
-        .dump_and_encrypt_into_shares(self.threshold, total_share_count)
+        .dump_and_encrypt_into_shares_with_rng(self.threshold, total_share_count, &mut rng)
         .into_iter();
 
         for (recipient, shares_count) in &self.per_recipient_shares {

--- a/libparsec/crates/types/src/shamir.rs
+++ b/libparsec/crates/types/src/shamir.rs
@@ -46,11 +46,29 @@ impl ShamirRecoverySecret {
         threshold: NonZeroU8,
         shares: NonZeroU8,
     ) -> Vec<ShamirShare> {
+        self.dump_and_encrypt_into_shares_with_rng(threshold, shares, &mut rand::thread_rng())
+    }
+
+    /// Same as [`Self::dump_and_encrypt_into_shares`], but the share generation is
+    /// driven by the provided RNG.
+    ///
+    /// This is only useful for testing purpose: passing a seeded RNG makes the
+    /// output deterministic, so that a given shamir recovery setup yields
+    /// byte-identical share certificates across processes (e.g. the testbed
+    /// generates the certificates independently on the client and on the server,
+    /// and combining shares obtained from different parties only works if both
+    /// sides used the same secret sharing polynomial).
+    pub fn dump_and_encrypt_into_shares_with_rng(
+        &self,
+        threshold: NonZeroU8,
+        shares: NonZeroU8,
+        rng: &mut impl rand::Rng,
+    ) -> Vec<ShamirShare> {
         let secret = self.dump();
 
         let blahaj = blahaj::Sharks(threshold.get());
         blahaj
-            .dealer(&secret)
+            .dealer_rng(&secret, rng)
             .map(ShamirShare)
             // Note, unlike what Sharks's documentation claims, at most
             // 255 shares can be generated !


### PR DESCRIPTION
Disclaimer: I encountered a problem with the testbed when implementing the shamir recovery in the GUI. I iterated on the problem using Claude, it did found the problem's root (discussed with @touilleMan) and this is its proposed fix. I does solve my problem but I have no idea whether this code is valid, good, follows norms or anything.

Here's Claude's explanation of the issue:
> Symptom: In the Shamir claim flow on the shamir testbed template, collecting shares from two recipients fails. Contacting Bob alone (2 shares, meets threshold) works. Contacting Mike first (1 share) then Bob (2 shares) makes claimer_shamir_recovery_add_share fail with ShamirRecoveryClaimAddShareError::CorruptedSecret / BadSerialization { format: None, step: "format detection" }. The GUI code and handle threading are fine — this is a testbed data problem.
> 
> Root cause: ShamirRecoverySecret::dump_and_encrypt_into_shares (libparsec/crates/types/src/shamir.rs) deals the Shamir shares with blahaj::Sharks::dealer, which uses rand::thread_rng() — non-deterministic. The shared secret itself (data_key/reveal_token) is counter-deterministic and identical everywhere, but the polynomial coefficients differ on every generate_certificates() run.
> 
> The testbed client (one WASM instance behind the SharedWorker) and the testbed server (separate process) each run their own test_get_template("shamir") → their own generate_certificates() → different share bytes for the same shamir setup. The template CRC check doesn't catch this because impl_event_crc_hash! for the shamir event doesn't include the generated certificates.
> 
> Why it depends on which device greets: get_shamir_recovery_share_data serves the share from the greeter's local certificate store.
> - alice@dev1, bob@dev1, mallory@dev1, mike@dev1 get their stores pre-seeded from the template (certificates_storage_fetch_certificates in shamir.rs) → client dealing.
> - bob@dev2 has an empty store (per the template docstring) → the greeter polls the server → server dealing.
> 
> The GUI logs in with the most recent device, so Bob greets as bob@dev2 (server dealing) while Mike greets as mike@dev1 (client dealing). add_share then tries to reconstruct the secret from shares belonging to two different polynomials → garbage → the deserialization error. Bob-alone works because his two shares are internally consistent (both server dealing).
> 
> Suggested fix: Make the testbed's Shamir dealing deterministic — an RNG-injectable variant of dump_and_encrypt_into_shares using blahaj::Sharks::dealer_rng, seeded in TestbedEventNewShamirRecovery::generate_certificates from deterministic template data (a builder counter or data_key bytes), so client and server emit byte-identical share certificates. Possibly also fold the share certs into the event CRC.
